### PR TITLE
Fixes to add the SeriesUID and EchoTime in the files table.

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -700,7 +700,7 @@ sub register_db {
     # build the insert query
     my $query = "INSERT INTO files SET ";
 
-    foreach my $key ('File', 'SessionID', 'CoordinateSpace', 'ClassifyAlgorithm', 'OutputType', 'AcquisitionProtocolID', 'FileType', 'InsertedByUserID') {
+    foreach my $key ('File', 'SeriesUID', 'EchoTime','SessionID', 'CoordinateSpace', 'ClassifyAlgorithm', 'OutputType', 'AcquisitionProtocolID', 'FileType', 'InsertedByUserID') {
         # add the key=value pair to the query
         $query .= "$key=".$dbh->quote($${fileData{$key}}).", ";
     }

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -350,6 +350,8 @@ foreach my $minc (@minc_files)  {
 # Set some file information
     $file->setParameter('ScannerID', $scannerID);
     $file->setFileData('SessionID', $sessionID);
+    $file->setFileData('SeriesUID', $file->getParameter('series_instance_uid'));
+    $file->setFileData('EchoTime', $file->getParameter('echo_time'));
     $file->setFileData('PendingStaging', $requiresStaging);
     $file->setFileData('CoordinateSpace', 'native');
     $file->setFileData('OutputType', 'native');


### PR DESCRIPTION
This fix inserts in the files table the SeriesUID and the EchoTime to be able to change FileID once MRI pipeline re-run.

```
    modified:   uploadNeuroDB/NeuroDB/MRI.pm
modified:   uploadNeuroDB/tarchiveLoader
```
