### PR TITLE
Fixed the SeriesUID section of the insert Violated MRI function in MRI.p...

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -416,7 +416,7 @@ sub identify_scan_db {
     my $xspace = $${fileref}->getParameter('xspace');
     my $yspace = $${fileref}->getParameter('yspace');
     my $zspace = $${fileref}->getParameter('zspace');
-    my $seriesUID = $${fileref}->getParameter('SeriesUID');
+    my $seriesUID = $${fileref}->getParameter('series_instance_uid');
     my $slice_thickness = $${fileref}->getParameter('slice_thickness');
     my $series_description = $${fileref}->getParameter('series_description');
     
@@ -507,7 +507,7 @@ sub identify_scan_db {
         }
     }
     # if we got here, we're really clueless...
-    insert_violated_scans($dbhr,$series_description,$minc_location,$patient_name,$candid, $pscid,$visit,$tr,$te,$ti,$slice_thickness,$xstep,$ystep,$zstep,$xspace,$yspace,$zspace,$time);
+    insert_violated_scans($dbhr,$series_description,$minc_location,$patient_name,$candid, $pscid,$visit,$tr,$te,$ti,$slice_thickness,$xstep,$ystep,$zstep,$xspace,$yspace,$zspace,$time,$seriesUID);
 
     return 'unknown';
 }    
@@ -515,7 +515,7 @@ sub identify_scan_db {
 
 sub insert_violated_scans {
 
-   my ($dbhr,$series_description,$minc_location,$patient_name,$candid, $pscid,$visit,$tr,$te,$ti,$slice_thickness,$xstep,$ystep,$zstep,$xspace,$yspace,$zspace,$time) = @_;
+   my ($dbhr,$series_description,$minc_location,$patient_name,$candid, $pscid,$visit,$tr,$te,$ti,$slice_thickness,$xstep,$ystep,$zstep,$xspace,$yspace,$zspace,$time,$seriesUID) = @_;
    my $query;
    my $sth;
     


### PR DESCRIPTION
...m.

This field was not populated for three reasons:
- SeriesUID is mapped as series_instance_uid and not SeriesUID in MapDicomParameter
- $seriesUID was not called in function insert_violated_scans
- $seriesUID was not populated in the function insert_violated_scans (@_)
