### PR TITLE
find_uploads_tarchive: Removed hardcoded connection to DB

### DIFF
--- a/find_uploads_tarchive
+++ b/find_uploads_tarchive
@@ -18,8 +18,6 @@ use NeuroDB::DBI;
 
 use Data::Dumper;
 
-my $dbh = NeuroDB::DBI::connect_to_db('dbname', 'dbuser', 'dbpass', 'dbhost');
-
 my $update = 1;
 my @studies = ();
 
@@ -30,6 +28,7 @@ if(-f "$ENV{HOME}/.neurodb/prod") {
 }
 #######################################################################################
 
+my $dbh = NeuroDB::DBI::connect_to_db(@Settings::db);
 
 my @args_list = grep /-noupdate/, @ARGV;
 if(scalar(@args_list) > 0) { $update=0; }


### PR DESCRIPTION
Username, password, database and host to connect to database were hardcoded instead of looking into the Settings.

Don't know if that file is really used at some point? In any case, removed hardcoded connection to the database in this file.
