### PR TITLE
Fixed issue with path for tarchiveLoader not working

### DIFF
--- a/batch_uploads_tarchive
+++ b/batch_uploads_tarchive
@@ -46,7 +46,7 @@ foreach my $input (@inputs)
     ## processor will do all the real magic
 
     $input =~ s/\t/ /;
-    my $command = "uploadNeuroDB/tarchiveLoader -globLocation -profile prod $Settings::tarchiveLibraryDir/$input";
+    my $command = "tarchiveLoader -globLocation -profile prod $Settings::tarchiveLibraryDir/$input";
     ##if qsub is enabled use it
     if ($Settings::is_qsub) {
 	     open QSUB, "| qsub -V -e $stderr -o $stdout -N process_tarchive_${counter}";

--- a/environment
+++ b/environment
@@ -1,4 +1,3 @@
-source /data/ibis/bin/quarantine/Linux-x86_64/init-sge.sh
-export PATH=/data/ibis/bin/mri:$PATH
+export PATH=/data/ibis/bin/mri:/data/ibis/bin/mri/uploadNeuroDB:$PATH
 export PERL5LIB=/data/ibis/bin/mri/uploadNeuroDB:$PERL5LIB
 export TMPDIR=/tmp


### PR DESCRIPTION
You can't call a subdirectory of something in the $PATH variable from the command line, which batch_uploads_tarchive was trying to do. This adds the subdirectory uploadNeuroDB to the path and calls tarchiveLoader instead of trying to call uploadNeuroDB/tarchiveLoader which will only work if you're in the right directory.
