### PR TITLE
Installs the new module Path::Class

### DIFF
--- a/mri_pipeline_install.sh
+++ b/mri_pipeline_install.sh
@@ -67,7 +67,6 @@ sudo -S cpan install Math::Round
 sudo -S cpan install Getopt::Tabular
 sudo -S cpan install Time::JulianDay
 sudo -S cpan install Path::Class
-
 echo
 ##########################################################################################
 #############################Create directories########################################


### PR DESCRIPTION
The Path::Class module is currently needed by the uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm to create new directory (i.e):

  my $dir = dir($LogDir);  
  my $file = $dir->file($file_name);
  my $LOG = $file->openw();

Note: for existing project, installation of the new module, needs to be ran manually as follows:
sudo -S cpan install Path::Class
