### PR TITLE
installs a new perl lib (path::class)

### DIFF
--- a/mri_pipeline_install.sh
+++ b/mri_pipeline_install.sh
@@ -66,6 +66,7 @@ sudo -S cpan install Math::Round
 ##echo $rootpass | sudo -S cpan install Bundle::CPAN
 sudo -S cpan install Getopt::Tabular
 sudo -S cpan install Time::JulianDay
+sudo -S cpan install Path::Class
 echo
 ##########################################################################################
 #############################Create directories########################################


### PR DESCRIPTION
A new perl lib (PATH::CLASS) is installed since it's needed by the 'MRIProcessingUtility.pm' script.

For the existing installations the following command should be ran:
 sudo -S cpan install Path::Class
