### PR TITLE
updating url for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dicom-archive"]
 	path = dicom-archive
-	url = git@github.com:aces/dicom-archive-tools.git
+	url = https://github.com/aces/dicom-archive-tools.git


### PR DESCRIPTION
https, now that dicom-archive-tools and Loris-MRI repositories are public.  
