### PR TITLE
Mac compatible imaging pipeline

### DIFF
--- a/Mincinfo
+++ b/Mincinfo
@@ -1,1 +1,0 @@
-uploadNeuroDB/bin/Mincinfo

--- a/Mincinfo_wrapper
+++ b/Mincinfo_wrapper
@@ -1,0 +1,1 @@
+uploadNeuroDB/bin/Mincinfo_wrapper

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -714,7 +714,7 @@ sub get_mincs {
     my @files_list;
     foreach my $file (@files) {
         next unless $file =~ /\.mnc(\.gz)?$/;
-        my $cmd= "Mincinfo -quiet -tab -file -date $this->{TmpDir}/$file";
+        my $cmd= "Mincinfo_wrapper -quiet -tab -file -date $this->{TmpDir}/$file";
         push @files_list, `$cmd`;
     }
     open SORTER, "|sort -nk2 | cut -f1 > $this->{TmpDir}/sortlist";

--- a/uploadNeuroDB/bin/Mincinfo_wrapper
+++ b/uploadNeuroDB/bin/Mincinfo_wrapper
@@ -12,7 +12,7 @@
 #             software for any purpose.  It is provided "as is" without
 #             express or implied warranty.
 #---------------------------------------------------------------------------- 
-#$RCSfile: Mincinfo,v $
+#$RCSfile: Mincinfo_wrapper,v $
 #$Revision: 1.1.1.1 $
 #$Author: moi $
 #$Date: 2006/05/31 11:33:39 $
@@ -131,7 +131,7 @@ sub SetupArgTables
 {
    my (@args) = 
        (
-	["Mincinfo options", "section"],
+	["Mincinfo_wrapper options", "section"],
 	["-image_info", "call", undef, \&MincInfoOption,
 	 "Print out the default information about the images"],
 	["-dimnames", "call", undef, \&MincInfoOption,

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -182,7 +182,7 @@ my $template         = "TarLoad-$hour-$min-XXXXXX"; # for tempdir
 my $User             = `whoami`;
 
 # fixme there are better ways 
-my @progs = ("convert", "Mincinfo", "mincpik", $converter);
+my @progs = ("convert", "Mincinfo_wrapper", "mincpik", $converter);
 # create the temp dir
 my $TmpDir = tempdir(
                  $template, TMPDIR => 1, CLEANUP => 1 

--- a/uploadNeuroDB/upload
+++ b/uploadNeuroDB/upload
@@ -10,7 +10,7 @@ CURRENTLY BROKEN . DO not USE!
     session, parameter_file, parameter_type, parameter_type_category, files, mri_staging, notification_spool
 =cut
 
-# fixme Mincinfo path
+# fixme Mincinfo_wrapper path
 # fixme add a check for all programms that will be used
 # fixme add a check for registered protocols...
 # fixme the Phantom problem
@@ -461,7 +461,7 @@ sub confirm_single_study {
 	
 	my %hash;
 	foreach my $minc_file (@$minc_files_ref) {
-		my $cmd = "Mincinfo -quiet -tab -attvalue dicom_0x0020:el_0x000d -attvalue patient:full_name $minc_file";
+		my $cmd = "Mincinfo_wrapper -quiet -tab -attvalue dicom_0x0020:el_0x000d -attvalue patient:full_name $minc_file";
 		my $key = `$cmd`;
 		$hash{$key} = 1;
 	}
@@ -536,7 +536,7 @@ sub get_mincs
    my @dates_list;
    foreach my $file (@files) {
       next unless $file =~ /\.mnc(\.gz)?$/;
-      push @files_list, `Mincinfo -quiet -tab -file -date $TmpDir/$file`;
+      push @files_list, `Mincinfo_wrapper -quiet -tab -file -date $TmpDir/$file`;
    }
     open SORTER, "|sort -nk2 | cut -f1 > $TmpDir/sortlist";
     print SORTER join("", @files_list);
@@ -570,7 +570,7 @@ sub refresh_mincs
 	next unless `mincinfo -dimlength xspace $TmpDir/$file` >  5;
 	next unless `mincinfo -dimlength yspace $TmpDir/$file` >  5;
 	next unless `mincinfo -dimlength zspace $TmpDir/$file` >  5;
-	push @files_list, `Mincinfo -quiet -tab -file -date $TmpDir/$file`;
+	push @files_list, `Mincinfo_wrapper -quiet -tab -file -date $TmpDir/$file`;
     }
     open SORTER, "|sort -nk2 | cut -f1 > $TmpDir/sortlist";
     print SORTER join("", @files_list);


### PR DESCRIPTION
Apple filesystems are "case preserving" by default making it impossible to differentiate between Mincinfo and mincinfo. As Mincinfo script calls mincinfo, this creates a demoniac loop that calls Mincinfo for the rest of your terminal's life! Therefore, Mincinfo has been renamed Mincinfo_wrapper to make apples and linux happy ever after.
