### PR TITLE
Added create visit label option.

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -95,7 +95,7 @@ sub subjectIDIsValid {
     my $rowhr = $sth->fetchrow_hashref();
     
     # Check that visit label exists in the database if don't want to create visit labels via imaging pipeline 
-    if (($rowhr->{'isValid'} == 1) && ($create_visit_label eq "no")) {
+    if (($rowhr->{'isValid'} == 1) && (!$create_visit_label)) {
         $query = "SELECT COUNT(*) AS isValid FROM Visit_Windows WHERE BINARY Visit_label=".$${dbhr}->quote($visit_label);
         $sth = $${dbhr}->prepare($query);
         $sth->execute();

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1048,11 +1048,11 @@ sub validateCandidate {
     $query = "SELECT Visit_label FROM Visit_Windows WHERE BINARY Visit_label=?";
     $sth =  ${$this->{'dbhr'}}->prepare($query);
     $sth->execute($subjectIDsref->{'visitLabel'});
-    if (($sth->rows == 0) && ($subjectIDsref->{'createVisitLabel'} eq "no")) {
+    if (($sth->rows == 0) && (!$subjectIDsref->{'createVisitLabel'})) {
         print LOG  "\n\n => No Visit label";
         $CandMismatchError= 'Visit label does not exist';
         return $CandMismatchError;
-    } elsif (($sth->rows == 0) && ($subjectIDsref->{'createVisitLabel'} eq "yes")) {
+    } elsif (($sth->rows == 0) && ($subjectIDsref->{'createVisitLabel'})) {
         print LOG  "\n\n => Will create visit label $subjectIDsref->{'visitLabel'}";
     } 
 


### PR DESCRIPTION
Added a "createVisitLabel" option in $subjectIDs to allow creation of visit label by imaging pipeline if set to "yes". Otherwise, phantom scans cannot be uploaded in the database (or/and for projects that prefer having visit label created by imaging pipeline). 
