### PR TITLE
Modification of the spool function in Notify.pm

### DIFF
--- a/uploadNeuroDB/NeuroDB/Notify.pm
+++ b/uploadNeuroDB/NeuroDB/Notify.pm
@@ -77,7 +77,7 @@ sub spool {
     my $row = $sth->fetchrow_hashref();
     
     if($row->{'counter'} == 0) {
-        $query = "INSERT INTO notification_spool SET NotificationTypeID=$typeID, TimeSpooled=UNIX_TIMESTAMP(), Message=".$dbh->quote($message);
+        $query = "INSERT INTO notification_spool SET NotificationTypeID=$typeID, TimeSpooled=NOW(), Message=".$dbh->quote($message);
 	$query .= ", CenterID='$centerID'" if $centerID;
         $dbh->do($query);
     }


### PR DESCRIPTION
Modified the spool function to use NOW() instead of UNIX_TIMESTAMP() for TimeSpooled column. The reason for this is change is that the data-type for the TimeSpooled column in the notification_spool table is now changed from int to datetime.