### PR TITLE
Modification made to Notify.pm

### DIFF
--- a/uploadNeuroDB/NeuroDB/Notify.pm
+++ b/uploadNeuroDB/NeuroDB/Notify.pm
@@ -77,7 +77,7 @@ sub spool {
     my $row = $sth->fetchrow_hashref();
     
     if($row->{'counter'} == 0) {
-        $query = "INSERT INTO notification_spool SET NotificationTypeID=$typeID, TimeSpooled=UNIX_TIMESTAMP(), Message=".$dbh->quote($message);
+        $query = "INSERT INTO notification_spool SET NotificationTypeID=$typeID, TimeSpooled=NOW(), Message=".$dbh->quote($message);
 	$query .= ", CenterID='$centerID'" if $centerID;
         $dbh->do($query);
     }


### PR DESCRIPTION
Modified the spool function in Notify.pm to use MySQL function NOW() Instead of UNIX_TIMESTAMP() for TimeSpooled column when inserting into notification_spool table. The reason is because the MySQL datatype of Timespooled column  is now changed from int to datetime.