### PR TITLE
correcting environment file : LORIS_CONFIG path 

### DIFF
--- a/environment
+++ b/environment
@@ -1,4 +1,4 @@
 export PATH=/data/%PROJECT%/bin/mri:/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/dicom-archive:$PATH
 export PERL5LIB=/data/%PROJECT%/bin/mri/uploadNeuroDB:$PERL5LIB
 export TMPDIR=/tmp
-export LORIS_CONFIG=/data/%PROJECT%/bin/mri
+export LORIS_CONFIG=/data/%PROJECT%/bin/mri/dicom-archive


### PR DESCRIPTION
Updating environment file template so that new imaging installations will have the correct setup
Correcting LORIS_CONFIG variable path to point to ..../dicom-archive/
so that the imaging pipeline's calls to LORIS_CONFIG/.loris_mri/prod will find it in the right place 
(issue since #56 )
