### PR TITLE
Enabled Notification Spool in MRIProcessingUtility.pm and Informative messages print only if $verbose option is set

### DIFF
--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -130,7 +130,7 @@ sub IsValid {
         $message =
             "\n The uploadID "
           . $this->{'upload_id'}
-          . "Does Not Exist ";
+          . " Does Not Exist \n";
         $this->spool($message, 'Y');
         return 0;
     }
@@ -146,7 +146,8 @@ sub IsValid {
             "\n The Scan for the uploadID "
           . $this->{'upload_id'}
           . " has already been ran with tarchiveID: "
-          . $row[1];
+          . $row[1]
+	  . "\n";
         $this->spool($message, 'Y');
         return 0;
     }
@@ -177,7 +178,7 @@ sub IsValid {
 
     if ( $files_not_dicom > 0 ) {
         $message = "\n ERROR: there are $files_not_dicom files which are "
-          . "Are not of type DICOM";
+          . "Are not of type DICOM \n";
         $this->spool($message, 'Y');
         return 0;
     }
@@ -185,7 +186,7 @@ sub IsValid {
     if ( $files_with_unmatched_patient_name > 0 ) {
         $message =
             "\n ERROR: there are $files_with_unmatched_patient_name files"
-          . " where the patient-name doesn't match ";
+          . " where the patient-name doesn't match \n";
         $this->spool($message, 'Y');
         return 0;
     }
@@ -354,7 +355,7 @@ sub PatientNameMatch {
     if ($pname ne  $this->{'pname'}) {
         my $message = "The patient-name $pname does not Match " .
             $this->{'pname'};
-    $this->spool($message, 'Y');
+    	$this->spool($message, 'Y');
         return 0; ##return false
     }
     return 1;     ##return true
@@ -554,7 +555,7 @@ sub updateMRIUploadTable  {
     my $this = shift;
 
     my ( $field, $value ) = @_;
-        ########################################################
+	########################################################
         #################Update MRI_upload table accordingly####
         ########################################################
         my $where = "WHERE UploadID=?";

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -351,17 +351,16 @@ sub PatientNameMatch {
     my $this         = shift;
     my ($dicom_file) = @_;
     my $cmd          = "dcmdump $dicom_file | grep PatientName";
-
-    my $patient_name_string = $this->runCommand($cmd);
+    my $patient_name_string =  `$cmd`;
     if (!($patient_name_string)) {
-	my $message = "the patient name cannot be extracted";
+	my $message = "\n The patient name cannot be extracted \n";
         $this->spool($message, 'Y');
         exit 1;
     }
     my ($l,$pname,$t) = split /\[(.*?)\]/, $patient_name_string;
     if ($pname ne  $this->{'pname'}) {
-        my $message = "The patient-name $pname does not Match " .
-        		$this->{'pname'};
+        my $message = "\n The patient-name $pname does not Match " .
+        		$this->{'pname'}. "\n";
     	$this->spool($message, 'Y');
         return 0; ##return false
     }
@@ -387,9 +386,10 @@ Arguments:
 sub isDicom {
     my $this         = shift;
     my ($dicom_file) = @_;
-    my $file_type    = $this->runCommand("file $dicom_file");
+    my $cmd    = "file $dicom_file";
+    my $file_type    = `$cmd`;
     if ( !( $file_type =~ /DICOM/ ) ) {
-        print "not of type DICOM";
+        print "\n Not of type DICOM \n";
         return 0;
     }
     return 1;

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -131,7 +131,7 @@ sub IsValid {
             "\nThe uploadID "
           . $this->{'upload_id'}
           . " Does Not Exist \n";
-        $this->spool($message, 'Y');
+        $this->spool($message, 'Y','N');
         return 0;
     }
 
@@ -148,7 +148,7 @@ sub IsValid {
           . " has already been ran with tarchiveID: "
           . $row[1]
 	  . "\n";
-        $this->spool($message, 'Y');
+        $this->spool($message, 'Y','N');
         return 0;
     }
 
@@ -179,7 +179,7 @@ sub IsValid {
     if ( $files_not_dicom > 0 ) {
         $message = "\nERROR: there are $files_not_dicom files which are "
           . "Are not of type DICOM \n";
-        $this->spool($message, 'Y');
+        $this->spool($message, 'Y','N');
         return 0;
     }
 
@@ -187,7 +187,7 @@ sub IsValid {
         $message =
             "\nERROR: there are $files_with_unmatched_patient_name files"
           . " where the patient-name doesn't match \n";
-        $this->spool($message, 'Y');
+        $this->spool($message, 'Y','N');
         return 0;
     }
 
@@ -221,7 +221,7 @@ Arguments:
 =cut
 sub runDicomTar {
     my $this              = shift;
-    my $tarchive_id       = '';
+    my $tarchive_id       = undef;
     my $query             = '';
     my $where             = '';
     my $tarchive_location = $Settings::tarchiveLibraryDir;
@@ -354,14 +354,14 @@ sub PatientNameMatch {
     my $patient_name_string =  `$cmd`;
     if (!($patient_name_string)) {
 	my $message = "\nThe patient name cannot be extracted \n";
-        $this->spool($message, 'Y');
+        $this->spool($message, 'Y','N');
         exit 1;
     }
     my ($l,$pname,$t) = split /\[(.*?)\]/, $patient_name_string;
     if ($pname ne  $this->{'pname'}) {
         my $message = "\nThe patient-name $pname does not Match " .
         		$this->{'pname'}. "\n";
-    	$this->spool($message, 'Y');
+    	$this->spool($message, 'Y','N');
         return 0; ##return false
     }
     return 1;     ##return true
@@ -531,15 +531,16 @@ Arguments:
  $this      : Reference to the class
  $message   : Message to be logged in the database 
  $error     : if 'Y' it's an error log , 'N' otherwise
+ $verb      : 'N' for few main messages, 'Y' for more messages (developers)
  Returns    : NULL
 =cut
 
 sub spool  {
     my $this = shift;
-    my ( $message, $error ) = @_;
+    my ( $message, $error, $verb ) = @_;
     print "Spool message is: $message \n";
     $this->{'Notify'}->spool('mri upload processing class', $message, 0,
-           'Imaging_Upload.pm', $this->{'upload_id'},$error);
+           'Imaging_Upload.pm', $this->{'upload_id'},$error,$verb);
 }
 
 

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -128,7 +128,7 @@ sub IsValid {
     }
     else {
         $message =
-            "\n The uploadID "
+            "\nThe uploadID "
           . $this->{'upload_id'}
           . " Does Not Exist \n";
         $this->spool($message, 'Y');
@@ -143,7 +143,7 @@ sub IsValid {
     if ( ( $row[1] ) || ( $row[2] ) ) {
 
         $message =
-            "\n The Scan for the uploadID "
+            "\nThe Scan for the uploadID "
           . $this->{'upload_id'}
           . " has already been ran with tarchiveID: "
           . $row[1]
@@ -177,7 +177,7 @@ sub IsValid {
     }
 
     if ( $files_not_dicom > 0 ) {
-        $message = "\n ERROR: there are $files_not_dicom files which are "
+        $message = "\nERROR: there are $files_not_dicom files which are "
           . "Are not of type DICOM \n";
         $this->spool($message, 'Y');
         return 0;
@@ -185,7 +185,7 @@ sub IsValid {
 
     if ( $files_with_unmatched_patient_name > 0 ) {
         $message =
-            "\n ERROR: there are $files_with_unmatched_patient_name files"
+            "\nERROR: there are $files_with_unmatched_patient_name files"
           . " where the patient-name doesn't match \n";
         $this->spool($message, 'Y');
         return 0;
@@ -230,7 +230,7 @@ sub runDicomTar {
     my $command =
         $dicomtar . " " . $this->{'uploaded_temp_folder'} 
       . " $tarchive_location -clobber -database -profile prod";
-    if ($this->{'verbose'}) {
+    if ($this->{verbose}) {
         $command .= " -verbose";
     }
     my $output = $this->runCommandWithExitCode($command);
@@ -317,7 +317,7 @@ sub runTarchiveLoader {
       . "/uploadNeuroDB/tarchiveLoader"
       . " -globLocation -profile prod $archived_file_path";
 
-    if ($this->{'verbose'}){
+    if ($this->{verbose}){
         $command .= " -verbose";
     }
     my $output = $this->runCommandWithExitCode($command);
@@ -353,13 +353,13 @@ sub PatientNameMatch {
     my $cmd          = "dcmdump $dicom_file | grep PatientName";
     my $patient_name_string =  `$cmd`;
     if (!($patient_name_string)) {
-	my $message = "\n The patient name cannot be extracted \n";
+	my $message = "\nThe patient name cannot be extracted \n";
         $this->spool($message, 'Y');
         exit 1;
     }
     my ($l,$pname,$t) = split /\[(.*?)\]/, $patient_name_string;
     if ($pname ne  $this->{'pname'}) {
-        my $message = "\n The patient-name $pname does not Match " .
+        my $message = "\nThe patient-name $pname does not Match " .
         		$this->{'pname'}. "\n";
     	$this->spool($message, 'Y');
         return 0; ##return false
@@ -460,7 +460,7 @@ Arguments:
 sub runCommand {
     my $this = shift;
     my ($command) = @_;
-    print "\n\n $command \n\n " if $this->{'verbose'};
+    print "\n\n $command \n\n " if $this->{verbose};
     return `$command`;
 }
 

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -98,7 +98,7 @@ sub IsValid {
     my $files_with_unmatched_patient_name = 0;
     my $is_valid                          = 0;
     my @row                               = ();
-
+    my $verb_notification		  = 'N';
     ############################################################
     ####Get a list of files from the folder#####################
     ############################################################
@@ -131,7 +131,7 @@ sub IsValid {
             "\nThe uploadID "
           . $this->{'upload_id'}
           . " Does Not Exist \n";
-        $this->spool($message, 'Y','N');
+        $this->spool($message, 'Y', $verb_notification);
         return 0;
     }
 
@@ -148,7 +148,7 @@ sub IsValid {
           . " has already been ran with tarchiveID: "
           . $row[1]
 	  . "\n";
-        $this->spool($message, 'Y','N');
+        $this->spool($message, 'Y', $verb_notification);
         return 0;
     }
 
@@ -179,7 +179,7 @@ sub IsValid {
     if ( $files_not_dicom > 0 ) {
         $message = "\nERROR: there are $files_not_dicom files which are "
           . "Are not of type DICOM \n";
-        $this->spool($message, 'Y','N');
+        $this->spool($message, 'Y', $verb_notification);
         return 0;
     }
 
@@ -187,7 +187,7 @@ sub IsValid {
         $message =
             "\nERROR: there are $files_with_unmatched_patient_name files"
           . " where the patient-name doesn't match \n";
-        $this->spool($message, 'Y','N');
+        $this->spool($message, 'Y', $verb_notification);
         return 0;
     }
 
@@ -350,18 +350,19 @@ Arguments:
 sub PatientNameMatch {
     my $this         = shift;
     my ($dicom_file) = @_;
+    my $verb_notification = 'N';
     my $cmd          = "dcmdump $dicom_file | grep PatientName";
     my $patient_name_string =  `$cmd`;
     if (!($patient_name_string)) {
 	my $message = "\nThe patient name cannot be extracted \n";
-        $this->spool($message, 'Y','N');
+        $this->spool($message, 'Y', $verb_notification);
         exit 1;
     }
     my ($l,$pname,$t) = split /\[(.*?)\]/, $patient_name_string;
     if ($pname ne  $this->{'pname'}) {
         my $message = "\nThe patient-name $pname does not Match " .
         		$this->{'pname'}. "\n";
-    	$this->spool($message, 'Y','N');
+    	$this->spool($message, 'Y', $verb_notification);
         return 0; ##return false
     }
     return 1;     ##return true

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -530,7 +530,7 @@ Arguments:
 sub spool  {
     my $this = shift;
     my ( $message, $error ) = @_;
-    print "message is $message \n";
+    print "Spool message is: $message \n";
     $this->{'Notify'}->spool('mri upload processing class', $message, 0,
            'Imaging_Upload.pm', $this->{'upload_id'},$error);
 }

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -98,7 +98,7 @@ sub IsValid {
     my $files_with_unmatched_patient_name = 0;
     my $is_valid                          = 0;
     my @row                               = ();
-    my $verb_default		  	  = 'N';
+    my $notification_verbose		  	  = 'N';
     ############################################################
     ####Get a list of files from the folder#####################
     ############################################################
@@ -131,7 +131,7 @@ sub IsValid {
             "\nThe uploadID "
           . $this->{'upload_id'}
           . " Does Not Exist \n";
-        $this->spool($message, 'Y', $verb_default);
+        $this->spool($message, 'Y', $notification_verbose);
         return 0;
     }
 
@@ -148,7 +148,7 @@ sub IsValid {
           . " has already been ran with tarchiveID: "
           . $row[1]
 	  . "\n";
-        $this->spool($message, 'Y', $verb_default);
+        $this->spool($message, 'Y', $notification_verbose);
         return 0;
     }
 
@@ -179,7 +179,7 @@ sub IsValid {
     if ( $files_not_dicom > 0 ) {
         $message = "\nERROR: there are $files_not_dicom files which are "
           . "Are not of type DICOM \n";
-        $this->spool($message, 'Y', $verb_default);
+        $this->spool($message, 'Y', $notification_verbose);
         return 0;
     }
 
@@ -187,7 +187,7 @@ sub IsValid {
         $message =
             "\nERROR: there are $files_with_unmatched_patient_name files"
           . " where the patient-name doesn't match \n";
-        $this->spool($message, 'Y', $verb_default);
+        $this->spool($message, 'Y', $notification_verbose);
         return 0;
     }
 
@@ -350,19 +350,19 @@ Arguments:
 sub PatientNameMatch {
     my $this         = shift;
     my ($dicom_file) = @_;
-    my $verb_default = 'N';
+    my $notification_verbose = 'N';
     my $cmd          = "dcmdump $dicom_file | grep PatientName";
     my $patient_name_string =  `$cmd`;
     if (!($patient_name_string)) {
 	my $message = "\nThe patient name cannot be extracted \n";
-        $this->spool($message, 'Y', $verb_default);
+        $this->spool($message, 'Y', $notification_verbose);
         exit 1;
     }
     my ($l,$pname,$t) = split /\[(.*?)\]/, $patient_name_string;
     if ($pname ne  $this->{'pname'}) {
         my $message = "\nThe patient-name $pname does not Match " .
         		$this->{'pname'}. "\n";
-    	$this->spool($message, 'Y', $verb_default);
+    	$this->spool($message, 'Y', $notification_verbose);
         return 0; ##return false
     }
     return 1;     ##return true

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -230,6 +230,9 @@ sub runDicomTar {
     my $command =
         $dicomtar . " " . $this->{'uploaded_temp_folder'} 
       . " $tarchive_location -clobber -database -profile prod";
+    if ($this->{'verbose'}) {
+        $command .= " -verbose";
+    }
     my $output = $this->runCommandWithExitCode($command);
 
     if ( $output == 0 ) {
@@ -313,6 +316,10 @@ sub runTarchiveLoader {
         $Settings::bin_dir
       . "/uploadNeuroDB/tarchiveLoader"
       . " -globLocation -profile prod $archived_file_path";
+
+    if ($this->{'verbose'}){
+        $command .= " -verbose";
+    }
     my $output = $this->runCommandWithExitCode($command);
     if ( $output == 0 ) {
         return 1;
@@ -347,14 +354,14 @@ sub PatientNameMatch {
 
     my $patient_name_string = $this->runCommand($cmd);
     if (!($patient_name_string)) {
-	    my $message = "the patientname cannot be extracted";
+	my $message = "the patient name cannot be extracted";
         $this->spool($message, 'Y');
         exit 1;
     }
     my ($l,$pname,$t) = split /\[(.*?)\]/, $patient_name_string;
     if ($pname ne  $this->{'pname'}) {
         my $message = "The patient-name $pname does not Match " .
-            $this->{'pname'};
+        		$this->{'pname'};
     	$this->spool($message, 'Y');
         return 0; ##return false
     }
@@ -382,7 +389,7 @@ sub isDicom {
     my ($dicom_file) = @_;
     my $file_type    = $this->runCommand("file $dicom_file");
     if ( !( $file_type =~ /DICOM/ ) ) {
-        print "not of type DICOM" if $this->{'verbose'};
+        print "not of type DICOM";
         return 0;
     }
     return 1;

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -98,7 +98,7 @@ sub IsValid {
     my $files_with_unmatched_patient_name = 0;
     my $is_valid                          = 0;
     my @row                               = ();
-    my $verb_notification		  = 'N';
+    my $verb_default		  	  = 'N';
     ############################################################
     ####Get a list of files from the folder#####################
     ############################################################
@@ -131,7 +131,7 @@ sub IsValid {
             "\nThe uploadID "
           . $this->{'upload_id'}
           . " Does Not Exist \n";
-        $this->spool($message, 'Y', $verb_notification);
+        $this->spool($message, 'Y', $verb_default);
         return 0;
     }
 
@@ -148,7 +148,7 @@ sub IsValid {
           . " has already been ran with tarchiveID: "
           . $row[1]
 	  . "\n";
-        $this->spool($message, 'Y', $verb_notification);
+        $this->spool($message, 'Y', $verb_default);
         return 0;
     }
 
@@ -179,7 +179,7 @@ sub IsValid {
     if ( $files_not_dicom > 0 ) {
         $message = "\nERROR: there are $files_not_dicom files which are "
           . "Are not of type DICOM \n";
-        $this->spool($message, 'Y', $verb_notification);
+        $this->spool($message, 'Y', $verb_default);
         return 0;
     }
 
@@ -187,7 +187,7 @@ sub IsValid {
         $message =
             "\nERROR: there are $files_with_unmatched_patient_name files"
           . " where the patient-name doesn't match \n";
-        $this->spool($message, 'Y', $verb_notification);
+        $this->spool($message, 'Y', $verb_default);
         return 0;
     }
 
@@ -350,19 +350,19 @@ Arguments:
 sub PatientNameMatch {
     my $this         = shift;
     my ($dicom_file) = @_;
-    my $verb_notification = 'N';
+    my $verb_default = 'N';
     my $cmd          = "dcmdump $dicom_file | grep PatientName";
     my $patient_name_string =  `$cmd`;
     if (!($patient_name_string)) {
 	my $message = "\nThe patient name cannot be extracted \n";
-        $this->spool($message, 'Y', $verb_notification);
+        $this->spool($message, 'Y', $verb_default);
         exit 1;
     }
     my ($l,$pname,$t) = split /\[(.*?)\]/, $patient_name_string;
     if ($pname ne  $this->{'pname'}) {
         my $message = "\nThe patient-name $pname does not Match " .
         		$this->{'pname'}. "\n";
-    	$this->spool($message, 'Y', $verb_notification);
+    	$this->spool($message, 'Y', $verb_default);
         return 0; ##return false
     }
     return 1;     ##return true

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -11,11 +11,8 @@ use NeuroDB::FileDecompress;
 use NeuroDB::Notify;
 use File::Temp qw/ tempdir /;
 
-################################################################
-################# Define Constants #############################
-################################################################
-
-my $notify_detailed  = 'Y';  # notification_spool message flag for messages to be displayed 
+## Define Constants ##
+my $notify_detailed   = 'Y'; # notification_spool message flag for messages to be displayed 
                              # with DETAILED OPTION in the front-end/imaging_uploader 
 my $notify_notsummary = 'N'; # notification_spool message flag for messages to be displayed 
                              # with SUMMARY Option in the front-end/imaging_uploader 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -106,7 +106,7 @@ extracts it so data can actually be uploaded
 =cut
 sub extract_tarchive {
     my $this = shift;
-    my ($tarchive, $tarchive_id, $verbose) = @_;
+    my ($tarchive, $tarchive_id) = @_;
     my $upload_id = undef;
     my $message = '';
     # get the upload_id from the tarchive_id to pass to the notification_spool
@@ -143,9 +143,9 @@ sub extract_tarchive {
 sub extractAndParseTarchive {
 
     my $this = shift;
-    my ($tarchive, $tarchive_id, $verbose) = @_;
+    my ($tarchive, $tarchive_id) = @_;
     # get the upload_id from the tarchive_id to pass to notification_spool
-    my $upload_id = getUploadIDUsingTarchiveID($tarchive_id, $verbose);
+    my $upload_id = getUploadIDUsingTarchiveID($tarchive_id);
     my $study_dir = $this->{TmpDir}  . "/" .
         $this->extract_tarchive($tarchive, $tarchive_id);
     my $ExtractSuffix  = basename($tarchive, ".tar");
@@ -285,8 +285,8 @@ sub determineScannerID {
     my $upload_id = getUploadIDUsingTarchiveID($tarchive_id);
     my $message = '';
     $to_log = 1 unless defined $to_log;
+    $message = "\n\n==> Trying to determine scanner ID\n";
     if ($to_log) {
-        $message = "\n\n==> Trying to determine scanner ID\n";
         $this->{LOG}->print($message);
     }
     $this->spool($message, 'N', $upload_id, 'Y');
@@ -726,7 +726,7 @@ sub dicom_to_minc {
 
     my $this = shift;
     my ($study_dir, $converter,$get_dicom_info,
-		$exclude,$mail_user, $tarchive_id, $verbose) = @_;
+		$exclude,$mail_user, $tarchive_id) = @_;
     my ($d2m_cmd,$d2m_log,$exit_code);
     my $message = '';
     my $upload_id = getUploadIDUsingTarchiveID($tarchive_id);
@@ -773,7 +773,7 @@ sub dicom_to_minc {
 sub get_mincs {
   
     my $this = shift;
-    my ($minc_files, $tarchive_id, $verbose) = @_;
+    my ($minc_files, $tarchive_id) = @_;
     my $message = '';
     my $upload_id = getUploadIDUsingTarchiveID($tarchive_id);
     @$minc_files = ();
@@ -868,7 +868,7 @@ sub registerProgs() {
 sub moveAndUpdateTarchive {
 
     my $this = shift;
-    my ($tarchive_location,$tarchiveInfo,$verbose) = @_;
+    my ($tarchive_location,$tarchiveInfo) = @_;
     my $query = '';
     my $message = '';
     my ($newTarchiveLocation, $newTarchiveFilename,$mvTarchiveCmd);

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -109,6 +109,7 @@ sub extract_tarchive {
     my ($tarchive, $tarchive_id) = @_;
     my $upload_id = undef;
     my $message = '';
+    my $verb_notification = 'N';
     # get the upload_id from the tarchive_id to pass to the notification_spool
     $upload_id = getUploadIDUsingTarchiveID($tarchive_id);
     $message = "\nExtracting tarchive $tarchive in $this->{TmpDir} \n";
@@ -126,7 +127,7 @@ sub extract_tarchive {
         my $message = "Error: Could not find inner tar in $tarchive!\n";
         print $message;
         print @tars . "\n";
-        $this->spool($message, 'Y', $upload_id, 'N');
+        $this->spool($message, 'Y', $upload_id, $verb_notification);
         exit 1 ;
     }
     my $dcmtar = $tars[0];
@@ -167,6 +168,7 @@ sub determineSubjectID {
 
     my $this = shift;
     my ($scannerID,$tarchiveInfo,$to_log) = @_;
+    my $verb_notification = 'N';
     my $tarchive_id = $tarchiveInfo->{'TarchiveID'};
     my $upload_id = getUploadIDUsingTarchiveID($tarchive_id);
     $to_log = 1 unless defined $to_log;
@@ -175,7 +177,7 @@ sub determineSubjectID {
             my $message =  "\nERROR: Profile does not contain getSubjectIDs ".
                            "routine. Upload will exit now.\n\n";
             $this->writeErrorLog($message, 2);
-	    $this->spool($message, 'Y', $upload_id, 'N');
+	    $this->spool($message, 'Y', $upload_id, $verb_notification);
 	    exit 2;
         }
     }
@@ -207,6 +209,7 @@ sub createTarchiveArray {
     my $this = shift;
     my %tarchiveInfo;
     my ($tarchive,$globArchiveLocation) = @_;
+    my $verb_notification = 'N';
     my $where = "ArchiveLocation='$tarchive'";
     if ($globArchiveLocation) {
         $where = "ArchiveLocation LIKE '%".basename($tarchive)."'";
@@ -233,7 +236,7 @@ sub createTarchiveArray {
 	# no $tarchive nor $tarchive_id can be fetched since the archive 
 	# could not be found, making $upload_id hard to trace, so send some 
 	# random number (99999) instead for $upload_id in the notification_spool
-        $this->spool($message, 'Y', 99999, 'N');
+        $this->spool($message, 'Y', 99999, $verb_notification);
         exit 3;
     }
 
@@ -249,6 +252,7 @@ sub determinePSC {
     my ($tarchiveInfo,$to_log) = @_;
     my $tarchive_id = $tarchiveInfo->{'TarchiveID'};
     my $upload_id = undef;
+    my $verb_notification = 'N';
     $to_log = 1 unless defined $to_log;
     my ($center_name, $centerID) =
     NeuroDB::MRI::getPSC(
@@ -261,7 +265,7 @@ sub determinePSC {
 
             my $message = "\nERROR: No center found for this candidate \n\n";
             $this->writeErrorLog($message, 4);
-	    $this->spool($message, 'Y', $upload_id, 'N');
+	    $this->spool($message, 'Y', $upload_id, $verb_notification);
             exit 4;
         }
         my $message =
@@ -281,6 +285,7 @@ sub determineScannerID {
 
     my $this = shift;
     my ($tarchiveInfo,$to_log,$centerID,$NewScanner) = @_;
+    my $verb_notification = 'N';
     my $tarchive_id = $tarchiveInfo->{'TarchiveID'};
     my $upload_id = getUploadIDUsingTarchiveID($tarchive_id);
     my $message = '';
@@ -302,7 +307,7 @@ sub determineScannerID {
             $NewScanner 
         );
     if ($scannerID == 0) {
-       	$this->spool($message, 'Y', $upload_id, 'N');
+       	$this->spool($message, 'Y', $upload_id, $verb_notification);
         if ($to_log) {
             $message = "\nERROR: The ScannerID for this particular scanner ".
                           "does not exist. Enable creating new ScannerIDs in ".
@@ -366,6 +371,7 @@ sub getAcquisitionProtocol {
     my $tarchive_id = $tarchiveInfo->{'TarchiveID'};
     my $upload_id = getUploadIDUsingTarchiveID($tarchive_id);
     my $message = '';
+    my $verb_notification = 'N';
     
 
     ############################################################
@@ -410,7 +416,7 @@ sub getAcquisitionProtocol {
 		$this->spool($message, 'N', $upload_id, 'Y');
 	}
 	else{
-		$this->spool($message, 'Y', $upload_id, 'N');
+		$this->spool($message, 'Y', $upload_id, $verb_notification);
 	}
     }
     return ($acquisitionProtocol, $acquisitionProtocolID, @checks);
@@ -727,6 +733,7 @@ sub dicom_to_minc {
     my $this = shift;
     my ($study_dir, $converter,$get_dicom_info,
 		$exclude,$mail_user, $tarchive_id) = @_;
+    my $verb_notification = 'N';
     my ($d2m_cmd,$d2m_log,$exit_code);
     my $message = '';
     my $upload_id = getUploadIDUsingTarchiveID($tarchive_id);
@@ -752,7 +759,7 @@ sub dicom_to_minc {
         # just email. ##########################################
         ########################################################
         $message = "\nDicom to Minc conversion failed\n";
-        $this->spool($message, 'Y', $upload_id, 'N');
+        $this->spool($message, 'Y', $upload_id, $verb_notification);
         open MAIL, "| mail $mail_user";
         print MAIL "Subject: [URGENT Automated] uploadNeuroDB: ".
                    "dicom->minc failed\n";
@@ -925,6 +932,7 @@ sub CreateMRICandidates {
     my $this = shift;
     my $query = '';
     my ($subjectIDsref,$gender,$tarchiveInfo,$User,$centerID) = @_;
+    my $verb_notification = 'N';
     my ($message);
     my $tarchive_id = undef;
     my $upload_id   = undef;
@@ -983,7 +991,7 @@ sub CreateMRICandidates {
                        "The dicom header PatientName is: ". 
                        $tarchiveInfo->{'PatientName'}. "\n\n";
             $this->writeErrorLog($message, 6); 
-            $this->spool($message, 'Y', $upload_id, 'N');
+            $this->spool($message, 'Y', $upload_id, $verb_notification);
             exit 6;
      }
 }
@@ -1048,6 +1056,7 @@ sub setMRISession {
 sub validateArchive {
     my $this = shift;
     my ($tarchive,$tarchiveInfo) = @_;
+    my $verb_notification = 'N';
     my $tarchive_id = $tarchiveInfo->{'TarchiveID'};
     my $upload_id = getUploadIDUsingTarchiveID($tarchive_id);
     my $message = "\n==> verifying dicom archive md5sum (checksum)\n";
@@ -1069,7 +1078,7 @@ sub validateArchive {
                        "upload will exit now.\nplease read the creation logs ".
                        " for more  information!\n\n";
         $this->writeErrorLog($message, 7); 
-        $this->spool($message, 'Y', $upload_id, 'N');
+        $this->spool($message, 'Y', $upload_id, $verb_notification);
         exit 7;
     }
 }

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -12,7 +12,7 @@ use NeuroDB::Notify;
 use Path::Class;
 
 ## Define Constants ##
-my $notify_detailed  = 'Y';  # notification_spool message flag for messages to be displayed 
+my $notify_detailed   = 'Y'; # notification_spool message flag for messages to be displayed 
                              # with DETAILED OPTION in the front-end/imaging_uploader 
 my $notify_notsummary = 'N'; # notification_spool message flag for messages to be displayed 
                              # with SUMMARY Option in the front-end/imaging_uploader 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -422,9 +422,9 @@ sub getAcquisitionProtocol {
     	if ($this->{verbose}){
 		$message = "\n Worst error: $checks[0]\n";
 		$this->{LOG}->print($message);
-		# Here I am assuming that 'warn' and 'pass' are n
-		# errors, and only 'exclude' is an error in the 
-		# notifiucation_spool_table
+		# Here I am assuming that 'warn' and 'pass' are
+		# not errors, and only 'exclude' is an error in  
+		# the notification_spool_table
 		if (!($checks[0] eq 'exclude')){
 			$this->spool($message, 'N', $upload_id);
 		}
@@ -805,7 +805,9 @@ sub dicom_to_minc {
 sub get_mincs {
   
     my $this = shift;
-    my ($minc_files) = @_;
+    my ($minc_files, $tarchive_id, $verbose) = @_;
+    my $message = '';
+    my $upload_id = getUploadIDUsingTarchiveID($tarchive_id);
     @$minc_files = ();
     opendir TMPDIR, $this->{TmpDir} ;
     my @files = readdir TMPDIR;
@@ -827,9 +829,12 @@ sub get_mincs {
     }
     close SORTLIST;
     `rm -f $this->{TmpDir}/sortlist`;
-    my $message = "\n### These MINC files have been created: \n".
+    $message = "\n### These MINC files have been created: \n".
         join("\n", @$minc_files)."\n";
-    $this->{LOG}->print($message);
+    if ($verbose){ 
+        $this->{LOG}->print($message);
+        $this->spool($message, 'N', $upload_id);
+    }
 }  
 
 ################################################################

--- a/uploadNeuroDB/NeuroDB/Notify.pm
+++ b/uploadNeuroDB/NeuroDB/Notify.pm
@@ -70,62 +70,39 @@ sub spool {
     my $typeID = $this->getTypeID($type);
     return 0 unless defined $typeID;
 
-    my $query = "SELECT COUNT(*) AS counter FROM notification_spool 
-                 WHERE NotificationTypeID= ?
-                 AND Message= ?
-                 AND Sent='N'";
+    my @insert_params = ();
+    my $query = "INSERT INTO notification_spool SET NotificationTypeID=?,
+                TimeSpooled=NOW(), 
+                Message=? ";
 
-    push @params, $typeID;
-    push @params, $message;
+    push @insert_params, $typeID;
+    push @insert_params, $message;
 
     if ($centerID) {
-    	$query .= " AND CenterID= ? ";
-        push @params, $centerID;	
+        $query .= " , CenterID=? ";
+        push @insert_params, $centerID;
     }
     if ($origin) {
-    	$query .= " AND Origin= ? ";
-        push @params, $origin;
+        $query .= " , Origin=? ";
+        push @insert_params, $origin;
     }
-    my $sth = $dbh->prepare($query);
-    $sth->execute(@params);    
-    my $row = $sth->fetchrow_hashref();
-    
-    if ($row->{'counter'} == 0) {
 
-	    my @insert_params = ();
-            $query = "INSERT INTO notification_spool SET NotificationTypeID=?,
-                  TimeSpooled=NOW(), 
-                  Message=? ";
-
-            push @insert_params, $typeID;
-            push @insert_params, $message;
-
-            if ($centerID) {
-                $query .= " , CenterID=? ";
-                push @insert_params, $centerID;
-            }
-            if ($origin) {
-                $query .= " , Origin=? ";
-                push @insert_params, $origin;
-            }
-
-            if ($processID) {
-                $query .= " , ProcessID=? ";
-                push @insert_params, $processID;
-            }
-
-            if ($isError) {
-                $query .= " , Error=? ";
-                push @insert_params, $isError;
-            }
-
-            if ($isVerb) {
-                $query .= " , Verbose=? ";
-                push @insert_params, $isVerb;
-            }
-            my $insert = $dbh->prepare($query);
-            $insert->execute(@insert_params);
+    if ($processID) {
+        $query .= " , ProcessID=? ";
+        push @insert_params, $processID;
     }
+
+    if ($isError) {
+        $query .= " , Error=? ";
+        push @insert_params, $isError;
+    }
+
+    if ($isVerb) {
+        $query .= " , Verbose=? ";
+        push @insert_params, $isVerb;
+    }
+    my $insert = $dbh->prepare($query);
+    $insert->execute(@insert_params);
     
     return 1;
 }

--- a/uploadNeuroDB/NeuroDB/Notify.pm
+++ b/uploadNeuroDB/NeuroDB/Notify.pm
@@ -50,7 +50,7 @@ sub new {
 
 =pod
 
-B<spool( C<$type>, C<$message>, C<$centerID>, C<$origin>, C<$processID>, C<$isError> )>
+B<spool( C<$type>, C<$message>, C<$centerID>, C<$origin>, C<$processID>, C<$isError>, C<$isVerb> )>
 
 Spools a new notification message, C<$message>, into the spool for
 notification type C<$type>, unless the exact same message (including
@@ -63,7 +63,7 @@ Returns: 1 on success, 0 on failure
 
 sub spool {
     my $this = shift;
-    my ($type, $message, $centerID, $origin, $processID, $isError) = @_;
+    my ($type, $message, $centerID, $origin, $processID, $isError, $isVerb) = @_;
     my $dbh = ${$this->{'dbhr'}};
     my @params = ();
     
@@ -117,6 +117,11 @@ sub spool {
             if ($isError) {
                 $query .= " , Error=? ";
                 push @insert_params, $isError;
+            }
+
+            if ($isVerb) {
+                $query .= " , Verbose=? ";
+                push @insert_params, $isVerb;
             }
             my $insert = $dbh->prepare($query);
             $insert->execute(@insert_params);

--- a/uploadNeuroDB/NeuroDB/Notify.pm
+++ b/uploadNeuroDB/NeuroDB/Notify.pm
@@ -53,8 +53,7 @@ sub new {
 B<spool( C<$type>, C<$message>, C<$centerID>, C<$origin>, C<$processID>, C<$isError>, C<$isVerb> )>
 
 Spools a new notification message, C<$message>, into the spool for
-notification type C<$type>, unless the exact same message (including
-type) is already in the spool.  If C<$centerID> is specified, only
+notification type C<$type>.  If C<$centerID> is specified, only
 recipients in that site will receive the message.
 
 Returns: 1 on success, 0 on failure

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -190,13 +190,13 @@ my $is_valid = $imaging_upload->IsValid();
 if ( !($is_valid) ) {
     $imaging_upload->updateMRIUploadTable(
 	'Inserting', 0);
-    $message = "The validation has failed";
+    $message = "\n The validation has failed \n";
     spool($message,'Y');
     print $message;
     exit 6;
 }
 
-$message = "The validation has passed";
+$message = "\n The validation has passed \n";
 spool($message,'N');
 
 ################################################################
@@ -206,7 +206,7 @@ $output = $imaging_upload->runDicomTar();
 if ( !$output ) {
     $imaging_upload->updateMRIUploadTable(
 	'Inserting', 0);
-    $message = "\n The dicomtar execution has failed";
+    $message = "\n The dicomtar execution has failed\n";
     spool($message,'Y');
     print $message;
     exit 7;
@@ -220,7 +220,7 @@ spool($message,'N');
 $output = $imaging_upload->runTarchiveLoader();
 $imaging_upload->updateMRIUploadTable('Inserting', 0);
 if ( !$output ) {
-    $message = "\n The insertion scripts have failed";
+    $message = "\n The insertion scripts have failed\n";
     spool($message,'Y'); 
     print $message;
     exit 8;

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -190,13 +190,13 @@ my $is_valid = $imaging_upload->IsValid();
 if ( !($is_valid) ) {
     $imaging_upload->updateMRIUploadTable(
 	'Inserting', 0);
-    $message = "\n The validation has failed \n";
+    $message = "\nThe validation has failed \n";
     spool($message,'Y');
     print $message;
     exit 6;
 }
 
-$message = "\n The validation has passed \n";
+$message = "\nThe validation has passed \n";
 spool($message,'N');
 
 ################################################################
@@ -206,12 +206,12 @@ $output = $imaging_upload->runDicomTar();
 if ( !$output ) {
     $imaging_upload->updateMRIUploadTable(
 	'Inserting', 0);
-    $message = "\n The dicomtar execution has failed\n";
+    $message = "\nThe dicomtar execution has failed\n";
     spool($message,'Y');
     print $message;
     exit 7;
 }
-$message = "\n The dicomtar execution has successfully completed";
+$message = "\nThe dicomtar execution has successfully completed\n";
 spool($message,'N');
 
 ################################################################
@@ -220,12 +220,12 @@ spool($message,'N');
 $output = $imaging_upload->runTarchiveLoader();
 $imaging_upload->updateMRIUploadTable('Inserting', 0);
 if ( !$output ) {
-    $message = "\n The insertion scripts have failed\n";
+    $message = "\nThe insertion scripts have failed\n";
     spool($message,'Y'); 
     print $message;
     exit 8;
 }
-$message = "\n The insertion scripts have successfully completed";
+$message = "\nThe insertion scripts have successfully completed\n";
 spool($message,'N');
 
 ################################################################

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -37,8 +37,11 @@ my $TmpDir_decompressed_folder =
 my $output              = undef;
 my $uploaded_file       = undef;
 my $message             = undef;
-my $verbose             = 0;           # default for now
-my $verb_default   = 'N';
+my $verbose             = 0;           # default for now, run with -verbose option to re-enable
+my $notification_verbose= 'N';	       # notification_spool message flag for messages to 
+				       # be displayed BY DEFAULT in the front-end/imaging_uploader 
+my $notification_silent = 'Y';	       # notification_spool message flag for messages to 
+				       # be displayed UPON REQUEST in the front-end/imaging_uploader 
 my @opt_table           = (
     [ "Basic options", "section" ],
     [
@@ -192,13 +195,13 @@ if ( !($is_valid) ) {
     $imaging_upload->updateMRIUploadTable(
 	'Inserting', 0);
     $message = "\nThe validation has failed \n";
-    spool($message,'Y', $verb_default);
+    spool($message,'Y', $notification_verbose);
     print $message;
     exit 6;
 }
 
 $message = "\nThe validation has passed \n";
-spool($message,'N', $verb_default);
+spool($message,'N', $notification_verbose);
 
 ################################################################
 ############### Run DicomTar  ##################################
@@ -208,12 +211,12 @@ if ( !$output ) {
     $imaging_upload->updateMRIUploadTable(
 	'Inserting', 0);
     $message = "\nThe dicomtar execution has failed\n";
-    spool($message,'Y', $verb_default);
+    spool($message,'Y', $notification_verbose);
     print $message;
     exit 7;
 }
 $message = "\nThe dicomtar execution has successfully completed\n";
-spool($message,'N', $verb_default);
+spool($message,'N', $notification_verbose);
 
 ################################################################
 ############### Run runTarchiveLoader###########################
@@ -222,12 +225,12 @@ $output = $imaging_upload->runTarchiveLoader();
 $imaging_upload->updateMRIUploadTable('Inserting', 0);
 if ( !$output ) {
     $message = "\nThe insertion scripts have failed\n";
-    spool($message,'Y', $verb_default); 
+    spool($message,'Y', $notification_verbose); 
     print $message;
     exit 8;
 }
 $message = "\nThe insertion scripts have successfully completed\n";
-spool($message,'N', $verb_default);
+spool($message,'N', $notification_verbose);
 
 ################################################################
 ### If we got this far, dicomTar and tarchiveLoader completed###
@@ -236,7 +239,7 @@ spool($message,'N', $verb_default);
 my $isCleaned = $imaging_upload->CleanUpDataIncomingDir($uploaded_file);
 if ( !$isCleaned ) {
     $message = "The uploaded file " . $uploaded_file . " was not removed\n";
-    spool($message,'Y', $verb_notification);
+    spool($message,'Y', $notification_verbose);
     print $message;
     exit 9;
 }

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -191,13 +191,13 @@ if ( !($is_valid) ) {
     $imaging_upload->updateMRIUploadTable(
 	'Inserting', 0);
     $message = "\nThe validation has failed \n";
-    spool($message,'Y');
+    spool($message,'Y', 'N');
     print $message;
     exit 6;
 }
 
 $message = "\nThe validation has passed \n";
-spool($message,'N');
+spool($message,'N', 'N');
 
 ################################################################
 ############### Run DicomTar  ##################################
@@ -207,12 +207,12 @@ if ( !$output ) {
     $imaging_upload->updateMRIUploadTable(
 	'Inserting', 0);
     $message = "\nThe dicomtar execution has failed\n";
-    spool($message,'Y');
+    spool($message,'Y', 'N');
     print $message;
     exit 7;
 }
 $message = "\nThe dicomtar execution has successfully completed\n";
-spool($message,'N');
+spool($message,'N','N');
 
 ################################################################
 ############### Run runTarchiveLoader###########################
@@ -221,12 +221,12 @@ $output = $imaging_upload->runTarchiveLoader();
 $imaging_upload->updateMRIUploadTable('Inserting', 0);
 if ( !$output ) {
     $message = "\nThe insertion scripts have failed\n";
-    spool($message,'Y'); 
+    spool($message,'Y', 'N'); 
     print $message;
     exit 8;
 }
 $message = "\nThe insertion scripts have successfully completed\n";
-spool($message,'N');
+spool($message,'N', 'N');
 
 ################################################################
 ### If we got this far, dicomTar and tarchiveLoader completed###
@@ -288,16 +288,18 @@ Arguments:
  $this      : Reference to the class
  $message   : Message to be logged in the database 
  $error     : if 'Y' it's an error log , 'N' otherwise
+ $verb      : 'N' for few main messages, 'Y' for more messages (developers)
+
  Returns    : NULL
 =cut
 
 sub spool  {
-    my ( $message, $error ) = @_;
+    my ( $message, $error, $verb) = @_;
     $Notify->spool('mri upload runner', 
                    $message, 
                    0, 
         		   'imaging_upload_file.pl',
-                   $upload_id,$error
+                   $upload_id,$error, $verb
     );
 }
 

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -38,6 +38,7 @@ my $output              = undef;
 my $uploaded_file       = undef;
 my $message             = undef;
 my $verbose             = 0;           # default for now
+my $verb_notification   = 'N';
 my @opt_table           = (
     [ "Basic options", "section" ],
     [
@@ -191,13 +192,13 @@ if ( !($is_valid) ) {
     $imaging_upload->updateMRIUploadTable(
 	'Inserting', 0);
     $message = "\nThe validation has failed \n";
-    spool($message,'Y', 'N');
+    spool($message,'Y', $verb_notification);
     print $message;
     exit 6;
 }
 
 $message = "\nThe validation has passed \n";
-spool($message,'N', 'N');
+spool($message,'N', $verb_notification);
 
 ################################################################
 ############### Run DicomTar  ##################################
@@ -207,12 +208,12 @@ if ( !$output ) {
     $imaging_upload->updateMRIUploadTable(
 	'Inserting', 0);
     $message = "\nThe dicomtar execution has failed\n";
-    spool($message,'Y', 'N');
+    spool($message,'Y', $verb_notification);
     print $message;
     exit 7;
 }
 $message = "\nThe dicomtar execution has successfully completed\n";
-spool($message,'N','N');
+spool($message,'N', $verb_notification);
 
 ################################################################
 ############### Run runTarchiveLoader###########################
@@ -221,12 +222,12 @@ $output = $imaging_upload->runTarchiveLoader();
 $imaging_upload->updateMRIUploadTable('Inserting', 0);
 if ( !$output ) {
     $message = "\nThe insertion scripts have failed\n";
-    spool($message,'Y', 'N'); 
+    spool($message,'Y', $verb_notification); 
     print $message;
     exit 8;
 }
 $message = "\nThe insertion scripts have successfully completed\n";
-spool($message,'N', 'N');
+spool($message,'N', $verb_notification);
 
 ################################################################
 ### If we got this far, dicomTar and tarchiveLoader completed###
@@ -235,7 +236,7 @@ spool($message,'N', 'N');
 my $isCleaned = $imaging_upload->CleanUpDataIncomingDir($uploaded_file);
 if ( !$isCleaned ) {
     $message = "The uploaded file " . $uploaded_file . " was not removed\n";
-    spool($message,'Y'); 
+    spool($message,'Y', $verb_notification);
     print $message;
     exit 9;
 }

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -30,7 +30,7 @@ my $date    = sprintf(
               );
 my $profile = undef;    # this should never be set unless you are in a
                         # stable production environment
-my $upload_id =         # The uploadID
+my $upload_id = undef;         # The uploadID
 my $template  = "ImagingUpload-$hour-$min-XXXXXX";    # for tempdir
 my $TmpDir_decompressed_folder =
      tempdir( $template, TMPDIR => 1, CLEANUP => 1 );

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -225,7 +225,7 @@ if ( !$output ) {
     print $message;
     exit 8;
 }
-$message = "\n The insertion Script has successfully completed";
+$message = "\n The insertion scripts have successfully completed";
 spool($message,'N');
 
 ################################################################

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -38,7 +38,7 @@ my $output              = undef;
 my $uploaded_file       = undef;
 my $message             = undef;
 my $verbose             = 0;           # default for now
-my $verb_notification   = 'N';
+my $verb_default   = 'N';
 my @opt_table           = (
     [ "Basic options", "section" ],
     [
@@ -192,13 +192,13 @@ if ( !($is_valid) ) {
     $imaging_upload->updateMRIUploadTable(
 	'Inserting', 0);
     $message = "\nThe validation has failed \n";
-    spool($message,'Y', $verb_notification);
+    spool($message,'Y', $verb_default);
     print $message;
     exit 6;
 }
 
 $message = "\nThe validation has passed \n";
-spool($message,'N', $verb_notification);
+spool($message,'N', $verb_default);
 
 ################################################################
 ############### Run DicomTar  ##################################
@@ -208,12 +208,12 @@ if ( !$output ) {
     $imaging_upload->updateMRIUploadTable(
 	'Inserting', 0);
     $message = "\nThe dicomtar execution has failed\n";
-    spool($message,'Y', $verb_notification);
+    spool($message,'Y', $verb_default);
     print $message;
     exit 7;
 }
 $message = "\nThe dicomtar execution has successfully completed\n";
-spool($message,'N', $verb_notification);
+spool($message,'N', $verb_default);
 
 ################################################################
 ############### Run runTarchiveLoader###########################
@@ -222,12 +222,12 @@ $output = $imaging_upload->runTarchiveLoader();
 $imaging_upload->updateMRIUploadTable('Inserting', 0);
 if ( !$output ) {
     $message = "\nThe insertion scripts have failed\n";
-    spool($message,'Y', $verb_notification); 
+    spool($message,'Y', $verb_default); 
     print $message;
     exit 8;
 }
 $message = "\nThe insertion scripts have successfully completed\n";
-spool($message,'N', $verb_notification);
+spool($message,'N', $verb_default);
 
 ################################################################
 ### If we got this far, dicomTar and tarchiveLoader completed###

--- a/uploadNeuroDB/imaging_upload_file_cronjob.pl
+++ b/uploadNeuroDB/imaging_upload_file_cronjob.pl
@@ -88,8 +88,8 @@ while(@row = $sth->fetchrow_array()) {
 	my $command = "imaging_upload_file.pl -upload_id $row[0] -profile prod $row[1]";
 	if ($verbose){
 	    $command .= " -verbose";
+            print "\n" . $command . "\n";
 	}
-	print "\n" . $command . "\n";
 	my $output = system($command);
     } else {
     	print "\nERROR: Could not find the uploaded file

--- a/uploadNeuroDB/imaging_upload_file_cronjob.pl
+++ b/uploadNeuroDB/imaging_upload_file_cronjob.pl
@@ -76,7 +76,7 @@ my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 my @row=();
 (my $query = <<QUERY) =~ s/\n/ /gm;
 SELECT UploadID, UploadLocation FROM mri_upload 
-    WHERE Inserting <> 1 AND InsertionComplete <> 1 
+    WHERE Inserting IS NULL AND InsertionComplete <> 1 
         AND (TarchiveID IS NULL AND number_of_mincInserted IS NULL);
 QUERY
 print "\n" . $query . "\n" if $debug;

--- a/uploadNeuroDB/imaging_upload_file_cronjob.pl
+++ b/uploadNeuroDB/imaging_upload_file_cronjob.pl
@@ -24,8 +24,8 @@ my $date    = sprintf(
                 $year + 1900,
                 $mon + 1, $mday, $hour, $min, $sec
               );
-my $debug   = 1;
-my $verbose = 1;        # default for now
+my $debug   = 0;
+my $verbose = 0;        # default for now
 my $profile = undef;    # this should never be set unless you are in a
                         # stable production environment
 my $output              = undef;
@@ -36,7 +36,8 @@ my @opt_table           = (
     [
         "-profile", "string", 1, \$profile,
         "name of config file in ../dicom-archive/.loris_mri"
-    ]
+    ],
+    ["-verbose", "boolean", 1,    \$verbose, "Be verbose."]
 );
 
 my $Help = <<HELP;
@@ -78,13 +79,16 @@ SELECT UploadID, UploadLocation FROM mri_upload
     WHERE Inserting <> 1 AND InsertionComplete <> 1 
         AND (TarchiveID IS NULL AND number_of_mincInserted IS NULL);
 QUERY
-print "\n" . $query . "\n";
+print "\n" . $query . "\n" if $debug;
 my $sth = $dbh->prepare($query);
 $sth->execute();
 while(@row = $sth->fetchrow_array()) { 
 
     if ( -e $row[1] ) {
 	my $command = "imaging_upload_file.pl -upload_id $row[0] -profile prod $row[1]";
+	if ($verbose){
+	    $command .= " -verbose";
+	}
 	print "\n" . $command . "\n";
 	my $output = system($command);
     } else {

--- a/uploadNeuroDB/imaging_upload_file_cronjob.pl
+++ b/uploadNeuroDB/imaging_upload_file_cronjob.pl
@@ -25,7 +25,7 @@ my $date    = sprintf(
                 $mon + 1, $mday, $hour, $min, $sec
               );
 my $debug   = 0;
-my $verbose = 0;        # default for now
+my $verbose = 0;        # default for now unless launched with -verbose option
 my $profile = undef;    # this should never be set unless you are in a
                         # stable production environment
 my $output              = undef;

--- a/uploadNeuroDB/mass_jiv.pl
+++ b/uploadNeuroDB/mass_jiv.pl
@@ -9,7 +9,7 @@ use NeuroDB::File;
 use NeuroDB::MRI;
 
 # Set stuff for GETOPT
-my $verbose    = 1;
+my $verbose    = 0;
 my $profile    = undef;
 my $minFileID  = undef;
 my $maxFileID  = undef;
@@ -80,6 +80,6 @@ while(my $rowhr = $sth->fetchrow_hashref()) {
 
 $dbh->disconnect();
 
-print "Finished\n" if $verbose;
+print "\n Finished mass_jiv.pl execution\n" if $verbose;
 exit 0;
 

--- a/uploadNeuroDB/mass_nii.pl
+++ b/uploadNeuroDB/mass_nii.pl
@@ -16,7 +16,7 @@ my $versionInfo = sprintf "%d revision %2d", q$Revision: 1.00 $
 ################################################################
 ################## Set variables for GETOPT ####################
 ################################################################
-my $verbose    = 1;
+my $verbose    = 0;
 my $profile    = undef;
 my $minFileID  = undef;
 my $maxFileID  = undef;
@@ -157,7 +157,7 @@ while(my $rowhr = $sth->fetchrow_hashref()) {
 
 # Close database handler
 $dbh->disconnect();
-print "Finished\n" if $verbose;
+print "\n Finished mass_nii.pl execution\n" if $verbose;
 
 # Exit script
 exit 0;

--- a/uploadNeuroDB/mass_pic.pl
+++ b/uploadNeuroDB/mass_pic.pl
@@ -123,5 +123,5 @@ while(my $rowhr = $sth->fetchrow_hashref()) {
 
 $dbh->disconnect();
 
-print "\n Finished mass_pic.pl execustion\n" if $verbose;
+print "\n Finished mass_pic.pl execution\n" if $verbose;
 exit 0;

--- a/uploadNeuroDB/mass_pic.pl
+++ b/uploadNeuroDB/mass_pic.pl
@@ -123,5 +123,5 @@ while(my $rowhr = $sth->fetchrow_hashref()) {
 
 $dbh->disconnect();
 
-print "\n Finished mass_pic.pl execution\n" if $verbose;
+print "\nFinished mass_pic.pl execution\n" if $verbose;
 exit 0;

--- a/uploadNeuroDB/mass_pic.pl
+++ b/uploadNeuroDB/mass_pic.pl
@@ -10,7 +10,7 @@ use NeuroDB::MRI;
 ################################################################
 ################## Set stuff for GETOPT ########################
 ################################################################
-my $verbose    = 1;
+my $verbose    = 0;
 my $profile    = undef;
 my $minFileID  = undef;
 my $maxFileID  = undef;
@@ -107,7 +107,7 @@ my $sth = $dbh->prepare($query);
 $sth->execute();
 
 while(my $rowhr = $sth->fetchrow_hashref()) {
-    print "$rowhr->{'FileID'}\n" if $verbose;
+    print "FileID from mass_pic.pl is: $rowhr->{'FileID'}\n" if $verbose;
     my $file = NeuroDB::File->new(\$dbh);
     $file->loadFile($rowhr->{'FileID'});
 
@@ -123,5 +123,5 @@ while(my $rowhr = $sth->fetchrow_hashref()) {
 
 $dbh->disconnect();
 
-print "Finished\n" if $verbose;
+print "\n Finished mass_pic.pl execustion\n" if $verbose;
 exit 0;

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -207,7 +207,7 @@ if ($globArchiveLocation) {
 }
 my $query = "SELECT m.IsTarchiveValidated FROM mri_upload m " .
             "JOIN tarchive t on (t.TarchiveID = m.TarchiveID) $where ";
-print $query . "\n";
+print $query . "\n" if $debug;
 my $is_valid = $dbh->selectrow_array($query);
 
 ## Setup  for the notification_spool table ##
@@ -277,7 +277,9 @@ my $subjectIDsref = $utility->determineSubjectID(
 ################################################################
 
 my $CandMismatchError = undef;
-$CandMismatchError= $utility->validateCandidate($subjectIDsref);
+$CandMismatchError= $utility->validateCandidate(
+                                $subjectIDsref,
+                                $tarchiveInfo{'TarchiveID'});
 
 my $logQuery = "INSERT INTO MRICandidateErrors".
               "(SeriesUID, TarchiveID,MincFile, PatientName, Reason) ".

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -31,6 +31,7 @@ my $message     = '';
 my $tarchive_id = undef;
 my $upload_id   = undef;
 my $verbose     = 0;           # default for now
+my $verb_notification = 'N';   # default for the notification spool table
 my $profile     = undef;       # this should never be set unless you are in a 
                                # stable production environment
 my $reckless    = 0;           # this is only for playing and testing. Don't 
@@ -239,7 +240,8 @@ if (($is_valid == 0) && ($force==0)) {
     print $message;
     $utility->writeErrorLog($message,6,$logfile); 
     $notifier->spool('tarchive validation', $message, 0,
-                   'minc_insertion', $upload_id, 'Y', 'N'
+                   'minc_insertion', $upload_id, 'Y', 
+                   $verb_notification
     );
     exit 6;
 }
@@ -327,7 +329,8 @@ if (defined($CandMismatchError)) {
     );
     
     $notifier->spool('tarchive validation', $message, 0,
-                   'minc_insertion', $upload_id, 'Y', 'N'
+                   'minc_insertion', $upload_id, 'Y', 
+                   $verb_notification
     );
 
     exit 7 ;
@@ -353,7 +356,8 @@ if (!$unique) {
     print $message if $verbose;
     print LOG $message; 
     $notifier->spool('tarchive validation', $message, 0,
-                   'minc_insertion', $upload_id, 'Y', 'N'
+                   'minc_insertion', $upload_id, 'Y', 
+                   $verb_notification
     );
 #    exit 8; 
 } 
@@ -390,7 +394,8 @@ if($acquisitionProtocol =~ /unknown/) {
 
    print LOG $message;
    $notifier->spool('tarchive validation', $message, 0,
-                  'minc_insertion', $upload_id, 'Y', 'N'
+                  'minc_insertion', $upload_id, 'Y', 
+                  $verb_notification
    );
    exit 9;
 }

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -31,7 +31,8 @@ my $message     = '';
 my $tarchive_id = undef;
 my $upload_id   = undef;
 my $verbose     = 0;           # default for now
-my $verb_notification = 'N';   # default for the notification spool table
+my $verb_default = 'N';        # default for the notification spool table
+my $verb_notdefault = 'Y';     # default for the notification spool table
 my $profile     = undef;       # this should never be set unless you are in a 
                                # stable production environment
 my $reckless    = 0;           # this is only for playing and testing. Don't 
@@ -241,7 +242,7 @@ if (($is_valid == 0) && ($force==0)) {
     $utility->writeErrorLog($message,6,$logfile); 
     $notifier->spool('tarchive validation', $message, 0,
                    'minc_insertion', $upload_id, 'Y', 
-                   $verb_notification
+                   $verb_default
     );
     exit 6;
 }
@@ -330,7 +331,7 @@ if (defined($CandMismatchError)) {
     
     $notifier->spool('tarchive validation', $message, 0,
                    'minc_insertion', $upload_id, 'Y', 
-                   $verb_notification
+                   $verb_default
     );
 
     exit 7 ;
@@ -357,7 +358,7 @@ if (!$unique) {
     print LOG $message; 
     $notifier->spool('tarchive validation', $message, 0,
                    'minc_insertion', $upload_id, 'Y', 
-                   $verb_notification
+                   $verb_default
     );
 #    exit 8; 
 } 
@@ -395,7 +396,7 @@ if($acquisitionProtocol =~ /unknown/) {
    print LOG $message;
    $notifier->spool('tarchive validation', $message, 0,
                   'minc_insertion', $upload_id, 'Y', 
-                  $verb_notification
+                  $verb_default
    );
    exit 9;
 }
@@ -420,7 +421,7 @@ $notifier->spool(
     	$subjectIDsref->{'visitLabel'} .
     	"\tacquired " . $file->getParameter('acquisition_date')
     	. "\t" . $file->getParameter('series_description'),
-    	0, 'minc_insertion.pl', $upload_id, 'N', 'Y');
+    	0, 'minc_insertion.pl', $upload_id, 'N', $verb_notdefault);
 
 if ($verbose) {
     print "\nFinished file:  ".$file->getFileDatum('File')." \n";

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -421,7 +421,7 @@ $notifier->spool(
     	$subjectIDsref->{'visitLabel'} .
     	"\tacquired " . $file->getParameter('acquisition_date')
     	. "\t" . $file->getParameter('series_description'),
-    	0, 'minc_insertion.pl', $upload_id, 'N', $verb_notdefault);
+    	$centerID, 'minc_insertion.pl', $upload_id, 'N', $verb_notdefault);
 
 if ($verbose) {
     print "\nFinished file:  ".$file->getFileDatum('File')." \n";

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -31,10 +31,10 @@ my $message     = '';
 my $tarchive_srcloc = '';
 my $upload_id   = undef;
 my $verbose     = 0;           # default, overwritten if scripts are run with -verbose
-my $notification_verbose= 'N'; # notification_spool message flag for messages to 
-                               # be displayed BY DEFAULT in the front-end/imaging_uploader 
-my $notification_silent = 'Y'; # notification_spool message flag for messages to 
-                               # be displayed UPON REQUEST in the front-end/imaging_uploader 
+my $notify_detailed   = 'Y';   # notification_spool message flag for messages to be displayed 
+                               # with DETAILED OPTION in the front-end/imaging_uploader 
+my $notify_notsummary = 'N';   # notification_spool message flag for messages to be displayed 
+                               # with SUMMARY Option in the front-end/imaging_uploader 
 my $profile     = undef;       # this should never be set unless you are in a 
                                # stable production environment
 my $reckless    = 0;           # this is only for playing and testing. Don't 
@@ -243,9 +243,8 @@ if (($is_valid == 0) && ($force==0)) {
     print $message;
     $utility->writeErrorLog($message,6,$logfile); 
     $notifier->spool('tarchive validation', $message, 0,
-                   'minc_insertion', $upload_id, 'Y', 
-                   $notification_verbose
-    );
+                    'minc_insertion', $upload_id, 'Y', 
+                    $notify_notsummary);
     exit 6;
 }
 
@@ -332,9 +331,8 @@ if (defined($CandMismatchError)) {
     );
     
     $notifier->spool('tarchive validation', $message, 0,
-                   'minc_insertion', $upload_id, 'Y', 
-                   $notification_verbose
-    );
+                    'minc_insertion', $upload_id, 'Y', 
+                    $notify_notsummary);
 
     exit 7 ;
 }
@@ -355,13 +353,12 @@ my ($sessionID, $requiresStaging) =
 my $unique = $utility->computeMd5Hash($file, 
 				$tarchiveInfo{'SourceLocation'});
 if (!$unique) { 
-    $message = "\n--> WARNING: This file has already been uploaded! \n";  
+    $message = "\n--> WARNING: This file has already been uploaded!\n";  
     print $message if $verbose;
     print LOG $message; 
     $notifier->spool('tarchive validation', $message, 0,
-                   'minc_insertion', $upload_id, 'Y', 
-                   $notification_verbose
-    );
+                    'minc_insertion', $upload_id, 'Y', 
+                    $notify_notsummary);
 #    exit 8; 
 } 
 
@@ -397,9 +394,8 @@ if($acquisitionProtocol =~ /unknown/) {
 
    print LOG $message;
    $notifier->spool('tarchive validation', $message, 0,
-                  'minc_insertion', $upload_id, 'Y', 
-                  $notification_verbose
-   );
+                   'minc_insertion', $upload_id, 'Y', 
+                   $notify_notsummary);
    exit 9;
 }
 
@@ -417,13 +413,16 @@ $utility->registerScanIntoDB(
 ################################################################
 ### Add series notification ####################################
 ################################################################
-$notifier->spool(
-	'mri new series', "\n" . $subjectIDsref->{'CandID'} . " " .
+$message =
+	"\n" . $subjectIDsref->{'CandID'} . " " .
     	$subjectIDsref->{'PSCID'} ." " .
     	$subjectIDsref->{'visitLabel'} .
-    	"\tacquired " . $file->getParameter('acquisition_date')
-    	. "\t" . $file->getParameter('series_description'),
-    	$centerID, 'minc_insertion.pl', $upload_id, 'N', $notification_silent);
+    	"\tacquired " . $file->getParameter('acquisition_date') .
+    	"\t" . $file->getParameter('series_description') .
+	"\n";
+$notifier->spool('mri new series', $message,
+    		$centerID, 'minc_insertion.pl', $upload_id, 'N', 
+		$notify_detailed);
 
 if ($verbose) {
     print "\nFinished file:  ".$file->getFileDatum('File')." \n";

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -640,7 +640,7 @@ if (!$valid_study) {
 ### Set Processed to 1 in mri_upload table#####################
 ###############################################################
 my $where = "WHERE TarchiveID=?";
-my $query = "UPDATE mri_upload SET InsertionComplete=1 ";
+$query = "UPDATE mri_upload SET InsertionComplete=1 ";
 $query = $query . $where;
 
 my $mri_upload_update = $dbh->prepare($query);

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -59,10 +59,10 @@ my $message     = '';
 my $tarchive_srcloc = '';
 my $upload_id   = undef;
 my $verbose     = 0;           # default, overwritten if the scripts are run with -verbose
-my $notification_verbose= 'N'; # notification_spool message flag for messages to 
-                               # be displayed BY DEFAULT in the front-end/imaging_uploader 
-my $notification_silent = 'Y'; # notification_spool message flag for messages to 
-                               # be displayed UPON REQUEST in the front-end/imaging_uploader 
+my $notify_detailed   = 'Y';   # notification_spool message flag for messages to be displayed 
+                               # with DETAILED OPTION in the front-end/imaging_uploader 
+my $notify_notsummary = 'N';   # notification_spool message flag for messages to be displayed 
+                               # with SUMMARY Option in the front-end/imaging_uploader 
 my $profile     = 'prod';      # this should never be set unless you are in a
                                # stable production environment
 my $reckless    = 0;           # this is only for playing and testing. Don't 
@@ -307,8 +307,7 @@ if (($output != 0)  && ($force==0)) {
  $utility->writeErrorLog($message,5,$logfile); 
  $notifier->spool('tarchive loader', $message, 0, 
 		'tarchiveLoader', $upload_id, 'Y',
-		$notification_verbose
- );
+		$notify_notsummary);
  exit 5;
 }
 
@@ -378,7 +377,8 @@ my $mcount = $#minc_files + 1;
 $message = "\nNumber of MINC files that will be considered for inserting ".
       "into the database: $mcount\n";
 $notifier->spool('tarchive loader', $message, 0,
-               'tarchiveLoader', $upload_id, 'N', $notification_silent);
+		'tarchiveLoader', $upload_id, 'N', 
+		$notify_detailed);
 if ($verbose){
     print $message;
 }
@@ -390,9 +390,8 @@ if ($mcount < 1) {
                "Localizers will not be considered! \n" ; 
     $utility->writeErrorLog($message,6,$logfile); 
     $notifier->spool('tarchive loader', $message, 0,
-                   'tarchiveLoader', $upload_id, 'Y',
-		   $notification_verbose
-    );
+		    'tarchiveLoader', $upload_id, 'Y',
+		    $notify_notsummary);
     exit 6; 
 }
 
@@ -516,14 +515,15 @@ if ($valid_study) {
     ############################################################
     # spool a new study message ################################
     ############################################################
-    $notifier->spool(
-            'mri new study', 
-            "\n" . $subjectIDsref->{'CandID'} . 
+    $message =             
+	    "\n" . $subjectIDsref->{'CandID'} . 
             " " . $subjectIDsref->{'PSCID'} .
             " " . $subjectIDsref->{'visitLabel'} .
-            "\tacquired ". $tarchiveInfo{'DateAcquired'},
-	    0, 'tarchiveLoader', $upload_id, 'N', $notification_silent
-        );
+            "\tacquired ". $tarchiveInfo{'DateAcquired'} .
+	    "\n";
+    $notifier->spool('mri new study', $message,
+		    0, 'tarchiveLoader', $upload_id, 'N', 
+		    $notify_detailed);
     ############################################################
     #### link the tarchive and mri_upload table  with session ##
     ############################################################
@@ -547,12 +547,14 @@ if ($valid_study) {
     ## spool a failure message This has been changed to tarchive
     ## instead of using patientName ############################
     ############################################################
-    $notifier->spool(
-        'mri invalid study', "\n" . $tarchive. " acquired ". 
-        $tarchiveInfo{'DateAcquired'} .
-        " was deemed invalid\n\n". $study_dir,
-	0, 'tarchiveLoader', $upload_id, 'Y', $notification_verbose
-    );
+    $message = 
+	    "\n" . $tarchive. " acquired ". 
+            $tarchiveInfo{'DateAcquired'} .
+            " was deemed invalid\n\n". $study_dir .
+	    "\n";
+    $notifier->spool('mri invalid study', $message,
+		    0, 'tarchiveLoader', $upload_id, 'Y', 
+		    $notify_notsummary);
 }
 
 ################################################################
@@ -591,6 +593,9 @@ if (scalar(@leftovers) > 0) {
     my $trashdir = $data_dir . '/trashbin/' . $temp[$#temp];
     $message = "\n==> LEFTOVERS: ".scalar(@leftovers).
     "\n --> Moving leftovers to $trashdir\n";
+    $notifier->spool('tarchive loader', $message, 0,
+		    'tarchiveLoader', $upload_id, 'Y', 
+		    $notify_notsummary);
     print LOG $message;
     `mkdir -p -m 770 $trashdir`;
     `chmod -R u+w $TmpDir/*`;
@@ -604,7 +609,8 @@ if (scalar(@leftovers) > 0) {
 }
 $message ="\n==> Done tarchiveLoader execution!  Removing $TmpDir.\n";
 $notifier->spool('tarchive loader', $message, 0,
-            'tarchiveLoader', $upload_id, 'N', $notification_silent);
+		'tarchiveLoader', $upload_id, 'N', 
+		$notify_detailed);
 print LOG $message;
 close LOG;
 `gzip -9 $logfile`;
@@ -624,10 +630,9 @@ if ($xlog) {
 if (!$valid_study) {
     $message =  "\n No Mincs inserted \n \n";
     print ($message);
-    $notifier->spool(
-        'mri invalid study', $message, 0,
-        'tarchiveLoader', $upload_id, 'Y', $notification_verbose
-    );
+    $notifier->spool('mri invalid study', $message, 0,
+		    'tarchiveLoader', $upload_id, 'Y', 
+		    $notify_notsummary);
     exit 9;
 }
 

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -59,8 +59,9 @@ my $message     = '';
 my $tarchive_id = undef;
 my $upload_id   = undef;
 my $verbose     = 0;           # default for now
-my $verb_notification     = 'N';           # default for the notification_spool
-my $profile     = 'prod';       # this should never be set unless you are in a
+my $verb_default     = 'N';    # default for the notification_spool
+my $verb_notdefault  = 'Y';    # default for the notification_spool
+my $profile     = 'prod';      # this should never be set unless you are in a
                                # stable production environment
 my $reckless    = 0;           # this is only for playing and testing. Don't 
                                #set it to 1!!!
@@ -304,7 +305,7 @@ if (($output != 0)  && ($force==0)) {
  $utility->writeErrorLog($message,5,$logfile); 
  $notifier->spool('tarchive loader', $message, 0, 
 		'tarchiveLoader', $upload_id, 'Y',
-		$verb_notification
+		$verb_default
  );
  exit 5;
 }
@@ -375,7 +376,7 @@ my $mcount = $#minc_files + 1;
 $message = "\nNumber of MINC files that will be considered for inserting ".
       "into the database: $mcount\n";
 $notifier->spool('tarchive loader', $message, 0,
-               'tarchiveLoader', $upload_id, 'N', 'Y');
+               'tarchiveLoader', $upload_id, 'N', $verb_notdefault);
 if ($verbose){
     print $message;
 }
@@ -390,7 +391,7 @@ if ($mcount < 1) {
     # to pass it on to the notification_spool table
     $notifier->spool('tarchive loader', $message, 0,
                    'tarchiveLoader', $upload_id, 'Y',
-		   $verb_notification
+		   $verb_default
     );
     exit 6; 
 }
@@ -521,7 +522,7 @@ if ($valid_study) {
             " " . $subjectIDsref->{'PSCID'} .
             " " . $subjectIDsref->{'visitLabel'} .
             "\tacquired ". $tarchiveInfo{'DateAcquired'},
-	    0, 'tarchiveLoader', $upload_id, 'N', 'Y'
+	    0, 'tarchiveLoader', $upload_id, 'N', $verb_notdefault
         );
     ############################################################
     #### link the tarchive and mri_upload table  with session ##
@@ -550,7 +551,7 @@ if ($valid_study) {
         'mri invalid study', "\n" . $tarchive. " acquired ". 
         $tarchiveInfo{'DateAcquired'} .
         " was deemed invalid\n\n". $study_dir,
-	0, 'tarchiveLoader', $upload_id, 'Y', $verb_notification
+	0, 'tarchiveLoader', $upload_id, 'Y', $verb_default
     );
 }
 
@@ -603,7 +604,7 @@ if (scalar(@leftovers) > 0) {
 }
 $message ="\n==> Done tarchiveLoader execution!  Removing $TmpDir.\n";
 $notifier->spool('tarchive loader', $message, 0,
-            'tarchiveLoader', $upload_id, 'N', 'Y');
+            'tarchiveLoader', $upload_id, 'N', $verb_notdefault);
 print LOG $message;
 close LOG;
 `gzip -9 $logfile`;
@@ -625,7 +626,7 @@ if (!$valid_study) {
     print ($message);
     $notifier->spool(
         'mri invalid study', $message, 0,
-        'tarchiveLoader', $upload_id, 'Y', $verb_notification
+        'tarchiveLoader', $upload_id, 'Y', $verb_default
     );
     exit 9;
 }

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -54,7 +54,7 @@ my $date        = sprintf(
                     "%4d-%02d-%02d %02d:%02d:%02d",
                      $year+1900,$mon+1,$mday,$hour,$min,$sec
                   );
-my $debug       = 1;  
+my $debug       = 0;  
 my $message     = '';
 my $tarchive_id = '';
 my $upload_id   = '';
@@ -268,6 +268,10 @@ my $script = "tarchive_validation.pl $tarchive -profile $profile";
 if ($globArchiveLocation) {
     $script .= " -globLocation";
 }
+
+if ($verbose) {
+    $script .= " -verbose";
+}
 ################################################################
 ###### Note: system call returns the process ID ################
 ###### To the actual exit value, shift right by ################
@@ -348,7 +352,7 @@ my ($sessionID, $requiresStaging) =
 ################################################################
 my ($ExtractSuffix,$study_dir,$header) = 
     $utility->extractAndParseTarchive(
-		$tarchive, $tarchiveInfo{'TarchiveID'});
+		$tarchive, $tarchiveInfo{'TarchiveID'}, $verbose);
 
 
 ################################################################
@@ -356,7 +360,7 @@ my ($ExtractSuffix,$study_dir,$header) =
 ################################################################
 $utility->dicom_to_minc(
     $study_dir,$converter,$get_dicom_info,
-    $exclude,$mail_user, $tarchiveInfo{'TarchiveID'}
+    $exclude,$mail_user, $tarchiveInfo{'TarchiveID'}, $verbose
 );
 
 
@@ -409,7 +413,8 @@ foreach my $minc (@minc_files) {
     }
     elsif (!$valid_study) {
         $newTarchiveLocation = 
-            $utility->moveAndUpdateTarchive($tarchive,\%tarchiveInfo);
+            $utility->moveAndUpdateTarchive($tarchive,
+					\%tarchiveInfo, $verbose);
     }
     $tarchive = $newTarchiveLocation;
 
@@ -433,6 +438,10 @@ foreach my $minc (@minc_files) {
  
     if ($debug) {
         print $script . "\n";
+    }
+
+    if ($verbose) {
+        $script .= " -verbose";
     }
     ###########################################################
     ## Note: system call returns the process ID ###############
@@ -488,6 +497,9 @@ if ($valid_study) {
     if (@row) {
         my $script = "mass_pic.pl -minFileID $row[0] -maxFileID $row[1] ".
                      "-profile $profile ";
+        if ($verbose) {
+            $script .= " -verbose";
+	}
     ############################################################
     ## Note: system call returns the process ID ################
     ## To get the actual exit value, shift right by eight as ### 
@@ -501,14 +513,16 @@ if ($valid_study) {
     ############################################################
     # spool a new study message ################################
     ############################################################
-    $notifier->spool(
-        'mri new study', 
-        "\n" . $subjectIDsref->{'CandID'} . 
-        " " . $subjectIDsref->{'PSCID'} .
-        " " . $subjectIDsref->{'visitLabel'} .
-        "\tacquired ". $tarchiveInfo{'DateAcquired'},
-	0, 'tarchiveLoader', $upload_id, 'N'
-    );
+    if ($verbose) {
+    	$notifier->spool(
+            'mri new study', 
+            "\n" . $subjectIDsref->{'CandID'} . 
+            " " . $subjectIDsref->{'PSCID'} .
+            " " . $subjectIDsref->{'visitLabel'} .
+            "\tacquired ". $tarchiveInfo{'DateAcquired'},
+	    0, 'tarchiveLoader', $upload_id, 'N'
+        );
+    }
     ############################################################
     #### link the tarchive and mri_upload table  with session ##
     ############################################################
@@ -587,8 +601,8 @@ if (scalar(@leftovers) > 0) {
     print MAIL "Files left over:\n".join("", @leftovers)."\n";
     close MAIL;
 }
-$message ="\n==> Done!  Removing $TmpDir.\n";
-print LOG $message;
+$message ="\n==> Done tarchiveLoader execution!  Removing $TmpDir.\n";
+print LOG $message if $verbose;
 close LOG;
 `gzip -9 $logfile`;
 my $cmd = "mv $logfile.gz $data_dir/logs/$final_logfile";

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -360,23 +360,22 @@ my ($ExtractSuffix,$study_dir,$header) =
 ################################################################
 $utility->dicom_to_minc(
     $study_dir,$converter,$get_dicom_info,
-    $exclude,$mail_user, $tarchiveInfo{'TarchiveID'}, $verbose
-);
+    $exclude,$mail_user, $tarchiveInfo{'TarchiveID'}, $verbose);
 
 
 ################################################################
 ############### get a list of mincs ############################
 ################################################################
 my @minc_files = ();
-$utility->get_mincs(\@minc_files);
+$utility->get_mincs(\@minc_files,
+		     	 $tarchiveInfo{'TarchiveID'}, $verbose);
 my $mcount = $#minc_files + 1;
 $message = "\nNumber of MINC files that will be considered for inserting ".
       "into the database: $mcount\n";
 if ($verbose){
     print $message;
     $notifier->spool('tarchive loader', $message, 0,
-                   'tarchiveLoader', $upload_id, 'N'
-    );
+                   'tarchiveLoader', $upload_id, 'N');
 }
 ################################################################
 # If no good data was found stop processing and write error log.
@@ -414,7 +413,7 @@ foreach my $minc (@minc_files) {
     elsif (!$valid_study) {
         $newTarchiveLocation = 
             $utility->moveAndUpdateTarchive($tarchive,
-					\%tarchiveInfo, $verbose);
+					\%tarchiveInfo,$verbose);
     }
     $tarchive = $newTarchiveLocation;
 
@@ -602,7 +601,11 @@ if (scalar(@leftovers) > 0) {
     close MAIL;
 }
 $message ="\n==> Done tarchiveLoader execution!  Removing $TmpDir.\n";
-print LOG $message if $verbose;
+if ($verbose) {
+    print LOG $message;
+    $notifier->spool('tarchive loader', $message, 0,
+                'tarchiveLoader', $upload_id, 'N');
+}
 close LOG;
 `gzip -9 $logfile`;
 my $cmd = "mv $logfile.gz $data_dir/logs/$final_logfile";

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -56,11 +56,13 @@ my $date        = sprintf(
                   );
 my $debug       = 0;  
 my $message     = '';
-my $tarchive_id = undef;
+my $tarchive_srcloc = '';
 my $upload_id   = undef;
-my $verbose     = 0;           # default for now
-my $verb_default     = 'N';    # default for the notification_spool
-my $verb_notdefault  = 'Y';    # default for the notification_spool
+my $verbose     = 0;           # default, overwritten if the scripts are run with -verbose
+my $notification_verbose= 'N'; # notification_spool message flag for messages to 
+                               # be displayed BY DEFAULT in the front-end/imaging_uploader 
+my $notification_silent = 'Y'; # notification_spool message flag for messages to 
+                               # be displayed UPON REQUEST in the front-end/imaging_uploader 
 my $profile     = 'prod';      # this should never be set unless you are in a
                                # stable production environment
 my $reckless    = 0;           # this is only for playing and testing. Don't 
@@ -285,14 +287,14 @@ $output = $output >> 8;
 ################################################################
 ### get the UploadID to log in the notification spool table ####
 ################################################################
-# first get the tarchive_id from $tarchive 
-$tarchive_id = $tarchiveInfo{'TarchiveID'};
-# then get the upload_id from tarchive_id
+# first get the tarchive SourceLocation from $tarchiveInfo 
+$tarchive_srcloc = $tarchiveInfo{'SourceLocation'};
+# then get the upload_id from tarchive_srcloc
 my $query =
         "SELECT UploadID FROM mri_upload "
-        . "WHERE TarchiveID =?";
+        . "WHERE DecompressedLocation =?";
 my $sth = $dbh->prepare($query);
-$sth->execute($tarchive_id);
+$sth->execute($tarchive_srcloc);
 $upload_id = $sth->fetchrow_array;
 
 ################################################################
@@ -305,7 +307,7 @@ if (($output != 0)  && ($force==0)) {
  $utility->writeErrorLog($message,5,$logfile); 
  $notifier->spool('tarchive loader', $message, 0, 
 		'tarchiveLoader', $upload_id, 'Y',
-		$verb_default
+		$notification_verbose
  );
  exit 5;
 }
@@ -355,7 +357,7 @@ my ($sessionID, $requiresStaging) =
 ################################################################
 my ($ExtractSuffix,$study_dir,$header) = 
     $utility->extractAndParseTarchive(
-		$tarchive, $tarchiveInfo{'TarchiveID'});
+		$tarchive, $tarchiveInfo{'SourceLocation'});
 
 
 ################################################################
@@ -363,7 +365,7 @@ my ($ExtractSuffix,$study_dir,$header) =
 ################################################################
 $utility->dicom_to_minc(
     $study_dir,$converter,$get_dicom_info,
-    $exclude,$mail_user, $tarchiveInfo{'TarchiveID'});
+    $exclude,$mail_user, $tarchiveInfo{'SourceLocation'});
 
 
 ################################################################
@@ -371,12 +373,12 @@ $utility->dicom_to_minc(
 ################################################################
 my @minc_files = ();
 $utility->get_mincs(\@minc_files,
-		     	 $tarchiveInfo{'TarchiveID'});
+		     	 $tarchiveInfo{'SourceLocation'});
 my $mcount = $#minc_files + 1;
 $message = "\nNumber of MINC files that will be considered for inserting ".
       "into the database: $mcount\n";
 $notifier->spool('tarchive loader', $message, 0,
-               'tarchiveLoader', $upload_id, 'N', $verb_notdefault);
+               'tarchiveLoader', $upload_id, 'N', $notification_silent);
 if ($verbose){
     print $message;
 }
@@ -387,11 +389,9 @@ if ($mcount < 1) {
     $message = "\nNo data could be converted into valid MINC files. ".
                "Localizers will not be considered! \n" ; 
     $utility->writeErrorLog($message,6,$logfile); 
-    # get the upload_id from the tarchive_id
-    # to pass it on to the notification_spool table
     $notifier->spool('tarchive loader', $message, 0,
                    'tarchiveLoader', $upload_id, 'Y',
-		   $verb_default
+		   $notification_verbose
     );
     exit 6; 
 }
@@ -522,7 +522,7 @@ if ($valid_study) {
             " " . $subjectIDsref->{'PSCID'} .
             " " . $subjectIDsref->{'visitLabel'} .
             "\tacquired ". $tarchiveInfo{'DateAcquired'},
-	    0, 'tarchiveLoader', $upload_id, 'N', $verb_notdefault
+	    0, 'tarchiveLoader', $upload_id, 'N', $notification_silent
         );
     ############################################################
     #### link the tarchive and mri_upload table  with session ##
@@ -551,7 +551,7 @@ if ($valid_study) {
         'mri invalid study', "\n" . $tarchive. " acquired ". 
         $tarchiveInfo{'DateAcquired'} .
         " was deemed invalid\n\n". $study_dir,
-	0, 'tarchiveLoader', $upload_id, 'Y', $verb_default
+	0, 'tarchiveLoader', $upload_id, 'Y', $notification_verbose
     );
 }
 
@@ -604,7 +604,7 @@ if (scalar(@leftovers) > 0) {
 }
 $message ="\n==> Done tarchiveLoader execution!  Removing $TmpDir.\n";
 $notifier->spool('tarchive loader', $message, 0,
-            'tarchiveLoader', $upload_id, 'N', $verb_notdefault);
+            'tarchiveLoader', $upload_id, 'N', $notification_silent);
 print LOG $message;
 close LOG;
 `gzip -9 $logfile`;
@@ -626,7 +626,7 @@ if (!$valid_study) {
     print ($message);
     $notifier->spool(
         'mri invalid study', $message, 0,
-        'tarchiveLoader', $upload_id, 'Y', $verb_default
+        'tarchiveLoader', $upload_id, 'Y', $notification_verbose
     );
     exit 9;
 }

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -59,6 +59,7 @@ my $message     = '';
 my $tarchive_id = undef;
 my $upload_id   = undef;
 my $verbose     = 0;           # default for now
+my $verb_notification     = 'N';           # default for the notification_spool
 my $profile     = 'prod';       # this should never be set unless you are in a
                                # stable production environment
 my $reckless    = 0;           # this is only for playing and testing. Don't 
@@ -302,7 +303,8 @@ if (($output != 0)  && ($force==0)) {
             "tarchiveLoader using -force to force the execution.\n\n";
  $utility->writeErrorLog($message,5,$logfile); 
  $notifier->spool('tarchive loader', $message, 0, 
-		'tarchiveLoader', $upload_id, 'Y', 'N'
+		'tarchiveLoader', $upload_id, 'Y',
+		$verb_notification
  );
  exit 5;
 }
@@ -387,7 +389,8 @@ if ($mcount < 1) {
     # get the upload_id from the tarchive_id
     # to pass it on to the notification_spool table
     $notifier->spool('tarchive loader', $message, 0,
-                   'tarchiveLoader', $upload_id, 'Y', 'N'
+                   'tarchiveLoader', $upload_id, 'Y',
+		   $verb_notification
     );
     exit 6; 
 }
@@ -547,7 +550,7 @@ if ($valid_study) {
         'mri invalid study', "\n" . $tarchive. " acquired ". 
         $tarchiveInfo{'DateAcquired'} .
         " was deemed invalid\n\n". $study_dir,
-	0, 'tarchiveLoader', $upload_id, 'Y', 'N'
+	0, 'tarchiveLoader', $upload_id, 'Y', $verb_notification
     );
 }
 
@@ -622,7 +625,7 @@ if (!$valid_study) {
     print ($message);
     $notifier->spool(
         'mri invalid study', $message, 0,
-        'tarchiveLoader', $upload_id, 'Y', 'N'
+        'tarchiveLoader', $upload_id, 'Y', $verb_notification
     );
     exit 9;
 }

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -56,8 +56,8 @@ my $date        = sprintf(
                   );
 my $debug       = 0;  
 my $message     = '';
-my $tarchive_id = '';
-my $upload_id   = '';
+my $tarchive_id = undef;
+my $upload_id   = undef;
 my $verbose     = 0;           # default for now
 my $profile     = 'prod';       # this should never be set unless you are in a
                                # stable production environment

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -302,7 +302,7 @@ if (($output != 0)  && ($force==0)) {
             "tarchiveLoader using -force to force the execution.\n\n";
  $utility->writeErrorLog($message,5,$logfile); 
  $notifier->spool('tarchive loader', $message, 0, 
-		'tarchiveLoader', $upload_id, 'Y'
+		'tarchiveLoader', $upload_id, 'Y', 'N'
  );
  exit 5;
 }
@@ -372,10 +372,10 @@ $utility->get_mincs(\@minc_files,
 my $mcount = $#minc_files + 1;
 $message = "\nNumber of MINC files that will be considered for inserting ".
       "into the database: $mcount\n";
+$notifier->spool('tarchive loader', $message, 0,
+               'tarchiveLoader', $upload_id, 'N', 'Y');
 if ($verbose){
     print $message;
-    $notifier->spool('tarchive loader', $message, 0,
-                   'tarchiveLoader', $upload_id, 'N');
 }
 ################################################################
 # If no good data was found stop processing and write error log.
@@ -387,7 +387,7 @@ if ($mcount < 1) {
     # get the upload_id from the tarchive_id
     # to pass it on to the notification_spool table
     $notifier->spool('tarchive loader', $message, 0,
-                   'tarchiveLoader', $upload_id, 'Y'
+                   'tarchiveLoader', $upload_id, 'Y', 'N'
     );
     exit 6; 
 }
@@ -512,16 +512,14 @@ if ($valid_study) {
     ############################################################
     # spool a new study message ################################
     ############################################################
-    if ($verbose) {
-    	$notifier->spool(
+    $notifier->spool(
             'mri new study', 
             "\n" . $subjectIDsref->{'CandID'} . 
             " " . $subjectIDsref->{'PSCID'} .
             " " . $subjectIDsref->{'visitLabel'} .
             "\tacquired ". $tarchiveInfo{'DateAcquired'},
-	    0, 'tarchiveLoader', $upload_id, 'N'
+	    0, 'tarchiveLoader', $upload_id, 'N', 'Y'
         );
-    }
     ############################################################
     #### link the tarchive and mri_upload table  with session ##
     ############################################################
@@ -549,7 +547,7 @@ if ($valid_study) {
         'mri invalid study', "\n" . $tarchive. " acquired ". 
         $tarchiveInfo{'DateAcquired'} .
         " was deemed invalid\n\n". $study_dir,
-	0, 'tarchiveLoader', $upload_id, 'Y'
+	0, 'tarchiveLoader', $upload_id, 'Y', 'N'
     );
 }
 
@@ -601,11 +599,9 @@ if (scalar(@leftovers) > 0) {
     close MAIL;
 }
 $message ="\n==> Done tarchiveLoader execution!  Removing $TmpDir.\n";
-if ($verbose) {
-    print LOG $message;
-    $notifier->spool('tarchive loader', $message, 0,
-                'tarchiveLoader', $upload_id, 'N');
-}
+$notifier->spool('tarchive loader', $message, 0,
+            'tarchiveLoader', $upload_id, 'N', 'Y');
+print LOG $message;
 close LOG;
 `gzip -9 $logfile`;
 my $cmd = "mv $logfile.gz $data_dir/logs/$final_logfile";
@@ -626,7 +622,7 @@ if (!$valid_study) {
     print ($message);
     $notifier->spool(
         'mri invalid study', $message, 0,
-        'tarchiveLoader', $upload_id, 'Y'
+        'tarchiveLoader', $upload_id, 'Y', 'N'
     );
     exit 9;
 }

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -356,7 +356,7 @@ my ($ExtractSuffix,$study_dir,$header) =
 ################################################################
 $utility->dicom_to_minc(
     $study_dir,$converter,$get_dicom_info,
-    $exclude,$mail_user
+    $exclude,$mail_user, $tarchiveInfo{'TarchiveID'}
 );
 
 
@@ -368,10 +368,12 @@ $utility->get_mincs(\@minc_files);
 my $mcount = $#minc_files + 1;
 $message = "\nNumber of MINC files that will be considered for inserting ".
       "into the database: $mcount\n";
-print $message;
-$notifier->spool('tarchive loader', $message, 0,
-               'tarchiveLoader', $upload_id, 'N'
+if ($verbose){
+    print $message;
+    $notifier->spool('tarchive loader', $message, 0,
+                   'tarchiveLoader', $upload_id, 'N'
     );
+}
 ################################################################
 # If no good data was found stop processing and write error log.
 ################################################################

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -56,6 +56,8 @@ my $date        = sprintf(
                   );
 my $debug       = 1;  
 my $message     = '';
+my $tarchive_id = '';
+my $upload_id   = '';
 my $verbose     = 0;           # default for now
 my $profile     = 'prod';       # this should never be set unless you are in a
                                # stable production environment
@@ -139,7 +141,6 @@ USAGE
 ################################################################
 ################### input option error checking ################
 ################################################################
-
 { package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
 if ($profile && !@Settings::db) { 
     print "\n\tERROR: You don't have a configuration file named ". 
@@ -214,7 +215,8 @@ if ($xlog) {
 ######### Establish database connection ########################
 ################################################################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
-print LOG "\n==> Successfully connected to database \n";
+$message ="\n==> Successfully connected to database \n";
+print LOG $message;
 
 =pod
 ################################################################
@@ -242,6 +244,11 @@ my $utility = NeuroDB::MRIProcessingUtility->new(
 $utility->registerProgs(@progs);
 
 ################################################################
+##### make the notifier object #################################
+################################################################
+my $notifier = NeuroDB::Notify->new(\$dbh);
+
+################################################################
 ################ Construct the tarchiveInfo Array ##############
 ################################################################
 my $tarchiveLibraryDir = $Settings::tarchiveLibraryDir;
@@ -256,7 +263,7 @@ my %tarchiveInfo = $utility->createTarchiveArray(
 ################################################################
 ################## Call the validation script ##################
 ################################################################
-my $script = "tarchive_validation.pl $tarchive -profile $profile ";
+my $script = "tarchive_validation.pl $tarchive -profile $profile";
 
 if ($globArchiveLocation) {
     $script .= " -globLocation";
@@ -269,6 +276,18 @@ if ($globArchiveLocation) {
 my $output = system($script); 
 $output = $output >> 8;
 
+################################################################
+### get the UploadID to log in the notification spool table ####
+################################################################
+# first get the tarchive_id from $tarchive 
+$tarchive_id = $tarchiveInfo{'TarchiveID'};
+# then get the upload_id from tarchive_id
+my $query =
+        "SELECT UploadID FROM mri_upload "
+        . "WHERE TarchiveID =?";
+my $sth = $dbh->prepare($query);
+$sth->execute($tarchive_id);
+$upload_id = $sth->fetchrow_array;
 
 ################################################################
 #############Exit if the is_valid is false and $force is not####
@@ -278,6 +297,9 @@ if (($output != 0)  && ($force==0)) {
             "validation again and fix the problem. Or re-run ".
             "tarchiveLoader using -force to force the execution.\n\n";
  $utility->writeErrorLog($message,5,$logfile); 
+ $notifier->spool('tarchive loader', $message, 0, 
+		'tarchiveLoader', $upload_id, 'Y'
+ );
  exit 5;
 }
 
@@ -325,12 +347,9 @@ my ($sessionID, $requiresStaging) =
 ###### Dir to the uploader #####################################
 ################################################################
 my ($ExtractSuffix,$study_dir,$header) = 
-    $utility->extractAndParseTarchive($tarchive);
+    $utility->extractAndParseTarchive(
+		$tarchive, $tarchiveInfo{'TarchiveID'});
 
-################################################################
-##### make the notifier object #################################
-################################################################
-my $notifier = NeuroDB::Notify->new(\$dbh);
 
 ################################################################
 ##################### convert the dicom data to minc ###########
@@ -347,8 +366,12 @@ $utility->dicom_to_minc(
 my @minc_files = ();
 $utility->get_mincs(\@minc_files);
 my $mcount = $#minc_files + 1;
-print "\nNumber of MINC files that will be considered for inserting ".
+$message = "\nNumber of MINC files that will be considered for inserting ".
       "into the database: $mcount\n";
+print $message;
+$notifier->spool('tarchive loader', $message, 0,
+               'tarchiveLoader', $upload_id, 'N'
+    );
 ################################################################
 # If no good data was found stop processing and write error log.
 ################################################################
@@ -356,6 +379,11 @@ if ($mcount < 1) {
     $message = "\nNo data could be converted into valid MINC files. ".
                "Localizers will not be considered! \n" ; 
     $utility->writeErrorLog($message,6,$logfile); 
+    # get the upload_id from the tarchive_id
+    # to pass it on to the notification_spool table
+    $notifier->spool('tarchive loader', $message, 0,
+                   'tarchiveLoader', $upload_id, 'Y'
+    );
     exit 6; 
 }
 
@@ -430,7 +458,7 @@ if ($valid_study) {
     ### And number_of_mincInserted #############################
     ############################################################
     my $where = "WHERE TarchiveID=?";
-    my $query = "UPDATE mri_upload SET number_of_mincInserted=?, ".
+    $query = "UPDATE mri_upload SET number_of_mincInserted=?, ".
                  "number_of_mincCreated=? ";
     $query = $query . $where;
     if ($debug) {
@@ -467,16 +495,17 @@ if ($valid_study) {
         $output = $output >> 8;
 
     }
-    
+
     ############################################################
     # spool a new study message ################################
     ############################################################
     $notifier->spool(
         'mri new study', 
-        $subjectIDsref->{'CandID'} . 
+        "\n" . $subjectIDsref->{'CandID'} . 
         " " . $subjectIDsref->{'PSCID'} .
         " " . $subjectIDsref->{'visitLabel'} .
-        "\tacquired ". $tarchiveInfo{'DateAcquired'}
+        "\tacquired ". $tarchiveInfo{'DateAcquired'},
+	0, 'tarchiveLoader', $upload_id, 'N'
     );
     ############################################################
     #### link the tarchive and mri_upload table  with session ##
@@ -502,9 +531,10 @@ if ($valid_study) {
     ## instead of using patientName ############################
     ############################################################
     $notifier->spool(
-        'mri invalid study', $tarchive. " acquired ". 
+        'mri invalid study', "\n" . $tarchive. " acquired ". 
         $tarchiveInfo{'DateAcquired'} .
-        " was deemed invalid\n\n". $study_dir
+        " was deemed invalid\n\n". $study_dir,
+	0, 'tarchiveLoader', $upload_id, 'Y'
     );
 }
 
@@ -530,8 +560,9 @@ $final_logfile .= '.log.gz';
 ################################################################
 # fixme for now we assume that extracted data will not be kept #
 ################################################################
-my $cleanup = "rm -rf ${TmpDir}/${ExtractSuffix}*"; 
-print "\nCleaning up temp files: $cleanup\n" if $verbose;
+my $cleanup = "rm -rf ${TmpDir}/${ExtractSuffix}*";
+$message = "\nCleaning up temp files: $cleanup\n";
+print $message if $verbose;
 `$cleanup`;
 
 ################################################################
@@ -541,8 +572,9 @@ my @leftovers = `\\ls -1 $TmpDir`;
 
 if (scalar(@leftovers) > 0) {
     my $trashdir = $data_dir . '/trashbin/' . $temp[$#temp];
-    print LOG "\n==> LEFTOVERS: ".scalar(@leftovers).
+    $message = "\n==> LEFTOVERS: ".scalar(@leftovers).
     "\n --> Moving leftovers to $trashdir\n";
+    print LOG $message;
     `mkdir -p -m 770 $trashdir`;
     `chmod -R u+w $TmpDir/*`;
     `mv $TmpDir/* $trashdir`;
@@ -553,8 +585,8 @@ if (scalar(@leftovers) > 0) {
     print MAIL "Files left over:\n".join("", @leftovers)."\n";
     close MAIL;
 }
-
-print LOG "\n==> Done!  Removing $TmpDir.\n";
+$message ="\n==> Done!  Removing $TmpDir.\n";
+print LOG $message;
 close LOG;
 `gzip -9 $logfile`;
 my $cmd = "mv $logfile.gz $data_dir/logs/$final_logfile";
@@ -571,7 +603,12 @@ if ($xlog) {
 ################################################################
 
 if (!$valid_study) {
-    print "No Mincs inserted \n \n";
+    $message =  "\n No Mincs inserted \n \n";
+    print ($message);
+    $notifier->spool(
+        'mri invalid study', $message, 0,
+        'tarchiveLoader', $upload_id, 'Y'
+    );
     exit 9;
 }
 

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -352,7 +352,7 @@ my ($sessionID, $requiresStaging) =
 ################################################################
 my ($ExtractSuffix,$study_dir,$header) = 
     $utility->extractAndParseTarchive(
-		$tarchive, $tarchiveInfo{'TarchiveID'}, $verbose);
+		$tarchive, $tarchiveInfo{'TarchiveID'});
 
 
 ################################################################
@@ -360,7 +360,7 @@ my ($ExtractSuffix,$study_dir,$header) =
 ################################################################
 $utility->dicom_to_minc(
     $study_dir,$converter,$get_dicom_info,
-    $exclude,$mail_user, $tarchiveInfo{'TarchiveID'}, $verbose);
+    $exclude,$mail_user, $tarchiveInfo{'TarchiveID'});
 
 
 ################################################################
@@ -368,7 +368,7 @@ $utility->dicom_to_minc(
 ################################################################
 my @minc_files = ();
 $utility->get_mincs(\@minc_files,
-		     	 $tarchiveInfo{'TarchiveID'}, $verbose);
+		     	 $tarchiveInfo{'TarchiveID'});
 my $mcount = $#minc_files + 1;
 $message = "\nNumber of MINC files that will be considered for inserting ".
       "into the database: $mcount\n";
@@ -413,7 +413,7 @@ foreach my $minc (@minc_files) {
     elsif (!$valid_study) {
         $newTarchiveLocation = 
             $utility->moveAndUpdateTarchive($tarchive,
-					\%tarchiveInfo,$verbose);
+					\%tarchiveInfo);
     }
     $tarchive = $newTarchiveLocation;
 

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -26,12 +26,12 @@ my $date        = sprintf(
                     "%4d-%02d-%02d %02d:%02d:%02d",
                     $year+1900,$mon+1,$mday,$hour,$min,$sec
                   );
-my $debug       = 1 ;  
+my $debug       = 0 ;  
 my $where       = '';
 my $sth         = undef;
 my $query       = '';
 my $message     = '';
-my $verbose     = 1;           # default for now
+my $verbose     = 0;           # default for now
 my $profile     = undef;       # this should never be set unless you are in a
                                # stable production environment
 my $reckless    = 0;           # this is only for playing and testing. Don't
@@ -59,7 +59,12 @@ my @opt_table = (
                  ["-newScanner", "boolean", 1, \$NewScanner, "By default a". 
                   " new scanner will be registered if the data you upload".
                   " requires it. You can risk turning it off."],
-                 ["Fancy options","section"]
+
+                 ["Fancy options","section"],
+
+                 ["General options","section"],
+                 ["-verbose", "boolean", 1, \$verbose, "Be verbose."],
+
                  );
 
 my $Help = <<HELP;
@@ -288,7 +293,7 @@ my ($sessionID, $requiresStaging) =
 ################################################################
 my ($ExtractSuffix,$study_dir,$header) = 
     $utility->extractAndParseTarchive(
-                $tarchive, $tarchiveInfo{'TarchiveID'});
+                $tarchive, $tarchiveInfo{'TarchiveID'}, $verbose);
 
 ################################################################
 # Optionally do extra filtering on the dicom data, if needed ###

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -31,7 +31,7 @@ my $where       = '';
 my $sth         = undef;
 my $query       = '';
 my $message     = '';
-my $verbose     = 0;           # default for now
+my $verbose     = 0;           # default, overwritten if scripts are run with -verbose
 my $profile     = undef;       # this should never be set unless you are in a
                                # stable production environment
 my $reckless    = 0;           # this is only for playing and testing. Don't
@@ -275,7 +275,7 @@ $utility->CreateMRICandidates(
 ################################################################
 my $CandMismatchError= $utility->validateCandidate(
 				$subjectIDsref,
-				$tarchiveInfo{'TarchiveID'});
+				$tarchiveInfo{'SourceLocation'});
 if (defined $CandMismatchError) {
     print $CandMismatchError;
     ##Note that the script will not exit, so that further down
@@ -293,7 +293,7 @@ my ($sessionID, $requiresStaging) =
 ################################################################
 my ($ExtractSuffix,$study_dir,$header) = 
     $utility->extractAndParseTarchive(
-                $tarchive, $tarchiveInfo{'TarchiveID'});
+                $tarchive, $tarchiveInfo{'SourceLocation'});
 
 ################################################################
 # Optionally do extra filtering on the dicom data, if needed ###

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -293,7 +293,7 @@ my ($sessionID, $requiresStaging) =
 ################################################################
 my ($ExtractSuffix,$study_dir,$header) = 
     $utility->extractAndParseTarchive(
-                $tarchive, $tarchiveInfo{'TarchiveID'}, $verbose);
+                $tarchive, $tarchiveInfo{'TarchiveID'});
 
 ################################################################
 # Optionally do extra filtering on the dicom data, if needed ###

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -268,7 +268,9 @@ $utility->CreateMRICandidates(
 ## correct here. ###############################################
 ################################################################
 ################################################################
-my $CandMismatchError= $utility->validateCandidate($subjectIDsref);
+my $CandMismatchError= $utility->validateCandidate(
+				$subjectIDsref,
+				$tarchiveInfo{'TarchiveID'});
 if (defined $CandMismatchError) {
     print $CandMismatchError;
     ##Note that the script will not exit, so that further down
@@ -285,7 +287,8 @@ my ($sessionID, $requiresStaging) =
 ### The uploader ###############################################
 ################################################################
 my ($ExtractSuffix,$study_dir,$header) = 
-    $utility->extractAndParseTarchive($tarchive);
+    $utility->extractAndParseTarchive(
+                $tarchive, $tarchiveInfo{'TarchiveID'});
 
 ################################################################
 # Optionally do extra filtering on the dicom data, if needed ###


### PR DESCRIPTION
- notification_spool_table from MRIProcessingUtility.pm gets updated now with messages (the messages are similar to the messages in the log files), to be consistent with the ImagingUpload.pm
- printing messages to LOG files is still enabled for now
- printing messages on-screen only if $verbose option is set (when 'launching imaging_upload_file.pl' OR 'imaging_upload_file_cronjob.pl' with -verbose)
- Messages printed to LOG files and to notification_spool table  irrespective of the verbose option. Error messages print all the time, irrespective of verbose option as well. The notification_spool table now has a column with a verbose flag. This flag will be used by the Imaging Upoloader in the front-end to decide which messages are reported under the "Summary" or "Detailed" options
- In ImagingUpload.pm, dcmdump() and isDicom() (more specifically the 'file' command) do NOT print a message for each file even if $verbose is set to 1
- the messages in the notification_spool table have the upload_id parameter set, so this assumes that the MRI images are uploaded using the imaging_uploader which creates this upload_id in the mri_upload table (running tarchiveLoader will get the upload_id from mri_upload table using the tarchive_id directly, or indirectly using tarchive SourceLocation)
- if $debug is now reserved for printing queries
- a few cleanup on the printed messages to be more informative
- To be used in conjunction with:
https://github.com/aces/dicom-archive-tools/pull/31
and
https://github.com/aces/Loris/pull/1567 (for the SQL patches)