### PR TITLE
Making MINC Toolkit check better + Clarifications on the toolkits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # System Requirements
  * Perl
- * DICOM toolkit (Will be installed by Install Script if not already installed)
+ * DICOM toolkit
  * MINC tools (http://www.bic.mni.mcgill.ca/ServicesSoftware/MINC)
 
-Note: For Ubuntu installations, DICOM toolkit and MINC toolkit are installed by the imaging install script (see step 3 below). This script will apt-get install these packages: minc-tools and dcmtk.   
+Note: For Ubuntu installations, DICOM toolkit will be installed by the imaging install script (see step 3 below). This script will apt-get install dcmtk.   
 
 The following installation should be run by the $lorisadmin user. sudo permission is required.
 See aces/Loris README.md for further information and Loris installation information. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # System Requirements
  * Perl
- * DICOM toolkit
- * MINC tools
+ * DICOM toolkit (Will be installed by Install Script if not already installed)
+ * MINC tools (http://www.bic.mni.mcgill.ca/ServicesSoftware/MINC)
 
 Note: For Ubuntu installations, DICOM toolkit and MINC toolkit are installed by the imaging install script (see step 3 below). This script will apt-get install these packages: minc-tools and dcmtk.   
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See aces/Loris README.md for further information and Loris installation informat
    git submodule update
    ```
 
-3. Run installer to install MINC & DICOM toolkits, Perl libraries, configure environment, and setup directories:
+3. Run installer to install DICOM toolkit, Perl libraries, configure environment, and setup directories:
 
    ```bash 
    cd /data/$projectname/bin/mri/

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -13,6 +13,14 @@ LOGFILE="/tmp/$(basename $0).$$.tmp"
 touch $LOGFILE
 trap "rm  $LOGFILE" EXIT
  
+if [[ -n $(which mincheader) ]]; then
+    echo ""
+    echo "MINC Toolkit appears to be installed."
+else
+    echo ""
+    echo "MINC Toolkit does not appear to be installed. Aborting."
+    exit 2;
+fi
 
 #First, check that all required modules are installed.
 #Check if cpan module installed
@@ -57,12 +65,8 @@ mridir=`pwd`
 #read -p "Enter Full Loris-code directory path "   lorisdir
 
 ################################################################################################
-########################################MINC TOOL###############################################
+#####################################DICOM TOOLKIT##############################################
 ################################################################################################
-echo "Installing Minc toolkit (May prompt for sudo password)"
-sudo -S apt-get install minc-tools
-echo
-
 echo "Installing dicom toolkit (May prompt for sudo password)"
 sudo -S apt-get install dcmtk
 echo

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -18,7 +18,7 @@ if [[ -n $(which mincheader) ]]; then
     echo "MINC Toolkit appears to be installed."
 else
     echo ""
-    echo "MINC Toolkit does not appear to be installed. Aborting."
+    echo "MINC Toolkit does not appear to be installed. Please see http://www.bic.mni.mcgill.ca/ServicesSoftware/MINC. Aborting."
     exit 2;
 fi
 

--- a/imaging_install_MacOSX.sh
+++ b/imaging_install_MacOSX.sh
@@ -5,6 +5,7 @@
 #1)It doesn't set up the SGE
 #2)It doesn't fetch the CIVET stuff   TODO:Get the CIVET stuff from somewhere and place somewhere
 #3)It doesn't change the config.xml
+#4)It doesn't install DICOM toolkit
 
 
 #Create a temporary log for installation and delete it on completion 


### PR DESCRIPTION
No longer apt-get installing wrong MINC Toolkit.
Directing users to look at the BIC MINC site.
Misc toolkit clarifications.