### PR TITLE
Removing the message "The file cannot be moved. Make sure the getIncomingDir is set" (exit 9 code)

### DIFF
--- a/DTIPrep/DTI/DTI.pm
+++ b/DTIPrep/DTI/DTI.pm
@@ -56,7 +56,7 @@ sub createOutputFolders{
                         $visit  . "/mri/processed/" .
                         substr(basename($protocol),0,-4);
 
-    system("mkdir -p -m 755 $QC_out")   unless (-e $QC_out || !$runDTIPrep);
+    system("mkdir -p -m 770 $QC_out")   unless (-e $QC_out || !$runDTIPrep);
 
 
     return  ($QC_out) if (-e $QC_out);

--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -90,7 +90,7 @@ if (!$DTIPrepVersion) {
 # Needed for log file
 my  $data_dir    =  $Settings::data_dir;
 my  $log_dir     =  "$data_dir/logs/DTIPrep_register";
-system("mkdir -p -m 755 $log_dir") unless (-e $log_dir);
+system("mkdir -p -m 770 $log_dir") unless (-e $log_dir);
 my  ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)=localtime(time);
 my  $date        =  sprintf("%4d-%02d-%02d_%02d:%02d:%02d",$year+1900,$mon+1,$mday,$hour,$min,$sec);
 my  $log         =  "$log_dir/DTIregister$date.log";
@@ -358,7 +358,7 @@ sub registerProtocol {
 
     # Move file into protocol folder
     my $tooldir = $data_dir . "/protocols/" . $tool;
-    `mkdir $tooldir`    unless (-e $tooldir);
+    `mkdir -m 770 $tooldir`    unless (-e $tooldir);
     my $protPath= $tooldir . "/" . basename($protocol);
     `cp $protocol $protPath`    unless (-e $protPath);
 

--- a/DTIPrep/DTIPrep_pipeline.pl
+++ b/DTIPrep/DTIPrep_pipeline.pl
@@ -96,7 +96,7 @@ my  $QCed2_step     =   $Settings::QCed2_step;
 my  ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)   =   localtime(time);
 my  $date   =   sprintf("%4d-%02d-%02d_%02d:%02d:%02d",$year+1900,$mon+1,$mday,$hour,$min,$sec);
 my  $logdir =   $data_dir . "/logs/DTIPrep_pipeline/";
-system("mkdir -p -m 755 $logdir") unless (-e $logdir);
+system("mkdir -p -m 770 $logdir") unless (-e $logdir);
 my  $log    =   $logdir . "DTI_QC" . $date . ".log";
 open(LOG,">>$log");
 print LOG "Log file, $date\n";

--- a/MNI/FileUtilities.pm
+++ b/MNI/FileUtilities.pm
@@ -264,7 +264,7 @@ sub check_output_dirs
       }
       else                      # no file, no dangling link
       {
-	 if (! mkdir ($dir, 0755))
+	 if (! mkdir ($dir, 0770))
 	 {
 	    warn "couldn't create \"$dir\": $!\n";
 	    $num_err++;
@@ -412,7 +412,7 @@ sub check_output_path
 
       if (! (-e $partial || -l $partial))
       {
-	 unless (mkdir ($partial, 0755))
+	 unless (mkdir ($partial, 0770))
 	 {
 	    warn "\"$path\" not a writeable path: couldn't create \"$partial\": $!\n";
 	    return 0;
@@ -442,7 +442,7 @@ sub check_output_path
 
    if (! (-e $partial || -l $partial))
    {
-      unless (mkdir ($partial, 0755))
+      unless (mkdir ($partial, 0770))
       {
 	 warn "\"$path\" not a writeable path: couldn't create \"$partial\": $!\n";
 	 return 0;

--- a/README.md
+++ b/README.md
@@ -51,5 +51,9 @@ Ensure that /home/$lorisadmin/.bashrc includes the statements:
 
 ```source /data/$projectname/bin/mri/environment```
 
+For MINC tools installed manually, ensure that the apache envvars file includes all the EXPORT statements
+from minc-toolkit-config.sh (file located in the path where the MINC tools are installed), then restart apache.
+This is necessary for Brainbrowser to successfully load MINC images.
+
 Installation complete. For customizations & protocol configurations, see [LORIS Imaging Setup Guide](https://github.com/aces/Loris/wiki/Imaging-Database).
 

--- a/auto/MNI/FileUtilities/check_output_dirs.al
+++ b/auto/MNI/FileUtilities/check_output_dirs.al
@@ -48,7 +48,7 @@ sub check_output_dirs
       }
       else                      # no file, no dangling link
       {
-	 if (! mkdir ($dir, 0755))
+	 if (! mkdir ($dir, 0770))
 	 {
 	    warn "couldn't create \"$dir\": $!\n";
 	    $num_err++;

--- a/auto/MNI/FileUtilities/check_output_path.al
+++ b/auto/MNI/FileUtilities/check_output_path.al
@@ -78,7 +78,7 @@ sub check_output_path
 
       if (! (-e $partial || -l $partial))
       {
-	 unless (mkdir ($partial, 0755))
+	 unless (mkdir ($partial, 0770))
 	 {
 	    warn "\"$path\" not a writeable path: couldn't create \"$partial\": $!\n";
 	    return 0;
@@ -108,7 +108,7 @@ sub check_output_path
 
    if (! (-e $partial || -l $partial))
    {
-      unless (mkdir ($partial, 0755))
+      unless (mkdir ($partial, 0770))
       {
 	 warn "\"$path\" not a writeable path: couldn't create \"$partial\": $!\n";
 	 return 0;

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -90,24 +90,26 @@ echo
 #############################Create directories########################################
 #######################################################################################
 echo "Creating the data directories"
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/"
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/trashbin"         #holds mincs that didn't match protocol
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/tarchive"         #holds tared dicom-folder
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/pic"              #holds jpegs generated for the MRI-browser
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/logs"             #holds logs from pipeline script
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/jiv"              #holds JIVs used for JIV viewer
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/assembly"         #holds the MINC files
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/batch_output"     #contains the result of the SGE (queue
-  sudo -S su $USER -c "mkdir -p $mridir/dicom-archive/.loris_mri"
+  sudo -S su $USER -c "mkdir -m 2770 -p /data/$PROJ/data/"
+  sudo -S su $USER -c "chgrp lorisadmin /data/$PROJ/data/"
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/trashbin"         #holds mincs that didn't match protocol
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/tarchive"         #holds tared dicom-folder
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/pic"              #holds jpegs generated for the MRI-browser
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/logs"             #holds logs from pipeline script
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/jiv"              #holds JIVs used for JIV viewer
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/assembly"         #holds the MINC files
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/batch_output"     #contains the result of the SGE (queue
+  sudo -S su $USER -c "mkdir -m 770 -p $mridir/dicom-archive/.loris_mri"
 echo
 
 #####################################################################################
 ###############incoming directory using sites########################################
 #####################################################################################
-sudo -S su $USER -c "mkdir -p /data/incoming/"
+sudo -S su $USER -c "mkdir -m 2770 -p /data/incoming/"
+sudo -S su $USER -c "chgrp lorisadmin /dat/incoming/"
 echo "Creating incoming director(y/ies)"
  for s in $site; do 
-  sudo -S su $USER -c "mkdir -p /data/incoming/$s/incoming"
+  sudo -S su $USER -c "mkdir -m 770 -p /data/incoming/$s/incoming"
  done
 echo
 
@@ -127,30 +129,22 @@ echo
 ####################################################################################
 #echo "Changing permissions"
 
-sudo chmod -R 750 $mridir/dicom-archive/.loris_mri/
-sudo chmod -R 750 /data/$PROJ/
-sudo chmod -R 750 /data/incoming/
+sudo chmod -R 770 $mridir/dicom-archive/.loris_mri/
+sudo chmod -R 770 /data/$PROJ/
+sudo chmod -R 770 /data/incoming/
 echo
 
 ####################################################################################
-######################Add the proper Apache group user #############################
+###################### #############################
 ####################################################################################
-if egrep ^www-data: /etc/group > $LOGFILE 2>&1;
-then 
-    group=www-data
-elif egrep ^www: /etc/group  > $LOGFILE 2>&1;
-then
-    group=www
-elif egrep -e ^apache: /etc/group  > $LOGFILE 2>&1;
-then
-    group=apache
-else
-    read -p "Cannot find the apache group name for your installation. Please provide? " group
-fi
 
-#Setting group permissions 
-sudo chgrp $group -R /data/$PROJ/data/
-sudo chgrp $group -R /data/incoming/
+#Setting Unix group ID to lorisadmin for all files/dirs under /data/$PROJ/data
+sudo chgrp lorisadmin -R /data/$PROJ/data/
+sudo chmod g+s /data/$PROJ/data/
+
+#Setting Unix group ID to lorisadmin for all files/dirs under /data/incoming
+sudo chgrp lorisadmin -R /data/incoming/
+sudo chmod g+s /data/incoming
 echo
 
 #####################################################################################

--- a/imaging_install_MacOSX.sh
+++ b/imaging_install_MacOSX.sh
@@ -37,23 +37,26 @@ mridir=`pwd`
 #############################Create directories######################################
 #####################################################################################
 echo "Creating the data directories"
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/"
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/trashbin"          #holds mincs that didn't match protocol
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/tarchive"          #holds tared dicom-folder
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/pic"               #holds jpegs generated for the MRI-browser
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/logs"              #holds logs from pipeline script
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/jiv"               #holds JIVs used for JIV viewer
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/assembly"          #holds the MINC files
-  sudo -S su $USER -c "mkdir -p /data/$PROJ/data/batch_output"      #contains the result of the SGE (queue
-  sudo -S su $USER -c "mkdir -p $mridir/dicom-archive/.loris_mri"
+  sudo -S su $USER -c "mkdir -m 2770 -p /data/$PROJ/data/"
+  sudo -S su $USER -c "chgrp lorisadmin /data/$PROJ/data/"
+  sudo -S su $USER -c "chmod g+s /data/$PROJ/data/"
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/trashbin"          #holds mincs that didn't match protocol
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/tarchive"          #holds tared dicom-folder
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/pic"               #holds jpegs generated for the MRI-browser
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/logs"              #holds logs from pipeline script
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/jiv"               #holds JIVs used for JIV viewer
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/assembly"          #holds the MINC files
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/batch_output"      #contains the result of the SGE (queue
+  sudo -S su $USER -c "mkdir -m 770 -p $mridir/dicom-archive/.loris_mri"
 echo
 #####################################################################################
 ###############incoming directory using sites########################################
 #####################################################################################
-sudo -S su $USER -c "mkdir -p /data/incoming/";
+sudo -S su $USER -c "mkdir -m 2770 -p /data/incoming/";
+sudo -S su $USER -c "chgrp lorisadmin /data/incoming/"
 echo "Creating incoming director(y/ies)"
  for s in $site; do 
-  sudo -S su $USER -c "mkdir -p /data/incoming/$s/incoming";
+  sudo -S su $USER -c "mkdir -m 770 -p /data/incoming/$s/incoming";
  done;
 echo
 
@@ -72,9 +75,9 @@ echo
 ####################################################################################
 #echo "Changing permissions"
 
-sudo chmod -R 750 $mridir/.loris_mri/
-sudo chmod -R 750 /data/$PROJ/
-sudo chmod -R 750 /data/incoming/
+sudo chmod -R 770 $mridir/.loris_mri/
+sudo chmod -R 770 /data/$PROJ/
+sudo chmod -R 770 /data/incoming/
 echo
 
 #####################################################################################

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -161,15 +161,17 @@ sub IsValid {
             if ( !$this->isDicom($_) ) {
                 $files_not_dicom++;
             }
+	    else {
          #######################################################
          #Validate the Patient-Name, only if it's not a phantom#
+         ############## and the file is of type DICOM###########
          #######################################################
-	    if ($row[4] eq 'N') {
-            	if ( !$this->PatientNameMatch($_) ) {
-	        	$files_with_unmatched_patient_name++;
-	        }
-
-	    }
+                if ($row[4] eq 'N') {
+                    if ( !$this->PatientNameMatch($_) ) {
+                            $files_with_unmatched_patient_name++;
+                    }
+                }
+            }
         }
     }
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1112,7 +1112,7 @@ sub make_pics {
     $mincbase =~ s/\.mnc(\.gz)?$//;
 
     my $pic = $dest_dir . '/' . $rowhr->{'CandID'};
-    unless (-e $pic) { system("mkdir -p -m 755 $pic") == 0 or return 0; }
+    unless (-e $pic) { system("mkdir -p -m 770 $pic") == 0 or return 0; }
     my $tmpdir = tempdir( CLEANUP => 1 );
 
     # if the file has a fileid, add that to the filename
@@ -1168,7 +1168,7 @@ sub make_jiv {
     }
 
     # relocate jiv files to jiv destination dir
-    unless (-e $jiv) { system("mkdir -p -m 755 $jiv"); return 0 unless -e $jiv; }
+    unless (-e $jiv) { system("mkdir -p -m 770 $jiv"); return 0 unless -e $jiv; }
     `mv $tempdir/* $jiv/`;
 
     # update mri table

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -521,7 +521,7 @@ sub move_minc {
     ### figure out where to put the files ######################
     ############################################################
     $dir = $this->which_directory($subjectIDsref,$data_dir);
-    `mkdir -p -m 755 $dir/native`;
+    `mkdir -p -m 770 $dir/native`;
 
     ############################################################
     ####### figure out what to call files ######################
@@ -754,7 +754,7 @@ sub concat_mri {
         print CONCATFILES "$file\n";
     }
     close CONCATFILES;
-    mkdir("$this->{TmpDir} /concat", 0700);
+    mkdir("$this->{TmpDir} /concat", 0770);
     $cmd = "cat $this->{TmpDir} /concatfilelist.txt | concat_mri.pl ".
            "-maxslicesep 3.1 -compress -postfix _concat -targetdir ".
            "$this->{TmpDir} /concat -stdin";
@@ -809,7 +809,7 @@ sub moveAndUpdateTarchive {
     ##### make the directory if it does not yet exist ##########
     ############################################################
     unless(-e $newTarchiveLocation) {
-        mkdir($newTarchiveLocation, 0755);
+        mkdir($newTarchiveLocation, 0770);
     }
     ############################################################
     ####### determine the new name of the tarchive #############

--- a/uploadNeuroDB/cleanupTarchives.pl
+++ b/uploadNeuroDB/cleanupTarchives.pl
@@ -71,7 +71,7 @@ $tarchiveLibraryDir     =~ s/\/$//g;
 ##############################
 # create logdir(if !exists) and logfile
 my $LogDir   = "$data_dir/logs"; 
-mkdir ($LogDir, 0700) if (!-d $LogDir);
+mkdir ($LogDir, 0770) if (!-d $LogDir);
 my $logfile  = "$LogDir/RemoveDuplicateTarchives_$date.log";
 open LOG, ">$logfile";
 LOG->autoflush(1);

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -71,7 +71,7 @@ The program does the following
    1) Validate the uploaded file   (set the validation to true)
    2) Run dicomtar.pl on the file  (set the dicomtar to true)
    3) Run tarchiveLoader on the file (set the minc-created to true)
-   4) Move the uploaded file to the proper directory
+   4) Removes the uploaded file once the previous steps have completed
    5) Update the mri_upload table 
 
 HELP
@@ -229,20 +229,18 @@ $message = "\n The insertion Script has successfully completed";
 spool($message,'N');
 
 ################################################################
-######### moves the uploaded folder to the Incoming Directory###
+### If we got this far, dicomTar and tarchiveLoader completed###
+#### Remove the uploaded file from the incoming directory#######
 ################################################################
-if (!$imaging_upload->moveUploadedFile()) {
-    $message = "\n The file cannot be moved. Make sure the getIncomingDir".
-               "config option is set\n";
-    spool($message,'Y');
+my $isCleaned = $imaging_upload->CleanUpDataIncomingDir($uploaded_file);
+if ( !$isCleaned ) {
+    $message = "The uploaded file " . $uploaded_file . " was not removed\n";
+    spool($message,'Y'); 
     print $message;
     exit 9;
 }
-
-################################################################
-############### removes the uploaded folder from the /tmp#######
-################################################################
-$imaging_upload->CleanUpTMPDir();
+$message = "The uploaded file " . $uploaded_file . " has been removed\n";
+spool($message,'N');
 
 ################################################################
 ############### getPnameUsingUploadID###########################

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -164,7 +164,7 @@ my $tarchiveLibraryDir = $Settings::tarchiveLibraryDir;
 $tarchiveLibraryDir    =~ s/\/$//g;
 print "log dir is $LogDir \n";
 if (!-d $LogDir) { 
-    mkdir($LogDir, 0700); 
+    mkdir($LogDir, 0770); 
 }
 my $logfile  = "$LogDir/$templog.log";
 open LOG, ">>", $logfile or die "Error Opening $logfile";

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -88,7 +88,7 @@ my  $prefix     =   $Settings::prefix;
 
 # Needed for log file
 my  $log_dir    =   "$data_dir/logs/registerProcessed";
-system("mkdir -p -m 755 $log_dir") unless (-e $log_dir);
+system("mkdir -p -m 770 $log_dir") unless (-e $log_dir);
 my  ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)    =   localtime(time);
 my  $date       =   sprintf("%4d-%02d-%02d_%02d:%02d:%02d",$year+1900,$mon+1,$mday,$hour,$min,$sec);
 my  $log        =   "$log_dir/registerProcessed$date.log";
@@ -373,7 +373,7 @@ sub copy_file {
 
     # figure out where to put the files
     my $dir         =   &which_directory($subjectIDsref);
-    `mkdir -p -m 755 $dir/processed/$sourcePipeline`;
+    `mkdir -p -m 770 $dir/processed/$sourcePipeline`;
 
     # figure out what to call files
     my @exts        =   split(/\./, basename($$filename));

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -191,7 +191,7 @@ my @temp     = split(/\//, $TmpDir);
 my $templog  = $temp[$#temp];
 my $LogDir   = "$data_dir/logs"; 
 if (!-d $LogDir) { 
-    mkdir($LogDir, 0700); 
+    mkdir($LogDir, 0770); 
 }
 my $logfile  = "$LogDir/$templog.log";
 open LOG, ">$logfile";
@@ -543,7 +543,7 @@ if (scalar(@leftovers) > 0) {
     my $trashdir = $data_dir . '/trashbin/' . $temp[$#temp];
     print LOG "\n==> LEFTOVERS: ".scalar(@leftovers).
     "\n --> Moving leftovers to $trashdir\n";
-    `mkdir -p -m 755 $trashdir`;
+    `mkdir -p -m 770 $trashdir`;
     `chmod -R u+w $TmpDir/*`;
     `mv $TmpDir/* $trashdir`;
     open MAIL, "| mail $mail_user";

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -91,7 +91,7 @@ The program does the following validation
 
 - Optionally do extra filtering on the dicom data, if needed
 
-- Finally the isValid is set true in the MRI_Upload table
+- Finally the isTarchiveValidated is set true in the MRI_Upload table
 
 HELP
 my $Usage = <<USAGE;
@@ -205,8 +205,8 @@ if ($tarchiveid_count==0)  {
        ##otherwise insert it####################################
        #########################################################
        $query = "INSERT INTO mri_upload (UploadedBy, ".
-                "UploadDate,TarchiveID, DecompressedLocation, IsTarchiveValidated)" .
-                " VALUES (?,now(),?,?,'1')";
+                "UploadDate,TarchiveID, DecompressedLocation)" .
+                " VALUES (?,now(),?,?)";
        my $mri_upload_inserts = $dbh->prepare($query);
        $mri_upload_inserts->execute(
            $User,
@@ -295,15 +295,13 @@ if ( defined( &Settings::dicomFilter )) {
 }
 
 ################################################################
-### Update the mri_upload table with the correct tarchiveID ####
+##Update the IsTarchiveValidated flag in the mri_upload table ##
 ################################################################
-if ($tarchiveid_count!=0) {
-    $where = "WHERE TarchiveID=?";
-    $query = "UPDATE mri_upload SET IsTarchiveValidated='1' ";
-    $query = $query . $where;
-    my $mri_upload_update = $dbh->prepare($query);
-    $mri_upload_update->execute($tarchiveInfo{TarchiveID});
-}
+$where = "WHERE TarchiveID=?";
+$query = "UPDATE mri_upload SET IsTarchiveValidated='1' ";
+$query = $query . $where;
+my $mri_upload_update = $dbh->prepare($query);
+$mri_upload_update->execute($tarchiveInfo{TarchiveID});
 
 
 exit 0;

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -134,7 +134,7 @@ my @temp     = split(/\//, $TmpDir);
 my $templog  = $temp[$#temp];
 my $LogDir   = "$data_dir/logs"; 
 if (!-d $LogDir) { 
-    mkdir($LogDir, 0700); 
+    mkdir($LogDir, 0770); 
 }
 my $logfile  = "$LogDir/$templog.log";
 open LOG, ">>", $logfile or die "Error Opening $logfile";

--- a/uploadNeuroDB/upload
+++ b/uploadNeuroDB/upload
@@ -96,13 +96,13 @@ my $pic_dir = $data_dir.'/pic';
 my $jiv_dir = $data_dir.'/jiv';
 
 # create temp dir
-if (! -e $TmpDir) { mkdir($TmpDir, 0700); } else { if(! -w $TmpDir) { $TmpDir .= 'a'; mkdir($TmpDir, 0700); } }
+if (! -e $TmpDir) { mkdir($TmpDir, 0770); } else { if(! -w $TmpDir) { $TmpDir .= 'a'; mkdir($TmpDir, 0770); } }
 
 # create logdir(if !exists) and logfile
 my @temp = split(/\//, $TmpDir);
 my $templog = $temp[$#temp];
 my $LogDir = "$data_dir/logs";
-if (!-d $LogDir) { mkdir($LogDir, 0700); }
+if (!-d $LogDir) { mkdir($LogDir, 0770); }
 my $logfile = "$LogDir/$templog.log";
 
 # if xlog is set fork a tail on the actual log file.
@@ -371,7 +371,7 @@ my @leftovers = `\\ls -1 $TmpDir`;
 if(scalar(@leftovers) > 0) {
     my $trashdir = $data_dir . '/trashbin/' . $temp[$#temp];
     print LOG "LEFTOVERS: ".scalar(@leftovers)."\nMoving leftovers to $trashdir\n";
-    `mkdir -p -m 755 $trashdir`;
+    `mkdir -p -m 770 $trashdir`;
     `mv $TmpDir/* $trashdir`;
 
     open MAIL, "| mail $mail_user";
@@ -592,7 +592,7 @@ sub concat_mri
 {
     my ($minc_files) = @_;
 
-    mkdir("$TmpDir/concat", 0700);
+    mkdir("$TmpDir/concat", 0770);
     my $cmd = "concat_mri.pl -maxslicesep 3.1 -compress -postfix _concat -targetdir $TmpDir/concat ".join(' ', @$minc_files);
     my $log = `$cmd`;
 
@@ -621,7 +621,7 @@ sub move_minc
     # figure out where to put the files
     my $dir = which_directory($subjectIDsref);
     
-    `mkdir -p -m 755 $dir/native`;
+    `mkdir -p -m 770 $dir/native`;
 
     # figure out what to call files
     my @exts = split(/\./, $$minc);
@@ -673,14 +673,14 @@ sub jivify
 
     my $jiv = "$data_dir/jiv/$dispid/$visitNo/native";
     $jiv =~ s/ //g;
-    `mkdir -p -m 755 $jiv`;
+    `mkdir -p -m 770 $jiv`;
 
     $log = `minc2jiv.pl -quiet -force -slices -output_path $jiv $minc`;
     
     # make jpgs
     my $pik = "$data_dir/pic/$dispid/$visitNo/native";
     $pik =~ s/ //g;
-    `mkdir -p -m 755 $pik`;
+    `mkdir -p -m 770 $pik`;
 
     @fileparts = split(/\//, $minc);
     $mincbase = $fileparts[$#fileparts];
@@ -705,7 +705,7 @@ sub jivify
 #    
 #    my $dir = which_directory($subjectIDsref);
 #    $dir .= '/incoming';
-#    `mkdir -p -m 755 $dir`;
+#    `mkdir -p -m 770 $dir`;
 #
 #    my $study = basename($study_dir);
 #


### PR DESCRIPTION
- This gets rid of the exit 9 code we all get "The file cannot be moved. Make sure the getIncomingDir config option is set"
- Removed the moveUploadedFile() and CleanUpTMPDir() from imaging_upload_file.pl, and replaced with a removal of the uploaded file cleanUpDataIncomingDir().
- Before removal, one check is performed to ensure the file that was used to run tarchiveLoader is in the tarchive directory
- Once PR104 is merged, the spool messages need to be updated with the 'Verbose' flag