### PR TITLE
Check patient name only if the file is DICOM, otherwise dcmdump crashes

### DIFF
--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -161,15 +161,17 @@ sub IsValid {
             if ( !$this->isDicom($_) ) {
                 $files_not_dicom++;
             }
+	    else {
          #######################################################
          #Validate the Patient-Name, only if it's not a phantom#
+         ############## and the file is of type DICOM###########
          #######################################################
-	    if ($row[4] eq 'N') {
-            	if ( !$this->PatientNameMatch($_) ) {
-	        	$files_with_unmatched_patient_name++;
-	        }
-
-	    }
+                if ($row[4] eq 'N') {
+                    if ( !$this->PatientNameMatch($_) ) {
+                            $files_with_unmatched_patient_name++;
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Just added an "else" statement to the if condition that checks if the file is NOT dicom