### PR TITLE
Bypassing redundant checking on center name; check using ScannerID

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -398,7 +398,7 @@ Returns: Textual name of scan type
 
 sub identify_scan_db {
 
-    my  ($psc, $subjectref, $fileref, $dbhr,$minc_location) = @_;
+    my  ($subjectref, $fileref, $dbhr,$minc_location) = @_;
 
     my $candid = ${subjectref}->{'CandID'};
     my $pscid = ${subjectref}->{'PSCID'};
@@ -469,7 +469,7 @@ sub identify_scan_db {
               xstep_range, ystep_range, zstep_range, time_range, series_description_regex
               FROM mri_protocol
               WHERE
-             (Center_name='$psc' AND ScannerID='$ScannerID')
+             (ScannerID='$ScannerID')
               OR ((Center_name='ZZZZ' OR Center_name='AAAA') AND ScannerID='0')
               ORDER BY Center_name ASC, ScannerID DESC";
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -368,7 +368,7 @@ sub computeMd5Hash {
 sub getAcquisitionProtocol {
    
     my $this = shift;
-    my ($file,$subjectIDsref,$tarchiveInfo,$center_name,$minc) = @_;
+    my ($file,$subjectIDsref,$tarchiveInfo,$minc) = @_;
     my $tarchive_srcloc = $tarchiveInfo->{'SourceLocation'};
     my $upload_id = getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc);
     my $message = '';
@@ -382,7 +382,6 @@ sub getAcquisitionProtocol {
     $this->spool($message, 'N', $upload_id, $notify_detailed);
 
     my $acquisitionProtocol =  &NeuroDB::MRI::identify_scan_db(
-                                   $center_name,
                                    $subjectIDsref,
                                    $file, 
                                    $this->{dbhr}, 

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -384,7 +384,7 @@ my ($acquisitionProtocol,$acquisitionProtocolID,@checks)
   = $utility->getAcquisitionProtocol(
         $file,
         $subjectIDsref,
-        \%tarchiveInfo,$center_name,
+        \%tarchiveInfo,
         $minc
     );
 


### PR DESCRIPTION
This is for the very unique case when the mri_protocol table has a center name (as opposed to ZZZZ or AAAA) and a scanner ID, AND the candidate gets scanned at an MRI site other than the recruiting site, the protocol will return unknown.
The check of center name AND scannerID is redundant, irrespective of the scenario above, but the proposed change should make it work for the scenario above.  