### PR TITLE
Proposing -usecoordinates as the default option for dcm2mnc

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -745,7 +745,7 @@ sub dicom_to_minc {
     if ($converter ne 'dcm2mnc') {
         $d2m_cmd .= "$converter $this->{TmpDir}  -notape -compress -stdin";
     } else {
-        $d2m_cmd .= "dcm2mnc -dname '' -stdin -clobber $this->{TmpDir} ";
+        $d2m_cmd .= "dcm2mnc -dname '' -stdin -clobber -usecoordinates $this->{TmpDir} ";
     }
     $d2m_log = `$d2m_cmd`;
 


### PR DESCRIPTION
This PR corrects the flipping of the scenario (3) below (dcm2mnc will use -3 instead of 3.3), and should not impact scenarios (1) and (2):

1) When slice spacing (read form the DICOM header) is consistent with coordinate values (obtained from the XYZ position of each slice), this option should have no effect.
2) When the values are equal in magnitude and signs are opposite, dcm2mnc automatically uses                -usecoordinates option (this is a typical warning we get: 
WARNING: Coordinate spacing (-1) differs from DICOM slice spacing (1)
 (perhaps you should consider the -usecoordinates option)
 Using -1 for the slice spacing value
3) When values are different in magnitude and sign, then slice spacing is used BUT image will be flipped; 
a typical warning:
WARNING: Coordinate spacing (-3) differs from DICOM slice spacing (3.3)
 (perhaps you should consider the -usecoordinates option)
 Using 3.3 for the slice spacing value.