### PR TITLE
Number of mincs inserted in the mri_upload could be wrong in some cases

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -626,8 +626,9 @@ sub registerScanIntoDB {
     ) = @_;
     my $data_dir = $Settings::data_dir;
     my $prefix   = $Settings::prefix;
+    my $acquisitionProtocolID = undef;
     my (
-        $acquisitionProtocolID,$Date_taken,$minc_protocol_identified,
+        $Date_taken,$minc_protocol_identified,
         $file_path,$tarchive_path,$fileID
     );
     my $tarchive_srcloc = $tarchiveInfo->{'SourceLocation'};
@@ -720,6 +721,7 @@ sub registerScanIntoDB {
             $tarchiveInfo->{'DateAcquired'}
         );
     }
+    return $acquisitionProtocolID;
 }
 
 ################################################################

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -404,12 +404,24 @@ if($acquisitionProtocol =~ /unknown/) {
 # to keep optionally controlled by the config file #############
 ################################################################
 
-$utility->registerScanIntoDB(
+my $acquisitionProtocolIDFromProd = $utility->registerScanIntoDB(
     \$file, \%tarchiveInfo,$subjectIDsref, 
     $acquisitionProtocol, $minc, \@checks, 
     $reckless, $tarchive, $sessionID
 );
 
+if ((!defined$acquisitionProtocolIDFromProd)
+   && (defined(&Settings::isFileToBeRegisteredGivenProtocol))
+   ) {
+   $message = "\n  --> The minc file cannot be registered ".
+                "since $acquisitionProtocol ".
+                "does not exist in $profile \n";
+   print LOG $message;
+   $notifier->spool('minc insertion', $message, 0,
+                   'minc_insertion', $upload_id, 'Y',
+                   $notify_notsummary);
+    exit 10;
+}
 ################################################################
 ### Add series notification ####################################
 ################################################################


### PR DESCRIPTION
If the mri_protocol table checks pass, but the protocol is not registered in the prof file, the number of minc inserted in the mri_upload table was still incrementing.
An exit code is now used to track this and prevent incrementing the count for the number of minc files inserted.