### PR TITLE
Readme updates for 16.0 (Loris-MRI Ubuntu Readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # System Requirements
  * Perl
- * DICOM toolkit (step 3)
- * MINC toolkit (step 2)
+ * DICOM toolkit (step 4)
+ * MINC toolkit (step 3)
 
-Note: For Ubuntu installations, DICOM toolkit will be installed by the imaging install script (see step 3 below). This script will apt-get install dcmtk.   
+Note: For Ubuntu installations, DICOM toolkit will be installed by the imaging install script (see step 4 below). This script will apt-get install dcmtk.   
 
 The following installation should be run by the $lorisadmin user. sudo permission is required.
 See aces/Loris README.md for further information and Loris installation information. 
@@ -19,7 +19,7 @@ See aces/Loris README.md for further information and Loris installation informat
    git clone https://github.com/aces/Loris-MRI.git mri
    ```
    
-2. Install Dicom-archive within the mri/ directory (created by the git clone command):
+2. Install dicom-archive-tools sub-repo within the mri/ directory (created by the git clone command):
 
    ```bash
    cd /data/$projectname/bin/mri/

--- a/README.md
+++ b/README.md
@@ -53,16 +53,12 @@ See aces/Loris README.md for further information and Loris installation informat
 
   If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir and chmod commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/master/imaging_install.sh#L90)
 
-5. Configure paths and environment
+5. Ensure your _project/config.xml_ file (in your main LORIS codebase) contains the following tagset (where /opt/minc/ is the MINC tools path in this example).
 
-   Ensure that /home/$lorisadmin/.bashrc includes the statement: 
-
-   ```source /data/$projectname/bin/mri/environment```
-
-   Ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (this file located in the path where the MINC tools are installed). This is necessary for BrainBrowser to successfully load MINC images.
-
-   Finally, source the .bashrc file and restart apache.
-
+   ```xml
+   <!-- MINC TOOLS PATH -->
+   <MINCToolsPath>/opt/minc/</MINCToolsPath>
+   ```
 
 Installation complete. For customizations and protocol configurations, see [LORIS Imaging Setup Guide](https://github.com/aces/Loris/wiki/Imaging-Database).
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+This Readme covers release 16.0 of the LORIS Imaging Insertion Pipeline
+
+This repo accompanies the [LORIS neuroimaging data platform main repo](https://github.com/aces/Loris)</b>
+For documentation and detailed setup information, please see the [LORIS wiki](https://github.com/aces/Loris/wiki/Imaging-Database)</b>
+
+This repo can be installed on either the same VM as your main LORIS codebase, or on a different machine such as a designated fileserver where your large imaging filesets are to be stored. 
+
 # System Requirements
  * Perl
  * DICOM toolkit (step 4)
@@ -6,7 +13,7 @@
 Note: For Ubuntu installations, DICOM toolkit will be installed by the imaging install script (see step 4 below). This script will apt-get install dcmtk.   
 
 The following installation should be run by the $lorisadmin user. sudo permission is required.
-See aces/Loris README.md for further information and Loris installation information. 
+See [aces/Loris README.md](https://github.com/aces/loris) for further information and Loris installation information. 
 
 # Installation
 
@@ -53,12 +60,23 @@ See aces/Loris README.md for further information and Loris installation informat
 
   If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir and chmod commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/master/imaging_install.sh#L90)
 
-5. Ensure your _project/config.xml_ file (in your main LORIS codebase) contains the following tagset (where /opt/minc/ is the MINC tools path in this example).
+  
+5. To ensure the Imaging Uploader (apache) can write to the data directories, run: 
+
+   ```bash
+   cd /data/$projectname/data/
+   chown -R lorisadmin.www-data *   # if running Ubuntu
+   chown -R lorisadmin.apache *     # if running CentOS
+   chmod 770 
+   chmod g+s
+   ```
+
+6. Ensure your _project/config.xml_ file (in your main LORIS codebase) contains the following tagset (where /opt/minc/ is the MINC toolkit path in this example).
 
    ```xml
    <!-- MINC TOOLS PATH -->
    <MINCToolsPath>/opt/minc/</MINCToolsPath>
    ```
 
-Installation complete. For customizations and protocol configurations, see [LORIS Imaging Setup Guide](https://github.com/aces/Loris/wiki/Imaging-Database).
+   Installation complete. For customizations and protocol configurations, see [LORIS Imaging Setup Guide](https://github.com/aces/Loris/wiki/Imaging-Database).
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ See aces/Loris README.md for further information and Loris installation informat
  * What prod file name would you like to use? default: prod  [leave blank]
  * Enter the list of Site names (space separated) site1 site2
 
-If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir and chmod commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/master/imaging_install.sh#L90)
+  If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir and chmod commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/master/imaging_install.sh#L90)
 
-4. Install MINC toolkit from: http://bic-mni.github.io/ 
-Ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (this file located in the path where the MINC tools are installed), then restart apache. This is necessary for BrainBrowser to successfully load MINC images.
+4. Install MINC toolkit from http://bic-mni.github.io/ 
+
+   Ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (this file located in the path where the MINC tools are installed), then restart apache. This is necessary for BrainBrowser to successfully load MINC images.
 
 5. Ensure that /home/$lorisadmin/.bashrc includes the statements: 
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
 
   If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir and chmod commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/16.0-dev/imaging_install.sh#L90)
 
-  The installer will make apache (www-data) part of the lorisadmin linux group.  
+  The installer will make lorisadmin part of apache (or www-data) linux group.  
 
 5. Configure paths and environment
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
 
 3. Install MINC toolkit from http://bic-mni.github.io/ 
 
-   Pre-compiled packages are available for major operating systems.
+   Pre-compiled packages are available for major operating systems. Note required dependencies such as imagemagick.
 
 4. Run installer to install DICOM toolkit, Perl libraries, configure environment, and setup directories:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This Readme covers release 16.0 of the LORIS Imaging Insertion Pipeline
+This Readme covers release 16.0 of the LORIS Imaging Insertion Pipeline for Ubuntu or CentOS systems
 
 This repo accompanies the [LORIS neuroimaging data platform main repo](https://github.com/aces/Loris)</b>
 For documentation and detailed setup information, please see the [LORIS wiki](https://github.com/aces/Loris/wiki/Imaging-Database)</b>
@@ -60,22 +60,31 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
 
   If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir and chmod commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/master/imaging_install.sh#L90)
 
-5. Ensure that /home/$lorisadmin/.bashrc includes the statement: 
+  The installer will make apache (www-data) part of the lorisadmin linux group.  
+
+5. Configure paths and environment
+
+   Ensure that /home/$lorisadmin/.bashrc includes the statement: 
 
    ```source /data/$projectname/bin/mri/environment```
 
    Then source the .bashrc file.   
 
-6. Configure path variables to ensure that BrainBrowser can load MINC images: 
- 
    Ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (file located in the path where the MINC toolkit is installed), then restart apache.
-  
-  Ensure your _project/config.xml_ file (in the main LORIS codebase) contains the following tagset specifying the MINC toolkit path (/opt/minc/ in this example).
+
+6. Set up MINC utilities for BrainBrowser visualization
+
+   To ensure that BrainBrowser can load MINC images, the MINC toolkit must be accessible to the main LORIS codebase.
+   (If the Loris-MRI codebase is installed on a separate machine, ensure the MINC toolkit is installed in both locations.)
+
+   Ensure your _project/config.xml_ file (in the main LORIS codebase) contains the following tagset, specifying the MINC toolkit path local to the main LORIS codebase (/opt/minc/ in this example).
+
 
    ```xml
    <!-- MINC TOOLS PATH -->
    <MINCToolsPath>/opt/minc/</MINCToolsPath>
    ```
+
 
    Installation complete. For customizations and protocol configurations, see [LORIS Imaging Setup Guide](https://github.com/aces/Loris/wiki/Imaging-Database).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # System Requirements
  * Perl
- * DICOM toolkit (step 3 below)
- * MINC toolkit (step 5 below; also see http://bic-mni.github.io/)
+ * DICOM toolkit (step 3)
+ * MINC toolkit (step 2)
 
 Note: For Ubuntu installations, DICOM toolkit will be installed by the imaging install script (see step 3 below). This script will apt-get install dcmtk.   
 
@@ -28,7 +28,11 @@ See aces/Loris README.md for further information and Loris installation informat
    git submodule update
    ```
 
-3. Run installer to install DICOM toolkit, Perl libraries, configure environment, and setup directories:
+3. Install MINC toolkit from http://bic-mni.github.io/ 
+
+   Pre-compiled packages are available for major operating systems.
+
+4. Run installer to install DICOM toolkit, Perl libraries, configure environment, and setup directories:
 
    ```bash 
    cd /data/$projectname/bin/mri/
@@ -49,14 +53,14 @@ See aces/Loris README.md for further information and Loris installation informat
 
   If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir and chmod commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/master/imaging_install.sh#L90)
 
-4. Install MINC toolkit from http://bic-mni.github.io/ 
+5. Configure paths and environment
 
-   Ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (this file located in the path where the MINC tools are installed), then restart apache. This is necessary for BrainBrowser to successfully load MINC images.
-
-5. Ensure that /home/$lorisadmin/.bashrc includes the statements: 
+   Ensure that /home/$lorisadmin/.bashrc includes the statements: 
 
 ```source /data/$projectname/bin/mri/environment```
 
+   Finally, ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (this file located in the path where the MINC tools are installed), then restart apache. This is necessary for BrainBrowser to successfully load MINC images.
 
-Installation complete. For customizations & protocol configurations, see [LORIS Imaging Setup Guide](https://github.com/aces/Loris/wiki/Imaging-Database).
+
+Installation complete. For customizations and protocol configurations, see [LORIS Imaging Setup Guide](https://github.com/aces/Loris/wiki/Imaging-Database).
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 This Readme covers release 16.0 of the LORIS Imaging Insertion Pipeline for Ubuntu or CentOS systems
 
-This repo accompanies the [LORIS neuroimaging data platform main repo](https://github.com/aces/Loris)</b>
-For documentation and detailed setup information, please see the [LORIS wiki](https://github.com/aces/Loris/wiki/Imaging-Database)</b>
+This repo accompanies the [LORIS neuroimaging data platform main repo](https://github.com/aces/Loris)</b>.<br>
+For documentation and detailed setup information, please see the [LORIS wiki](https://github.com/aces/Loris/wiki/Imaging-Database)</b>.
 
-This repo can be installed on either the same VM as your main LORIS codebase, or on a different machine such as a designated fileserver where your large imaging filesets are to be stored. 
+This repo can be installed on either the same VM as the main LORIS codebase, or on a different machine such as a designated fileserver where large imaging filesets are to be stored. 
 
 # System Requirements
  * Perl
  * DICOM toolkit (step 4)
  * MINC toolkit (step 3)
 
-Note: For Ubuntu installations, DICOM toolkit will be installed by the imaging install script (see step 4 below). This script will apt-get install dcmtk.   
+Note: For Ubuntu installations, DICOM toolkit will be installed by the imaging install script (see step 4 below). This script will _apt-get install dcmtk_.   
 
 The following installation should be run by the $lorisadmin user. sudo permission is required.
 See [aces/Loris README.md](https://github.com/aces/loris) for further information and Loris installation information. 
@@ -58,7 +58,7 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
  * What prod file name would you like to use? default: prod  [leave blank]
  * Enter the list of Site names (space separated) site1 site2
 
-  If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir and chmod commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/master/imaging_install.sh#L90)
+  If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir and chmod commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/16.0-dev/imaging_install.sh#L90)
 
   The installer will make apache (www-data) part of the lorisadmin linux group.  
 
@@ -69,15 +69,14 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
    ```source /data/$projectname/bin/mri/environment```
 
    Then source the .bashrc file.   
-
-   Ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (file located in the path where the MINC toolkit is installed), then restart apache.
+   Also ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (file located in the path where the MINC toolkit is installed), then restart apache.
 
 6. Set up MINC utilities for BrainBrowser visualization
 
    To ensure that BrainBrowser can load MINC images, the MINC toolkit must be accessible to the main LORIS codebase.
    (If the Loris-MRI codebase is installed on a separate machine, ensure the MINC toolkit is installed in both locations.)
 
-   Ensure your _project/config.xml_ file (in the main LORIS codebase) contains the following tagset, specifying the MINC toolkit path local to the main LORIS codebase (/opt/minc/ in this example).
+   Ensure the _project/config.xml_ file (in the main LORIS codebase) contains the following tagset, specifying the MINC toolkit path local to the main LORIS codebase (/opt/minc/ in this example):
 
 
    ```xml
@@ -85,6 +84,6 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
    <MINCToolsPath>/opt/minc/</MINCToolsPath>
    ```
 
-
+<br>
    Installation complete. For customizations and protocol configurations, see [LORIS Imaging Setup Guide](https://github.com/aces/Loris/wiki/Imaging-Database).
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
 
  * What is the database name? $dbname
  * What is the database host? $dbhost
- * What is the MySQL user? $lorisuser 
+ * What is the MySQL user? $lorisuser [Use the same mysql user from the Loris installation, i.e. _lorisuser_]
  * What is the MySQL password? 
  * What is the Linux user which the installation will be based on? $lorisadmin
  * What is the project name? $projectname
@@ -60,18 +60,17 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
 
   If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir and chmod commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/master/imaging_install.sh#L90)
 
+5. Ensure that /home/$lorisadmin/.bashrc includes the statement: 
+
+   ```source /data/$projectname/bin/mri/environment```
+
+   Then source the .bashrc file.   
+
+6. Configure path variables to ensure that BrainBrowser can load MINC images: 
+ 
+   Ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (file located in the path where the MINC toolkit is installed), then restart apache.
   
-5. To ensure the Imaging Uploader (apache) can write to the data directories, run: 
-
-   ```bash
-   cd /data/$projectname/data/
-   chown -R lorisadmin.www-data *   # if running Ubuntu
-   chown -R lorisadmin.apache *     # if running CentOS
-   chmod 770 
-   chmod g+s
-   ```
-
-6. Ensure your _project/config.xml_ file (in your main LORIS codebase) contains the following tagset (where /opt/minc/ is the MINC toolkit path in this example).
+  Ensure your _project/config.xml_ file (in the main LORIS codebase) contains the following tagset specifying the MINC toolkit path (/opt/minc/ in this example).
 
    ```xml
    <!-- MINC TOOLS PATH -->

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See aces/Loris README.md for further information and Loris installation informat
 
    Ensure that /home/$lorisadmin/.bashrc includes the statements: 
 
-```source /data/$projectname/bin/mri/environment```
+   ```source /data/$projectname/bin/mri/environment```
 
    Finally, ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (this file located in the path where the MINC tools are installed), then restart apache. This is necessary for BrainBrowser to successfully load MINC images.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # System Requirements
  * Perl
- * DICOM toolkit
- * MINC tools (http://www.bic.mni.mcgill.ca/ServicesSoftware/MINC)
+ * DICOM toolkit (step 3 below)
+ * MINC toolkit (step 5 below; also see http://bic-mni.github.io/)
 
 Note: For Ubuntu installations, DICOM toolkit will be installed by the imaging install script (see step 3 below). This script will apt-get install dcmtk.   
 
@@ -47,13 +47,15 @@ See aces/Loris README.md for further information and Loris installation informat
  * What prod file name would you like to use? default: prod  [leave blank]
  * Enter the list of Site names (space separated) site1 site2
 
-Ensure that /home/$lorisadmin/.bashrc includes the statements: 
+If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir and chmod commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/master/imaging_install.sh#L90)
+
+4. Install MINC toolkit from: http://bic-mni.github.io/ 
+Ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (this file located in the path where the MINC tools are installed), then restart apache. This is necessary for BrainBrowser to successfully load MINC images.
+
+5. Ensure that /home/$lorisadmin/.bashrc includes the statements: 
 
 ```source /data/$projectname/bin/mri/environment```
 
-For MINC tools installed manually, ensure that the apache envvars file includes all the EXPORT statements
-from minc-toolkit-config.sh (file located in the path where the MINC tools are installed), then restart apache.
-This is necessary for Brainbrowser to successfully load MINC images.
 
 Installation complete. For customizations & protocol configurations, see [LORIS Imaging Setup Guide](https://github.com/aces/Loris/wiki/Imaging-Database).
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ See aces/Loris README.md for further information and Loris installation informat
 
 5. Configure paths and environment
 
-   Ensure that /home/$lorisadmin/.bashrc includes the statements: 
+   Ensure that /home/$lorisadmin/.bashrc includes the statement: 
 
    ```source /data/$projectname/bin/mri/environment```
 
-   Finally, ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (this file located in the path where the MINC tools are installed), then restart apache. This is necessary for BrainBrowser to successfully load MINC images.
+   Ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (this file located in the path where the MINC tools are installed). This is necessary for BrainBrowser to successfully load MINC images.
+
+   Finally, source the .bashrc file and restart apache.
 
 
 Installation complete. For customizations and protocol configurations, see [LORIS Imaging Setup Guide](https://github.com/aces/Loris/wiki/Imaging-Database).


### PR DESCRIPTION
Updating the Loris-MRI Readme for 16.0 : 

* Now recommending manual install of minc toolkit via Vlad's webpage on GitHub
* On certain /data/ mounts (especially Ubuntu) the mkdir commands fail when running the imaging_install.sh script.  User needs to manually run these commands afterwards.  This typically affects all the subdirectories under /data/$PROJ/data/ 
* Release version stated in the Readme
* Adding instruction to enable apache writability on data directories for Imaging Uploader

