### PR TITLE
Batch upload of scans for projects not using the front-end imaging uploader

### DIFF
--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -1,0 +1,123 @@
+#!/usr/bin/perl -w
+use strict;
+use warnings;
+use File::Basename;
+
+#####Get config setting#######################################################
+# checking for profile settings
+if(-f "$ENV{LORIS_CONFIG}/.loris_mri/prod") {
+    { package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/prod" }
+} ##Possibly the script can exit if the prod doesn't exist
+#######################################################################################
+
+# define project space
+my ($debug, $verbose) = (0,1);
+my ($stdoutbase, $stderrbase) = ("$Settings::data_dir/batch_output/imuploadstdout.log", "$Settings::data_dir/batch_output/imuploadstderr.log");
+my $stdout = '';
+my $stderr = '';
+
+my @opt_table           = (
+    [ "Basic options", "section" ],
+    ["-verbose", "boolean", 1,   \$verbose, "Be verbose."]
+);
+
+
+while($_ = $ARGV[0], /^-/) {
+    shift;
+    last if /^--$/; ## -- ends argument processing
+    if (/^-D/) { $debug++ } ## debug level
+    if (/^-v/) { $verbose++ } ## verbosity
+}
+
+
+## read input from STDIN, store into array @inputs (`find ....... | this_script`)
+my @linearray = ();
+my @resultsarray = ();
+my @patientname = ();
+my @patientnamearray = ();
+my @fullpath = ();
+my @fullpatharray = ();
+my @phantom = ();
+my @phantomarray = ();
+my @submitted = ();
+
+my $counter = 0;
+
+while(my $line = <STDIN>)
+{
+    chomp $line;
+    my @linearray = split(" " , $line);
+    push (@resultsarray, @linearray);
+    @patientname = $linearray[0];
+    @fullpath = $linearray[1];
+    @phantom = $linearray[2];
+    push (@patientnamearray, @patientname);
+    push (@fullpatharray, @fullpath);
+    push (@phantomarray, @phantom);
+}
+close STDIN;
+
+## foreach series, batch magic
+foreach my $input (@resultsarray)
+{
+    $counter++;
+    $stdout = $stdoutbase.$counter;
+    $stderr = $stderrbase.$counter;
+
+    #$stdout = '/dev/null';
+    #$stderr = '/dev/null';
+
+    my $patientname = $patientnamearray[$counter-1];
+    my $fullpath = $fullpatharray[$counter-1];
+    my $phantom = $phantomarray[$counter-1];
+
+    ## Ensure that 
+    ## 1) the uploaded file is of type .tgz or .tar.gz or .zip
+    ## 2) the patient name and path entries are identical; this mimics the imaging uploader in the front-end
+    ## 3) check that input file provides phantom details (Y for phantom, N for real candidates)
+    my ($base,$path,$type) = fileparse($fullpath, qr{\..*});
+    if (($type ne '.tgz') && ($type ne '.tar.gz') && ($type ne '.zip')) {
+	print "The file on line $counter is not of type .tgz, tar.gz, or .zip and will not be processed\n";
+	exit(1);
+    }
+    if ($base ne $patientname) {
+	print "Make sure the patient name $patientname " .
+	      "matches the file name $base in $path\n";
+	exit(2);
+    }
+    if (($phantom eq '') || ($phantom ne 'N') || ($phantom eq 'Y')) {
+	print "Make sure the Phantom entry is filled out " .
+	      "with Y if the scan if for a phantom, and N otherwise\n";
+	exit(3);
+    }
+
+    ## this is where the subprocesses are created...  should basically run processor script with study directory as argument.
+    ## processor will do all the real magic
+
+    my $command = "$Settings::bin_dir/uploadNeuroDB/imaging_upload_file.pl "
+		. "-profile prod -phantom $phantom -patient_name $patientname $fullpath";
+    if ($verbose) {
+        $command .= " -verbose";
+    }
+
+    ##if qsub is enabled use it
+    if ($Settings::is_qsub) {
+	     open QSUB, "| qsub -V -e $stderr -o $stdout -N process_imageuploader_${counter}";
+    	 print QSUB $command;
+    	 close QSUB;
+    }
+    ##if qsub is not enabled
+    else {
+         system($command);
+    }
+
+     push @submitted, $input;
+}
+open MAIL, "|mail $Settings::mail_user";
+print MAIL "Subject: BATCH_UPLOADS_IMAGEUPLOADER: ".scalar(@submitted)." studies submitted.\n";
+print MAIL join("\n", @submitted)."\n";
+close MAIL;
+
+## exit 0 for find to consider this -cmd true (in case we ever run it that way...)
+exit(0);
+

--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -131,12 +131,10 @@ foreach my $input (@resultsarray)
 
     ## Populate the mri_upload table with necessary entries and get an upload_id 
 
-print "PN and Phantom and Full Path are: $patientname and $phantom and $fullpath\n";
     $upload_id = insertIntoMRIUpload(\$dbh,
 				     $patientname,
                                      $phantom,
                                      $fullpath);
-print "UploadID returned is: $upload_id\n";
 
     ## this is where the subprocesses are created...  should basically run processor script with study directory as argument.
     ## processor will do all the real magic
@@ -155,8 +153,8 @@ print "UploadID returned is: $upload_id\n";
     }
     ##if qsub is not enabled
     else {
-print "Command is: $command\n";
-         system($command);
+	print "Running now the following command: $command\n" if $verbose;
+	system($command);
     }
 
      push @submitted, $input;

--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -1,10 +1,17 @@
 #!/usr/bin/perl -w
 use strict;
 use warnings;
+no warnings 'once';
 use File::Basename;
 use Getopt::Tabular;
+use NeuroDB::DBI;
+use NeuroDB::Notify;
 
 my $profile   = undef;
+my $upload_id = undef; 
+my $fullpath = undef; 
+my $phantom = undef; 
+my $patientname = undef; 
 my ($debug, $verbose) = (0,1);
 my $stdout = '';
 my $stderr = '';
@@ -20,12 +27,24 @@ my @opt_table           = (
 
 &Getopt::Tabular::GetOptions( \@opt_table, \@ARGV ) || exit 1;
 
-#####Get config setting#######################################################
+################################################################
+################ Get config setting#############################
+################################################################
 { package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
-##############################################################################
+if ( $profile && !@Settings::db ) {
+    print "\n\tERROR: You don't have a
+    configuration file named '$profile' in:
+    $ENV{LORIS_CONFIG}/.loris_mri/ \n\n";
+    exit 2;
+}
 
-my ($stdoutbase, $stderrbase) = ("$Settings::data_dir/batch_output/imuploadstdout.log", "$Settings::data_dir/batch_output/imuploadstderr.log");
+################################################################
+################ Establish database connection #################
+################################################################
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 
+my ($stdoutbase, $stderrbase) = ("$Settings::data_dir/batch_output/imuploadstdout.log", 
+				 "$Settings::data_dir/batch_output/imuploadstderr.log");
 
 
 while($_ = $ARGV[0], /^-/) {
@@ -54,9 +73,9 @@ while(my $line = <STDIN>)
     chomp $line;
     my @linearray = split(" " , $line);
     push (@resultsarray, @linearray);
-    @patientname = $linearray[0];
-    @fullpath = $linearray[1];
-    @phantom = $linearray[2];
+    @fullpath = $linearray[0];
+    @phantom = $linearray[1];
+    @patientname = $linearray[2];
     push (@patientnamearray, @patientname);
     push (@fullpatharray, @fullpath);
     push (@phantomarray, @phantom);
@@ -73,35 +92,57 @@ foreach my $input (@resultsarray)
     #$stdout = '/dev/null';
     #$stderr = '/dev/null';
 
-    my $patientname = $patientnamearray[$counter-1];
-    my $fullpath = $fullpatharray[$counter-1];
-    my $phantom = $phantomarray[$counter-1];
+    $fullpath = $fullpatharray[$counter-1];
+    $phantom = $phantomarray[$counter-1];
+    $patientname = $patientnamearray[$counter-1];
 
     ## Ensure that 
     ## 1) the uploaded file is of type .tgz or .tar.gz or .zip
-    ## 2) the patient name and path entries are identical; this mimics the imaging uploader in the front-end
-    ## 3) check that input file provides phantom details (Y for phantom, N for real candidates)
+    ## 2) check that input file provides phantom details (Y for phantom, N for real candidates)
+    ## 3) for non-phantoms, the patient name and path entries are identical; this mimics the imaging uploader in the front-end
     my ($base,$path,$type) = fileparse($fullpath, qr{\..*});
     if (($type ne '.tgz') && ($type ne '.tar.gz') && ($type ne '.zip')) {
 	print "The file on line $counter is not of type .tgz, tar.gz, or .zip and will not be processed\n";
-	exit(1);
-    }
-    if ($base ne $patientname) {
-	print "Make sure the patient name $patientname " .
-	      "matches the file name $base in $path\n";
-	exit(2);
-    }
-    if (($phantom eq '') || ($phantom ne 'N') || ($phantom eq 'Y')) {
-	print "Make sure the Phantom entry is filled out " .
-	      "with Y if the scan if for a phantom, and N otherwise\n";
 	exit(3);
     }
+    if (($phantom eq '') || (($phantom ne 'N') && ($phantom ne 'Y'))) {
+	print "Make sure the Phantom entry is filled out " .
+	      "with Y if the scan if for a phantom, and N otherwise\n";
+	exit(4);
+    }
+    if ($phantom eq 'N') {
+        if ($base ne $patientname) {
+       	    print "Make sure the patient name $patientname " .
+	          "for non-phantom entries matches the file " .
+		  "name $base in $path\n";
+	    exit(5);
+	}
+    }
+    else {
+        if ($patientname ne '') {
+       	    print "Please leave the patient name blank " .
+	          "for phantom entries\n";
+	    exit(6);
+	}
+	else {
+	    $patientname = 'NULL';
+	}
+    }
+
+    ## Populate the mri_upload table with necessary entries and get an upload_id 
+
+print "PN and Phantom and Full Path are: $patientname and $phantom and $fullpath\n";
+    $upload_id = insertIntoMRIUpload(\$dbh,
+				     $patientname,
+                                     $phantom,
+                                     $fullpath);
+print "UploadID returned is: $upload_id\n";
 
     ## this is where the subprocesses are created...  should basically run processor script with study directory as argument.
     ## processor will do all the real magic
 
     my $command = "$Settings::bin_dir/uploadNeuroDB/imaging_upload_file.pl "
-		. "-profile $profile -phantom $phantom -patient_name $patientname $fullpath";
+		. "-profile $profile -upload_id $upload_id $fullpath";
     if ($verbose) {
         $command .= " -verbose";
     }
@@ -114,6 +155,7 @@ foreach my $input (@resultsarray)
     }
     ##if qsub is not enabled
     else {
+print "Command is: $command\n";
          system($command);
     }
 
@@ -123,6 +165,48 @@ open MAIL, "|mail $Settings::mail_user";
 print MAIL "Subject: BATCH_UPLOADS_IMAGEUPLOADER: ".scalar(@submitted)." studies submitted.\n";
 print MAIL join("\n", @submitted)."\n";
 close MAIL;
+
+
+################################################################
+############### insertIntoMRIUpload ############################
+################################################################
+=pod
+insertIntoMRIUpload()
+Description:
+  - Insert into the mri_upload table entries for data coming
+    from batch_upload_imageuploader
+
+Arguments:
+  $patientname: The patient name
+  $phantom : 'Y' if the entry is for a phantom, and 'N' othwrwose
+  $fullpath: Path to the uploaded file
+
+  Returns: $upload_id : The Upload ID
+=cut
+
+
+sub insertIntoMRIUpload {
+
+    my ( $dbhr, $patientname, $phantom, $fullpath ) = @_;
+    my $User = `whoami`;
+
+    my $query = "INSERT INTO mri_upload ".
+                "(UploadedBy, UploadDate, PatientName, ".
+                "IsPhantom, UploadLocation) ".
+                "VALUES (?, now(), ?, ?, ?)";
+    my $mri_upload_insert = $dbh->prepare($query);
+    $mri_upload_insert->execute($User,$patientname,
+                                $phantom, $fullpath);
+
+    my $where = " WHERE mu.UploadLocation =?";
+    $query = "SELECT mu.UploadID FROM mri_upload mu";
+    $query .= $where;
+    my $sth = $dbh->prepare($query);
+    $sth->execute($fullpath);
+    my $upload_id = $sth->fetchrow_array;
+
+    return $upload_id;
+}
 
 ## exit 0 for find to consider this -cmd true (in case we ever run it that way...)
 exit(0);

--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -2,24 +2,30 @@
 use strict;
 use warnings;
 use File::Basename;
+use Getopt::Tabular;
 
-#####Get config setting#######################################################
-# checking for profile settings
-if(-f "$ENV{LORIS_CONFIG}/.loris_mri/prod") {
-    { package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/prod" }
-} ##Possibly the script can exit if the prod doesn't exist
-#######################################################################################
-
-# define project space
+my $profile   = undef;
 my ($debug, $verbose) = (0,1);
-my ($stdoutbase, $stderrbase) = ("$Settings::data_dir/batch_output/imuploadstdout.log", "$Settings::data_dir/batch_output/imuploadstderr.log");
 my $stdout = '';
 my $stderr = '';
 
 my @opt_table           = (
     [ "Basic options", "section" ],
+    [
+        "-profile", "string", 1, \$profile,
+        "name of config file in ../dicom-archive/.loris_mri"
+    ],
     ["-verbose", "boolean", 1,   \$verbose, "Be verbose."]
 );
+
+&Getopt::Tabular::GetOptions( \@opt_table, \@ARGV ) || exit 1;
+
+#####Get config setting#######################################################
+{ package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
+##############################################################################
+
+my ($stdoutbase, $stderrbase) = ("$Settings::data_dir/batch_output/imuploadstdout.log", "$Settings::data_dir/batch_output/imuploadstderr.log");
+
 
 
 while($_ = $ARGV[0], /^-/) {
@@ -95,7 +101,7 @@ foreach my $input (@resultsarray)
     ## processor will do all the real magic
 
     my $command = "$Settings::bin_dir/uploadNeuroDB/imaging_upload_file.pl "
-		. "-profile prod -phantom $phantom -patient_name $patientname $fullpath";
+		. "-profile $profile -phantom $phantom -patient_name $patientname $fullpath";
     if ($verbose) {
         $command .= " -verbose";
     }

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -28,7 +28,7 @@ my $date    = sprintf(
                 $year + 1900,
                 $mon + 1, $mday, $hour, $min, $sec
               );
-my $profile   = undef;    # this should never be set unless you are in a
+my $profile = undef;    # this should never be set unless you are in a
                         # stable production environment
 my $upload_id = undef;         # The uploadID
 my $template  = "ImagingUpload-$hour-$min-XXXXXX";    # for tempdir
@@ -109,9 +109,9 @@ if ( !$ARGV[0] || !$profile ) {
     exit 3;
 }
 
-if ( !$upload_id ) { 
+if ( !$upload_id ) {
     print $Help;
-    print "$Usage\n\tERROR: No upload_id or patient name provided \n\n";
+    print "$Usage\n\tERROR: The Upload_id is missing \n\n";
     exit 4;
 }
 

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -61,7 +61,9 @@ my @opt_table           = (
     ],
     [
         "-phantom", "string", 1, \$phantom,
-        "Y for phantom and N for real study participants"
+        "Y for phantom and N for real study participants; " .
+	" needed only when using batch_upload_imaguploader"
+
     ],
     ["-verbose", "boolean", 1,   \$verbose, "Be verbose."],
     [ "Advanced options", "section" ],
@@ -120,10 +122,12 @@ if ( !$ARGV[0] || !$profile ) {
     exit 3;
 }
 
-if ( !$upload_id ) { #check for upload_id only if this script is not called from batch_upload_imageuploader
+# check if patient name is provided in case of no upload_id; 
+# expected when script is called from batch_upload_imageuploader 
+if ( !$upload_id ) { 
     if (!$patient_name_batch) { 
         print $Help;
-        print "$Usage\n\tERROR: The Upload_id is missing \n\n";
+        print "$Usage\n\tERROR: No upload_id or patient name provided \n\n";
         exit 4;
     }
 }

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -31,9 +31,6 @@ my $date    = sprintf(
 my $profile   = undef;    # this should never be set unless you are in a
                         # stable production environment
 my $upload_id = undef;         # The uploadID
-my $phantom   = undef;         # Y if Phantom
-my $patient_name_batch = undef;         # Patient Name as obtained from batch upload
-my $pname = undef;         
 my $template  = "ImagingUpload-$hour-$min-XXXXXX";    # for tempdir
 my $TmpDir_decompressed_folder =
      tempdir( $template, TMPDIR => 1, CLEANUP => 1 );
@@ -54,16 +51,6 @@ my @opt_table           = (
     [
         "-upload_id", "string", 1, \$upload_id,
         "The uploadID of the given scan uploaded"
-    ],
-    [
-        "-patient_name_batch", "string", 1, \$patient_name_batch,
-        "The patient name; needed only when using batch_upload_imaguploader"
-    ],
-    [
-        "-phantom", "string", 1, \$phantom,
-        "Y for phantom and N for real study participants; " .
-	" needed only when using batch_upload_imaguploader"
-
     ],
     ["-verbose", "boolean", 1,   \$verbose, "Be verbose."],
     [ "Advanced options", "section" ],
@@ -122,14 +109,10 @@ if ( !$ARGV[0] || !$profile ) {
     exit 3;
 }
 
-# check if patient name is provided in case of no upload_id; 
-# expected when script is called from batch_upload_imageuploader 
 if ( !$upload_id ) { 
-    if (!$patient_name_batch) { 
-        print $Help;
-        print "$Usage\n\tERROR: No upload_id or patient name provided \n\n";
-        exit 4;
-    }
+    print $Help;
+    print "$Usage\n\tERROR: No upload_id or patient name provided \n\n";
+    exit 4;
 }
 
 $uploaded_file = abs_path( $ARGV[0] );
@@ -175,30 +158,7 @@ my $result = $file_decompress->Extract(
 ############### Get Patient_name using UploadID#################
 ################################################################
 ################################################################
-if (!$patient_name_batch) { 
-    $pname = getPnameUsingUploadID($upload_id);
-}
-else {
-    $pname = $patient_name_batch;
-}
-
-################################################################
-############# For entries coming from batch_upload #############
-########### Created entries into the mri_upload table ##########
-################################################################
-if ($patient_name_batch) {
-    if (!$phantom) {
-        print "Please ensure that entries from " .
-              "batch_upload_imageuploader contain " .
-	      "a Y or N for phantoms or no phantoms, ".
-	      "respectively\n";
-    } 
-    else {
-         $upload_id = insertIntoMRIUpload($patient_name_batch, 
-				          $phantom, 
-				          $uploaded_file);
-    }
-}
+my $pname = getPnameUsingUploadID($upload_id);
 
 ################################################################
 ################ ImagingUpload  Object #########################
@@ -318,47 +278,6 @@ sub getPnameUsingUploadID {
         }
     }
     return $patient_name;
-}
-
-################################################################
-############### insertIntoMRIUpload ############################
-################################################################
-=pod
-insertIntoMRIUpload()
-Description:
-  - Insert into the mri_upload table entries for data coming 
-    from batch_upload_imageuploader
-
-Arguments:
-  $patient_name_batch: The patient name
-  $phantom : 'Y' if the entry is for a phantom, and 'N' othwrwose
-  $uploaded_file: Path to the uploaded file
- 
-  Returns: $upload_id : The Upload ID
-=cut
-
-
-sub insertIntoMRIUpload {
-
-    my ( $patient_name_batch, $phantom, $uploaded_file ) = @_;
-    my $User = `whoami`;
-
-    my $query = "INSERT INTO mri_upload ".
-      		"(UploadedBy, UploadDate, PatientName, ".
-		"IsPhantom, UploadLocation) ".
-    		"VALUES (?, now(), ?, ?, ?)";
-    my $mri_upload_insert = $dbh->prepare($query);
-    $mri_upload_insert->execute($User,$patient_name_batch,
-				$phantom, $uploaded_file);
-
-    my $where = " WHERE mu.UploadLocation =?";
-    $query = "SELECT mu.UploadID FROM mri_upload mu";
-    $query .= $where;
-    my $sth = $dbh->prepare($query);
-    $sth->execute($uploaded_file);
-    my $upload_id = $sth->fetchrow_array;
-
-    return $upload_id;
 }
 
 ################################################################


### PR DESCRIPTION
Run it as follows form where the Loris-MRI code base is:

$ ./batch_uploads_imageuploader -profile prod < imageuploader_list >log_batch_imageuploader.txt 2>&1

where imageuploader_list is a text file that has one scan details per line (example for 2 entries shown below); and each line (for each scan) consists of space delimited 1) the full path to the DICOM zipped scan, 2) Y or N depending on whether the scan is for a phantom or not, and 3) patient name following the PSCID_CandID_VisitLabel Loris convention for real candidates and left BLANK for phantoms 

An example of uploading 2 entries/scans to be uploaded:
/data/incoming/PSC0001_123457_V1.tar.gz  N  PSC0000_123456_V1
/data/incoming/Lego_Phantom_MNI_20140101.zip  Y  
