### PR TITLE
Creation of mkdir with correct permissions when user=apache

### DIFF
--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -148,6 +148,9 @@ else
     read -p "Cannot find the apache group name for your installation. Please provide? " group
 fi
 
+# Making lorisadmin part of the apache group
+sudo usermod -a -G $group $USER
+
 #Setting group permissions to apache and group ID for all files/dirs under /data/$PROJ/data
 sudo chgrp $group -R /data/$PROJ/data/
 sudo chmod -R g+s /data/$PROJ/data/

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -578,7 +578,23 @@ sub move_minc {
     ### figure out where to put the files ######################
     ############################################################
     $dir = $this->which_directory($subjectIDsref,$data_dir);
-    `mkdir -p -m 770 $dir/native`;
+
+    # create the last 4 subdirectories: CandID, Visit Lavel, mri, native
+    # one at a time to make sure mode 770 is applicable to each
+    # since `mkdir -p -m 770 $dir/native`
+    # will only apply 770 to last directory
+    my (@subdir) = split (/\//, $dir);
+    my $size = scalar(@subdir);
+    my $partial1=$subdir[$size-3];
+    my $partial2=$subdir[$size-2];
+    my $partial3=$subdir[$size-1];
+    my $full1 = $data_dir . "/assembly/" . $partial1;
+    my $full2 = $data_dir . "/assembly/" . $partial1 . "/" . $partial2;
+    my $full3 = $data_dir . "/assembly/" . $partial1 . "/" . $partial2 ."/" . $partial3;
+    unless (-e $full1) {`mkdir -m 770 $full1`};
+    unless (-e $full2) {`mkdir -m 770 $full2`};
+    unless (-e $full3) {`mkdir -m 770 $full3`};
+    `mkdir -m 770 $dir/native`;
 
     ############################################################
     ####### figure out what to call files ######################
@@ -888,7 +904,7 @@ sub moveAndUpdateTarchive {
     ##### make the directory if it does not yet exist ##########
     ############################################################
     unless(-e $newTarchiveLocation) {
-        mkdir($newTarchiveLocation, 0770);
+        `mkdir -m 770 $newTarchiveLocation`;
     }
     ############################################################
     ####### determine the new name of the tarchive #############


### PR DESCRIPTION
Creation of some directories are now explicitely invoked so that permissions are set properly (to allow the front end user or lorisadmin to run the pipeline seamlessly)