### PR TITLE
MRI Readme updates re environment, usergroups, version

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
 
   If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir/chmod/chown commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/16.0-dev/imaging_install.sh#L90)
 
-  Note: The installer will allow Apache to write to the /data/ directories by adding user lorisadmin to the Apache linux group, and setting Apache group ownership of /data/ subdirectories.  
+  Note: The installer will allow Apache to write to the /data/ directories by adding user lorisadmin to the Apache linux group, and setting Apache group ownership of certain /data/ subdirectories.  
   To help ensure Apache-writability, verify that your environment file contains the following line:
     ```bash
     umask 0002

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
    sudo mkdir -p /data/$projectname/bin/mri
    sudo chown -R lorisadmin:lorisadmin /data/$projectname
    cd /data/$projectname/bin
-   git clone https://github.com/aces/Loris-MRI.git mri
+   git clone -b 16.0-dev https://github.com/aces/Loris-MRI.git mri
    ```
    
 2. Install dicom-archive-tools sub-repo within the mri/ directory (created by the git clone command):
@@ -69,7 +69,6 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
    ```source /data/$projectname/bin/mri/environment```
 
    Then source the .bashrc file.   
-   Also ensure that the apache envvars file includes all the EXPORT statements from minc-toolkit-config.sh (file located in the path where the MINC toolkit is installed), then restart apache.
 
 6. Set up MINC utilities for BrainBrowser visualization
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-This Readme covers release 16.0 of the LORIS Imaging Insertion Pipeline for Ubuntu or CentOS systems
+This Readme covers release 16.0.0 of the LORIS Imaging Insertion Pipeline for Ubuntu or CentOS systems
 
-This repo accompanies the [LORIS neuroimaging data platform main repo](https://github.com/aces/Loris)</b>.<br>
+This repo accompanies the [LORIS neuroimaging data platform main repo](https://github.com/aces/Loris)</b>, release 16.0.*.<br>
 For documentation and detailed setup information, please see the [LORIS wiki](https://github.com/aces/Loris/wiki/Imaging-Database)</b>.
 
 This repo can be installed on either the same VM as the main LORIS codebase, or on a different machine such as a designated fileserver where large imaging filesets are to be stored. 
@@ -58,9 +58,12 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
  * What prod file name would you like to use? default: prod  [leave blank]
  * Enter the list of Site names (space separated) site1 site2
 
-  If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir and chmod commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/16.0-dev/imaging_install.sh#L90)
+  If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir/chmod/chown commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/16.0-dev/imaging_install.sh#L90)
 
-  The installer will make lorisadmin part of apache (or www-data) linux group.  
+  Note: The installer will allow Apache to write to the /data/ directories by adding user lorisadmin to the Apache linux group, and setting Apache group ownership of certain /data/ subdirectories.  To help ensure Apache-writability, verify that the installer has added the following line to your environment file:
+    ```bash
+    umask 0002
+    ```
 
 5. Configure paths and environment
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
 
 # Installation
 
-1. Create directories
+1. Create directories and download Loris-MRI Release 16.0.0 code
 
    ```bash
    sudo mkdir -p /data/$projectname/bin/mri
    sudo chown -R lorisadmin:lorisadmin /data/$projectname
    cd /data/$projectname/bin
-   git clone -b 16.0-dev https://github.com/aces/Loris-MRI.git mri
+   git clone -b v16.0.0 https://github.com/aces/Loris-MRI.git mri
    ```
    
 2. Install dicom-archive-tools sub-repo within the mri/ directory (created by the git clone command):

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This Readme covers release 16.0.0 of the LORIS Imaging Insertion Pipeline for Ubuntu or CentOS systems
+This Readme covers release 16.* of the LORIS Imaging Insertion Pipeline for Ubuntu or CentOS systems
 
 This repo accompanies the [LORIS neuroimaging data platform main repo](https://github.com/aces/Loris)</b>, release 16.0.*.<br>
 For documentation and detailed setup information, please see the [LORIS wiki](https://github.com/aces/Loris/wiki/Imaging-Database)</b>.
@@ -17,13 +17,13 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
 
 # Installation
 
-1. Create directories and download Loris-MRI Release 16.0.0 code
+1. Create directories and download Loris-MRI code
 
    ```bash
    sudo mkdir -p /data/$projectname/bin/mri
    sudo chown -R lorisadmin:lorisadmin /data/$projectname
    cd /data/$projectname/bin
-   git clone -b v16.0.0 https://github.com/aces/Loris-MRI.git mri
+   git clone https://github.com/aces/Loris-MRI.git mri
    ```
    
 2. Install dicom-archive-tools sub-repo within the mri/ directory (created by the git clone command):
@@ -60,10 +60,13 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
 
   If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir/chmod/chown commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/16.0-dev/imaging_install.sh#L90)
 
-  Note: The installer will allow Apache to write to the /data/ directories by adding user lorisadmin to the Apache linux group, and setting Apache group ownership of certain /data/ subdirectories.  To help ensure Apache-writability, verify that the installer has added the following line to your environment file:
+  Note: The installer will allow Apache to write to the /data/ directories by adding user lorisadmin to the Apache linux group, and setting Apache group ownership of /data/ subdirectories.  
+  To help ensure Apache-writability, verify that your environment file contains the following line:
     ```bash
     umask 0002
     ```
+
+   Then source the environment file.   
 
 5. Configure paths and environment
 


### PR DESCRIPTION
Since we're now on release branches, it's not enough to just clone the repo, which will get you the master branch.  
Users attempting to install Loris-MRI 16.0 must clone the v16.0.0 tag specifically.
Updated Readme to reflect this.

Also removed spurious minc path export instruction.