### PR TITLE
remove minc, add a minc based on SeriesUID

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -120,7 +120,7 @@ sub getFileNamesfromSeriesUID {
     }
 
     my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
-    my ($seriesuid) = @_;
+    my ($seriesuid, @alltarfiles) = @_;
     my @filearray;
     my $tarstring = ' --wildcards ';
     my $query = "select tf.FileName from tarchive_files as tf".
@@ -134,7 +134,7 @@ sub getFileNamesfromSeriesUID {
         $tarstring .= "'*" . $tf->{'FileName'} . "' ";
     }
 
-    my $lcp = LCP(@filearray);
+    my $lcp = LCP(@alltarfiles);
     $tarstring =~ s/$lcp//g;
 
     return $tarstring;
@@ -175,15 +175,17 @@ sub extract_tarchive {
         exit 1 ;
     }
 
-    if (defined($seriesuid)) {
-        print "seriesuid: $seriesuid\n";
-        $tarnames = getFileNamesfromSeriesUID($seriesuid);
-        print "tarnames: $tarnames\n";
-    }
-
     my $dcmtar = $tars[0];
     my $dcmdir = $dcmtar;
     $dcmdir =~ s/\.tar\.gz$//;
+
+    if (defined($seriesuid)) {
+        print "seriesuid: $seriesuid\n";
+        my @alltarfiles = `cd $this->{TmpDir} ; tar -tzf $dcmtar`;
+        $tarnames = getFileNamesfromSeriesUID($seriesuid, @alltarfiles);
+        print "tarnames: $tarnames\n";
+    }
+
     `cd $this->{TmpDir} ; tar -xzf $dcmtar $tarnames`;
     return $dcmdir;
 }

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -795,10 +795,10 @@ sub dicom_to_minc {
     ############################################################
     #### use some other converter if specified in the config ###
     ############################################################
-    if ($converter ne 'dcm2mnc') {
+    if ($converter !=  /dcm2mnc/) {
         $d2m_cmd .= "$converter $this->{TmpDir}  -notape -compress -stdin";
     } else {
-        $d2m_cmd .= "dcm2mnc -dname '' -stdin -clobber -usecoordinates $this->{TmpDir} ";
+        $d2m_cmd .= "$converter -dname '' -stdin -clobber -usecoordinates $this->{TmpDir} ";
     }
     $d2m_log = `$d2m_cmd`;
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -120,7 +120,7 @@ sub getFileNamesfromSeriesUID {
     }
 
     my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
-    my $seriesuid = @_;
+    my ($seriesuid) = @_;
     my @filearray;
     my $tarstring = ' --wildcards ';
     my $query = "select tf.FileName from tarchive_files as tf".

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -113,10 +113,8 @@ sub getFileNamesfromSeriesUID {
     my ($seriesuid) = @_;
     my $tarstring = ' --wildcards ';
     my $query = "select tf.FileName from tarchive_files as tf".
-        " where tf.TarchiveID = (select distinct ts.tarchiveID   from tarchive_series".
-        " as ts where ts.SeriesUID=?)".
-        " and tf.SeriesNumber = (select distinct ts.SeriesNumber from tarchive_series".
-        " as ts where ts.SeriesUID=?)".
+        " where tf.TarchiveID = (select distinct ts.tarchiveID   from tarchive_series as ts where ts.SeriesUID=?)".
+        " and tf.SeriesNumber = (select distinct ts.SeriesNumber from tarchive_series as ts where ts.SeriesUID=?)".
         " order by tf.FileNumber";
     my $sth = $dbh->prepare($query);
     $sth->execute($seriesuid, $seriesuid);
@@ -782,10 +780,10 @@ sub dicom_to_minc {
     ############################################################
     #### use some other converter if specified in the config ###
     ############################################################
-    if ($converter !~ /dcm2mnc/) {
+    if ($converter ne 'dcm2mnc') {
         $d2m_cmd .= "$converter $this->{TmpDir}  -notape -compress -stdin";
     } else {
-        $d2m_cmd .= "$converter -dname '' -stdin -clobber -usecoordinates $this->{TmpDir} ";
+        $d2m_cmd .= "dcm2mnc -dname '' -stdin -clobber -usecoordinates $this->{TmpDir} ";
     }
     $d2m_log = `$d2m_cmd`;
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -795,7 +795,7 @@ sub dicom_to_minc {
     ############################################################
     #### use some other converter if specified in the config ###
     ############################################################
-    if ($converter !=  /dcm2mnc/) {
+    if ($converter !~ /dcm2mnc/) {
         $d2m_cmd .= "$converter $this->{TmpDir}  -notape -compress -stdin";
     } else {
         $d2m_cmd .= "$converter -dname '' -stdin -clobber -usecoordinates $this->{TmpDir} ";

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -59,6 +59,12 @@ Deletes minc files from the web interface by:
     .mnc .jpg .header .raw_byte.gz
   - Deleting all related data from 4 database tables.
     parameter_file, files_qcstatus, feedback_mri_comments, files
+  - Deletes mri_acquisition_dates entry if it is the last file
+    removed from that session.
+
+Use the argument "select" to view the record that could be removed
+from the database.  Use "confirm" to acknowledge that the data in 
+the database will be deleted once the script executes.
 
 HELP
 my $Usage = <<USAGE;

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -137,9 +137,13 @@ sub selORdel {
   }
 
   if ($selORdel eq "SELECT * ") {
-    while (my $pf = $sth->fetchrow_hashref()) {
-        print "\n$field: " . $pf->{$field};
+    if ($seriesuid) {
+      $query =~ s/\?/'$seriesuid'/g;
+    } elsif ($fileid) {
+      $query =~ s/\?/'$fileid'/g;
     }
+
+    print "\n" . $query;
   }
 }
 

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -18,7 +18,7 @@ use NeuroDB::DBI;
 use NeuroDB::Notify;
 use NeuroDB::MRIProcessingUtility;
 
-my $profile   = 'prod';      # this should never be set unless you are in a
+my $profile   = '';      # this should never be set unless you are in a
                              # stable production environment
 my $seriesuid = '';
 my $query     = '';
@@ -101,10 +101,10 @@ my $jiv_header   = $pic_path[0] . ".header";
 my $jiv_raw_byte = $pic_path[0] . ".raw_byte.gz";
 
 if ($ARGV[0] eq "confirm") {
-  unlink($data_dir . "/" . $f->{'File'});
-  unlink($data_dir . "/pic/" . $f->{'VALUE'});
-  unlink($data_dir . "/jiv/" . $jiv_header);
-  unlink($data_dir . "/jiv/" . $jiv_raw_byte);
+  rename($data_dir . "/" . $f->{'File'}, $data_dir . "/archive/" . $f->{'File'});
+  rename($data_dir . "/pic/" . $f->{'VALUE'}, $data_dir . "/archive/pic/" . $f->{'VALUE'});
+  rename($data_dir . "/jiv/" . $jiv_header, $data_dir . "/archive/jiv/" . $jiv_header);
+  rename($data_dir . "/jiv/" . $jiv_raw_byte, $data_dir . "/archive/jiv/" . $jiv_raw_byte);
 } else {
   print $data_dir . "/" . $f->{'File'} . "\n";
   print $data_dir . "/pic/" . $f->{'VALUE'} . "\n";

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -19,6 +19,8 @@ use NeuroDB::DBI;
 use NeuroDB::Notify;
 use NeuroDB::MRIProcessingUtility;
 
+my $versionInfo = sprintf "%d revision %2d", q$Revision: 1.2 $
+    =~ /: (\d+)\.(\d+)/;
 my $profile   = '';      # this should never be set unless you are in a
                              # stable production environment
 my $seriesuid = '';
@@ -30,7 +32,7 @@ my $selORdel  = '';
 my @opt_table = (
                  ["Basic options","section"],
                  ["-profile     ","string",1, \$profile,
-                  "name of config file in ../dicom-archive/.loris_mri"
+                  "config file in ../dicom-archive/.loris_mri"
                  ],
                  ["-seriesuid", "string", 1, \$seriesuid, "Only deletes this SeriesUID"
                  ],
@@ -38,6 +40,32 @@ my @opt_table = (
                  ],
                  );
 
+
+my $Help = <<HELP;
+*******************************************************************************
+Minc Deletion
+*******************************************************************************
+
+Author  :   Gregory Luneau
+Date    :   July 2016
+Version :   $versionInfo
+
+
+The program does the following:
+
+Deletes minc files from the web interface by:
+  - Moving the existing files to an archive directory.
+    .mnc .jpg .header .raw_byte.gz
+  - Deleting all related data from 4 database tables.
+    parameter_file, files_qcstatus, feedback_mri_comments, files
+
+HELP
+my $Usage = <<USAGE;
+usage: $0 [options] select|confirm
+       $0 -help to list options
+
+USAGE
+&Getopt::Tabular::SetHelp($Help, $Usage);
 &Getopt::Tabular::GetOptions(\@opt_table, \@ARGV) || exit 1;
 
 ################################################################
@@ -50,6 +78,7 @@ if ($profile && !@Settings::db) {
     exit 2; 
 }
 if (!$ARGV[0] || !$profile) { 
+    print $Help;
     print " ERROR: You must type select or confirm and have an ".
           "existing profile.\n\n";
     exit 3;  

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -54,9 +54,9 @@ Version :   $versionInfo
 
 The program does the following:
 
-Deletes minc files from the web interface by:
+Deletes minc files from Loris by:
   - Moving the existing files to an archive directory.
-    .mnc .jpg .header .raw_byte.gz
+    .mnc .nii .jpg .header .raw_byte.gz
   - Deleting all related data from 4 database tables.
     parameter_file, files_qcstatus, feedback_mri_comments, files
   - Deletes mri_acquisition_dates entry if it is the last file

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -149,7 +149,6 @@ if ($seriesuid) {
   $query .= "(SELECT FileID FROM files WHERE SeriesUID = ?)";
   $sth = $dbh->prepare($query);
   $rvl = $sth->execute($seriesuid);
-print "|$seriesuid|$query|"
 } elsif ($fileid) {
   $query .= "?";
   $sth = $dbh->prepare($query);
@@ -160,7 +159,6 @@ if ($sth->err) {
   die "ERROR! return code:" . $sth->err . " error msg: " . $sth->errstr . "\n";
 }
 
-print "rvl:$rvl\n";
 if (defined $rvl && $rvl == 0) {
   die "Can't rename if there is no value return from: \n" . $query . "\n";
 }
@@ -266,7 +264,7 @@ if ($sth->rows > 0) {
 # If no related files were found, delete the entry
 if (!$sessionfilesfound) {
 
-  my $query = $selORdel . "FROM mri_acquisition_dates as m where m.SessionID=?";
+  my $query = $selORdel . "FROM mri_acquisition_dates where SessionID=?";
   print $query . "\n";
   my $sth = $dbh->prepare($query);
   $sth->execute($sessionid);

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -1,0 +1,123 @@
+#! /usr/bin/perl
+use strict;
+use warnings;
+use Carp;
+use Getopt::Tabular;
+use FileHandle;
+use File::Basename;
+use File::Temp qw/ tempdir /;
+use Data::Dumper;
+use FindBin;
+use Cwd qw/ abs_path /;
+
+# These are the NeuroDB modules to be used
+use lib "$FindBin::Bin";
+use NeuroDB::File;
+use NeuroDB::MRI;
+use NeuroDB::DBI;
+use NeuroDB::Notify;
+use NeuroDB::MRIProcessingUtility;
+
+my $profile   = 'prod';      # this should never be set unless you are in a
+                             # stable production environment
+my $seriesuid = '';
+my $query     = '';
+my $selORdel  = '';
+my @opt_table = (
+                 ["Basic options","section"],
+                 ["-profile     ","string",1, \$profile,
+                  "name of config file in ../dicom-archive/.loris_mri"
+                 ],
+                 ["-seriesuid", "string", 1, \$seriesuid, "Only deletes this SeriesUID"
+                 ],
+                 );
+
+&Getopt::Tabular::GetOptions(\@opt_table, \@ARGV) || exit 1;
+
+################################################################
+################### input option error checking ################
+################################################################
+{ package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
+if ($profile && !@Settings::db) { 
+    print "\n\tERROR: You don't have a configuration file named ". 
+          "'$profile' in:  $ENV{LORIS_CONFIG}/.loris_mri/ \n\n"; 
+    exit 2; 
+}
+if (!$ARGV[0] || !$profile) { 
+    print " ERROR: You must type select or confirm and have an ".
+          "existing profile.\n\n";
+    exit 3;  
+}
+
+if ($ARGV[0] eq "confirm") {
+  $selORdel  = "DELETE ";
+} else {
+  $selORdel  = "SELECT * ";
+}
+
+my $data_dir         = $Settings::data_dir;
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+
+
+sub selORdel {
+  my ($table, $field) = @_;
+  my $where = '';
+
+  if ($table eq "parameter_file") {
+    $where = " WHERE FileID = (SELECT FileID FROM files WHERE SeriesUID = ?)";
+  } else {
+    $where = " WHERE SeriesUID = ?";
+  }
+
+  my $query = $selORdel . "FROM " . $table . $where;
+  print $query . "\n";
+  my $sth = $dbh->prepare($query);
+  $sth->execute($seriesuid);
+
+  if ($selORdel eq "SELECT * ") {
+    while (my $pf = $sth->fetchrow_hashref()) {
+        print "\n$field: " . $pf->{$field};
+    }
+  }
+}
+
+
+# Delete from FS:
+# /data/ibis/data_assembly/858677/V24/mri/native/ibis_858677_V24_dti_005.mnc
+# /data/ibis/data/pic/858677/ibis_858677_V24_dti_005_43606_check.jpg
+# /data/ibis/data/jiv
+
+# get the file names
+$query = "select f.File, pf.`VALUE` from files as f ".
+         "left join parameter_file as pf using (FileID) where ".
+         "pf.ParameterTypeID = (select pt.ParameterTypeID from parameter_type as pt where pt.Name = 'check_pic_filename') and ".
+         "pf.FileID = (SELECT FileID FROM files WHERE SeriesUID = ?)";
+my $sth = $dbh->prepare($query);
+$sth->execute($seriesuid);
+my $f = $sth->fetchrow_hashref();
+
+my @pic_path     = split /_check/, $f->{'VALUE'};
+my $jiv_header   = $pic_path[0] . ".header";
+my $jiv_raw_byte = $pic_path[0] . ".raw_byte.gz";
+
+if ($ARGV[0] eq "confirm") {
+  unlink($data_dir . "/" . $f->{'File'});
+  unlink($data_dir . "/pic/" . $f->{'VALUE'});
+  unlink($data_dir . "/jiv/" . $jiv_header);
+  unlink($data_dir . "/jiv/" . $jiv_raw_byte);
+} else {
+  print $data_dir . "/" . $f->{'File'} . "\n";
+  print $data_dir . "/pic/" . $f->{'VALUE'} . "\n";
+  print $data_dir . "/jiv/" . $jiv_header . "\n";
+  print $data_dir . "/jiv/" . $jiv_raw_byte . "\n";
+}
+
+
+# Delete from DB
+selORdel("parameter_file","Value");
+selORdel("files_qcstatus","QCStatus");
+selORdel("feedback_mri_comments","Comment");
+# selORdel("mri_protocol_violated_scans","ID");  # if there is data here, the mnc will be in the trashbin
+# selORdel("MRICandidateErrors","Reason");       # not applicable to /assembly
+# selORdel("mri_violations_log","LogID");        # "
+selORdel("files","File");

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -79,6 +79,7 @@ my $no_jiv      = 0;           # Should bet set to 1, if jivs should not be
                                # created
 my $valid_study = 0;
 my $newTarchiveLocation = undef;
+my $seriesuid   = '';          # if you want to insert a specific SeriesUID
 my @opt_table = (
                  ["Basic options","section"],
                  ["-profile     ","string",1, \$profile,
@@ -109,6 +110,7 @@ my @opt_table = (
                  ],
                  ["General options", "section"],
                  ["-verbose", "boolean", 1,   \$verbose, "Be verbose."],
+                 ["-seriesuid", "string", 1, \$seriesuid, "Only insert this SeriesUID"],
                  );
 
 my $Help = <<HELP;
@@ -357,7 +359,7 @@ my ($sessionID, $requiresStaging) =
 ################################################################
 my ($ExtractSuffix,$study_dir,$header) = 
     $utility->extractAndParseTarchive(
-		$tarchive, $tarchiveInfo{'SourceLocation'});
+		$tarchive, $tarchiveInfo{'SourceLocation'}, $seriesuid);
 
 
 ################################################################

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -80,6 +80,8 @@ my $no_jiv      = 0;           # Should bet set to 1, if jivs should not be
 my $valid_study = 0;
 my $newTarchiveLocation = undef;
 my $seriesuid   = '';          # if you want to insert a specific SeriesUID
+my $bypass_extra_file_checks=0;# If you need to bypass the extra_file_checks, set to 1.
+my $acquisitionProtocol;       # Specify the acquisition Protocol also bypasses the checks
 my @opt_table = (
                  ["Basic options","section"],
                  ["-profile     ","string",1, \$profile,
@@ -111,6 +113,10 @@ my @opt_table = (
                  ["General options", "section"],
                  ["-verbose", "boolean", 1,   \$verbose, "Be verbose."],
                  ["-seriesuid", "string", 1, \$seriesuid, "Only insert this SeriesUID"],
+                 ["-acquisition_protocol","string", 1, \$acquisitionProtocol,
+                  "Suggest the acquisition protocol to use."],
+                 ["-bypass_extra_file_checks", "boolean", 1, \$bypass_extra_file_checks,
+                  "Bypasses extra_file_checks."],
                  );
 
 my $Help = <<HELP;
@@ -442,12 +448,21 @@ foreach my $minc (@minc_files) {
         $script .= " -noJIV";
     }
  
-    if ($debug) {
-        print $script . "\n";
-    }
-
     if ($verbose) {
         $script .= " -verbose";
+    }
+
+    if ($acquisitionProtocol) {
+        $script .= " -acquisition_protocol " . $acquisitionProtocol;
+    }
+
+    if ($bypass_extra_file_checks) {
+        $script .= " -bypass_extra_file_checks";
+    }
+
+    # Should be kept last
+    if ($debug) {
+        print $script . "\n";
     }
     ###########################################################
     ## Note: system call returns the process ID ###############

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -365,7 +365,7 @@ my ($sessionID, $requiresStaging) =
 ################################################################
 my ($ExtractSuffix,$study_dir,$header) = 
     $utility->extractAndParseTarchive(
-		$tarchive, $tarchiveInfo{'SourceLocation'}, $seriesuid);
+        $tarchive, $tarchiveInfo{'SourceLocation'}, $seriesuid);
 
 
 ################################################################


### PR DESCRIPTION
New script to delete minc file based on SeriesUID

`uploadNeuroDB/minc_deletion.pl -profile prod -seriesuid 1.3.12.2.1107.5.2.32.35045.201507232316035928639007.0.0.0 confirm`

```
./uploadNeuroDB/minc_deletion.pl -help                                                                                              
*******************************************************************************
Minc Deletion 
*******************************************************************************

Author  :   Gregory Luneau
Date    :   July 2016
Version :   1 revision  2


The program does the following:

Deletes minc files from the web interface by:
  - Moving the existing files to an archive directory.
    .mnc .jpg .header .raw_byte.gz
  - Deleting all related data from 4 database tables.
    parameter_file, files_qcstatus, feedback_mri_comments, files


Summary of options:

-- Basic options ---------------------------------------------------------------
   -profile       config file in ../dicom-archive/.loris_mri [default: ""]
   -seriesuid     Only deletes this SeriesUID [default: ""]
   -fileid        Only deletes this FileID [default: ""]

usage: ./uploadNeuroDB/minc_deletion.pl [options] select|confirm
       ./uploadNeuroDB/minc_deletion.pl -help to list options
```

Also, modification of tarchiveLoader so that a unique file can be inserted based on SeriesUID

`uploadNeuroDB/tarchiveLoader -globLocation -profile null_grads -seriesuid 1.3.12.2.1107.5.2.32.35045.201507232316035928639007.0.0.0 DCM_2015-07-23_ImagingUpload-10-38-WiBmLY.tar`
