### PR TITLE
new converter can use dcm2mnc command structure

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -744,10 +744,10 @@ sub dicom_to_minc {
     ############################################################
     #### use some other converter if specified in the config ###
     ############################################################
-    if ($converter ne 'dcm2mnc') {
+    if ($converter !~ /dcm2mnc/) {
         $d2m_cmd .= "$converter $this->{TmpDir}  -notape -compress -stdin";
     } else {
-        $d2m_cmd .= "dcm2mnc -dname '' -stdin -clobber -usecoordinates $this->{TmpDir} ";
+        $d2m_cmd .= "$converter -dname '' -stdin -clobber -usecoordinates $this->{TmpDir} ";
     }
     $d2m_log = `$d2m_cmd`;
 


### PR DESCRIPTION
This change allows project to modify their prod files to use a different version of dcm2mnc and still use the same command format. For example dcm2mnc4ng does match the proper command string now.