### PR TITLE
allow the insertion of violated scans

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -369,7 +369,7 @@ sub computeMd5Hash {
 sub getAcquisitionProtocol {
    
     my $this = shift;
-    my ($file,$subjectIDsref,$tarchiveInfo,$center_name,$minc,$acquisitionProtocol,$force) = @_;
+    my ($file,$subjectIDsref,$tarchiveInfo,$center_name,$minc,$acquisitionProtocol,$bypass_extra_file_checks) = @_;
     my $tarchive_srcloc = $tarchiveInfo->{'SourceLocation'};
     my $upload_id = getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc);
     my $message = '';
@@ -404,7 +404,7 @@ sub getAcquisitionProtocol {
           $acquisitionProtocol, $this->{dbhr}
         );
 
-        if ($force == 0) {
+        if ($bypass_extra_file_checks == 0) {
           @checks = $this->extra_file_checks(
                         $acquisitionProtocolID, 
                         $file, 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -369,7 +369,7 @@ sub computeMd5Hash {
 sub getAcquisitionProtocol {
    
     my $this = shift;
-    my ($file,$subjectIDsref,$tarchiveInfo,$center_name,$minc) = @_;
+    my ($file,$subjectIDsref,$tarchiveInfo,$center_name,$minc,$acquisitionProtocol,$force) = @_;
     my $tarchive_srcloc = $tarchiveInfo->{'SourceLocation'};
     my $upload_id = getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc);
     my $message = '';
@@ -378,17 +378,20 @@ sub getAcquisitionProtocol {
     ## get acquisition protocol (identify the volume) ##########
     ############################################################
 
-    $message = "\n==> verifying acquisition protocol\n";
-    $this->{LOG}->print($message);
-    $this->spool($message, 'N', $upload_id, $notify_detailed);
+    if(!defined($acquisitionProtocol)) {
+      $message = "\n==> verifying acquisition protocol\n";
+      $this->{LOG}->print($message);
+      $this->spool($message, 'N', $upload_id, $notify_detailed);
 
-    my $acquisitionProtocol =  &NeuroDB::MRI::identify_scan_db(
+      $acquisitionProtocol =  &NeuroDB::MRI::identify_scan_db(
                                    $center_name,
                                    $subjectIDsref,
                                    $file, 
                                    $this->{dbhr}, 
                                    $minc
-                               );
+                                 );
+    }
+
     $message = "\nAcquisition protocol is $acquisitionProtocol\n";
     $this->{LOG}->print($message);
     $this->spool($message, 'N', $upload_id, $notify_detailed);
@@ -400,23 +403,26 @@ sub getAcquisitionProtocol {
         &NeuroDB::MRI::scan_type_text_to_id(
           $acquisitionProtocol, $this->{dbhr}
         );
-        @checks = $this->extra_file_checks(
+
+        if ($force == 0) {
+          @checks = $this->extra_file_checks(
                         $acquisitionProtocolID, 
                         $file, 
                         $subjectIDsref->{'CandID'}, 
                         $subjectIDsref->{'visitLabel'},
                         $tarchiveInfo->{'PatientName'}
-                  );
-	$message = "\nWorst error: $checks[0]\n";
-	$this->{LOG}->print($message);
-	# 'warn' and 'exclude' are errors, while 'pass' is not
-	# log in the notification_spool_table the $Verbose flag accordingly
-	if (!($checks[0] eq 'pass')){
-		$this->spool($message, 'Y', $upload_id, $notify_notsummary);
-	}
-	else{
-		$this->spool($message, 'N', $upload_id, $notify_detailed);
-	}
+                    );
+          $message = "\nWorst error: $checks[0]\n";
+	  $this->{LOG}->print($message);
+	  # 'warn' and 'exclude' are errors, while 'pass' is not
+	  # log in the notification_spool_table the $Verbose flag accordingly
+	  if (!($checks[0] eq 'pass')){
+	          $this->spool($message, 'Y', $upload_id, $notify_notsummary);
+	  }
+	  else{
+	          $this->spool($message, 'N', $upload_id, $notify_detailed);
+	  }
+        }
     }
     return ($acquisitionProtocol, $acquisitionProtocolID, @checks);
 }

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -470,7 +470,11 @@ unless ($no_nii) {
 ################################################################
 if ($create_minc_pics) {
     print "\nCreating Minc Pics\n" if $verbose;
-    NeuroDB::MRI::make_minc_pics(\$tarchiveInfo{TarchiveID});
+    NeuroDB::MRI::make_minc_pics(\$dbh,
+                                  $tarchiveInfo{TarchiveID},
+                                  $profile,
+                                  1);
+    # Set minFileID to 1: minFileID $row[1] & maxFileID $row[1]
 }
 
 ################################################################

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -46,6 +46,7 @@ my $no_jiv      = 0;           # Should bet set to 1, if jivs should not be
 my $NewScanner  = 1;           # This should be the default unless you are a 
                                # control freak
 my $xlog        = 0;           # default should be 0
+my $bypass_extra_file_checks=0;# If you need to bypass the extra_file_checks, set to 1.
 my $acquisitionProtocol;       # Specify the acquisition Protocol also bypasses the checks
 my $acquisitionProtocolID;     # acquisition Protocol id
 my @checks      = ();          # Initialise the array
@@ -105,6 +106,9 @@ my @opt_table = (
 
                  ["-create_minc_pics", "boolean", 1, \$create_minc_pics,
                   "Creates the minc pics."],
+
+                 ["-bypass_extra_file_checks", "boolean", 1, \$bypass_extra_file_checks,
+                  "Bypasses extra_file_checks."],
 );
 
 
@@ -395,7 +399,7 @@ $file->setFileData('Caveat', 0);
       \%tarchiveInfo,$center_name,
       $minc,
       $acquisitionProtocol,
-      $force
+      $bypass_extra_file_checks
     );
 
 

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -388,15 +388,16 @@ $file->setFileData('Caveat', 0);
 ################################################################
 ## Get acquisition protocol (identify the volume) ##############
 ################################################################
-if(!defined($acquisitionProtocol)) {
-  ($acquisitionProtocol,$acquisitionProtocolID,@checks)
-    = $utility->getAcquisitionProtocol(
-        $file,
-        $subjectIDsref,
-        \%tarchiveInfo,$center_name,
-        $minc
-      );
-}
+($acquisitionProtocol,$acquisitionProtocolID,@checks)
+  = $utility->getAcquisitionProtocol(
+      $file,
+      $subjectIDsref,
+      \%tarchiveInfo,$center_name,
+      $minc,
+      $acquisitionProtocol,
+      $force
+    );
+
 
 if($acquisitionProtocol =~ /unknown/) {
    $message = "\n  --> The minc file cannot be registered ".

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -46,7 +46,8 @@ my $no_jiv      = 0;           # Should bet set to 1, if jivs should not be
 my $NewScanner  = 1;           # This should be the default unless you are a 
                                # control freak
 my $xlog        = 0;           # default should be 0
-my $acquisitionProtocol = '';  # Specify the acquisition Protocol also bypasses the checks
+my $acquisitionProtocol;       # Specify the acquisition Protocol also bypasses the checks
+my $acquisitionProtocolID;     # acquisition Protocol id
 my @checks      = ();          # Initialise the array
 my $create_minc_pics    = 0;   # Default is 0, set the option to overide.
 my $globArchiveLocation = 0;   # whether to use strict ArchiveLocation strings
@@ -388,7 +389,7 @@ $file->setFileData('Caveat', 0);
 ## Get acquisition protocol (identify the volume) ##############
 ################################################################
 if(!defined($acquisitionProtocol)) {
-  my ($acquisitionProtocol,$acquisitionProtocolID,@checks)
+  ($acquisitionProtocol,$acquisitionProtocolID,@checks)
     = $utility->getAcquisitionProtocol(
         $file,
         $subjectIDsref,
@@ -467,7 +468,7 @@ unless ($no_nii) {
 ############################################################
 ############# Create minc-pics #############################
 ############################################################
-unless ($create_minc_pics)
+if ($create_minc_pics)
 {
 	$where = "WHERE TarchiveSource = ? ";
 	$query = "SELECT Min(FileID) AS min, Max(FileID) as max FROM files ";

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -60,7 +60,7 @@ my ($tarchive,%tarchiveInfo,$minc);
 #### These settings are in a config file (profile) #############
 ################################################################
 my @opt_table = (
-                 ["casic options","section"],
+                 ["Basic options","section"],
 
                  ["-profile","string",1, \$profile, "name of config file". 
                  " in ../dicom-archive/.loris_mri"],
@@ -104,7 +104,7 @@ my @opt_table = (
                   "Suggest the acquisition protocol to use."],
 
                  ["-create_minc_pics", "boolean", 1, \$create_minc_pics,
-                  "Use this if invoked directly witouth tarchiveloader."],
+                  "Creates the minc pics."],
 );
 
 
@@ -465,38 +465,12 @@ unless ($no_nii) {
     NeuroDB::MRI::make_nii(\$file, $data_dir);
 }
 
-############################################################
-############# Create minc-pics #############################
-############################################################
-if ($create_minc_pics)
-{
-	$where = "WHERE TarchiveSource = ? ";
-	$query = "SELECT Min(FileID) AS min, Max(FileID) as max FROM files ";
-	$query = $query . $where;
-	if ($debug) {
-		print $query . "\n";
-	}
-	my $sth = $dbh->prepare($query);
-	$sth->execute($tarchiveInfo{TarchiveID});
-	#$sth->execute();
-	print "TarchiveSource is " . $tarchiveInfo{TarchiveID} . "\n";
-
-	my $script = undef;
-	my $output = undef;
-	my @row = $sth->fetchrow_array();
-	if (@row) {
-		$script = "mass_pic.pl -minFileID $row[1] -maxFileID $row[1] ".
-		             "-profile $profile";
-		print "Running mass_pic as follows : " .$script . "\n";
-		    
-		############################################################
-		## Note: system call returns the process ID ################
-		## To get the actual exit value, shift right by eight as ### 
-		## done below ##############################################
-		############################################################
-		$output = system($script);
-		$output = $output >> 8;
-	}
+################################################################
+################# Create minc-pics #############################
+################################################################
+if ($create_minc_pics) {
+    print "\nCreating Minc Pics\n" if $verbose;
+    NeuroDB::MRI::make_minc_pics(\$tarchiveInfo{TarchiveID});
 }
 
 ################################################################

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -473,7 +473,9 @@ if ($create_minc_pics) {
     NeuroDB::MRI::make_minc_pics(\$dbh,
                                   $tarchiveInfo{TarchiveID},
                                   $profile,
-                                  1);
+                                  1,
+                                  $debug,
+                                  $verbose);
     # Set minFileID to 1: minFileID $row[1] & maxFileID $row[1]
 }
 


### PR DESCRIPTION
This command will insert a violated scan since providing the acquisition protocol bypasses the protocol checks.  If you also need to bypass the extra_file_checks use bypass_extra_file_checks
Please note the -create_minc_pics option as well since it is usually created by the tarchiveloader script.

```
minc_insertion.pl -acquisition_protocol t2w -bypass_extra_file_checks -create_minc_pics -profile prod -globLocation -force  -tarchivePath /Users/xxxproject/dataTransfer/library/2009/DCM_2009-09-25_project_20110214_185904581.tar -mincPath /data/project/data/trashbin/TarLoad-3-34-pVzGC5/xxx0067_703739_v12_20090925_222403_18e1_mri.mnc
```
