### PR TITLE
removed the used only once warning

### DIFF
--- a/batch_uploads_tarchive
+++ b/batch_uploads_tarchive
@@ -1,6 +1,7 @@
 #!/usr/bin/perl -w
 use strict;
 use warnings;
+no warnings 'once';
 
 #####Get config setting#######################################################
 # checking for profile settings

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -3,6 +3,7 @@ use English;
 use Carp;
 use strict;
 use warnings;
+no warnings 'once';
 use Data::Dumper;
 use File::Basename;
 use NeuroDB::File;

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -24,6 +24,7 @@ mri_staging, notification_spool
 
 use strict;
 use warnings;
+no warnings 'once';
 use Carp;
 use Getopt::Tabular;
 use FileHandle;


### PR DESCRIPTION
This is in reference to Redmine 6645.
The changes in this pull request is one way to get rid of the warnings (but the warnings are supposedly not harmful to keep; another recommended solution is to duplicate the entries with that warning; but I opted for option 1)
