### PR TITLE
Proper permission in installation2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
    cd /data/$projectname/bin
    git clone https://github.com/aces/Loris-MRI.git mri
    ```
-
-  Note: Ensure that the permissions on /data/$projectname are such that lorisadmin and the Apache linux user can read/execute
    
 2. Install dicom-archive-tools sub-repo within the mri/ directory (created by the git clone command):
 
@@ -62,7 +60,7 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
 
   If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir/chmod/chown commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/16.0-dev/imaging_install.sh#L90)
 
-  Note: The installer will allow Apache to write to the /data/ directories by adding user lorisadmin to the Apache linux group, and setting Apache group ownership of certain /data/ subdirectories.  
+  Note: The installer will allow Apache to write to the /data/ directories by adding user lorisadmin to the Apache linux group, and setting Apache group ownership of /data/$PROJ subdirectories.  
   To help ensure Apache-writability, verify that your environment file contains the following line:
     ```bash
     umask 0002

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -151,12 +151,10 @@ fi
 # Making lorisadmin part of the apache group
 sudo usermod -a -G $group $USER
 
-#Setting group permissions to apache and group ID for all files/dirs under /data/$PROJ/data
-sudo chgrp $group -R /data/$PROJ/data/
+#Setting group permissions and group ID for all files/dirs under /data/$PROJ/data
 sudo chmod -R g+s /data/$PROJ/data/
 
-#Setting group permissions to apache and group ID for all files/dirs under /data/$PROJ/incoming
-sudo chgrp $group -R /data/incoming/
+#Setting group permissions and group ID for all files/dirs under /data/$PROJ/incoming
 sudo chmod -R g+s /data/incoming/
 echo
 
@@ -167,6 +165,8 @@ echo "Creating MRI config file"
 
 cp $mridir/dicom-archive/profileTemplate $mridir/dicom-archive/.loris_mri/$prodfilename
 sudo chmod 640 $mridir/dicom-archive/.loris_mri/$prodfilename
+#Setting group permissions for all files/dirs /data/$PROJ/ now that the prod file is created
+sudo chgrp $group -R /data/$PROJ/
 
 sed -e "s#project#$PROJ#g" -e "s#/PATH/TO/DATA/location#/data/$PROJ/data#g" -e "s#/PATH/TO/BIN/location#$mridir#g" -e "s#yourname\\\@example.com#$email#g" -e "s#/PATH/TO/get_dicom_info.pl#$mridir/dicom-archive/get_dicom_info.pl#g"  -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" -e "s#/PATH/TO/dicomlib/#/data/$PROJ/data/tarchive#g" $mridir/dicom-archive/profileTemplate > $mridir/dicom-archive/.loris_mri/$prodfilename
 echo "config file is located at $mridir/dicom-archive/.loris_mri/$prodfilename"

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -151,10 +151,10 @@ fi
 # Making lorisadmin part of the apache group
 sudo usermod -a -G $group $USER
 
-#Setting group permissions and group ID for all files/dirs under /data/$PROJ/data
+#Setting group ID for all files/dirs under /data/$PROJ/data
 sudo chmod -R g+s /data/$PROJ/data/
 
-#Setting group permissions and group ID for all files/dirs under /data/$PROJ/incoming
+#Setting group ID for all files/dirs under /data/incoming
 sudo chmod -R g+s /data/incoming/
 echo
 
@@ -165,7 +165,7 @@ echo "Creating MRI config file"
 
 cp $mridir/dicom-archive/profileTemplate $mridir/dicom-archive/.loris_mri/$prodfilename
 sudo chmod 640 $mridir/dicom-archive/.loris_mri/$prodfilename
-#Setting group permissions for all files/dirs /data/$PROJ/ now that the prod file is created
+#Setting group permissions for all files/dirs under /data/$PROJ/ now that the prod file is created
 sudo chgrp $group -R /data/$PROJ/
 
 sed -e "s#project#$PROJ#g" -e "s#/PATH/TO/DATA/location#/data/$PROJ/data#g" -e "s#/PATH/TO/BIN/location#$mridir#g" -e "s#yourname\\\@example.com#$email#g" -e "s#/PATH/TO/get_dicom_info.pl#$mridir/dicom-archive/get_dicom_info.pl#g"  -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" -e "s#/PATH/TO/dicomlib/#/data/$PROJ/data/tarchive#g" $mridir/dicom-archive/profileTemplate > $mridir/dicom-archive/.loris_mri/$prodfilename

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -150,8 +150,9 @@ sudo chmod -R 770 /data/incoming/
 # Making lorisadmin part of the apache group
 sudo usermod -a -G $group $USER
 
-#Setting group permissions for all files/dirs under /data/$PROJ/ now that the prod file is created
+#Setting group permissions for all files/dirs under /data/$PROJ/ and /data/incoming/
 sudo chgrp $group -R /data/$PROJ/
+sudo chgrp $group -R /data/incoming/
 
 #Setting group ID for all files/dirs under /data/$PROJ/data
 sudo chmod -R g+s /data/$PROJ/data/

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -123,16 +123,6 @@ export TMPDIR=/tmp
 echo
 
 ####################################################################################
-######################change permissions ###########################################
-####################################################################################
-#echo "Changing permissions"
-
-sudo chmod -R 770 $mridir/dicom-archive/.loris_mri/
-sudo chmod -R 770 /data/$PROJ/
-sudo chmod -R 770 /data/incoming/
-echo
-
-####################################################################################
 ######################Add the proper Apache group user #############################
 ####################################################################################
 if egrep ^www-data: /etc/group > $LOGFILE 2>&1;
@@ -148,8 +138,32 @@ else
     read -p "Cannot find the apache group name for your installation. Please provide? " group
 fi
 
+#####################################################################################
+##########################change the prod file#######################################
+#####################################################################################
+echo "Creating MRI config file"
+
+cp $mridir/dicom-archive/profileTemplate $mridir/dicom-archive/.loris_mri/$prodfilename
+sudo chmod 640 $mridir/dicom-archive/.loris_mri/$prodfilename
+
+sed -e "s#project#$PROJ#g" -e "s#/PATH/TO/DATA/location#/data/$PROJ/data#g" -e "s#/PATH/TO/BIN/location#$mridir#g" -e "s#yourname\\\@example.com#$email#g" -e "s#/PATH/TO/get_dicom_info.pl#$mridir/dicom-archive/get_dicom_info.pl#g"  -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" -e "s#/PATH/TO/dicomlib/#/data/$PROJ/data/tarchive#g" $mridir/dicom-archive/profileTemplate > $mridir/dicom-archive/.loris_mri/$prodfilename
+echo "config file is located at $mridir/dicom-archive/.loris_mri/$prodfilename"
+echo
+
+####################################################################################
+######################change permissions ###########################################
+####################################################################################
+#echo "Changing permissions"
+
+sudo chmod -R 770 $mridir/dicom-archive/.loris_mri/
+sudo chmod -R 770 /data/$PROJ/
+sudo chmod -R 770 /data/incoming/
+
 # Making lorisadmin part of the apache group
 sudo usermod -a -G $group $USER
+
+#Setting group permissions for all files/dirs under /data/$PROJ/ now that the prod file is created
+sudo chgrp $group -R /data/$PROJ/
 
 #Setting group ID for all files/dirs under /data/$PROJ/data
 sudo chmod -R g+s /data/$PROJ/data/
@@ -158,19 +172,6 @@ sudo chmod -R g+s /data/$PROJ/data/
 sudo chmod -R g+s /data/incoming/
 echo
 
-#####################################################################################
-##########################change the prod file#######################################
-#####################################################################################
-echo "Creating MRI config file"
-
-cp $mridir/dicom-archive/profileTemplate $mridir/dicom-archive/.loris_mri/$prodfilename
-sudo chmod 640 $mridir/dicom-archive/.loris_mri/$prodfilename
-#Setting group permissions for all files/dirs under /data/$PROJ/ now that the prod file is created
-sudo chgrp $group -R /data/$PROJ/
-
-sed -e "s#project#$PROJ#g" -e "s#/PATH/TO/DATA/location#/data/$PROJ/data#g" -e "s#/PATH/TO/BIN/location#$mridir#g" -e "s#yourname\\\@example.com#$email#g" -e "s#/PATH/TO/get_dicom_info.pl#$mridir/dicom-archive/get_dicom_info.pl#g"  -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" -e "s#/PATH/TO/dicomlib/#/data/$PROJ/data/tarchive#g" $mridir/dicom-archive/profileTemplate > $mridir/dicom-archive/.loris_mri/$prodfilename
-echo "config file is located at $mridir/dicom-archive/.loris_mri/$prodfilename"
-echo
 
 ######################################################################
 ###########Modify the config.xml######################################

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -138,18 +138,6 @@ else
     read -p "Cannot find the apache group name for your installation. Please provide? " group
 fi
 
-#####################################################################################
-##########################change the prod file#######################################
-#####################################################################################
-echo "Creating MRI config file"
-
-cp $mridir/dicom-archive/profileTemplate $mridir/dicom-archive/.loris_mri/$prodfilename
-sudo chmod 640 $mridir/dicom-archive/.loris_mri/$prodfilename
-
-sed -e "s#project#$PROJ#g" -e "s#/PATH/TO/DATA/location#/data/$PROJ/data#g" -e "s#/PATH/TO/BIN/location#$mridir#g" -e "s#yourname\\\@example.com#$email#g" -e "s#/PATH/TO/get_dicom_info.pl#$mridir/dicom-archive/get_dicom_info.pl#g"  -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" -e "s#/PATH/TO/dicomlib/#/data/$PROJ/data/tarchive#g" $mridir/dicom-archive/profileTemplate > $mridir/dicom-archive/.loris_mri/$prodfilename
-echo "config file is located at $mridir/dicom-archive/.loris_mri/$prodfilename"
-echo
-
 ####################################################################################
 ######################change permissions ###########################################
 ####################################################################################
@@ -172,6 +160,18 @@ sudo chmod -R g+s /data/$PROJ/data/
 sudo chmod -R g+s /data/incoming/
 echo
 
+#####################################################################################
+##########################change the prod file#######################################
+#####################################################################################
+echo "Creating MRI config file"
+
+cp $mridir/dicom-archive/profileTemplate $mridir/dicom-archive/.loris_mri/$prodfilename
+sudo chmod 640 $mridir/dicom-archive/.loris_mri/$prodfilename
+sudo chgrp $group $mridir/dicom-archive/.loris_mri/$prodfilename
+
+sed -e "s#project#$PROJ#g" -e "s#/PATH/TO/DATA/location#/data/$PROJ/data#g" -e "s#/PATH/TO/BIN/location#$mridir#g" -e "s#yourname\\\@example.com#$email#g" -e "s#/PATH/TO/get_dicom_info.pl#$mridir/dicom-archive/get_dicom_info.pl#g"  -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" -e "s#/PATH/TO/dicomlib/#/data/$PROJ/data/tarchive#g" $mridir/dicom-archive/profileTemplate > $mridir/dicom-archive/.loris_mri/$prodfilename
+echo "config file is located at $mridir/dicom-archive/.loris_mri/$prodfilename"
+echo
 
 ######################################################################
 ###########Modify the config.xml######################################

--- a/imaging_install_MacOSX.sh
+++ b/imaging_install_MacOSX.sh
@@ -84,18 +84,6 @@ else
     read -p "Cannot find the apache group name for your installation. Please provide? " group
 fi
 
-#####################################################################################
-##########################change the prod file#######################################
-#####################################################################################
-echo "Creating MRI config file"
-
-cp $mridir/dicom-archive/profileTemplate $mridir/dicom-archive/.loris_mri/$prodfilename
-sudo chmod 640 $mridir/dicom-archive/.loris_mri/$prodfilename
-
-sed -e "s#project#$PROJ#g" -e "s#/PATH/TO/DATA/location#/data/$PROJ/data#g" -e "s#yourname\\\@example.com#$email#g" -e "s#/PATH/TO/get_dicom_info.pl#$mridir/dicom-archive/get_dicom_info.pl#g"  -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" -e "s#/PATH/TO/dicomlib/#/data/$PROJ/data/tarchive#g" $mridir/dicom-archive/profileTemplate > $mridir/dicom-archive/.loris_mri/$prodfilename
-echo "config file is located at $mridir/dicom-archive/.loris_mri/$prodfilename"
-echo
-
 ####################################################################################
 ######################change permissions ###########################################
 ####################################################################################
@@ -118,3 +106,17 @@ sudo chmod -R g+s /data/$PROJ/data/
 #Setting group ID for all files/dirs under /data/incoming
 sudo chmod -R g+s /data/incoming/
 echo
+
+#####################################################################################
+##########################change the prod file#######################################
+#####################################################################################
+echo "Creating MRI config file"
+
+cp $mridir/dicom-archive/profileTemplate $mridir/dicom-archive/.loris_mri/$prodfilename
+sudo chmod 640 $mridir/dicom-archive/.loris_mri/$prodfilename
+sudo chgrp $group $mridir/dicom-archive/.loris_mri/$prodfilename
+
+sed -e "s#project#$PROJ#g" -e "s#/PATH/TO/DATA/location#/data/$PROJ/data#g" -e "s#yourname\\\@example.com#$email#g" -e "s#/PATH/TO/get_dicom_info.pl#$mridir/dicom-archive/get_dicom_info.pl#g"  -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" -e "s#/PATH/TO/dicomlib/#/data/$PROJ/data/tarchive#g" $mridir/dicom-archive/profileTemplate > $mridir/dicom-archive/.loris_mri/$prodfilename
+echo "config file is located at $mridir/dicom-archive/.loris_mri/$prodfilename"
+echo
+

--- a/imaging_install_MacOSX.sh
+++ b/imaging_install_MacOSX.sh
@@ -93,12 +93,12 @@ sudo chmod -R 770 $mridir/.loris_mri/
 sudo chmod -R 770 /data/$PROJ/
 sudo chmod -R 770 /data/incoming/
 
-
 # Making lorisadmin part of the apache group
 sudo usermod -a -G $group $USER
 
-#Setting group permissions for all files/dirs under /data/$PROJ/ now that the prod file is created
+#Setting group permissions for all files/dirs under /data/$PROJ/ and /data/incoming/
 sudo chgrp $group -R /data/$PROJ/
+sudo chgrp $group -R /data/incoming/
 
 #Setting group ID for all files/dirs under /data/$PROJ/data
 sudo chmod -R g+s /data/$PROJ/data/


### PR DESCRIPTION
I think this is better than adding a note (as I did in this pull request: https://github.com/aces/Loris-MRI/pull/144) because:

1) We change group in the installation on subdirectories of /data/$PROJ/ , so we might as well do it in the installation script as well to be consistent (as opposed to adding a note, and do it on all subdirectories, not just some; more specifically the bin/mri/ path)
2) Most importantly, changes to the group ownership should happen on the prod file after its creation 

NOTE: The note I added in PR144 is more appropriate if I added it after point 4. or 5. (after having run .imaging_install.sh); but in all cases, it might be a good note to keep somewhere in the Wiki perhaps as a way of debugging permission-related errors

***
MAC install updates in this pull request are UNTESTED (Mac OSX no longer supported as of 15.10 but incorporated changes from PR #112, #129, #134 here
***