### PR TITLE
Adding mnc2nii version to the parameter_file table (Redmine #5959 )

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1203,8 +1203,14 @@ sub make_nii {
                     $data_dir . "/" . $nifti;
     system($m2n_cmd);
 
+    #  write mnc2nii version into parameter_file 
+    my $m2nv_cmd = "mnc2nii -version";
+    my $m2n_version = `$m2nv_cmd`;
+    print "$m2nv_cmd \n" . "$m2n_version\n"; 
+
     # update mri table (parameter_file table)
     $file->setParameter('check_nii_filename', $nifti);
+    $file->setParameter('mnc2nii_version', $m2n_version);
 }
 
 =pod


### PR DESCRIPTION
- Running the insertion scripts form the command line now prints:
mnc2nii -version
program: 2.3.01
libminc: 2.3.01
netcdf : 4.3.3 of Feb  9 2016 13:43:57 $
HDF5   : 1.8.15

- Getting the same info from the database can be obtained by running the following mysql query :
mysql> select * from parameter_file as pf where pf.ParameterTypeID=(select pt.ParameterTypeID from parameter_type as pt where pt.Name = 'mnc2nii_version');

- Note that the version of the minc (Value: 2.3.01) is already in the database when querying for: 
where pt.Name = ':minc_version'
