### PR TITLE
Move minc pics creation to MRI.pm

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1216,7 +1216,7 @@ sub make_minc_pics {
     my $output = undef;
     my @row = $sth->fetchrow_array();
     if (@row) {
-        $script = "mass_pic.pl -minFileID $minFileID -maxFileID $row[1] ".
+        $script = "mass_pic.pl -minFileID $row[$minFileID] -maxFileID $row[1] ".
                      "-profile $profile";
         print "Running mass_pic as follows : " .$script . "\n";
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1201,6 +1201,36 @@ sub make_nii {
 }
 
 =pod
+Creates pics associated with MINC files
+=cut
+sub make_minc_pics {
+    my ($dbhr, $TarchiveSource, $profile, $minFileID) = @_;
+    my $where = "WHERE TarchiveSource = ? ";
+    my $query = "SELECT Min(FileID) AS min, Max(FileID) as max FROM files ";
+    $query    = $query . $where;
+    my $sth   = $${dbhr}->prepare($query);
+    $sth->execute($TarchiveSource);
+    print "TarchiveSource is " . $TarchiveSource . "\n";
+
+    my $script = undef;
+    my $output = undef;
+    my @row = $sth->fetchrow_array();
+    if (@row) {
+        $script = "mass_pic.pl -minFileID $minFileID -maxFileID $row[1] ".
+                     "-profile $profile";
+        print "Running mass_pic as follows : " .$script . "\n";
+
+        ############################################################
+        ## Note: system call returns the process ID ################
+        ## To get the actual exit value, shift right by eight as ###
+        ## done below ##############################################
+        ############################################################
+        $output = system($script);
+        $output = $output >> 8;
+    }
+}
+
+=pod
 B<DICOMDateToUnixTimestamp( C<$dicomDate> )>
 Converts a DICOM date field (YYYYMMDD) into a unix timestamp
 Returns: a unix timestamp (integer) or 0 if something went wrong

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1204,10 +1204,13 @@ sub make_nii {
 Creates pics associated with MINC files
 =cut
 sub make_minc_pics {
-    my ($dbhr, $TarchiveSource, $profile, $minFileID) = @_;
+    my ($dbhr, $TarchiveSource, $profile, $minFileID, $debug, $verbose) = @_;
     my $where = "WHERE TarchiveSource = ? ";
     my $query = "SELECT Min(FileID) AS min, Max(FileID) as max FROM files ";
     $query    = $query . $where;
+    if ($debug) {		
+        print $query . "\n";		
+    }
     my $sth   = $${dbhr}->prepare($query);
     $sth->execute($TarchiveSource);
     print "TarchiveSource is " . $TarchiveSource . "\n";
@@ -1218,7 +1221,9 @@ sub make_minc_pics {
     if (@row) {
         $script = "mass_pic.pl -minFileID $row[$minFileID] -maxFileID $row[1] ".
                      "-profile $profile";
-        print "Running mass_pic as follows : " .$script . "\n";
+        if ($verbose) {		
+            $script .= " -verbose";		
+	}
 
         ############################################################
         ## Note: system call returns the process ID ################

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -486,32 +486,13 @@ if ($valid_study) {
     ############################################################
     ############# Create minc-pics #############################
     ############################################################
+    print "\nCreating Minc Pics\n" if $verbose;
+    NeuroDB::MRI::make_minc_pics(\$dbh,
+                                  $tarchiveInfo{TarchiveID},
+                                  $profile,
+                                  0); # minFileID $row[0]
+                                      # maxFileID $row[1]
     
-    $where = "WHERE TarchiveSource =? ";
-    $query = "SELECT Min(FileID) AS min, Max(FileID) as max FROM files ";
-    $query = $query . $where;
-    if ($debug) {
-        print $query . "\n";
-    }
-    my $sth = $dbh->prepare($query);
-    $sth->execute($tarchiveInfo{TarchiveID});
-    my @row = $sth->fetchrow_array();
-    if (@row) {
-        my $script = "mass_pic.pl -minFileID $row[0] -maxFileID $row[1] ".
-                     "-profile $profile ";
-        if ($verbose) {
-            $script .= " -verbose";
-	}
-    ############################################################
-    ## Note: system call returns the process ID ################
-    ## To get the actual exit value, shift right by eight as ### 
-    ## done below ##############################################
-    ############################################################
-        $output = system($script);
-        $output = $output >> 8;
-
-    }
-
     ############################################################
     # spool a new study message ################################
     ############################################################

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -490,8 +490,9 @@ if ($valid_study) {
     NeuroDB::MRI::make_minc_pics(\$dbh,
                                   $tarchiveInfo{TarchiveID},
                                   $profile,
-                                  0); # minFileID $row[0]
-                                      # maxFileID $row[1]
+                                  0, # minFileID $row[0], maxFileID $row[1]
+                                  $debug, 
+                                  $verbose);
     
     ############################################################
     # spool a new study message ################################


### PR DESCRIPTION
This proto function was moved out of tarchiveLoader and into MRI.pm because it will be used also in minc_insertion.pl

`uploadNeuroDB/tarchiveLoader -globLocation -profile prod ../../../../xxx_test/DCM_2016-02-17_ImagingUpload-11-34-xxxxxx.tar`