### PR TITLE
Two minor formatting of error messages as they print

### DIFF
--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -364,7 +364,7 @@ sub PatientNameMatch {
         my $message = "\nThe patient-name $pname read ".
                       "from the DICOM header does not match " .
         	      $this->{'pname'} . 
-                      "from the mri_upload table\n";
+                      " from the mri_upload table\n";
     	$this->spool($message, 'Y', $notify_notsummary);
         return 0; ##return false
     }

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -277,7 +277,7 @@ my $CandMismatchError= $utility->validateCandidate(
 				$subjectIDsref,
 				$tarchiveInfo{'SourceLocation'});
 if (defined $CandMismatchError) {
-    print $CandMismatchError;
+    print "$CandMismatchError \n";
     ##Note that the script will not exit, so that further down
     ##it can be inserted per minc into the MRICandidateErrors
 }


### PR DESCRIPTION
Missing spaces and line breaks between two messages