### PR TITLE
mysql error on duplicate entries

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1219,7 +1219,7 @@ sub computeSNR {
 		    $paramID = $sth->fetchrow_array;
  		}
 
-                $query = "INSERT INTO parameter_file SET Value=?, ".
+                $query = "INSERT IGNORE INTO parameter_file SET Value=?, ".
 			 "FileID=?, ParameterTypeID=?";
                 if ($this->{debug}) {
                     print $query . "\n";
@@ -1231,7 +1231,7 @@ sub computeSNR {
 		$this->spool($message, 'N', $upload_id, $notify_detailed);
             }
             else {
-                $message = "The SNR was not be computed for $base. ".
+                $message = "The SNR can not be computed for $base. ".
                            "Either the getSNRModalities is not defined in your ".
                            "$profile file, or the imaging modality does not ".
                            "support SNR computation. \n";

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1206,13 +1206,15 @@ sub computeSNR {
                 my $file = NeuroDB::File->new($this->{dbhr});
                 $file->loadFile($fileID);
                 $SNR_old = $file->getParameter('SNR');
-                if ((defined ($SNR_old)) && ($SNR_old ne $SNR)) {
-                    $message = "The SNR value will be updated from " .
-                        "$SNR_old to $SNR. \n";
-                    $this->{LOG}->print($message);
-                    $this->spool($message, 'N', $upload_id, $notify_detailed);
+                if ($SNR ne '') {
+                    if (($SNR_old ne '') && ($SNR_old ne $SNR)) {
+                        $message = "The SNR value will be updated from " .
+                            "$SNR_old to $SNR. \n";
+                        $this->{LOG}->print($message);
+                        $this->spool($message, 'N', $upload_id, $notify_detailed);
+                    }
+                    $file->setParameter('SNR', $SNR);
                 }
-                $file->setParameter('SNR', $SNR);
         }
         else {
             $message = "The SNR can not be computed for $base. ".

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1206,7 +1206,7 @@ sub computeSNR {
                 my $file = NeuroDB::File->new($this->{dbhr});
                 $file->loadFile($fileID);
                 $SNR_old = $file->getParameter('SNR');
-                if ((defined ($SNR_old)) && ($SNR_old != $SNR)) {
+                if ((defined ($SNR_old)) && ($SNR_old ne $SNR)) {
                     $message = "The SNR value will be updated from " .
                         "$SNR_old to $SNR. \n";
                     $this->{LOG}->print($message);

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1192,37 +1192,36 @@ sub computeSNR {
     $minc_file_arr->execute($tarchiveID);
 
     while ($row = $minc_file_arr->fetchrow_hashref()) {
-           $filename = $row->{'file'};
-           $fileID = $row->{'FileID'};
-           $base = basename($filename);
-           $fullpath = $data_dir . "/" . $filename;
-           if (defined(&Settings::getSNRModalities)
-                && Settings::getSNRModalities($base)) {
-               $cmd = "noise_estimate --snr $fullpath";
-               $SNR = `$cmd`;
-               $SNR =~ s/\n//g;
-               print "$cmd \n" if ($this->{verbose});
-               print "SNR is: $SNR \n" if ($this->{verbose});
-
-	       my $file = NeuroDB::File->new($this->{dbhr});
-	       $file->loadFile($fileID);
-	       $SNR_old = $file->getParameter('SNR');
-	       if ((defined ($SNR_old)) && ($SNR_old != $SNR)) {
-                   $message = "The SNR value will be updated from " .
-			      "$SNR_old to $SNR. \n";
-		   $this->{LOG}->print($message);
-		   $this->spool($message, 'N', $upload_id, $notify_detailed);
-	       }
-	       $file->setParameter('SNR', $SNR);
-            }
-            else {
-                $message = "The SNR can not be computed for $base. ".
-                           "Either the getSNRModalities is not defined in your ".
-                           "$profile file, or the imaging modality is not ".
-                           "supported by the SNR computation. \n";
-		$this->{LOG}->print($message);
-		$this->spool($message, 'N', $upload_id, $notify_detailed);
-            }
+        $filename = $row->{'file'};
+        $fileID = $row->{'FileID'};
+        $base = basename($filename);
+        $fullpath = $data_dir . "/" . $filename;
+        if (defined(&Settings::getSNRModalities)
+            && Settings::getSNRModalities($base)) {
+                $cmd = "noise_estimate --snr $fullpath";
+                $SNR = `$cmd`;
+                $SNR =~ s/\n//g;
+                print "$cmd \n" if ($this->{verbose});
+                print "SNR is: $SNR \n" if ($this->{verbose});
+                my $file = NeuroDB::File->new($this->{dbhr});
+                $file->loadFile($fileID);
+                $SNR_old = $file->getParameter('SNR');
+                if ((defined ($SNR_old)) && ($SNR_old != $SNR)) {
+                    $message = "The SNR value will be updated from " .
+                        "$SNR_old to $SNR. \n";
+                    $this->{LOG}->print($message);
+                    $this->spool($message, 'N', $upload_id, $notify_detailed);
+                }
+                $file->setParameter('SNR', $SNR);
+        }
+        else {
+            $message = "The SNR can not be computed for $base. ".
+                "Either the getSNRModalities is not defined in your ".
+                "$profile file, or the imaging modality is not ".
+                "supported by the SNR computation. \n";
+            $this->{LOG}->print($message);
+            $this->spool($message, 'N', $upload_id, $notify_detailed);
+        }
     }
 }
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1233,8 +1233,8 @@ sub computeSNR {
             else {
                 $message = "The SNR can not be computed for $base. ".
                            "Either the getSNRModalities is not defined in your ".
-                           "$profile file, or the imaging modality does not ".
-                           "support SNR computation. \n";
+                           "$profile file, or the imaging modality is not ".
+                           "supported by the SNR computation. \n";
 		$this->{LOG}->print($message);
 		$this->spool($message, 'N', $upload_id, $notify_detailed);
             }


### PR DESCRIPTION
This pull request re-computes the SNR basing it on setParameter() and getParameter() built-in functions... It also checks if the new SNR is different from the old/stored SNR (happening in the case where the noise_estimate algorithm from the MincToolKit is updated) and stores the new SNR value.

(The computeSNR() in the 16.1 branch could throw an exception (of duplicate entries; If the file already had an SNR entry, i.e. FileID, ParameterTypeID exists, and we re-run tarchiveLoader for example).

