### PR TITLE
To_log set to 1 for determineScannerID

### DIFF
--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -240,7 +240,7 @@ my ($center_name, $centerID) =
 ################################################################
 ################################################################
 my $scannerID = $utility->determineScannerID(
-                    \%tarchiveInfo,0,
+                    \%tarchiveInfo,1,
                     $centerID,$NewScanner
                 );
 


### PR DESCRIPTION
To be in synch with determinePSC() and determineSubjectID()
which write to log in tarchive_validation and NOT in minc_insertion and tarchiveLoader. I think the same should apply to determineScannerID().