### PR TITLE
Readme and install script tweaks for 17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-This Readme covers release 16.1 of the LORIS Imaging Insertion Pipeline for Ubuntu or CentOS systems
+This Readme covers release 17.0 of the LORIS Imaging Insertion Pipeline for Ubuntu or CentOS systems
 
-This repo accompanies the [LORIS neuroimaging data platform main repo](https://github.com/aces/Loris/releases)</b>, release 16.1.*.<br>
+This repo accompanies the [LORIS neuroimaging data platform main repo](https://github.com/aces/Loris/releases)</b>, release 17.0.*.<br>
 For documentation and detailed setup information, please see the [LORIS wiki](https://github.com/aces/Loris/wiki/Imaging-Database)</b>.
 
 This repo can be installed on either the same VM as the main LORIS codebase, or on a different machine such as a designated fileserver where large imaging filesets are to be stored. 
@@ -13,6 +13,7 @@ This repo can be installed on either the same VM as the main LORIS codebase, or 
 On <u>Ubuntu</u>, DICOM toolkit will be installed by the imaging install script (step 4 below). This script will _apt-get install dcmtk_.   
 
 For <u>CentOS</u>: Dependency installation notes are included in the [LORIS wiki](https://github.com/aces/Loris/wiki/Imaging-Database) Imaging Setup page, Section 1 (installing codebase)</b>.
+As of the release date, this includes a transcript for [CentOS installation](https://github.com/aces/Loris/wiki/CentOS-Imaging-installation-transcript) and notes on dependencies including [DICOM toolkit](https://github.com/aces/Loris/wiki/CentOS-Imaging-installation-transcript#7-install-dicom-toolkit).
 
 The following installation should be run by the $lorisadmin user. sudo permission is required.
 See [aces/Loris README.md](https://github.com/aces/loris) for further information and Loris installation information. 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
 
 3. Install MINC toolkit from http://bic-mni.github.io/ 
 
-   Download the pre-compiled package for your operating system.  Install required dependencies such as _imagemagick. Then install your MINC toolkit package: 
+   Download the pre-compiled package for your operating system.  Install required dependencies such as _imagemagick_. Then install your MINC toolkit package: 
 
    ```bash
    run sudo dpkg i minc-toolkit<version>.deb

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repo can be installed on either the same VM as the main LORIS codebase, or 
 
 # System Requirements
  * Perl
- * DICOM toolkit (step 4)
  * MINC toolkit (step 3)
+ * DICOM toolkit (step 4)
 
 On <u>Ubuntu</u>, DICOM toolkit will be installed by the imaging install script (step 4 below). This script will _apt-get install dcmtk_.   
 
@@ -46,7 +46,7 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
    run sudo dpkg i minc-toolkit<version>.deb
    ```
 
-  Then source the environment in /opt/minc/minc-toolkit-config.sh for bash, or /opt/minc/minc-toolkit-config.csh for tcsh.
+  Then source the MINC toolkit environment by running (for bash) `source /opt/minc/minc-toolkit-config.sh` or (tcsh) `source /opt/minc/minc-toolkit-config.csh`.
 
 4. Run installer to install DICOM toolkit, Perl libraries, configure environment, and setup directories:
 
@@ -67,7 +67,7 @@ See [aces/Loris README.md](https://github.com/aces/loris) for further informatio
  * What prod file name would you like to use? default: prod  [leave blank]
  * Enter the list of Site names (space separated) site1 site2
 
-  If the imaging install script reports errors in creating directories (due to /data/ mount permissions), manually execute mkdir/chmod/chown commands starting at [imaging_install.sh:L90](https://github.com/aces/Loris-MRI/blob/master/imaging_install.sh#L90)
+  If the imaging install script reports errors in creating directories (due to /data/ mount permissions), review and manually execute `mkdir/chmod/chown` commands starting at [imaging_install.sh:L83](https://github.com/aces/Loris-MRI/blob/master/imaging_install.sh#L83)
 
   Note: The installer will allow Apache to write to the /data/ directories by adding user lorisadmin to the Apache linux group.  To ensure this change takes effect, log out and log back into your terminal session before running the imaging pipeline.
 The installer will also set Apache group ownership of certain /data/ subdirectories.  

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -80,7 +80,7 @@ echo
 #################################################################################################
 ############################INSTALL THE PERL LIBRARIES###########################################
 #################################################################################################
-echo "Installing the perl libraries...THis will take a few minutes..."
+echo "Installing the perl libraries...This will take a few minutes..."
 #echo $rootpass | sudo perl -MCPAN -e shell
 sudo -S cpan install Math::Round
 #echo $rootpass | sudo -S cpan install Bundle::CPAN

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -68,10 +68,11 @@ mridir=`pwd`
 ################################################################################################
 #####################################DICOM TOOLKIT##############################################
 ################################################################################################
-if [ ! -f "$APTGETCHECK" ]; then
-    echo "Please see Loris-MRI Readme for notes on how to install the DICOM TOOLKIT if your OS is not Ubuntu. Further information on installing dependencies is also included in the Loris GitHub Wiki Imaging Database page"
+os_distro=$(lsb_release -si)
+if [ $os_distro  = "CentOS" ]; then
+    echo "You are running CentOS. Please also see Loris-MRI Readme for notes and links to further documentation in our main GitHub Wiki on how to install the DICOM Toolkit and other required dependencies."
 else
-    echo "Installing dicom toolkit (May prompt for sudo password)"
+    echo "Installing DICOM Toolkit (May prompt for sudo password)"
     sudo -S apt-get install dcmtk
 fi
 echo

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -68,8 +68,12 @@ mridir=`pwd`
 ################################################################################################
 #####################################DICOM TOOLKIT##############################################
 ################################################################################################
-echo "Installing dicom toolkit (May prompt for sudo password)"
-sudo -S apt-get install dcmtk
+if [ ! -f "$APTGETCHECK" ]; then
+    echo "Please see Loris-MRI Readme for notes on how to install the DICOM TOOLKIT if your OS is not Ubuntu. Further information on installing dependencies is also included in the Loris GitHub Wiki Imaging Database page"
+else
+    echo "Installing dicom toolkit (May prompt for sudo password)"
+    sudo -S apt-get install dcmtk
+fi
 echo
 
 #################################################################################################

--- a/imaging_install_MacOSX.sh
+++ b/imaging_install_MacOSX.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
 ##################################
+# This script is not actively maintained. 
+# and has not been supported since 15.10
+##################################
+echo "NOTE: Mac is no longer supported as of 15.10."
+echo "This script is not actively maintained."
+echo 
+
+##################################
 ###WHAT THIS SCRIPT WILL NOT DO###
 #1)It doesn't set up the SGE
 #2)It doesn't fetch the CIVET stuff   TODO:Get the CIVET stuff from somewhere and place somewhere


### PR DESCRIPTION
Updating version numbers, plus: 

Loris-MRI Readme updates: 
* more explicit mention for CentOS of how DICOM toolkit can be installed

imaging_install.sh:
* will no longer attempt to install (via apt-get) DICOM toolkit when run on CentOS
As a result, this script should no longer abort when trying to apt-get install the DICOM toolkit, leaving the user to manually execute the rest of the code.  For the first time, CentOS installs will actually run the last half of the script. 

Mac install script:  added a note that it's not supported