### PR TITLE
Uncommented an exit statement that was commented by mistake...

### DIFF
--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -371,7 +371,7 @@ if (!$unique) {
     $notifier->spool('tarchive validation', $message, 0,
                     'minc_insertion.pl', $upload_id, 'Y', 
                     $notify_notsummary);
-#    exit 8; 
+    exit 8; 
 } 
 
 ################################################################


### PR DESCRIPTION
An exit statement was commented by mistake during testing of a pull request in October 2015... Commenting this exit prevailed from quitting the minc_insertion.pl pipeline in case the file was already registered therefore allowing to insert the same file several times in the files table. 

This bug has been present since October 2015. OOOOOOOPSIE 
