### PR TITLE
Removal of the deprecated array definition warning in mincpik: Redmine 11164

### DIFF
--- a/uploadNeuroDB/bin/mincpik
+++ b/uploadNeuroDB/bin/mincpik
@@ -432,7 +432,7 @@ if(defined($opt{'anot_bar'})){
    $bw = int($bh/10);
    
    # get range if not defined
-   if(!defined(@{$opt{'image_range'}[0]})){
+   if(!(@{$opt{'image_range'}[0]})){
       print STDERR "Getting image range\n" if $opt{'verbose'};
       
       @buf = split(/\n/, `mincstats -min -max -quiet $infile`);


### PR DESCRIPTION
this is on behalf of @gluneau 
