### PR TITLE
Loris-MRI configurations moved to the front end from the $profile file: Redmine 8893

### DIFF
--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -86,9 +86,14 @@ if (!$DTIPrepVersion) {
 }
 
 
+# Establish database connection
+my  $dbh    =   &DB::DBI::connect_to_db(@Settings::db);
+print LOG "\n==> Successfully connected to database \n";
 
 # Needed for log file
-my  $data_dir    =  $Settings::data_dir;
+my $data_dir = NeuroDB::DBI::getConfigSetting(
+                    $dbh,'mincPath'
+                    );
 my  $log_dir     =  "$data_dir/logs/DTIPrep_register";
 system("mkdir -p -m 770 $log_dir") unless (-e $log_dir);
 my  ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)=localtime(time);
@@ -101,13 +106,10 @@ print LOG "Log file, $date\n\n";
 
 # Fetch DTIPrep step during which a secondary QCed file will be created (for example: noMC for a file without motion correction). 
 # This is set as a config option in the config file.
-my  $QCed2_step =  $Settings::QCed2_step;
+my  $QCed2_step = NeuroDB::DBI::getConfigSetting(
+                    $dbh,'QCed2_step'
+                    );
 
-
-
-# Establish database connection
-my  $dbh    =   &DB::DBI::connect_to_db(@Settings::db);
-print LOG "\n==> Successfully connected to database \n";
 
 print LOG "\n==> DTI output directory is: $DTIPrep_subdir\n";
 

--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -60,7 +60,7 @@ GetOptions(\@args_table, \@ARGV, \@args) || exit 1;
 
 # input option error checking
 { package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
-if  ($profile && !defined @Settings::db) {
+if  ($profile && !@Settings::db) {
     print "\n\tERROR: You don't have a configuration file named '$profile' in:  $ENV{LORIS_CONFIG}/.loris_mri/ \n\n"; 
     exit 33;
 }
@@ -88,11 +88,10 @@ if (!$DTIPrepVersion) {
 
 # Establish database connection
 my  $dbh    =   &DB::DBI::connect_to_db(@Settings::db);
-print LOG "\n==> Successfully connected to database \n";
 
 # Needed for log file
-my $data_dir = NeuroDB::DBI::getConfigSetting(
-                    $dbh,'dataDirBasepath'
+my $data_dir = &DB::DBI::getConfigSetting(
+                    \$dbh,'dataDirBasepath'
                     );
 my  $log_dir     =  "$data_dir/logs/DTIPrep_register";
 system("mkdir -p -m 770 $log_dir") unless (-e $log_dir);
@@ -100,14 +99,15 @@ my  ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)=localtime(time);
 my  $date        =  sprintf("%4d-%02d-%02d_%02d:%02d:%02d",$year+1900,$mon+1,$mday,$hour,$min,$sec);
 my  $log         =  "$log_dir/DTIregister$date.log";
 open(LOG,">>$log");
+print LOG "\n==> Successfully connected to database \n";
 print LOG "Log file, $date\n\n";
 
 
 
 # Fetch DTIPrep step during which a secondary QCed file will be created (for example: noMC for a file without motion correction). 
 # This is set as a config option in the config file.
-my  $QCed2_step = NeuroDB::DBI::getConfigSetting(
-                    $dbh,'QCed2_step'
+my  $QCed2_step = &DB::DBI::getConfigSetting(
+                    \$dbh,'QCed2_step'
                     );
 
 

--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -92,7 +92,7 @@ print LOG "\n==> Successfully connected to database \n";
 
 # Needed for log file
 my $data_dir = NeuroDB::DBI::getConfigSetting(
-                    $dbh,'mincPath'
+                    $dbh,'dataDirBasepath'
                     );
 my  $log_dir     =  "$data_dir/logs/DTIPrep_register";
 system("mkdir -p -m 770 $log_dir") unless (-e $log_dir);

--- a/DTIPrep/DTIPrep_pipeline.pl
+++ b/DTIPrep/DTIPrep_pipeline.pl
@@ -85,26 +85,26 @@ my  $dbh    =   &DB::DBI::connect_to_db(@Settings::db);
 
 # These settings are in the ConfigSettings table
 my  $data_dir       =   &DB::DBI::getConfigSetting(
-                        $dbh,'dataDirBasepath'
+                        \$dbh,'dataDirBasepath'
                         );
 my  $t1_scan_type   =   &DB::DBI::getConfigSetting(
-                        $dbh,'t1_scan_type'
+                        \$dbh,'t1_scan_type'
                         );
 my  $DTI_volumes    =   &DB::DBI::getConfigSetting(
-                        $dbh,'DTI_volumes'
+                        \$dbh,'DTI_volumes'
                         );
 my  $reject_thresh  =   &DB::DBI::getConfigSetting(
-                        $dbh,'reject_thresh'
+                        \$dbh,'reject_thresh'
                         );
 my  $niak_path      =   &DB::DBI::getConfigSetting(
-                        $dbh,'niak_path'
+                        \$dbh,'niak_path'
                         );
 my  $QCed2_step     =   &DB::DBI::getConfigSetting(
-                        $dbh,'QCed2_step'
+                        \$dbh,'QCed2_step'
                         );
 
 my  $site           =   &DB::DBI::getConfigSetting(
-                        $dbh,'prefix'
+                        \$dbh,'prefix'
                         );
 
 # Needed for log file

--- a/DTIPrep/DTIPrep_pipeline.pl
+++ b/DTIPrep/DTIPrep_pipeline.pl
@@ -83,14 +83,29 @@ if (!$DTIPrepVersion) {
 
 
 
-# These settings are in a config file (profile)
-my  $data_dir       =   $Settings::data_dir;
-my  $t1_scan_type   =   $Settings::t1_scan_type;
-my  $DTI_volumes    =   $Settings::DTI_volumes;
-my  $reject_thresh  =   $Settings::reject_thresh;
-my  $niak_path      =   $Settings::niak_path;
-my  $QCed2_step     =   $Settings::QCed2_step;
+# These settings are in the ConfigSettings table
+my  $data_dir       =   NeuroDB::DBI::getConfigSetting(
+                        \$dbh,'mincPath'
+                        );
+my  $t1_scan_type   =   NeuroDB::DBI::getConfigSetting(
+                        \$dbh,'t1_scan_type'
+                        );
+my  $DTI_volumes    =   NeuroDB::DBI::getConfigSetting(
+                        \$dbh,'DTI_volumes'
+                        );
+my  $reject_thresh  =   NeuroDB::DBI::getConfigSetting(
+                        \$dbh,'reject_thresh'
+                        );
+my  $niak_path      =   NeuroDB::DBI::getConfigSetting(
+                        \$dbh,'niak_path'
+                        );
+my  $QCed2_step     =   NeuroDB::DBI::getConfigSetting(
+                        \$dbh,'QCed2_step'
+                        );
 
+my  $site           =   NeuroDB::DBI::getConfigSetting(
+                        \$dbh,'prefix'
+                        );
 
 # Needed for log file
 my  ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)   =   localtime(time);
@@ -121,9 +136,9 @@ foreach my $nativedir (@nativedirs)   {
 
     
     #######################
-    ####### Step 1: #######  Get Site, SubjectID and Visit label
+    ####### Step 1: #######  Get SubjectID and Visit label
     #######################
-    my ($site, $subjID, $visit) = &getIdentifiers($nativedir);
+    my ($subjID, $visit) = &getIdentifiers($nativedir);
     next if ((!$site) || (!$subjID) || !($visit));
 
 
@@ -269,28 +284,28 @@ sub identify_tool_version {
 
 
 =pod
-Fetches site, candID and visit label from the native directory of the dataset to process.
+Fetches candID and visit label from the native directory of the dataset to process.
 Input:  - $nativedir: native directory of the dataset to process
 Output: - undef if could not find the site, candID or visit label.
-        - $site, $candID and $visit_label informations if they were found.
+        - $candID and $visit_label informations if they were found.
 Relevant information will also be printed in the log file.
 =cut
 sub getIdentifiers {
     my ($nativedir) = @_;    
 
-    my ($site, $subjID, $visit) = &Settings::get_DTI_Site_CandID_Visit($nativedir); 
-    if ((!$site) || (!$subjID) || (!$visit))  {
+    my ($subjID, $visit) = &Settings::get_DTI_CandID_Visit($nativedir); 
+    if ((!$subjID) || (!$visit))  {
         print LOG "\n#############################\n";
-        print LOG "WARNING:Cannot find site,ID,visit for $nativedir\n";
+        print LOG "WARNING:Cannot find ID,visit for $nativedir\n";
         print LOG "\n#############################\n";
         return undef;
     }else{
         print LOG "\n################################\n";
-        print LOG "SITE". "\t" . "subID" . "\t" . "visit". "\n";
-        print LOG $site . "\t" . $subjID . "\t" . $visit . "\n";
+        print LOG "subID" . "\t" . "visit". "\n";
+        print LOG $subjID . "\t" . $visit . "\n";
         print LOG "--------------------------------\n";
-        print     $site . "\t" . $subjID . "\t" . $visit . "\n";
-        return ($site, $subjID, $visit);
+        print     $subjID . "\t" . $visit . "\n";
+        return ($subjID, $visit);
     }
 }
 

--- a/DTIPrep/DTIPrep_pipeline.pl
+++ b/DTIPrep/DTIPrep_pipeline.pl
@@ -85,7 +85,7 @@ if (!$DTIPrepVersion) {
 
 # These settings are in the ConfigSettings table
 my  $data_dir       =   NeuroDB::DBI::getConfigSetting(
-                        \$dbh,'mincPath'
+                        \$dbh,'dataDirBasepath'
                         );
 my  $t1_scan_type   =   NeuroDB::DBI::getConfigSetting(
                         \$dbh,'t1_scan_type'

--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -73,7 +73,7 @@ if (!$profile ) {
 ################################################################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'mincPath'
+                    $dbh,'dataDirBasepath'
                     );
 my $bin_dir = &NeuroDB::DBI::getConfigSetting(
                     $dbh,'MRICodePath'

--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -73,16 +73,16 @@ if (!$profile ) {
 ################################################################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'dataDirBasepath'
+                    \$dbh,'dataDirBasepath'
                     );
 my $bin_dir = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'MRICodePath'
+                    \$dbh,'MRICodePath'
                     );
 my $is_qsub = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'is_qsub'
+                    \$dbh,'is_qsub'
                     );
 my $mail_user = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'mail_user'
+                    \$dbh,'mail_user'
                     );
 
 my ($stdoutbase, $stderrbase) = ("$data_dir/batch_output/imuploadstdout.log", 

--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -72,9 +72,21 @@ if (!$profile ) {
 ################ Establish database connection #################
 ################################################################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+my $data_dir = &NeuroDB::DBI::getConfigSetting(
+                    $dbh,'mincPath'
+                    );
+my $bin_dir = &NeuroDB::DBI::getConfigSetting(
+                    $dbh,'MRICodePath'
+                    );
+my $is_qsub = &NeuroDB::DBI::getConfigSetting(
+                    $dbh,'is_qsub'
+                    );
+my $mail_user = &NeuroDB::DBI::getConfigSetting(
+                    $dbh,'mail_user'
+                    );
 
-my ($stdoutbase, $stderrbase) = ("$Settings::data_dir/batch_output/imuploadstdout.log", 
-				 "$Settings::data_dir/batch_output/imuploadstderr.log");
+my ($stdoutbase, $stderrbase) = ("$data_dir/batch_output/imuploadstdout.log", 
+				 "$data_dir/batch_output/imuploadstderr.log");
 
 
 while($_ = $ARGV[0], /^-/) {
@@ -169,14 +181,14 @@ foreach my $input (@resultsarray)
     ## this is where the subprocesses are created...  should basically run processor script with study directory as argument.
     ## processor will do all the real magic
 
-    my $command = "$Settings::bin_dir/uploadNeuroDB/imaging_upload_file.pl "
+    my $command = "$bin_dir/uploadNeuroDB/imaging_upload_file.pl "
 		. "-profile $profile -upload_id $upload_id $fullpath";
     if ($verbose) {
         $command .= " -verbose";
     }
 
     ##if qsub is enabled use it
-    if ($Settings::is_qsub) {
+    if ($is_qsub) {
 	     open QSUB, "| qsub -V -e $stderr -o $stdout -N process_imageuploader_${counter}";
     	 print QSUB $command;
     	 close QSUB;
@@ -189,7 +201,7 @@ foreach my $input (@resultsarray)
 
      push @submitted, $input;
 }
-open MAIL, "|mail $Settings::mail_user";
+open MAIL, "|mail $mail_user";
 print MAIL "Subject: BATCH_UPLOADS_IMAGEUPLOADER: ".scalar(@submitted)." studies submitted.\n";
 print MAIL join("\n", @submitted)."\n";
 close MAIL;

--- a/batch_uploads_tarchive
+++ b/batch_uploads_tarchive
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 no warnings 'once';
+use NeuroDB::DBI;
 
 #####Get config setting#######################################################
 # checking for profile settings
@@ -19,16 +20,16 @@ print "\nSuccessfully connected to database \n";
 # define project space
 my ($debug, $verbose) = (0,0);
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'dataDirBasepath'
+                    \$dbh,'dataDirBasepath'
                     );
-my $tarchiveLibraryir = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'tarchiveLibraryDir'
+my $tarchiveLibraryDir = &NeuroDB::DBI::getConfigSetting(
+                    \$dbh,'tarchiveLibraryDir'
                     );
 my $is_qsub = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'is_qsub'
+                    \$dbh,'is_qsub'
                     );
 my $mail_user = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'mail_user'
+                    \$dbh,'mail_user'
                     );
 
 my ($stdoutbase, $stderrbase) = ("$data_dir/batch_output/tarstdout.log", "$data_dir/batch_output/tarstderr.log");

--- a/batch_uploads_tarchive
+++ b/batch_uploads_tarchive
@@ -19,7 +19,7 @@ print "\nSuccessfully connected to database \n";
 # define project space
 my ($debug, $verbose) = (0,0);
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'mincPath'
+                    $dbh,'dataDirBasepath'
                     );
 my $tarchiveLibraryir = &NeuroDB::DBI::getConfigSetting(
                     $dbh,'tarchiveLibraryDir'

--- a/batch_uploads_tarchive
+++ b/batch_uploads_tarchive
@@ -9,9 +9,29 @@ if(-f "$ENV{LORIS_CONFIG}/.loris_mri/prod") {
     { package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/prod" }
 } ##Possibly the script can exit if the prod doesn't exist
 #######################################################################################
+
+################################################################
+######### Establish database connection ########################
+################################################################
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+print "\nSuccessfully connected to database \n";
+
 # define project space
 my ($debug, $verbose) = (0,0);
-my ($stdoutbase, $stderrbase) = ("$Settings::data_dir/batch_output/tarstdout.log", "$Settings::data_dir/batch_output/tarstderr.log");
+my $data_dir = &NeuroDB::DBI::getConfigSetting(
+                    $dbh,'mincPath'
+                    );
+my $tarchiveLibraryir = &NeuroDB::DBI::getConfigSetting(
+                    $dbh,'tarchiveLibraryDir'
+                    );
+my $is_qsub = &NeuroDB::DBI::getConfigSetting(
+                    $dbh,'is_qsub'
+                    );
+my $mail_user = &NeuroDB::DBI::getConfigSetting(
+                    $dbh,'mail_user'
+                    );
+
+my ($stdoutbase, $stderrbase) = ("$data_dir/batch_output/tarstdout.log", "$data_dir/batch_output/tarstderr.log");
 my $stdout = '';
 my $stderr = '';
 while($_ = $ARGV[0], /^-/) {
@@ -47,10 +67,10 @@ foreach my $input (@inputs)
     ## processor will do all the real magic
 
     $input =~ s/\t/ /;
-    $input =~ s/$Settings::tarchiveLibraryDir//;
-    my $command = "tarchiveLoader -globLocation -profile prod $Settings::tarchiveLibraryDir/$input";
+    $input =~ s/$tarchiveLibraryDir//;
+    my $command = "tarchiveLoader -globLocation -profile prod $tarchiveLibraryDir/$input";
     ##if qsub is enabled use it
-    if ($Settings::is_qsub) {
+    if ($is_qsub) {
 	     open QSUB, "| qsub -V -e $stderr -o $stdout -N process_tarchive_${counter}";
     	 print QSUB $command;
     	 close QSUB;
@@ -62,7 +82,7 @@ foreach my $input (@inputs)
 
      push @submitted, $input;
 }
-open MAIL, "|mail $Settings::mail_user";
+open MAIL, "|mail $mail_user";
 print MAIL "Subject: BATCH_UPLOADS_TARCHIVE: ".scalar(@submitted)." studies submitted.\n";
 print MAIL join("\n", @submitted)."\n";
 close MAIL;

--- a/database_files_update.pl
+++ b/database_files_update.pl
@@ -40,7 +40,7 @@ my $dbh     =   &NeuroDB::DBI::connect_to_db(@Settings::db);
 
 # these settings are in the database and can be set in the Configuration module of LORIS
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'dataDirBasepath'
+                    \$dbh,'dataDirBasepath'
                     );
 
 # Needed for log file

--- a/database_files_update.pl
+++ b/database_files_update.pl
@@ -26,7 +26,7 @@ GetOptions(\@args_table, \@ARGV, \@args)    ||  exit 1;
 
 # Input option error checking
 { package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
-if  ($profile && !defined @Settings::db)    { 
+if  ($profile && !@Settings::db)    { 
         print "\n\tERROR: You don't have a configuration file named '$profile' in:  $ENV{LORIS_CONFIG}/.loris_mri/ \n\n"; 
             exit 33; 
 }
@@ -37,7 +37,6 @@ if  (!$profile) {
 
 # Establish database connection
 my $dbh     =   &NeuroDB::DBI::connect_to_db(@Settings::db);
-print LOG "\n==> Successfully connected to database \n";
 
 # these settings are in the database and can be set in the Configuration module of LORIS
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
@@ -50,6 +49,7 @@ my  ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)    =   localtime(time)
 my  $date       =   sprintf("%4d-%02d-%02d_%02d:%02d:%02d",$year+1900,$mon+1,$mday,$hour,$min,$sec);
 my  $log        =   "$log_dir/replacePATH_$date.log";
 open (LOG,">>$log");
+print LOG "\n==> Successfully connected to database \n";
 print LOG "Log file, $date\n\n";
 
 

--- a/database_files_update.pl
+++ b/database_files_update.pl
@@ -35,8 +35,14 @@ if  (!$profile) {
             exit 33;
 }
 
-# hese settings are in the config file (profile)
-my  $data_dir   =   $Settings::data_dir;
+# Establish database connection
+my $dbh     =   &NeuroDB::DBI::connect_to_db(@Settings::db);
+print LOG "\n==> Successfully connected to database \n";
+
+# these settings are in the database and can be set in the Configuration module of LORIS
+my $data_dir = &NeuroDB::DBI::getConfigSetting(
+                    $dbh,'mincPath'
+                    );
 
 # Needed for log file
 my  $log_dir    =   "$data_dir/logs";
@@ -46,9 +52,6 @@ my  $log        =   "$log_dir/replacePATH_$date.log";
 open (LOG,">>$log");
 print LOG "Log file, $date\n\n";
 
-# Establish database connection
-my $dbh     =   &NeuroDB::DBI::connect_to_db(@Settings::db);
-print LOG "\n==> Successfully connected to database \n";
 
 
 #### Updating minc location in files table ####

--- a/database_files_update.pl
+++ b/database_files_update.pl
@@ -41,7 +41,7 @@ print LOG "\n==> Successfully connected to database \n";
 
 # these settings are in the database and can be set in the Configuration module of LORIS
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'mincPath'
+                    $dbh,'dataDirBasepath'
                     );
 
 # Needed for log file

--- a/find_uploads_tarchive
+++ b/find_uploads_tarchive
@@ -59,9 +59,15 @@ if(-f "$ENV{LORIS_CONFIG}/.loris_mri/$profile") {
 
 my $dbh = NeuroDB::DBI::connect_to_db(@Settings::db);
 
-# get path to tarchiveLibraryDir from config file
-my $tarchiveLibraryDir = $Settings::tarchiveLibraryDir;
+# get path to tarchiveLibraryDir from the database
+my $tarchiveLibraryDir = NeuroDB::DBI::getConfigSetting(
+                            $dbh,'tarchiveLibraryDir'
+                            );
 $tarchiveLibraryDir    =~ s/\/$//g;
+
+my $mail_user = NeuroDB::DBI::getConfigSetting(
+                    $dbh,'mail_user'
+                    );
 
 if($noUpdateSwitch == 1) { 
     $update=0; 
@@ -117,7 +123,7 @@ if($sth->rows > 0) {
 
 # print out which ones were queued
 if($update && (scalar(@studies) > 0)) {
-    open MAIL, "|mail $Settings::mail_user";
+    open MAIL, "|mail $mail_user";
     print MAIL "Subject: FIND_UPLOADS_TARCHIVE: ".scalar(@studies)." studies found.\n";
     foreach my $study (@studies) {
         print MAIL "$study->[0]    $study->[1]\n";

--- a/find_uploads_tarchive
+++ b/find_uploads_tarchive
@@ -57,15 +57,15 @@ if(-f "$ENV{LORIS_CONFIG}/.loris_mri/$profile") {
  }
 #######################################################################################
 
-my $dbh = NeuroDB::DBI::connect_to_db(@Settings::db);
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 
 # get path to tarchiveLibraryDir from the database
-my $tarchiveLibraryDir = NeuroDB::DBI::getConfigSetting(
+my $tarchiveLibraryDir = &NeuroDB::DBI::getConfigSetting(
                             $dbh,'tarchiveLibraryDir'
                             );
 $tarchiveLibraryDir    =~ s/\/$//g;
 
-my $mail_user = NeuroDB::DBI::getConfigSetting(
+my $mail_user = &NeuroDB::DBI::getConfigSetting(
                     $dbh,'mail_user'
                     );
 

--- a/find_uploads_tarchive
+++ b/find_uploads_tarchive
@@ -61,12 +61,12 @@ my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 
 # get path to tarchiveLibraryDir from the database
 my $tarchiveLibraryDir = &NeuroDB::DBI::getConfigSetting(
-                            $dbh,'tarchiveLibraryDir'
+                            \$dbh,'tarchiveLibraryDir'
                             );
 $tarchiveLibraryDir    =~ s/\/$//g;
 
 my $mail_user = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'mail_user'
+                    \$dbh,'mail_user'
                     );
 
 if($noUpdateSwitch == 1) { 

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -55,7 +55,6 @@ read -p "What is the MySQL password? " mysqlpass; echo
 stty echo
 read -p "What is the Linux user which the installation will be based on? " USER
 read -p "What is the project name? " PROJ   ##this will be used to create all the corresponding directories...i.e /data/gusto/bin.....
-read -p "What is your email address? " email
 read -p "What prod file name would you like to use? default: prod " prodfilename
 if [ -z "$prodfilename" ]; then
     prodfilename="prod"
@@ -175,7 +174,7 @@ cp $mridir/dicom-archive/profileTemplate $mridir/dicom-archive/.loris_mri/$prodf
 sudo chmod 640 $mridir/dicom-archive/.loris_mri/$prodfilename
 sudo chgrp $group $mridir/dicom-archive/.loris_mri/$prodfilename
 
-sed -e "s#project#$PROJ#g" -e "s#/PATH/TO/DATA/location#/data/$PROJ/data#g" -e "s#/PATH/TO/BIN/location#$mridir#g" -e "s#yourname\\\@example.com#$email#g" -e "s#/PATH/TO/get_dicom_info.pl#$mridir/dicom-archive/get_dicom_info.pl#g"  -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" -e "s#/PATH/TO/dicomlib/#/data/$PROJ/data/tarchive#g" $mridir/dicom-archive/profileTemplate > $mridir/dicom-archive/.loris_mri/$prodfilename
+sed -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" $mridir/dicom-archive/profileTemplate > $mridir/dicom-archive/.loris_mri/$prodfilename
 echo "config file is located at $mridir/dicom-archive/.loris_mri/$prodfilename"
 echo
 

--- a/imaging_install_MacOSX.sh
+++ b/imaging_install_MacOSX.sh
@@ -30,9 +30,6 @@ read -p "What is the MySQL password? " mysqlpass; echo
 stty echo
 read -p "What is the Linux user which the installation will be based on? " USER
 read -p "What is the project name? " PROJ   ##this will be used to create all the corresponding directories...i.e /data/gusto/bin.....
-
-read -p "What is your email address? " email
-
 read -p "What prod file name would you like to use? default: prod " prodfilename
 if [ -z "$prodfilename" ]; then
     prodfilename="prod"
@@ -124,7 +121,7 @@ cp $mridir/dicom-archive/profileTemplate $mridir/dicom-archive/.loris_mri/$prodf
 sudo chmod 640 $mridir/dicom-archive/.loris_mri/$prodfilename
 sudo chgrp $group $mridir/dicom-archive/.loris_mri/$prodfilename
 
-sed -e "s#project#$PROJ#g" -e "s#/PATH/TO/DATA/location#/data/$PROJ/data#g" -e "s#yourname\\\@example.com#$email#g" -e "s#/PATH/TO/get_dicom_info.pl#$mridir/dicom-archive/get_dicom_info.pl#g"  -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" -e "s#/PATH/TO/dicomlib/#/data/$PROJ/data/tarchive#g" $mridir/dicom-archive/profileTemplate > $mridir/dicom-archive/.loris_mri/$prodfilename
+sed -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" $mridir/dicom-archive/profileTemplate > $mridir/dicom-archive/.loris_mri/$prodfilename
 echo "config file is located at $mridir/dicom-archive/.loris_mri/$prodfilename"
 echo
 

--- a/tools/BackPopulateSNRAndAcquisitionOrder.pl
+++ b/tools/BackPopulateSNRAndAcquisitionOrder.pl
@@ -65,7 +65,7 @@ print "\nSuccessfully connected to database \n";
 ######### Initialize variables #################################
 ################################################################
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'mincPath'
+                    $dbh,'dataDirBasepath'
                     );
 my $tarchiveLibraryDir = &NeuroDB::DBI::getConfigSetting(
                        $dbh,'tarchiveLibraryDir'

--- a/tools/BackPopulateSNRAndAcquisitionOrder.pl
+++ b/tools/BackPopulateSNRAndAcquisitionOrder.pl
@@ -65,10 +65,10 @@ print "\nSuccessfully connected to database \n";
 ######### Initialize variables #################################
 ################################################################
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    $dbh,'dataDirBasepath'
+                    \$dbh,'dataDirBasepath'
                     );
 my $tarchiveLibraryDir = &NeuroDB::DBI::getConfigSetting(
-                       $dbh,'tarchiveLibraryDir'
+                       \$dbh,'tarchiveLibraryDir'
                        );
 $tarchiveLibraryDir    =~ s/\/$//g;
 my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) 

--- a/tools/BackPopulateSNRAndAcquisitionOrder.pl
+++ b/tools/BackPopulateSNRAndAcquisitionOrder.pl
@@ -55,7 +55,22 @@ if ($profile && !@Settings::db) {
     exit 2;
 }
 
-my $data_dir = $Settings::data_dir;
+################################################################
+######### Establish database connection ########################
+################################################################
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+print "\nSuccessfully connected to database \n";
+
+################################################################
+######### Initialize variables #################################
+################################################################
+my $data_dir = &NeuroDB::DBI::getConfigSetting(
+                    $dbh,'mincPath'
+                    );
+my $tarchiveLibraryDir = &NeuroDB::DBI::getConfigSetting(
+                       $dbh,'tarchiveLibraryDir'
+                       );
+$tarchiveLibraryDir    =~ s/\/$//g;
 my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) 
     =localtime(time);
 my $template = "TarLoad-$hour-$min-XXXXXX"; # for tempdir
@@ -69,18 +84,6 @@ if (!-d $LogDir) {
     mkdir($LogDir, 0770); 
 }
 my $logfile  = "$LogDir/$templog.log";
-
-################################################################
-#### This setting is in a config file (profile)    #############
-################################################################
-my $tarchiveLibraryDir = $Settings::tarchiveLibraryDir;
-$tarchiveLibraryDir    =~ s/\/$//g;
-
-################################################################
-######### Establish database connection ########################
-################################################################
-my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
-print "\nSuccessfully connected to database \n";
 
 ################################################################
 ################## Instantiate MRIProcessingUtility ############

--- a/tools/ProdToConfig.pl
+++ b/tools/ProdToConfig.pl
@@ -1,0 +1,133 @@
+#!/usr/bin/perl -w
+use strict;
+use warnings;
+no warnings 'once';
+use Getopt::Tabular;
+use NeuroDB::DBI;
+
+my $profile   = '';
+
+my @opt_table           = (
+    [ "Basic options", "section" ],
+    [
+        "-profile", "string", 1, \$profile,
+        "name of config file in ../dicom-archive/.loris_mri"
+    ]
+);
+
+my $Help = <<HELP;
+******************************************************************************
+Populate the Config table in the database with entries from the $profile file
+******************************************************************************
+
+This script needs to be run once during the upgrade to LORIS-MRI v17.1. Its purpose
+is to remove some variables defined in the $profile file to the Configuration module
+within LORIS. This script assumes that the LORIS upgrade patch has been run, with 
+table entries created and set to default values. This script will then update those
+values with those that already exist in the $profile file.
+
+HELP
+my $Usage = <<USAGE;
+usage: tools/ProdToConfig.pl -profile $profile
+       $0 -help to list options
+USAGE
+&Getopt::Tabular::SetHelp( $Help, $Usage );
+&Getopt::Tabular::GetOptions( \@opt_table, \@ARGV ) || exit 1;
+
+################################################################
+################ Get config setting#############################
+################################################################
+{ package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
+if ( $profile && !@Settings::db ) {
+    print "\n\tERROR: You don't have a
+    configuration file named '$profile' in:
+    $ENV{LORIS_CONFIG}/.loris_mri/ \n\n";
+    exit 2;
+}
+
+if (!$profile ) {
+    print $Help;
+    print "\n$Usage\n";
+    exit 3;
+}
+
+################################################################
+################ Establish database connection #################
+################################################################
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+
+my @config_name_arr = ("data_dir", "prefix", "mail_user", "get_dicom_info",
+                       "horizontalPics", "no_nii", "converter", "tarchiveLibraryDir",
+                       "lookupCenterNameUsing", "if_sge", "if_site", "DTI_volumes",
+                       "t1_scan_type", "reject_thresh", "niak_path", "QCed2_step");
+
+my $data_dir = $Settings::data_dir;
+my $prefix = $Settings::prefix;
+my $mail_user = $Settings::mail_user;
+my $get_dicom_info = $Settings::get_dicom_info;
+my $horizontalPics = $Settings::horizontalPics;
+my $no_nii = $Settings::no_nii;
+my $converter = $Settings::converter;
+my $tarchiveLibraryDir = $Settings::tarchiveLibraryDir;
+my $lookupCenterNameUsing = $Settings::lookupCenterNameUsing;
+my $if_sge = $Settings::if_sge;
+my $if_site = $Settings::if_site;
+my $DTI_volumes = $Settings::DTI_volumes;
+my $t1_scan_type = $Settings::t1_scan_type;
+my $reject_thresh = $Settings::reject_thresh;
+my $niak_path = $Settings::niak_path;
+my $QCed2_step = $Settings::QCed2_step;
+
+my @config_value_arr = ($data_dir, $prefix, $mail_user, $get_dicom_info,
+                       $horizontalPics, $no_nii, $converter, $tarchiveLibraryDir,
+                       $lookupCenterNameUsing, $if_sge, $if_site, $DTI_volumes,
+                       $t1_scan_type, $reject_thresh, $niak_path, $QCed2_step);
+
+
+my ($config_name, $config_value);
+    ## Populate the mri_upload table with necessary entries and get an upload_id 
+for my $index (0 .. $#config_name_arr) {
+    $config_name = $config_name_arr[$index];
+    ## This value was called if_sge, but should be called is_qsub
+    if ($config_name eq "if_sge" ) {
+        $config_name = "is_qsub";
+    }
+    $config_value = $config_value_arr[$index];
+    updateConfigFromProd(\$dbh, $config_name, $config_value);
+}
+
+################################################################
+############### insertIntoMRIUpload ############################
+################################################################
+=pod
+updateConfigFromProd()
+Description:
+  - Update the default values in the Config table to what is inside 
+    the $profile file
+
+Arguments:
+  $config_name: Variable to set in the Config table
+  $config_value : value to set in the Config table
+
+  Returns: $upload_id : The Upload ID
+=cut
+
+
+sub updateConfigFromProd {
+
+    my ( $dbhr, $config_name, $config_value ) = @_;
+
+    my $query = "UPDATE Config SET Value=? ";
+    my $where = "WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name=?)";
+    $query = $query . $where;
+
+    my $config_update = $dbh->prepare($query);
+    $config_update->execute(
+               $config_value,$config_name
+    );
+    print "Just updated the Configuration Setting value for " . $config_name . " to become " . $config_value . "\n";
+}
+
+## exit 0 for find to consider this -cmd true (in case we ever run it that way...)
+exit(0);
+

--- a/tools/ProdToConfig.pl
+++ b/tools/ProdToConfig.pl
@@ -109,7 +109,6 @@ Arguments:
   $config_name: Variable to set in the Config table
   $config_value : value to set in the Config table
 
-  Returns: $upload_id : The Upload ID
 =cut
 
 
@@ -128,6 +127,5 @@ sub updateConfigFromProd {
     print "Just updated the Configuration Setting value for " . $config_name . " to become " . $config_value . "\n";
 }
 
-## exit 0 for find to consider this -cmd true (in case we ever run it that way...)
 exit(0);
 

--- a/tools/ProdToConfig.pl
+++ b/tools/ProdToConfig.pl
@@ -143,8 +143,9 @@ sub updateConfigFromProd {
         my $config_select = $dbh->prepare($query_select);
         $config_select->execute($config_name);
         my $config_default = $config_select->fetchrow_array;
-print "Default is: $config_default \n";
-        print "The Configuration Setting value for " . $config_name . " is kept at its default value of " . $config_default . "\n";
+        print "*** WARNING *** " . 
+              "The Configuration Setting value for " . $config_name . " is kept at its default value of " . $config_default .
+              " because " . $config_name . " is not found in the " . $profile . " file \n";
     }
 }
 

--- a/tools/ProdToConfig.pl
+++ b/tools/ProdToConfig.pl
@@ -57,7 +57,7 @@ if (!$profile ) {
 ################################################################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 
-my @config_name_arr = ("data_dir", "prefix", "mail_user", "get_dicom_info",
+my @config_name_arr = ("dataDirBasepath", "prefix", "mail_user", "get_dicom_info",
                        "horizontalPics", "no_nii", "converter", "tarchiveLibraryDir",
                        "lookupCenterNameUsing", "if_sge", "if_site", "DTI_volumes",
                        "t1_scan_type", "reject_thresh", "niak_path", "QCed2_step");

--- a/tools/ProdToConfig.pl
+++ b/tools/ProdToConfig.pl
@@ -143,6 +143,7 @@ sub updateConfigFromProd {
         my $config_select = $dbh->prepare($query_select);
         $config_select->execute($config_name);
         my $config_default = $config_select->fetchrow_array;
+print "Default is: $config_default \n";
         print "The Configuration Setting value for " . $config_name . " is kept at its default value of " . $config_default . "\n";
     }
 }

--- a/uploadNeuroDB/NeuroDB/DBI.pm
+++ b/uploadNeuroDB/NeuroDB/DBI.pm
@@ -53,5 +53,21 @@ sub connect_to_db
     return $dbh;
 }
 
+sub getConfigSetting
+{
+    my ($dbh, $name) = @_;
+    my ($message,$query,$where) = '';
+    my $vakue = undef;
+
+    $where = " WHERE c.ConfigID=(Select cs.ID from ConfigSettings cs where cs.Name=?)";
+    $query = " SELECT c.Value FROM Config c";
+    $query = $query . $where;
+    my $sth = $$dbh->prepare($query);
+    $sth->execute($name);
+    if ( $sth->rows > 0 ) {
+        $value = $sth->fetchrow_array();
+    }
+    return $value;
+}
 
 1;

--- a/uploadNeuroDB/NeuroDB/DBI.pm
+++ b/uploadNeuroDB/NeuroDB/DBI.pm
@@ -57,7 +57,7 @@ sub getConfigSetting
 {
     my ($dbh, $name) = @_;
     my ($message,$query,$where) = '';
-    my $vakue = undef;
+    my $value = undef;
 
     $where = " WHERE c.ConfigID=(Select cs.ID from ConfigSettings cs where cs.Name=?)";
     $query = " SELECT c.Value FROM Config c";

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -154,13 +154,18 @@ sub IsCandidateInfoValid {
         if ( $sth->rows > 0 ) {
             $archived_file_path = $sth->fetchrow_array();
         }
-
-        unless ($archived_file_path =~ m/$Settings::tarchiveLibraryDir/i) {
-            $archived_file_path = ($Settings::tarchiveLibraryDir . "/" . $archived_file_path);
+        my $tarchivePath = NeuroDB::DBI::getConfigSetting(
+                            $this->{dbhr},'tarchiveLibraryDir'
+                            );
+        my $bin_dirPath = NeuroDB::DBI::getConfigSetting(
+                            $this->{dbhr},'MRICodePath'
+                            );
+        unless ($archived_file_path =~ m/$tarchivePath/i) {
+            $archived_file_path = ($tarchivePath . "/" . $archived_file_path);
         }
 
         my $command =
-            $Settings::bin_dir
+            $bin_dirPath
             . "/uploadNeuroDB/tarchiveLoader"
             . " -globLocation -profile prod $archived_file_path";
 
@@ -253,9 +258,14 @@ sub runDicomTar {
     my $tarchive_id       = undef;
     my $query             = '';
     my $where             = '';
-    my $tarchive_location = $Settings::tarchiveLibraryDir;
+    my $tarchive_location = NeuroDB::DBI::getConfigSetting(
+                            $this->{dbhr},'tarchiveLibraryDir'
+                            );
+    my $bin_dirPath = NeuroDB::DBI::getConfigSetting(
+                        $this->{dbhr},'MRICodePath'
+                        );
     my $dicomtar = 
-      $Settings::bin_dir . "/" . "dicom-archive" . "/" . "dicomTar.pl";
+      $bin_dirPath . "/" . "dicom-archive" . "/" . "dicomTar.pl";
     my $command =
         $dicomtar . " " . $this->{'uploaded_temp_folder'} 
       . " $tarchive_location -clobber -database -profile prod";
@@ -316,8 +326,11 @@ sub getTarchiveFileLocation {
         $archive_location = $sth->fetchrow_array();
     }
 
-    unless ($archive_location =~ m/$Settings::tarchiveLibraryDir/i) {
-        $archive_location = ($Settings::tarchiveLibraryDir . "/" . $archive_location);
+    my $tarchive_location = NeuroDB::DBI::getConfigSetting(
+                            $this->{dbhr},'tarchiveLibraryDir'
+                            );
+    unless ($archive_location =~ m/$tarchive_location/i) {
+        $archive_location = ($tarchive_location . "/" . $archive_location);
     }
     return $archive_location;
 }
@@ -340,8 +353,11 @@ Arguments:
 sub runTarchiveLoader {
     my $this               = shift;
     my $archived_file_path = $this->getTarchiveFileLocation();
+    my $bin_dirPath = NeuroDB::DBI::getConfigSetting(
+                        $this->{dbhr},'MRICodePath'
+                        );
     my $command =
-        $Settings::bin_dir
+        $bin_dirPath
       . "/uploadNeuroDB/tarchiveLoader"
       . " -globLocation -profile prod $archived_file_path";
 
@@ -441,7 +457,10 @@ Arguments:
 
 sub sourceEnvironment {
     my $this            = shift;
-    my $cmd =   "source  " . $Settings::bin_dir."/". "environment";
+    my $bin_dirPath = NeuroDB::DBI::getConfigSetting(
+                        $this->{dbhr},'MRICodePath'
+                        );
+    my $cmd =   "source  " . $bin_dirPath."/". "environment";
     $this->runCommand($cmd);
 }
 
@@ -515,7 +534,9 @@ sub CleanUpDataIncomingDir {
     my ($uploaded_file) = @_;
     my $output = undef;
     my $message = '';
-    my $tarchive_location = $Settings::tarchiveLibraryDir;
+    my $tarchive_location = NeuroDB::DBI::getConfigSetting(
+                            $this->{dbhr},'tarchiveLibraryDir'
+                            );
     ############################################################
     ################ Removes the uploaded file ################# 
     ##### Check first that the file is in the tarchive dir ##### 

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -535,7 +535,7 @@ sub CleanUpDataIncomingDir {
     my $output = undef;
     my $message = '';
     my $tarchive_location = NeuroDB::DBI::getConfigSetting(
-                            $this->{dbhr},'tarchiveLibraryDir'
+                                $this->{dbhr},'tarchiveLibraryDir'
                             );
     ############################################################
     ################ Removes the uploaded file ################# 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -974,9 +974,6 @@ sub moveAndUpdateTarchive {
     # now update tarchive table to store correct location ######
     ############################################################
     my $newArchiveLocationField = $newTarchiveLocation;
-    my $tarchivePath = NeuroDB::DBI::getConfigSetting(
-                        $this->{dbhr},'tarchiveLibraryDir'
-                        );
     $newArchiveLocationField    =~ s/$tarchivePath\/?//g;
     $query = "UPDATE tarchive ".
              " SET ArchiveLocation=" . 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -683,7 +683,7 @@ sub registerScanIntoDB {
     ) = @_;
 
     my $data_dir = NeuroDB::DBI::getConfigSetting(
-                        $this->{dbhr},'mincPath'
+                        $this->{dbhr},'dataDirBasepath'
                         );
     my $prefix = NeuroDB::DBI::getConfigSetting(
                         $this->{dbhr},'prefix'
@@ -1235,7 +1235,7 @@ sub computeSNR {
     my ($row, $filename, $fileID, $base, $fullpath, $cmd, $message, $SNR, $SNR_old);
     my ($tarchiveID, $tarchive_srcloc, $profile)= @_;
     my $data_dir = NeuroDB::DBI::getConfigSetting(
-                        $this->{dbhr},'mincPath'
+                        $this->{dbhr},'dataDirBasepath'
                         );
     my $upload_id = getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc);
 

--- a/uploadNeuroDB/cleanupTarchives.pl
+++ b/uploadNeuroDB/cleanupTarchives.pl
@@ -69,7 +69,7 @@ print LOG "\n==> Successfully connected to database \n";
 ##############################
 # These settings are in the database, accessible from the Configuration module
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    $this->{dbhr},'mincPath'
+                    $this->{dbhr},'dataDirBasepath'
                     );
 my $tarchiveLibraryDir = &NeuroDB::DBI::getConfigSetting(
                        $this->{dbhr},'tarchiveLibraryDir'

--- a/uploadNeuroDB/cleanupTarchives.pl
+++ b/uploadNeuroDB/cleanupTarchives.pl
@@ -57,12 +57,23 @@ if ($profile && !defined @Settings::db) {
 }
 
 
+
+##############################
+##  Establish db connection ##
+##############################
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+print LOG "\n==> Successfully connected to database \n";
+
 ##############################
 ####  Initiate variables  ####
 ##############################
-# These settings are in a config file (profile)
-my $data_dir            = $Settings::data_dir;
-my $tarchiveLibraryDir  = $Settings::tarchiveLibraryDir;
+# These settings are in the database, accessible from the Configuration module
+my $data_dir = &NeuroDB::DBI::getConfigSetting(
+                    $this->{dbhr},'mincPath'
+                    );
+my $tarchiveLibraryDir = &NeuroDB::DBI::getConfigSetting(
+                       $this->{dbhr},'tarchiveLibraryDir'
+                       );
 $tarchiveLibraryDir     =~ s/\/$//g;
 
 
@@ -76,20 +87,13 @@ my $logfile  = "$LogDir/RemoveDuplicateTarchives_$date.log";
 open LOG, ">$logfile";
 LOG->autoflush(1);
 
-
-
 ##############################
 ####     Main program     ####
 ##############################
 
-# Establish database connection
-my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
-print LOG "\n==> Successfully connected to database \n";
-
 # Get tarchives list from the database and stores ArchiveLocation and md5sumArchive informations in a hash.
 ## ArchiveLocation will be the key of the hash
 ## md5sumArchive will be the value of the hash
-my $tarchiveLibraryDir  = $Settings::tarchiveLibraryDir; # get tarchive directory from config file 
 my ($tarchivesList_db)  = &selectTarchives($dbh, $tarchiveLibraryDir);
 
 # Loop through the list of tarchives in the year subfolders

--- a/uploadNeuroDB/cleanupTarchives.pl
+++ b/uploadNeuroDB/cleanupTarchives.pl
@@ -62,7 +62,6 @@ if ($profile && !defined @Settings::db) {
 ##  Establish db connection ##
 ##############################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
-print LOG "\n==> Successfully connected to database \n";
 
 ##############################
 ####  Initiate variables  ####
@@ -86,6 +85,8 @@ mkdir ($LogDir, 0770) if (!-d $LogDir);
 my $logfile  = "$LogDir/RemoveDuplicateTarchives_$date.log";
 open LOG, ">$logfile";
 LOG->autoflush(1);
+
+print LOG "\n==> Successfully connected to database \n";
 
 ##############################
 ####     Main program     ####

--- a/uploadNeuroDB/mass_jiv.pl
+++ b/uploadNeuroDB/mass_jiv.pl
@@ -42,12 +42,15 @@ if ($profile && !@Settings::db) {
 
 if(!$profile) { print $Usage; print "\n\tERROR: You must specify an existing profile.\n\n";  exit 33;  }
 
-# where the JIVs should go
-my $jiv_dir = $Settings::data_dir . '/jiv';
-
 # establish database connection if database option is set
 print "Connecting to database.\n" if $verbose;
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+
+# where the JIVs should go
+my $data_dir = &NeuroDB::DBI::getConfigSetting(
+                    \$dbh,'mincPath'
+                    );
+my $jiv_dir = $data_dir . '/jiv';
 
 
 ## now go make the jivs
@@ -73,7 +76,7 @@ while(my $rowhr = $sth->fetchrow_hashref()) {
     my $file = NeuroDB::File->new(\$dbh);
     $file->loadFile($rowhr->{'FileID'});
 
-    unless(&NeuroDB::MRI::make_jiv(\$file, $Settings::data_dir, $jiv_dir)) {
+    unless(&NeuroDB::MRI::make_jiv(\$file, $data_dir, $jiv_dir)) {
 	print "FAILURE!\t$rowhr->{'FileID'}\n";
     }
 }

--- a/uploadNeuroDB/mass_jiv.pl
+++ b/uploadNeuroDB/mass_jiv.pl
@@ -48,7 +48,7 @@ my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 
 # where the JIVs should go
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    \$dbh,'mincPath'
+                    \$dbh,'dataDirBasepath'
                     );
 my $jiv_dir = $data_dir . '/jiv';
 

--- a/uploadNeuroDB/mass_nii.pl
+++ b/uploadNeuroDB/mass_nii.pl
@@ -135,7 +135,9 @@ if ($debug) {
 ################################################################
 # Create NIfTI files for each FileIDs from the query result ####
 ################################################################
-
+my $data_dir = &NeuroDB::DBI::getConfigSetting(
+                    \$dbh,'mincPath'
+                    );
 # Loop through FileIDs
 while(my $rowhr = $sth->fetchrow_hashref()) {
 
@@ -146,7 +148,7 @@ while(my $rowhr = $sth->fetchrow_hashref()) {
     $file->loadFile($rowhr->{'FileID'});
 
     # Create NIfTI file
-    &NeuroDB::MRI::make_nii(\$file, $Settings::data_dir);
+    &NeuroDB::MRI::make_nii(\$file, $data_dir);
 
 }
 

--- a/uploadNeuroDB/mass_nii.pl
+++ b/uploadNeuroDB/mass_nii.pl
@@ -136,7 +136,7 @@ if ($debug) {
 # Create NIfTI files for each FileIDs from the query result ####
 ################################################################
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    \$dbh,'mincPath'
+                    \$dbh,'dataDirBasepath'
                     );
 # Loop through FileIDs
 while(my $rowhr = $sth->fetchrow_hashref()) {

--- a/uploadNeuroDB/mass_pic.pl
+++ b/uploadNeuroDB/mass_pic.pl
@@ -55,15 +55,18 @@ if (!$profile) {
 }
 
 ################################################################
-# Where the pics should go #####################################
-################################################################
-my $pic_dir = $Settings::data_dir . '/pic';
-
-################################################################
 # Establish database connection if database option is set ######
 ################################################################
 print "Connecting to database.\n" if $verbose;
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+
+################################################################
+# Where the pics should go #####################################
+################################################################
+my $data_dir = &NeuroDB::DBI::getConfigSetting(
+                    \$dbh,'mincPath'
+                    );
+my $pic_dir = $data_dir . '/pic';
 
 ################################################################
 ##### Now go make the pics #####################################
@@ -103,6 +106,9 @@ if ($debug) {
     print $query . "\n";
 }
 
+my $horizontalPics = &NeuroDB::DBI::getConfigSetting(
+                    \$dbh,'horizontalPics'
+                    );
 my $sth = $dbh->prepare($query);
 $sth->execute();
 
@@ -113,8 +119,8 @@ while(my $rowhr = $sth->fetchrow_hashref()) {
 
     unless(
         &NeuroDB::MRI::make_pics(
-            \$file, $Settings::data_dir, 
-            $pic_dir, $Settings::horizontalPics
+            \$file, $data_dir, 
+            $pic_dir, $horizontalPics
         )
     ) {
         print "FAILURE!\n";

--- a/uploadNeuroDB/mass_pic.pl
+++ b/uploadNeuroDB/mass_pic.pl
@@ -64,7 +64,7 @@ my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 # Where the pics should go #####################################
 ################################################################
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    \$dbh,'mincPath'
+                    \$dbh,'dataDirBasepath'
                     );
 my $pic_dir = $data_dir . '/pic';
 

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -117,7 +117,7 @@ if ($ARGV[0] eq "confirm") {
 
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    \$dbh,'mincPath'
+                    \$dbh,'dataDirBasepath'
                     );
 
 sub selORdel {

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -115,9 +115,10 @@ if ($ARGV[0] eq "confirm") {
   $selORdel  = "SELECT * ";
 }
 
-my $data_dir         = $Settings::data_dir;
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
-
+my $data_dir = &NeuroDB::DBI::getConfigSetting(
+                    \$dbh,'mincPath'
+                    );
 
 sub selORdel {
   my ($table, $field) = @_;

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -173,16 +173,29 @@ unless (-e $minc) {
 }
 
 ################################################################
+############### Establish database connection ##################
+################################################################
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+
+################################################################
 ########### Create the Specific Log File #######################
 ################################################################
-my $data_dir = $Settings::data_dir;
-$no_nii      = $Settings::no_nii if defined $Settings::no_nii;
+my $data_dir = NeuroDB::DBI::getConfigSetting(
+                    \$dbh,'mincPath'
+                    );
+if (defined (NeuroDB::DBI::getConfigSetting(\$dbh,'no_nii'))) {
+    $no_nii = NeuroDB::DBI::getConfigSetting(
+                       \$dbh,'no_nii'
+                        ) 
+}
 my $jiv_dir  = $data_dir.'/jiv';
 my $TmpDir   = tempdir($template, TMPDIR => 1, CLEANUP => 1 );
 my @temp     = split(/\//, $TmpDir);
 my $templog  = $temp[$#temp];
-my $LogDir   = "$data_dir/logs"; 
-my $tarchiveLibraryDir = $Settings::tarchiveLibraryDir;
+my $LogDir   = "$data_dir/logs";
+my $tarchiveLibraryDir = &NeuroDB::DBI::getConfigSetting(
+                       \$dbh,'tarchiveLibraryDir'
+                       );
 $tarchiveLibraryDir    =~ s/\/$//g;
 if (!-d $LogDir) { 
     mkdir($LogDir, 0770); 
@@ -193,12 +206,7 @@ open LOG, ">>", $logfile or die "Error Opening $logfile";
 LOG->autoflush(1);
 &logHeader();
 
-################################################################
-############### Establish database connection ##################
-################################################################
-my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 print LOG "\n==> Successfully connected to database \n" if $verbose;
-
 
 ################################################################
 ################## MRIProcessingUtility object #################
@@ -371,7 +379,7 @@ if (!$unique) {
     $notifier->spool('tarchive validation', $message, 0,
                     'minc_insertion.pl', $upload_id, 'Y', 
                     $notify_notsummary);
-    exit 8; 
+    #exit 8; 
 } 
 
 ################################################################

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -181,7 +181,7 @@ my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 ########### Create the Specific Log File #######################
 ################################################################
 my $data_dir = NeuroDB::DBI::getConfigSetting(
-                    \$dbh,'mincPath'
+                    \$dbh,'dataDirBasepath'
                     );
 if (defined (NeuroDB::DBI::getConfigSetting(\$dbh,'no_nii'))) {
     $no_nii = NeuroDB::DBI::getConfigSetting(
@@ -379,7 +379,7 @@ if (!$unique) {
     $notifier->spool('tarchive validation', $message, 0,
                     'minc_insertion.pl', $upload_id, 'Y', 
                     $notify_notsummary);
-    #exit 8; 
+    exit 8; 
 } 
 
 ################################################################

--- a/uploadNeuroDB/registerFile.pl
+++ b/uploadNeuroDB/registerFile.pl
@@ -158,7 +158,7 @@ if(defined($source_list)) {
 	# get psc
 	my $centerID;
     my $lookupCenterNameUsing = NeuroDB::DBI::getConfigSetting(
-                                    $dbh,'lookupCenterNameUsing'
+                                    \$dbh,'lookupCenterNameUsing'
                                     );
 
     $lookupCenterNameUsing = 'patient_name' if ($lookupCenterNameUsing eq 'PatientName');

--- a/uploadNeuroDB/registerFile.pl
+++ b/uploadNeuroDB/registerFile.pl
@@ -157,9 +157,12 @@ if(defined($source_list)) {
 
 	# get psc
 	my $centerID;
-    my $lookupCenterNameUsing;
-    $lookupCenterNameUsing = 'patient_name' if ($Settings::lookupCenterNameUsing eq 'PatientName');
-    $lookupCenterNameUsing = 'patient_id' if ($Settings::lookupCenterNameUsing eq 'PatientID');
+    my $lookupCenterNameUsing = NeuroDB::DBI::getConfigSetting(
+                                    $dbh,'lookupCenterNameUsing'
+                                    );
+
+    $lookupCenterNameUsing = 'patient_name' if ($lookupCenterNameUsing eq 'PatientName');
+    $lookupCenterNameUsing = 'patient_id' if ($lookupCenterNameUsing eq 'PatientID');
 
     unless(defined($lookupCenterNameUsing)) {
         print "\nERROR: registerFile.pl only knows how to lookup center name using PatientName or PatientID.\n\n";

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -86,7 +86,7 @@ print LOG "\n==> Successfully connected to database \n";
 
 # These settings are in the config file (profile)
 my $data_dir = NeuroDB::DBI::getConfigSetting(
-                    $dbh,'mincPath'
+                    $dbh,'dataDirBasepath'
                     );
 my $pic_dir  =   $data_dir.'/pic';
 my $jiv_dir  =   $data_dir.'/jiv';

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -82,7 +82,6 @@ unless  (-r $filename)  { print "Cannot read $filename\n"; exit 1;}
 
 # Establish database connection
 my $dbh     =   &NeuroDB::DBI::connect_to_db(@Settings::db);
-print LOG "\n==> Successfully connected to database \n";
 
 # These settings are in the config file (profile)
 my $data_dir = NeuroDB::DBI::getConfigSetting(
@@ -100,6 +99,7 @@ my  ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)    =   localtime(time)
 my  $date       =   sprintf("%4d-%02d-%02d_%02d:%02d:%02d",$year+1900,$mon+1,$mday,$hour,$min,$sec);
 my  $log        =   "$log_dir/registerProcessed$date.log";
 open (LOG,">>$log");
+print LOG "\n==> Successfully connected to database \n";
 print LOG "Log file, $date\n\n";
 
 

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -85,12 +85,12 @@ my $dbh     =   &NeuroDB::DBI::connect_to_db(@Settings::db);
 
 # These settings are in the config file (profile)
 my $data_dir = NeuroDB::DBI::getConfigSetting(
-                    $dbh,'dataDirBasepath'
+                    \$dbh,'dataDirBasepath'
                     );
 my $pic_dir  =   $data_dir.'/pic';
 my $jiv_dir  =   $data_dir.'/jiv';
 my $prefix   = NeuroDB::DBI::getConfigSetting(
-                    $dbh,'prefix'
+                    \$dbh,'prefix'
                     );
 # Needed for log file
 my  $log_dir    =   "$data_dir/logs/registerProcessed";
@@ -130,7 +130,7 @@ if  ($file->getFileDatum('FileType') eq 'mnc')  {
 my  ($center_name,$centerID);
 if  ($file->getFileDatum('FileType') eq 'mnc')  {
     my  $lookupCenterName       =   NeuroDB::DBI::getConfigSetting(
-                                    $dbh,'lookupCenterNameUsing'
+                                    \$dbh,'lookupCenterNameUsing'
                                     );
     my  $patientInfo;
     if      ($lookupCenterName eq 'PatientName')    {
@@ -253,7 +253,7 @@ my $intermediary_insert = &insert_intermedFiles($fileID, $inputFileIDs, $tool);
 print LOG "\n==> FAILED TO INSERT INTERMEDIARY FILES FOR $fileID!\n\n" if (!$intermediary_insert);
 
 my $horizontalPics = &NeuroDB::DBI::getConfigSetting(
-                        $dbh,'horizontalPics'
+                        \$dbh,'horizontalPics'
                         );
 if  ($file->getFileDatum('FileType') eq 'mnc')  {
     # Jivify

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -80,12 +80,19 @@ unless  ((defined($sourceFileID)) && ($sourceFileID =~ /^[0-9]+$/)) {
 # Make sure we have permission to read the file
 unless  (-r $filename)  { print "Cannot read $filename\n"; exit 1;}
 
-# These settings are in the config file (profile)
-my  $data_dir   =   $Settings::data_dir;
-my  $pic_dir    =   $data_dir.'/pic';
-my  $jiv_dir    =   $data_dir.'/jiv';
-my  $prefix     =   $Settings::prefix;
+# Establish database connection
+my $dbh     =   &NeuroDB::DBI::connect_to_db(@Settings::db);
+print LOG "\n==> Successfully connected to database \n";
 
+# These settings are in the config file (profile)
+my $data_dir = NeuroDB::DBI::getConfigSetting(
+                    $dbh,'mincPath'
+                    );
+my $pic_dir  =   $data_dir.'/pic';
+my $jiv_dir  =   $data_dir.'/jiv';
+my $prefix   = NeuroDB::DBI::getConfigSetting(
+                    $dbh,'prefix'
+                    );
 # Needed for log file
 my  $log_dir    =   "$data_dir/logs/registerProcessed";
 system("mkdir -p -m 770 $log_dir") unless (-e $log_dir);
@@ -95,9 +102,6 @@ my  $log        =   "$log_dir/registerProcessed$date.log";
 open (LOG,">>$log");
 print LOG "Log file, $date\n\n";
 
-# Establish database connection
-my $dbh     =   &NeuroDB::DBI::connect_to_db(@Settings::db);
-print LOG "\n==> Successfully connected to database \n";
 
 
 # ----- STEP 1: Create and load File object.
@@ -125,7 +129,9 @@ if  ($file->getFileDatum('FileType') eq 'mnc')  {
 #       (only for minc files)
 my  ($center_name,$centerID);
 if  ($file->getFileDatum('FileType') eq 'mnc')  {
-    my  $lookupCenterName       =   $Settings::lookupCenterNameUsing;
+    my  $lookupCenterName       =   NeuroDB::DBI::getConfigSetting(
+                                    $dbh,'lookupCenterNameUsing'
+                                    );
     my  $patientInfo;
     if      ($lookupCenterName eq 'PatientName')    {
         $patientInfo    =   fetchMincHeader($filename,'patient:full_name');
@@ -246,6 +252,9 @@ unless  ($fileID)   {
 my $intermediary_insert = &insert_intermedFiles($fileID, $inputFileIDs, $tool);
 print LOG "\n==> FAILED TO INSERT INTERMEDIARY FILES FOR $fileID!\n\n" if (!$intermediary_insert);
 
+my $horizontalPics = &NeuroDB::DBI::getConfigSetting(
+                        $dbh,'horizontalPics'
+                        );
 if  ($file->getFileDatum('FileType') eq 'mnc')  {
     # Jivify
     print LOG "Making JIV\n";
@@ -253,7 +262,7 @@ if  ($file->getFileDatum('FileType') eq 'mnc')  {
     
     # make the browser pics
     print "Making browser pics\n";
-    &NeuroDB::MRI::make_pics(\$file, $data_dir, $pic_dir, $Settings::horizontalPics);
+    &NeuroDB::MRI::make_pics(\$file, $data_dir, $pic_dir, $horizontalPics);
 }
 
 # tell the user we've done so and include the MRIID for reference

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -195,7 +195,7 @@ unless (-e $tarchive) {
 #### accessible through the Configuration Module   #############
 ################################################################
 my $data_dir = NeuroDB::DBI::getConfigSetting(
-                 \$dbh,'mincPath'
+                 \$dbh,'dataDirBasepath'
                  );
 my $pic_dir = $data_dir.'/pic';
 my $jiv_dir = $data_dir.'/jiv';

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -155,6 +155,7 @@ USAGE
 ################### input option error checking ################
 ################################################################
 { package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
+
 if ($profile && !@Settings::db) { 
     print "\n\tERROR: You don't have a configuration file named ". 
           "'$profile' in:  $ENV{LORIS_CONFIG}/.loris_mri/ \n\n"; 
@@ -167,10 +168,18 @@ if (!$ARGV[0] || !$profile) {
     exit 3;  
 }
 
-my $tarchive = $ARGV[0];
+################################################################
+######### Establish database connection ########################
+################################################################
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+$message ="\n==> Successfully connected to database \n";
 
-unless ($tarchive =~ m/$Settings::tarchiveLibraryDir/i) {
-	$tarchive = ($Settings::tarchiveLibraryDir . "/" . $tarchive);
+my $tarchive = $ARGV[0];
+my $tarchivePath = NeuroDB::DBI::getConfigSetting(
+                        \$dbh,'tarchiveLibraryDir'
+                        );
+unless ($tarchive =~ m/$tarchivePath/i) {
+    $tarchive = ($tarchivePath . "/" . $tarchive);
 }
 
 unless (-e $tarchive) {
@@ -180,16 +189,28 @@ unless (-e $tarchive) {
     exit 4;
 }
 
+
 ################################################################
-#### These settings are in a config file (profile) #############
+#### These settings are in the database, & are     #############
+#### accessible through the Configuration Module   #############
 ################################################################
-my $data_dir         = $Settings::data_dir;
+my $data_dir = NeuroDB::DBI::getConfigSetting(
+                 \$dbh,'mincPath'
+                 );
 my $pic_dir = $data_dir.'/pic';
 my $jiv_dir = $data_dir.'/jiv';
-my $prefix           = $Settings::prefix;
-my $converter        = $Settings::converter;
-my $mail_user        = $Settings::mail_user;
-my $get_dicom_info   = $Settings::get_dicom_info;
+my $prefix = NeuroDB::DBI::getConfigSetting(
+               \$dbh,'prefix'
+               );
+my $converter = NeuroDB::DBI::getConfigSetting(
+                 \$dbh,'converter'
+                 );
+my $mail_user = NeuroDB::DBI::getConfigSetting(
+                 \$dbh,'mail_user'
+                 );
+my $get_dicom_info = NeuroDB::DBI::getConfigSetting(
+                 \$dbh,'get_dicom_info'
+                 );
 my $exclude          = "localizer"; # case insensitive
 my $template         = "TarLoad-$hour-$min-XXXXXX"; # for tempdir
 my $User             = `whoami`;
@@ -212,6 +233,8 @@ open LOG, ">$logfile";
 LOG->autoflush(1);
 &logHeader();
 
+print LOG $message;
+
 ################################################################
 ############### If xlog is set, fork a tail on log file. #######
 ################################################################
@@ -223,13 +246,6 @@ if ($xlog) {
         exit(0); 
     } 
 }
-
-################################################################
-######### Establish database connection ########################
-################################################################
-my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
-$message ="\n==> Successfully connected to database \n";
-print LOG $message;
 
 =pod
 ################################################################
@@ -264,7 +280,9 @@ my $notifier = NeuroDB::Notify->new(\$dbh);
 ################################################################
 ################ Construct the tarchiveInfo Array ##############
 ################################################################
-my $tarchiveLibraryDir = $Settings::tarchiveLibraryDir;
+my $tarchiveLibraryDir = NeuroDB::DBI::getConfigSetting(
+                            \$dbh,'tarchiveLibraryDir'
+                            );
 $tarchiveLibraryDir    =~ s/\/$//g;
 my $ArchiveLocation    = $tarchive;
 $ArchiveLocation       =~ s/$tarchiveLibraryDir\/?//g;
@@ -417,9 +435,9 @@ foreach my $minc (@minc_files) {
     # ($valid_study undefined)-> move the tarchive from the ####
     # inbox into the tarchive library ##########################
     ############################################################
-    if ((!defined($Settings::tarchiveLibraryDir)) || 
-        ((defined($Settings::tarchiveLibraryDir)) &&    
-        ($tarchive =~ m/$Settings::tarchiveLibraryDir\/\d\d\d\d\//i))) { 
+    if ((!defined($tarchivePath)) || 
+        (defined($tarchivePath) &&    
+        ($tarchive =~ m/$tarchivePath\/\d\d\d\d\//i))) { 
             $newTarchiveLocation = $tarchive; 
     }
     elsif (!$valid_study) {

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -140,7 +140,7 @@ my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 ########## Create the Specific Log File ########################
 ################################################################
 my $data_dir = NeuroDB::DBI::getConfigSetting(
-                    \$dbh,'mincPath'
+                    \$dbh,'dataDirBasepath'
                     );
 my $TmpDir = tempdir($template, TMPDIR => 1, CLEANUP => 1 );
 my @temp     = split(/\//, $TmpDir);

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -130,10 +130,18 @@ unless (-e $tarchive) {
 
 ################################################################
 ########## initialization ######################################
+
+################################################################
+################ Establish database connection #################
+################################################################
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+
 ################################################################
 ########## Create the Specific Log File ########################
 ################################################################
-my $data_dir         = $Settings::data_dir;
+my $data_dir = NeuroDB::DBI::getConfigSetting(
+                    \$dbh,'mincPath'
+                    );
 my $TmpDir = tempdir($template, TMPDIR => 1, CLEANUP => 1 );
 my @temp     = split(/\//, $TmpDir);
 my $templog  = $temp[$#temp];
@@ -146,10 +154,6 @@ open LOG, ">>", $logfile or die "Error Opening $logfile";
 LOG->autoflush(1);
 &logHeader();
 
-################################################################
-################ Establish database connection #################
-################################################################
-my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 print LOG "\n==> Successfully connected to database \n";
 
 ################################################################
@@ -164,7 +168,9 @@ my $utility = NeuroDB::MRIProcessingUtility->new(
 ############### Create tarchive array ##########################
 ################################################################
 ################################################################
-my $tarchiveLibraryDir = $Settings::tarchiveLibraryDir;
+my $tarchiveLibraryDir = NeuroDB::DBI::getConfigSetting(
+                       \$dbh,'tarchiveLibraryDir'
+                       );
 $tarchiveLibraryDir    =~ s/\/$//g;
 my $ArchiveLocation    = $tarchive;
 $ArchiveLocation       =~ s/$tarchiveLibraryDir\/?//g;


### PR DESCRIPTION
- Moving everything possible from the $profile file to the Configuration module (project-specific functions remain in the "prod" file)
- for existing projects: 
  - a tool script (in `tools/ProdToConfig.pl`) is provided to help migrate the values from the $profile to the Config tables in the database, and can be invoked as follows:
from /data/$PROJECTI/bin/mri, run:
` tools/ProdToConfig.pl -profile prod`
  - once the script is run successfully, projects are recommended to 1) make a backup of their original prod file, 2) cleanup/remove the entries that were migrated to the database from their $profile (essentially those that are in Section II), and 3) a) edit the function `get_DTI_Site_CandID_Visit` to become `get_DTI_CandID_Visit` (https://github.com/MounaSafiHarab/dicom-archive-tools/blob/744975d911ea32d0c474bb0cb676d658499009aa/profileTemplate#L129) and b) to no longer return `$site` (https://github.com/MounaSafiHarab/dicom-archive-tools/blob/744975d911ea32d0c474bb0cb676d658499009aa/profileTemplate#L135)
- TO DO: install script needs to be tested

related to:
https://github.com/aces/Loris/pull/2649
and
https://github.com/aces/dicom-archive-tools/pull/45