### PR TITLE
Run dicomtar.pl without the clobber option anymore to allow more than one tar per studyUID: Redmine 12171

### DIFF
--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -240,7 +240,7 @@ sub IsCandidateInfoValid {
 runDicomTar()
 Description:
  -Extracts tarchiveID using pname
- -Runs dicomTar.pl with -clobber -database -profile prod options
+ -Runs dicomTar.pl with -database -profile prod options
  -If successfull it updates MRI_upload table accordingly
 
 Arguments:
@@ -258,7 +258,7 @@ sub runDicomTar {
       $Settings::bin_dir . "/" . "dicom-archive" . "/" . "dicomTar.pl";
     my $command =
         $dicomtar . " " . $this->{'uploaded_temp_folder'} 
-      . " $tarchive_location -clobber -database -profile prod";
+      . " $tarchive_location -database -profile prod";
     if ($this->{verbose}) {
         $command .= " -verbose";
     }
@@ -297,7 +297,7 @@ sub runDicomTar {
 getTarchiveFileLocation()
 Description:
  -Extracts tarchiveID using pname
- -Runs dicomTar.pl with clobber -database -profile prod options
+ -Runs dicomTar.pl with -database -profile prod options
  -If successfull it updates MRI_upload Table accordingly
 
 Arguments:

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -968,7 +968,13 @@ sub moveAndUpdateTarchive {
               ${$this->{'dbhr'}}->quote($newArchiveLocationField) .
              " WHERE DicomArchiveID=". 
              ${$this->{'dbhr'}}->quote(
-                $tarchiveInfo->{'DicomArchiveID'}
+                $tarchiveInfo->{'DicomArchiveID'}) .
+             " AND TarchiveID=".
+             ${$this->{'dbhr'}}->quote(
+              $tarchiveInfo->{'TarchiveID'}) . 
+             " AND SourceLocation=".
+             ${$this->{'dbhr'}}->quote(
+              $tarchiveInfo->{'SourceLocation'}
              );
     print $query . "\n"  if $this->{debug};
     ${$this->{'dbhr'}}->do($query);


### PR DESCRIPTION
No more -clobber so as not to overwrite the existing .tar info in the tarchive table when the user needs to upload more than one upload with the same studyUID.
Related to:
https://github.com/aces/dicom-archive-tools/pull/48