### PR TITLE
Do not store PatientName header in notification_spool table:Redmine 13506

### DIFF
--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -418,7 +418,7 @@ sub PatientNameMatch {
     }
     my ($l,$pname,$t) = split /\[(.*?)\]/, $patient_name_string;
     if ($pname !~ /^$this->{'pname'}/) {
-        my $message = "\nThe patient-name $pname read ".
+        my $message = "\nThe patient-name read ".
                       "from the DICOM header does not start with " .
         	      $this->{'pname'} . 
                       " from the mri_upload table\n";


### PR DESCRIPTION
If the patientname header in the DICOM files does not match the PSCID_CandID_VisitLabel naming convention (as entered using Imaging Uploader GUI), the error message stored in the notification_spool table (and also in the Log Viewer in the front-end) will show both the actual header info and what it is supposed/expected to be.
That was supposed to be informative for the user so they know how to fix the problem before the pipeline exits, however, if the site did not anonymize the PatientName, then our database is storing this info which it should not.
Simply remove the PatientName in the DICOM header from the stored message in the database.