### PR TITLE
Check consistent upload_id and filename when running the pipeline: Redmine 13507

### DIFF
--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -306,17 +306,17 @@ sub getPnameUsingUploadID {
 }
 
 ################################################################
-############### getPnameUsingUploadID###########################
+############### getFilePathUsingUploadID########################
 ################################################################
 =pod
-getPnameUsingUploadID()
+getFilePathUsingUploadID()
 Description:
-  - Get the patient-name using the upload_id
+  - Get the file path from the mri_upload table using the upload_id
 
 Arguments:
   $upload_id: The Upload ID
 
-  Returns: $patient_name : The patientName
+  Returns: $file_path : The full path to the uploaded file
 =cut
 
 
@@ -327,7 +327,7 @@ sub getFilePathUsingUploadID {
 
     if ($upload_id) {
         ########################################################
-        ##########Extract pname using uploadid##################
+        #######Extract File with full path using upload_id######
         ########################################################
         $query = "SELECT UploadLocation FROM mri_upload WHERE UploadID =?";
         my $sth = $dbh->prepare($query);


### PR DESCRIPTION
Currently running imaging_upload_file.pl to launch the pipeline expects 2 arguments:
upload_id and filepath

These should correspond to the same mri_upload entry. If they don't, the user doesn't really know what is being inserted: the file that corresponds to the upload_id or the upload_id that corresponds to the filepath!. It is actually the latter that happens (upload_id takes precedence).

An error should be thrown when inconsistent entries are provided to prompt the user to fix either/or of the entries.

p.s: one can argue that no need to require 2 arguments from the user; but this is apparently the case specifically for the user to confirm (twice) that it is this file/upload_id to be inserted.