### PR TITLE
Get file list after removal of undesired directories like __MACOSX: Redmine 13508

### DIFF
--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -110,7 +110,7 @@ sub IsCandidateInfoValid {
     ####Get a list of files from the folder#####################
     #############Loop through the files#########################
     ############################################################
-    my $cmd = "find -path " . $this->{'uploaded_temp_folder'} . " -name '__MACOSX' -delete ";
+    my $cmd = "find -path " . quotemeta($this->{'uploaded_temp_folder'}) . " -name '__MACOSX' -delete ";
     print "\n $cmd \n";
     system($cmd);
 

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -104,10 +104,16 @@ sub IsCandidateInfoValid {
     my $files_with_unmatched_patient_name = 0;
     my $is_candinfovalid                  = 0;
     my @row                               = ();
+
     ############################################################
+    ####Remove __MACOSX directory from the upload if found######
     ####Get a list of files from the folder#####################
     #############Loop through the files#########################
     ############################################################
+    my $cmd = "cd " . $this->{'uploaded_temp_folder'} . "; find -name '__MACOSX' | xargs rm -rf";
+    print "\n $cmd \n";
+    system($cmd);
+
     my @file_list;
     find(
         sub {
@@ -186,13 +192,6 @@ sub IsCandidateInfoValid {
         return 0;
     }
 
-
-    ############################################################
-    ####Remove __MACOSX directory from the upload ##############
-    ############################################################
-    my $cmd = "cd " . $this->{'uploaded_temp_folder'} . "; find -name '__MACOSX' | xargs rm -rf";
-    system($cmd);
-
     foreach (@file_list) {
         ########################################################
         #1) Exlcude files starting with . (and ._ as a result)##
@@ -202,7 +201,7 @@ sub IsCandidateInfoValid {
         ########################################################
         if ( (basename($_) =~ /^\./)) {
             $cmd = "rm " . ($_);
-            print ($cmd);
+            print "\n $cmd \n";
             system($cmd);
         }
         else {

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -110,7 +110,7 @@ sub IsCandidateInfoValid {
     ####Get a list of files from the folder#####################
     #############Loop through the files#########################
     ############################################################
-    my $cmd = "cd " . $this->{'uploaded_temp_folder'} . "; find -name '__MACOSX' | xargs rm -rf";
+    my $cmd = "cd " . $this->{'uploaded_temp_folder'} . "; find -name '__MACOSX' -exec rm -r {} + ";
     print "\n $cmd \n";
     system($cmd);
 

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -110,7 +110,7 @@ sub IsCandidateInfoValid {
     ####Get a list of files from the folder#####################
     #############Loop through the files#########################
     ############################################################
-    my $cmd = "cd " . $this->{'uploaded_temp_folder'} . "; find -name '__MACOSX' -exec rm -r {} + ";
+    my $cmd = "find -path " . $this->{'uploaded_temp_folder'} . " -name '__MACOSX' -delete ";
     print "\n $cmd \n";
     system($cmd);
 


### PR DESCRIPTION
The pipeline 1) gets the list of files from the unzipped uploaded file, then 2) removes the `__MACOSX` directory, and then 3) loops through the file list generated in step 1) and removes all those starting with a `.` (including the `.DS_Store` file).

a) The logic should be that we swap steps 1 and 2 so that the file list we are dealing with in the rest of the script excludes the `__MACOSX` directory and the files within.
b) Add line breaks after file/directory removal for user readability of the messages at the terminal (cleanup)
