### PR TITLE
MySQL 5.7 - Mapping empty date of birth and scan to undef 

### DIFF
--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -187,6 +187,11 @@ QUERY
         }
     }
 
+    # If DoB is not set, $self->{header}->{birthdate} = '' which will
+    # not be allowed anymore in MySQL 5.7 for date fields 
+    $self->{header}->{birthdate} = undef if ($self->{header}->{birthdate} eq '');
+    $self->{header}->{scandate}  = undef if ($self->{header}->{scandate} eq '');
+
     my @values = 
       (
        $self->{studyuid},                 $self->{header}->{pname},           


### PR DESCRIPTION
If a scan for some reason does not contain a date of birth (for example when scanning a phantom), the dicom archive scripts would try to insert it as "". However, in MySQL 5.7, this creates an error and the tarchive entry is not created.

In order to fix this, reassigned date of birth and date of scan to undef if its value = ""
