### PR TITLE
Add TarchiveID to mri_protocol_violated_scans

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -398,12 +398,13 @@ Returns: Textual name of scan type
 
 sub identify_scan_db {
 
-    my  ($psc, $subjectref, $tarchiveInfo, $fileref, $dbhr,$minc_location) = @_;
+    my  ($psc, $subjectref, $tarchiveInfoRef, $fileref, $dbhr,$minc_location
+    ) = @_;
 
     my $candid = ${subjectref}->{'CandID'};
     my $pscid = ${subjectref}->{'PSCID'};
     my $visit = ${subjectref}->{'visitLabel'};
-    my $tarchiveID = $tarchiveInfo->{'TarchiveID'};
+    my $tarchiveID = $tarchiveInfoRef->{'TarchiveID'};
     my $objective = ${subjectref}->{'subprojectID'};
 
     # get parameters from minc header

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -571,11 +571,6 @@ QUERY
         $time,          $seriesUID
     );
 
-#    $sth = $${dbhr}->prepare("INSERT INTO mri_protocol_violated_scans#
-    # (CandID,PSCID,time_run,series_description,minc_location,PatientName,TR_range,TE_range,TI_range,slice_thickness_range,xspace_range,yspace_range,zspace_range,xstep_range,ystep_range,zstep_range,time_range,SeriesUID) VALUES (?,?,now(),?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
-#    my $success = $sth->execute($candid,$pscid,$series_description,
-#        $minc_location,$patient_name,$tr,$te,$ti,$slice_thickness,$xspace,$yspace,$zspace,$xstep,$ystep,$zstep,$time,$seriesUID);
-
 }
 # ------------------------------ MNI Header ----------------------------------
 #@NAME       : debug_inrange

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -398,11 +398,12 @@ Returns: Textual name of scan type
 
 sub identify_scan_db {
 
-    my  ($psc, $subjectref, $fileref, $dbhr,$minc_location) = @_;
+    my  ($psc, $subjectref, $tarchiveInfo, $fileref, $dbhr,$minc_location) = @_;
 
     my $candid = ${subjectref}->{'CandID'};
     my $pscid = ${subjectref}->{'PSCID'};
     my $visit = ${subjectref}->{'visitLabel'};
+    my $tarchiveID = $tarchiveInfo->{'TarchiveID'};
     my $objective = ${subjectref}->{'subprojectID'};
 
     # get parameters from minc header
@@ -525,7 +526,13 @@ sub identify_scan_db {
     }
 
     # if we got here, we're really clueless...
-    insert_violated_scans($dbhr,$series_description,$minc_location,$patient_name,$candid, $pscid,$visit,$tr,$te,$ti,$slice_thickness,$xstep,$ystep,$zstep,$xspace,$yspace,$zspace,$time,$seriesUID);
+    insert_violated_scans(
+        $dbhr,   $series_description, $minc_location,   $patient_name,
+        $candid, $pscid,              $tr,              $te,
+        $ti,     $slice_thickness,    $xstep,           $ystep,
+        $zstep,  $xspace,             $yspace,          $zspace,
+        $time,   $seriesUID,          $tarchiveID
+    );
 
     return 'unknown';
 }    
@@ -533,12 +540,41 @@ sub identify_scan_db {
 
 sub insert_violated_scans {
 
-   my ($dbhr,$series_description,$minc_location,$patient_name,$candid, $pscid,$visit,$tr,$te,$ti,$slice_thickness,$xstep,$ystep,$zstep,$xspace,$yspace,$zspace,$time,$seriesUID) = @_;
-   my $query;
-   my $sth;
-    
-   $sth = $${dbhr}->prepare("INSERT INTO mri_protocol_violated_scans (CandID,PSCID,time_run,series_description,minc_location,PatientName,TR_range,TE_range,TI_range,slice_thickness_range,xspace_range,yspace_range,zspace_range,xstep_range,ystep_range,zstep_range,time_range,SeriesUID) VALUES (?,?,now(),?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
-   my $success = $sth->execute($candid,$pscid,$series_description,$minc_location,$patient_name,$tr,$te,$ti,$slice_thickness,$xspace,$yspace,$zspace,$xstep,$ystep,$zstep,$time,$seriesUID);
+    my ($dbhr,   $series_description, $minc_location, $patient_name,
+        $candid, $pscid,              $tr,            $te,
+        $ti,     $slice_thickness,    $xstep,         $ystep,
+        $zstep,  $xspace,             $yspace,        $zspace,
+        $time,   $seriesUID,          $tarchiveID) = @_;
+
+    (my $query = <<QUERY) =~ s/\n//gm;
+  INSERT INTO mri_protocol_violated_scans (
+    CandID,             PSCID,         TarchiveID,            time_run,
+    series_description, minc_location, PatientName,           TR_range,
+    TE_range,           TI_range,      slice_thickness_range, xspace_range,
+    yspace_range,       zspace_range,  xstep_range,           ystep_range,
+    zstep_range,        time_range,    SeriesUID
+  ) VALUES (
+    ?, ?, ?, now(),
+    ?, ?, ?, ?,
+    ?, ?, ?, ?,
+    ?, ?, ?, ?,
+    ?, ?, ?
+  )
+QUERY
+
+    my $sth = $${dbhr}->prepare($query);
+    my $success = $sth->execute(
+        $candid,        $pscid,           $tarchiveID, $series_description,
+        $minc_location, $patient_name,    $tr,         $te,
+        $ti,            $slice_thickness, $xspace,     $yspace,
+        $zspace,        $xstep,           $ystep,      $zstep,
+        $time,          $seriesUID
+    );
+
+#    $sth = $${dbhr}->prepare("INSERT INTO mri_protocol_violated_scans#
+    # (CandID,PSCID,time_run,series_description,minc_location,PatientName,TR_range,TE_range,TI_range,slice_thickness_range,xspace_range,yspace_range,zspace_range,xstep_range,ystep_range,zstep_range,time_range,SeriesUID) VALUES (?,?,now(),?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
+#    my $success = $sth->execute($candid,$pscid,$series_description,
+#        $minc_location,$patient_name,$tr,$te,$ti,$slice_thickness,$xspace,$yspace,$zspace,$xstep,$ystep,$zstep,$time,$seriesUID);
 
 }
 # ------------------------------ MNI Header ----------------------------------

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -418,8 +418,8 @@ sub computeMd5Hash {
 sub getAcquisitionProtocol {
    
     my $this = shift;
-    my ($file,$subjectIDsref,$tarchiveInfo,$center_name,$minc,$acquisitionProtocol,$bypass_extra_file_checks) = @_;
-    my $tarchive_srcloc = $tarchiveInfo->{'SourceLocation'};
+    my ($file,$subjectIDsref,$tarchiveInfoRef,$center_name,$minc,$acquisitionProtocol,$bypass_extra_file_checks) = @_;
+    my $tarchive_srcloc = $tarchiveInfoRef->{'SourceLocation'};
     my $upload_id = getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc);
     my $message = '';
 
@@ -435,7 +435,7 @@ sub getAcquisitionProtocol {
       $acquisitionProtocol =  &NeuroDB::MRI::identify_scan_db(
                                    $center_name,
                                    $subjectIDsref,
-                                   $tarchiveInfo,
+                                   $tarchiveInfoRef,
                                    $file, 
                                    $this->{dbhr}, 
                                    $minc
@@ -460,7 +460,7 @@ sub getAcquisitionProtocol {
                         $file, 
                         $subjectIDsref->{'CandID'}, 
                         $subjectIDsref->{'visitLabel'},
-                        $tarchiveInfo->{'PatientName'}
+                        $tarchiveInfoRef->{'PatientName'}
                     );
           $message = "\nextra_file_checks from table mri_protocol_check " .
                      "logged in table mri_violations_log: $checks[0]\n";

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -435,6 +435,7 @@ sub getAcquisitionProtocol {
       $acquisitionProtocol =  &NeuroDB::MRI::identify_scan_db(
                                    $center_name,
                                    $subjectIDsref,
+                                   $tarchiveInfo,
                                    $file, 
                                    $this->{dbhr}, 
                                    $minc


### PR DESCRIPTION
Make sure to source the patch in [PR #3354](https://github.com/aces/Loris/pull/3354) to create and populate the column TarchiveID in the mri_protocol_violated_scans table.

Updates to the insertion scripts so that the new TarchiveID field of mri_protocol_violated_scans table can be populated when inserting a violated scan.

NOTE: this is for the next minor release of LORIS
