### PR TITLE
[Documentation] NeuroDB::File library perldocification

### DIFF
--- a/docs/scripts_md/File.md
+++ b/docs/scripts_md/File.md
@@ -165,11 +165,14 @@ Other operations should be added: perhaps get\* methods for those fields in the
 
 None reported.
 
-# COPYRIGHT
+# COPYRIGHT AND LICENSE
 
 Copyright (c) 2004,2005 by Jonathan Harlap, McConnell Brain Imaging Centre,
 Montreal Neurological Institute, McGill University.
 
+License: GPLv3
+
 # AUTHORS
 
-Jonathan Harlap <jharlap@bic.mni.mcgill.ca>
+Jonathan Harlap <jharlap@bic.mni.mcgill.ca>,
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/File.md
+++ b/docs/scripts_md/File.md
@@ -33,7 +33,7 @@ LORIS
 
 # DESCRIPTION
 
-This class defines a BIC MRI (or related) file (minc, bicobj, xfm,
+This class defines a MRI (or related) file (minc, bicobj, xfm,
 etc) as represented within the LORIS database system.
 
 **Note:** if a developer does something naughty (such as leaving out
@@ -73,8 +73,6 @@ RETURNS: (int) FileID or undef if no file was found.
 ### getFileData()
 
 Gets the set of file data (data from the `files` table in the database).
-
-INPUT: none
 
 RETURNS: hashref of the contents of the record in the `files` table for the
 loaded file.
@@ -158,8 +156,8 @@ RETURNS: string or array of the value without white spaces
 
 # TO DO
 
-Other operations should be added: perhaps get\* methods for those fields in the
-`files` table which are lookup fields.
+Other operations should be added: perhaps `get*` methods for those fields in
+the `files` table which are lookup fields.
 
 # BUGS
 

--- a/docs/scripts_md/File.md
+++ b/docs/scripts_md/File.md
@@ -1,0 +1,175 @@
+# NAME
+
+NeuroDB::File -- Provides an interface to the MRI file management subsystem of
+  LORIS
+
+# SYNOPSIS
+
+    use NeuroDB::File;
+    use NeuroDB::DBI;
+
+    my $dbh = NeuroDB::DBI::connect_to_db();
+
+    my $file = NeuroDB::File->new(\$dbh);
+
+    my $fileID = $file->findFile('/path/to/some/file');
+    $file->loadFile($fileID);
+
+    my $acquisition_date = $file->getParameter('acquisition_date');
+    my $parameters_hashref = $file->getParameters();
+
+    my $coordinate_space = $file->getFileDatum('CoordinateSpace');
+    my $filedata_hashref = $file->getFileData();
+
+
+    # less common to use methods, available mainly for register_db...
+    my $dbh_copy = $file->getDatabaseHandleRef();
+
+    $file->loadFileFromDisk('/path/to/some/file');
+    $file->setFileData('CoordinateSpace', 'nonlinear');
+    $file->setParameter('patient_name', 'Larry Wall');
+
+    my $parameterTypeID = $file->getParameterTypeID('patient_name');
+
+# DESCRIPTION
+
+This class defines a BIC MRI (or related) file (minc, bicobj, xfm,
+etc) as represented within the LORIS database system.
+
+**Note:** if a developer does something naughty (such as leaving out
+the database handle ref when instantiating a new object or so on) the
+class will croak.
+
+## Methods
+
+### `new(\$dbh)` (constructor)
+
+Create a new instance of this class. The parameter `\$dbh` is a
+reference to a DBI database handle, used to set the object's database
+handle, so that all the DB-driven methods will work.
+
+INPUT: DBI database handle.
+
+RETURNS: new instance of this class.
+
+### `loadFile($fileID)`
+
+Load the object with all the data pertaining to a file as defined by
+parameter `$fileID`.
+
+INPUT: ID of the file to load.
+
+RETURNS: 0 if no file was found, 1 otherwise.
+
+### `findFile($filename)`
+
+Finds the FileID pertaining to a file as defined by parameter `$filename`,
+which is a full /path/to/file.
+
+INPUT: full path to the file to look for an ID in the database.
+
+RETURNS: (int) FileID or undef if no file was found.
+
+### `getFileData()`
+
+Gets the set of file data (data from the `files` table in the database).
+
+INPUT: none
+
+RETURNS: hashref of the contents of the record in the `files` table for the
+loaded file.
+
+### `getFileDatum($datumName)`
+
+Gets one element from the file data (data from the `files` table in the
+database).
+
+INPUT: name of the element to get.
+
+RETURNS: scalar of the particular datum requested pertaining to the loaded file.
+
+### `getParameter($parameterName)`
+
+Gets one element from the file's parameters (data from the `parameter_file`
+table in the database).
+
+INPUT: name of the element from the file's parameter
+
+RETURNS: scalar of the particular parameter requested pertaining to the loaded
+file.
+
+### `getParameters()`
+
+Gets the set of parameters for the loaded file (data from the `parameter_file`
+table in the database).
+
+RETURNS: hashref of the records in the `parameter_file` table for the loaded
+file.
+
+### `getDatabaseHandleRef()`
+
+Gets the database handle reference which the object is using internally.
+
+RETURNS: DBI database handle reference.
+
+### `loadFileFromDisk($filename)`
+
+Reads the headers from the file specified by `$filename` and loads the current
+object with the resultant parameters.
+
+INPUT: file to read the headers from.
+
+RETURNS: 0 if any failure occurred or 1 otherwise.
+
+### `setFileData($propertyName, $value)`
+
+Sets the fileData property named `$propertyName` to the value of `$value`.
+
+INPUT: name of the fileData property, value of the fileData property to be set
+
+### `setParameter($parameterName, $value)`
+
+Sets the parameter named `$parameterName` to the value of `$value`.
+
+INPUT: name of the parameter, value of the parameter to be set
+
+### `removeParameter($parameterName)`
+
+Removes the parameter named `$parameterName`.
+
+INPUT: name of the parameter to remove
+
+### `getParameterTypeID($parameter)`
+
+Gets the ParameterTypeID for the parameter `$parameter`.  If `$parameter`
+does not exist, it will be created.
+
+INPUT: name of the parameter type
+
+RETURNS: (int) ParameterTypeID
+
+### `removeWhitespace($value)`
+
+Removes white space from variable `$value`.
+
+INPUT: variable to remove white space from (string or array)
+
+RETURNS: string or array of the value without white spaces
+
+# TO DO
+
+Other operations should be added: perhaps get\* methods for those fields in the
+`files` table which are lookup fields.
+
+# BUGS
+
+None reported.
+
+# COPYRIGHT
+
+Copyright (c) 2004,2005 by Jonathan Harlap, McConnell Brain Imaging Centre,
+Montreal Neurological Institute, McGill University.
+
+# AUTHORS
+
+Jonathan Harlap <jharlap@bic.mni.mcgill.ca>

--- a/docs/scripts_md/File.md
+++ b/docs/scripts_md/File.md
@@ -1,7 +1,7 @@
 # NAME
 
 NeuroDB::File -- Provides an interface to the MRI file management subsystem of
-  LORIS
+LORIS
 
 # SYNOPSIS
 

--- a/docs/scripts_md/File.md
+++ b/docs/scripts_md/File.md
@@ -42,7 +42,7 @@ class will croak.
 
 ## Methods
 
-### `new(\$dbh)` (constructor)
+### new(\\$dbh) >> (constructor)
 
 Create a new instance of this class. The parameter `\$dbh` is a
 reference to a DBI database handle, used to set the object's database
@@ -52,7 +52,7 @@ INPUT: DBI database handle.
 
 RETURNS: new instance of this class.
 
-### `loadFile($fileID)`
+### loadFile($fileID)
 
 Load the object with all the data pertaining to a file as defined by
 parameter `$fileID`.
@@ -61,7 +61,7 @@ INPUT: ID of the file to load.
 
 RETURNS: 0 if no file was found, 1 otherwise.
 
-### `findFile($filename)`
+### findFile($filename)
 
 Finds the FileID pertaining to a file as defined by parameter `$filename`,
 which is a full /path/to/file.
@@ -70,7 +70,7 @@ INPUT: full path to the file to look for an ID in the database.
 
 RETURNS: (int) FileID or undef if no file was found.
 
-### `getFileData()`
+### getFileData()
 
 Gets the set of file data (data from the `files` table in the database).
 
@@ -79,7 +79,7 @@ INPUT: none
 RETURNS: hashref of the contents of the record in the `files` table for the
 loaded file.
 
-### `getFileDatum($datumName)`
+### getFileDatum($datumName)
 
 Gets one element from the file data (data from the `files` table in the
 database).
@@ -88,7 +88,7 @@ INPUT: name of the element to get.
 
 RETURNS: scalar of the particular datum requested pertaining to the loaded file.
 
-### `getParameter($parameterName)`
+### getParameter($parameterName)
 
 Gets one element from the file's parameters (data from the `parameter_file`
 table in the database).
@@ -98,7 +98,7 @@ INPUT: name of the element from the file's parameter
 RETURNS: scalar of the particular parameter requested pertaining to the loaded
 file.
 
-### `getParameters()`
+### getParameters()
 
 Gets the set of parameters for the loaded file (data from the `parameter_file`
 table in the database).
@@ -106,13 +106,13 @@ table in the database).
 RETURNS: hashref of the records in the `parameter_file` table for the loaded
 file.
 
-### `getDatabaseHandleRef()`
+### getDatabaseHandleRef()
 
 Gets the database handle reference which the object is using internally.
 
 RETURNS: DBI database handle reference.
 
-### `loadFileFromDisk($filename)`
+### loadFileFromDisk($filename)
 
 Reads the headers from the file specified by `$filename` and loads the current
 object with the resultant parameters.
@@ -121,25 +121,25 @@ INPUT: file to read the headers from.
 
 RETURNS: 0 if any failure occurred or 1 otherwise.
 
-### `setFileData($propertyName, $value)`
+### setFileData($propertyName, $value)
 
 Sets the fileData property named `$propertyName` to the value of `$value`.
 
 INPUT: name of the fileData property, value of the fileData property to be set
 
-### `setParameter($parameterName, $value)`
+### setParameter($parameterName, $value)
 
 Sets the parameter named `$parameterName` to the value of `$value`.
 
 INPUT: name of the parameter, value of the parameter to be set
 
-### `removeParameter($parameterName)`
+### removeParameter($parameterName)
 
 Removes the parameter named `$parameterName`.
 
 INPUT: name of the parameter to remove
 
-### `getParameterTypeID($parameter)`
+### getParameterTypeID($parameter)
 
 Gets the ParameterTypeID for the parameter `$parameter`.  If `$parameter`
 does not exist, it will be created.
@@ -148,7 +148,7 @@ INPUT: name of the parameter type
 
 RETURNS: (int) ParameterTypeID
 
-### `removeWhitespace($value)`
+### removeWhitespace($value)
 
 Removes white space from variable `$value`.
 

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -58,7 +58,7 @@ my $VERSION = sprintf "%d.%03d", q$Revision: 1.6 $ =~ /: (\d+)\.(\d+)/;
 
 =pod
 
-=head3 C<<  new(\$dbh) >> (constructor)
+=head3 new(\$dbh) >> (constructor)
 
 Create a new instance of this class. The parameter C<\$dbh> is a
 reference to a DBI database handle, used to set the object's database
@@ -84,7 +84,7 @@ sub new {
 
 =pod
 
-=head3 C<< loadFile($fileID)  >>
+=head3 loadFile($fileID)
 
 Load the object with all the data pertaining to a file as defined by
 parameter C<$fileID>.
@@ -126,7 +126,7 @@ sub loadFile {
 
 =pod
 
-=head3 C<< findFile($filename) >>
+=head3 findFile($filename)
 
 Finds the FileID pertaining to a file as defined by parameter C<$filename>,
 which is a full /path/to/file.
@@ -156,7 +156,7 @@ sub findFile {
 
 =pod
 
-=head3 C<< getFileData() >>
+=head3 getFileData()
 
 Gets the set of file data (data from the C<files> table in the database).
 
@@ -174,7 +174,7 @@ sub getFileData {
 
 =pod
 
-=head3 C<< getFileDatum($datumName) >>
+=head3 getFileDatum($datumName)
 
 Gets one element from the file data (data from the C<files> table in the
 database).
@@ -194,7 +194,7 @@ sub getFileDatum {
 
 =pod
 
-=head3 C<< getParameter($parameterName) >>
+=head3 getParameter($parameterName)
 
 Gets one element from the file's parameters (data from the C<parameter_file>
 table in the database).
@@ -215,7 +215,7 @@ sub getParameter {
 
 =pod
 
-=head3 C<< getParameters() >>
+=head3 getParameters()
 
 Gets the set of parameters for the loaded file (data from the C<parameter_file>
 table in the database).
@@ -232,7 +232,7 @@ sub getParameters {
 
 =pod
 
-=head3 C<< getDatabaseHandleRef() >>
+=head3 getDatabaseHandleRef()
 
 Gets the database handle reference which the object is using internally.
 
@@ -247,7 +247,7 @@ sub getDatabaseHandleRef {
 
 =pod
 
-=head3 C<< loadFileFromDisk($filename) >>
+=head3 loadFileFromDisk($filename)
 
 Reads the headers from the file specified by C<$filename> and loads the current
 object with the resultant parameters.
@@ -340,7 +340,7 @@ sub loadFileFromDisk {
 
 =pod
 
-=head3 C<< setFileData($propertyName, $value) >>
+=head3 setFileData($propertyName, $value)
 
 Sets the fileData property named C<$propertyName> to the value of C<$value>.
 
@@ -365,7 +365,7 @@ sub setFileData {
 
 =pod
 
-=head3 C<< setParameter($parameterName, $value) >>
+=head3 setParameter($parameterName, $value)
 
 Sets the parameter named C<$parameterName> to the value of C<$value>.
 
@@ -400,7 +400,7 @@ sub setParameter {
 
 =pod
 
-=head3 C<< removeParameter($parameterName) >>
+=head3 removeParameter($parameterName)
 
 Removes the parameter named C<$parameterName>.
 
@@ -417,7 +417,7 @@ sub removeParameter {
 
 =pod
 
-=head3 C<< getParameterTypeID($parameter) >>
+=head3 getParameterTypeID($parameter)
 
 Gets the ParameterTypeID for the parameter C<$parameter>.  If C<$parameter>
 does not exist, it will be created.
@@ -455,7 +455,7 @@ sub getParameterTypeID {
 
 =pod
 
-=head3 C<< removeWhitespace($value) >>
+=head3 removeWhitespace($value)
 
 Removes white space from variable C<$value>.
 

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -498,13 +498,17 @@ C<files> table which are lookup fields.
 
 None reported.
 
-=head1 COPYRIGHT
+=head1 COPYRIGHT AND LICENSE
 
 Copyright (c) 2004,2005 by Jonathan Harlap, McConnell Brain Imaging Centre,
 Montreal Neurological Institute, McGill University.
 
+License: GPLv3
+
 =head1 AUTHORS
 
-Jonathan Harlap <jharlap@bic.mni.mcgill.ca>
+Jonathan Harlap <jharlap@bic.mni.mcgill.ca>,
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
 
 =cut    

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -8,7 +8,7 @@ use Carp;
 =head1 NAME
 
 NeuroDB::File -- Provides an interface to the MRI file management subsystem of
-  LORIS
+LORIS
 
 =head1 SYNOPSIS
 

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -40,7 +40,7 @@ LORIS
 
 =head1 DESCRIPTION
 
-This class defines a BIC MRI (or related) file (minc, bicobj, xfm,
+This class defines a MRI (or related) file (minc, bicobj, xfm,
 etc) as represented within the LORIS database system.
 
 B<Note:> if a developer does something naughty (such as leaving out
@@ -159,8 +159,6 @@ sub findFile {
 =head3 getFileData()
 
 Gets the set of file data (data from the C<files> table in the database).
-
-INPUT: none
 
 RETURNS: hashref of the contents of the record in the C<files> table for the
 loaded file.
@@ -491,8 +489,8 @@ __END__
 
 =head1 TO DO
 
-Other operations should be added: perhaps get* methods for those fields in the
-C<files> table which are lookup fields.
+Other operations should be added: perhaps C<get*> methods for those fields in
+the C<files> table which are lookup fields.
 
 =head1 BUGS
 

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -7,7 +7,8 @@ use Carp;
 
 =head1 NAME
 
-NeuroDB::File -- Provides an interface to the MRI file management subsystem of NeuroDB
+NeuroDB::File -- Provides an interface to the MRI file management subsystem of
+  LORIS
 
 =head1 SYNOPSIS
 
@@ -40,13 +41,13 @@ NeuroDB::File -- Provides an interface to the MRI file management subsystem of N
 =head1 DESCRIPTION
 
 This class defines a BIC MRI (or related) file (minc, bicobj, xfm,
-etc) as represented within the NeuroDB database system.
+etc) as represented within the LORIS database system.
 
 B<Note:> if a developer does something naughty (such as leaving out
 the database handle ref when instantiating a new object or so on) the
 class will croak.
 
-=head1 METHODS
+=head2 Methods
 
 =cut
 
@@ -57,13 +58,15 @@ my $VERSION = sprintf "%d.%03d", q$Revision: 1.6 $ =~ /: (\d+)\.(\d+)/;
 
 =pod
 
-B<new( \$dbh )> (constructor)
+=head3 C<<  new(\$dbh) >> (constructor)
 
-Create a new instance of this class.  The parameter C<\$dbh> is a
+Create a new instance of this class. The parameter C<\$dbh> is a
 reference to a DBI database handle, used to set the object's database
 handle, so that all the DB-driven methods will work.
 
-Returns: new instance of this class.
+INPUT: DBI database handle.
+
+RETURNS: new instance of this class.
 
 =cut
 
@@ -81,10 +84,14 @@ sub new {
 
 =pod
 
-B<loadFile( C<$fileID> )>
+=head3 C<< loadFile($fileID)  >>
 
 Load the object with all the data pertaining to a file as defined by
 parameter C<$fileID>.
+
+INPUT: ID of the file to load.
+
+RETURNS: 0 if no file was found, 1 otherwise.
 
 =cut
 
@@ -119,12 +126,14 @@ sub loadFile {
 
 =pod
 
-B<findFile( $filename )>
+=head3 C<< findFile($filename) >>
 
-Finds the FileID pertaining to a file as defined by
-parameter C<$filename>, which is a full /path/to/file.
+Finds the FileID pertaining to a file as defined by parameter C<$filename>,
+which is a full /path/to/file.
 
-Returns: (int) FileID or undef if no file was found.
+INPUT: full path to the file to look for an ID in the database.
+
+RETURNS: (int) FileID or undef if no file was found.
 
 =cut
 
@@ -147,11 +156,14 @@ sub findFile {
 
 =pod
 
-B<getFileData( )>
+=head3 C<< getFileData() >>
 
 Gets the set of file data (data from the C<files> table in the database).
 
-Returns: hashref of the contents of the record in the C<files> table for the loaded file.
+INPUT: none
+
+RETURNS: hashref of the contents of the record in the C<files> table for the
+loaded file.
 
 =cut
 
@@ -162,11 +174,14 @@ sub getFileData {
 
 =pod
 
-B<getFileDatum( C<$datumName> )>
+=head3 C<< getFileDatum($datumName) >>
 
-Gets one element from the file data (data from the C<files> table in the database).
+Gets one element from the file data (data from the C<files> table in the
+database).
 
-Returns: scalar of the particular datum requested pertaining to the loaded file.
+INPUT: name of the element to get.
+
+RETURNS: scalar of the particular datum requested pertaining to the loaded file.
 
 =cut
 
@@ -179,11 +194,15 @@ sub getFileDatum {
 
 =pod
 
-B<getParameter( C<$parameterName> )>
+=head3 C<< getParameter($parameterName) >>
 
-Gets one element from the file's parameters (data from the C<parameter_file> table in the database).
+Gets one element from the file's parameters (data from the C<parameter_file>
+table in the database).
 
-Returns: scalar of the particular parameter requested pertaining to the loaded file.
+INPUT: name of the element from the file's parameter
+
+RETURNS: scalar of the particular parameter requested pertaining to the loaded
+file.
 
 =cut
 
@@ -196,11 +215,13 @@ sub getParameter {
 
 =pod
 
-B<getParameters( )>
+=head3 C<< getParameters() >>
 
-Gets the set of parameters for the loaded file (data from the C<parameter_file> table in the database).
+Gets the set of parameters for the loaded file (data from the C<parameter_file>
+table in the database).
 
-Returns: hashref of the records in the C<parameter_file> table for the loaded file.
+RETURNS: hashref of the records in the C<parameter_file> table for the loaded
+file.
 
 =cut
 
@@ -211,11 +232,11 @@ sub getParameters {
 
 =pod
 
-B<getDatabaseHandleRef( )>
+=head3 C<< getDatabaseHandleRef() >>
 
 Gets the database handle reference which the object is using internally.
 
-Returns: DBI database handle reference
+RETURNS: DBI database handle reference.
 
 =cut
 
@@ -226,11 +247,14 @@ sub getDatabaseHandleRef {
 
 =pod
 
-B<loadFileFromDisk( C<$filename> )>
+=head3 C<< loadFileFromDisk($filename) >>
 
-Reads the headers from the file specified by C<$filename> and loads the current object with the resultant parameters.
+Reads the headers from the file specified by C<$filename> and loads the current
+object with the resultant parameters.
 
-Returns: 0 if any failure occurred or 1 otherwise
+INPUT: file to read the headers from.
+
+RETURNS: 0 if any failure occurred or 1 otherwise.
 
 =cut
 
@@ -280,14 +304,12 @@ sub loadFileFromDisk {
     foreach my $attribute (@attributes) {
         if($attribute =~ /\s*(\w*:\w+) = (.*)$/s) {
             $this->setParameter($1, $2);
-=pod
-#fixme debug if ever we run into weird values again
-            if (length($2) < 1000) {
-             #   print length($2)."\n";
-                print "$1\t\t\t---->\t\'" . $this->getParameter($1). "\'\t\n";
-            }
-#end fixme
-=cut
+#            fixme debug if ever we run into weird values again
+#            if (length($2) < 1000) {
+#             #   print length($2)."\n";
+#                print "$1\t\t\t---->\t\'" . $this->getParameter($1). "\'\t\n";
+#            }
+#            end fixme
         }
     }
     # get dimension lengths
@@ -318,9 +340,11 @@ sub loadFileFromDisk {
 
 =pod
 
-B<setFileData( C<$propertyName>, C<$value> )>
+=head3 C<< setFileData($propertyName, $value) >>
 
 Sets the fileData property named C<$propertyName> to the value of C<$value>.
+
+INPUT: name of the fileData property, value of the fileData property to be set
 
 =cut
 
@@ -341,9 +365,11 @@ sub setFileData {
 
 =pod
 
-B<setParameter( C<$parameterName>, C<$value> )>
+=head3 C<< setParameter($parameterName, $value) >>
 
 Sets the parameter named C<$parameterName> to the value of C<$value>.
+
+INPUT: name of the parameter, value of the parameter to be set
 
 =cut
 
@@ -374,9 +400,11 @@ sub setParameter {
 
 =pod
 
-B<removeParameter( C<$parameterName> )>
+=head3 C<< removeParameter($parameterName) >>
 
 Removes the parameter named C<$parameterName>.
+
+INPUT: name of the parameter to remove
 
 =cut
 
@@ -389,12 +417,14 @@ sub removeParameter {
 
 =pod
 
-B<getParameterTypeID( C<$parameter> )>
+=head3 C<< getParameterTypeID($parameter) >>
 
-Gets the ParameterTypeID for the parameter C<$parameter>.  If
-C<$parameter> does not exist, it will be created.
+Gets the ParameterTypeID for the parameter C<$parameter>.  If C<$parameter>
+does not exist, it will be created.
 
-Returns: (int) ParameterTypeID
+INPUT: name of the parameter type
+
+RETURNS: (int) ParameterTypeID
 
 =cut
 
@@ -422,6 +452,18 @@ sub getParameterTypeID {
     }
 }
 	
+
+=pod
+
+=head3 C<< removeWhitespace($value) >>
+
+Removes white space from variable C<$value>.
+
+INPUT: variable to remove white space from (string or array)
+
+RETURNS: string or array of the value without white spaces
+
+=cut
 sub removeWhitespace {
     my @vars = @_;
     foreach my $var (@vars) {
@@ -449,7 +491,8 @@ __END__
 
 =head1 TO DO
 
-Other operations should be added: perhaps get* methods for those fields in the C<files> table which are lookup fields.
+Other operations should be added: perhaps get* methods for those fields in the
+C<files> table which are lookup fields.
 
 =head1 BUGS
 


### PR DESCRIPTION
Using perldoc/perlpod to document `File.pm` so that users can type in the terminal
`perldoc File.pm` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `File.md` file has been created so that we have a web displayed version of the documentation.
`pod2markdown File.pm > File.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage