### PR TITLE
[Documentation] NeuroDB::FileDecompress library perldocification

### DIFF
--- a/docs/scripts_md/FileDecompress.md
+++ b/docs/scripts_md/FileDecompress.md
@@ -64,8 +64,10 @@ RETURNS: type of the archive
 
 None reported
 
-# COPYRIGHT
+# COPYRIGHT AND LICENSE
+
+License: GPLv3
 
 # AUTHORS
 
-LORIS TEAM
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/FileDecompress.md
+++ b/docs/scripts_md/FileDecompress.md
@@ -40,7 +40,7 @@ RETURNS: TRUE on success, FALSE on failure
 
 ### getArchivedFiles()
 
-This function will return an array ref with the paths of all the files in the 
+This function will return an array ref with the paths of all the files in the
 archive.
 
 RETURNS: array of archived files

--- a/docs/scripts_md/FileDecompress.md
+++ b/docs/scripts_md/FileDecompress.md
@@ -60,6 +60,8 @@ RETURNS: type of the archive
 
 # TO DO
 
+Nothing planned.
+
 # BUGS
 
 None reported

--- a/docs/scripts_md/FileDecompress.md
+++ b/docs/scripts_md/FileDecompress.md
@@ -1,7 +1,7 @@
 # NAME
 
 NeuroDB::FileDecompress -- Provides an interface to the file decompression of
- LORIS
+LORIS-MRI
 
 # SYNOPSIS
 
@@ -21,13 +21,13 @@ This library regroups utilities for manipulation of archived datasets.
 
 ## Methods
 
-### new($file\_path) (constructor)
+### new($file\_path) >> (constructor)
 
 Create a new instance of this class.
 
 INPUT: path of the file to extract.
 
-RETURNS: a `Archive::Extract` object on success, or false on failure
+RETURNS: an `Archive::Extract` object on success, or FALSE on failure
 
 ### Extract($destination\_folder)
 
@@ -50,7 +50,7 @@ RETURNS: array of archived files
 This function will return the path to the directory where the files will be
 extracted to.
 
-RETURNS: Path to the folder where file will be extracted
+RETURNS: path to the folder where file will be extracted
 
 ### getType()
 

--- a/docs/scripts_md/FileDecompress.md
+++ b/docs/scripts_md/FileDecompress.md
@@ -32,7 +32,7 @@ RETURNS: a `Archive::Extract` object on success, or false on failure
 ### Extract($destination\_folder)
 
 This function will automatically detect the file-type and will decompress the
- file by calling the appropriate function under the hood.
+file by calling the appropriate function under the hood.
 
 INPUT: full path to the destination folder
 
@@ -40,8 +40,8 @@ RETURNS: TRUE on success, FALSE on failure
 
 ### getArchivedFiles()
 
-This function will return an array ref with the paths of all the files in the
- archive.
+This function will return an array ref with the paths of all the files in the 
+archive.
 
 RETURNS: array of archived files
 

--- a/docs/scripts_md/FileDecompress.md
+++ b/docs/scripts_md/FileDecompress.md
@@ -1,0 +1,71 @@
+# NAME
+
+NeuroDB::FileDecompress -- Provides an interface to the file decompression of
+ LORIS
+
+# SYNOPSIS
+
+    use NeuroDB::FileDecompress;
+
+    my $file_decompress = NeuroDB::FileDecompress->new($uploaded_file);
+
+    my $extract = $file_decompress->Extract($decompressed_folder);
+
+    my $archived_files = $file_decompress->getArchivedFiles($decompressed_folder);
+
+    my $extract_directory = $file_decompress->getExtractedDirectory($decompressed_folder);
+
+# DESCRIPTION
+
+This library regroups utilities for manipulation of archived datasets.
+
+## Methods
+
+### new($file\_path) (constructor)
+
+Create a new instance of this class.
+
+INPUT: path of the file to extract.
+
+RETURNS: a `Archive::Extract` object on success, or false on failure
+
+### Extract($destination\_folder)
+
+This function will automatically detect the file-type and will decompress the
+ file by calling the appropriate function under the hood.
+
+INPUT: full path to the destination folder
+
+RETURNS: TRUE on success, FALSE on failure
+
+### getArchivedFiles()
+
+This function will return an array ref with the paths of all the files in the
+ archive.
+
+RETURNS: array of archived files
+
+### getExtractedDirectory()
+
+This function will return the path to the directory where the files will be
+extracted to.
+
+RETURNS: Path to the folder where file will be extracted
+
+### getType()
+
+This function will return the type of the archive
+
+RETURNS: type of the archive
+
+# TO DO
+
+# BUGS
+
+None reported
+
+# COPYRIGHT
+
+# AUTHORS
+
+LORIS TEAM

--- a/uploadNeuroDB/NeuroDB/FileDecompress.pm
+++ b/uploadNeuroDB/NeuroDB/FileDecompress.pm
@@ -87,7 +87,7 @@ sub Extract  {
 
 =head3 getArchivedFiles()
 
-This function will return an array ref with the paths of all the files in the 
+This function will return an array ref with the paths of all the files in the
 archive.
 
 RETURNS: array of archived files

--- a/uploadNeuroDB/NeuroDB/FileDecompress.pm
+++ b/uploadNeuroDB/NeuroDB/FileDecompress.pm
@@ -143,10 +143,12 @@ sub getType {
 
 None reported
 
-=head1 COPYRIGHT
+=head1 COPYRIGHT AND LICENSE
+
+License: GPLv3
 
 =head1 AUTHORS
 
-LORIS TEAM
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
 
 =cut

--- a/uploadNeuroDB/NeuroDB/FileDecompress.pm
+++ b/uploadNeuroDB/NeuroDB/FileDecompress.pm
@@ -66,7 +66,7 @@ sub new {
 =head3 Extract($destination_folder)
 
 This function will automatically detect the file-type and will decompress the
- file by calling the appropriate function under the hood.
+file by calling the appropriate function under the hood.
 
 INPUT: full path to the destination folder
 
@@ -87,8 +87,8 @@ sub Extract  {
 
 =head3 getArchivedFiles()
 
-This function will return an array ref with the paths of all the files in the
- archive.
+This function will return an array ref with the paths of all the files in the 
+archive.
 
 RETURNS: array of archived files
 

--- a/uploadNeuroDB/NeuroDB/FileDecompress.pm
+++ b/uploadNeuroDB/NeuroDB/FileDecompress.pm
@@ -139,6 +139,8 @@ sub getType {
 
 =head1 TO DO
 
+Nothing planned.
+
 =head1 BUGS
 
 None reported

--- a/uploadNeuroDB/NeuroDB/FileDecompress.pm
+++ b/uploadNeuroDB/NeuroDB/FileDecompress.pm
@@ -1,4 +1,32 @@
 package NeuroDB::FileDecompress;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::FileDecompress -- Provides an interface to the file decompression of
+ LORIS
+
+=head1 SYNOPSIS
+
+  use NeuroDB::FileDecompress;
+
+  my $file_decompress = NeuroDB::FileDecompress->new($uploaded_file);
+
+  my $extract = $file_decompress->Extract($decompressed_folder);
+
+  my $archived_files = $file_decompress->getArchivedFiles($decompressed_folder);
+
+  my $extract_directory = $file_decompress->getExtractedDirectory($decompressed_folder);
+
+=head1 DESCRIPTION
+
+This library regroups utilities for manipulation of archived datasets.
+
+=head2 Methods
+
+=cut
+
 use English;
 use Carp;
 use strict;
@@ -8,9 +36,19 @@ use Path::Class;
 use Archive::Extract;
 use Archive::Zip;
 
-################################################################
-#####################Constructor ###############################
-################################################################
+
+=pod
+
+=head3 new($file_path) (constructor)
+
+Create a new instance of this class.
+
+INPUT: path of the file to extract.
+
+RETURNS: a C<Archive::Extract> object on success, or false on failure
+
+=cut
+
 sub new {
     my $params = shift;
     my ($file_path) = @_;
@@ -22,44 +60,38 @@ sub new {
     return bless $self, $params;
 }
 
-################################################################
-#####################Extract()##################################
-################################################################
+
 =pod
-Extract()
-Description:
-  - This function will automatically detect the file-type
-    and will decompress the file by calling the appropriate
-    function under the hood and return false if the decompression
-    fails and true otherwise.
-Arguments:
-  $this              : reference to the class
-  $destination_folder: Full path to the destination folder
-  Returns            : True if success and false otherwise
+
+=head3 Extract($destination_folder)
+
+This function will automatically detect the file-type and will decompress the
+ file by calling the appropriate function under the hood.
+
+INPUT: full path to the destination folder
+
+RETURNS: TRUE on success, FALSE on failure
+
 =cut
 
 sub Extract  {
     my $this = shift;
     my ($destination_folder) = @_;
-    #####################################################
-    ##Check to see if the destination folder exists######
-    #####################################################
+
+    # Check to see if the destination folder exists
     return $this->{'extract_object'}->extract(to=>$destination_folder);
 }
 
 
-################################################################
-#####################getArchivedFiles()#########################
-################################################################
 =pod
-getArchivedFiles()
-Description:
-  - This function will return an array ref with the paths of 
-    all the files in the archive.
 
-Arguments:
-  $this              : reference to the class
-  Returns            : Array of a files
+=head3 getArchivedFiles()
+
+This function will return an array ref with the paths of all the files in the
+ archive.
+
+RETURNS: array of archived files
+
 =cut
 
 sub getArchivedFiles {
@@ -67,18 +99,16 @@ sub getArchivedFiles {
     return  $this->{'extract_object'}->files;
 }
 
-################################################################
-#####################getExtractedDirectory()####################
-################################################################
-=pod
-getExtractedDirectory()
-Description:
-  - It will return the directory that the files will be extracted
-    to. 
 
-Arguments:
-  $this              : Reference to the class
-  Returns            : Path to the folder where file will be extracted
+=pod
+
+=head3 getExtractedDirectory()
+
+This function will return the path to the directory where the files will be
+extracted to.
+
+RETURNS: Path to the folder where file will be extracted
+
 =cut
 
 sub getExtractedDirectory {
@@ -86,17 +116,15 @@ sub getExtractedDirectory {
     return $this->{'extract_object'}->extract_path();
 }
 
-################################################################
-#####################getType()##################################
-################################################################
-=pod
-getType()
-Description:
-  - This function will return the type of the archive
 
-Arguments:
-  $this              : reference to the class
-  Returns            : The type of the archive
+=pod
+
+=head3 getType()
+
+This function will return the type of the archive
+
+RETURNS: type of the archive
+
 =cut
 
 
@@ -105,3 +133,20 @@ sub getType {
     return  $this->{'extract_object'}->type;
 }
 1; 
+
+
+=pod
+
+=head1 TO DO
+
+=head1 BUGS
+
+None reported
+
+=head1 COPYRIGHT
+
+=head1 AUTHORS
+
+LORIS TEAM
+
+=cut

--- a/uploadNeuroDB/NeuroDB/FileDecompress.pm
+++ b/uploadNeuroDB/NeuroDB/FileDecompress.pm
@@ -5,7 +5,7 @@ package NeuroDB::FileDecompress;
 =head1 NAME
 
 NeuroDB::FileDecompress -- Provides an interface to the file decompression of
- LORIS
+LORIS-MRI
 
 =head1 SYNOPSIS
 
@@ -39,13 +39,13 @@ use Archive::Zip;
 
 =pod
 
-=head3 new($file_path) (constructor)
+=head3 new($file_path) >> (constructor)
 
 Create a new instance of this class.
 
 INPUT: path of the file to extract.
 
-RETURNS: a C<Archive::Extract> object on success, or false on failure
+RETURNS: an C<Archive::Extract> object on success, or FALSE on failure
 
 =cut
 
@@ -107,7 +107,7 @@ sub getArchivedFiles {
 This function will return the path to the directory where the files will be
 extracted to.
 
-RETURNS: Path to the folder where file will be extracted
+RETURNS: path to the folder where file will be extracted
 
 =cut
 


### PR DESCRIPTION
Using perldoc/perlpod to document `FileDecompress.pm` so that users can type in the terminal
`perldoc FileDecompress.pm` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `FileDecompress.md` file has been created so that we have a web displayed version of the documentation.
`pod2markdown FileDecompress.pm > FileDecompress.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage