### PR TITLE
[Documentation] NeuroDB::ImagingUpload library perldocification

### DIFF
--- a/docs/scripts_md/ImagingUpload.md
+++ b/docs/scripts_md/ImagingUpload.md
@@ -4,47 +4,48 @@ NeuroDB::ImagingUpload -- Provides an interface to the uploaded imaging file
 
 # SYNOPSIS
 
-use NeuroDB::ImagingUpload;
+    use NeuroDB::ImagingUpload;
 
-my $imaging\_upload = &NeuroDB::ImagingUpload->new(
-                       \\$dbh,
-                       $TmpDir\_decompressed\_folder,
-                       $upload\_id,
-                       $patient\_name,
-                       $profile,
-                       $verbose
-                     );
+    my $imaging_upload = &NeuroDB::ImagingUpload->new(
+                           \$dbh,
+                           $TmpDir_decompressed_folder,
+                           $upload_id,
+                           $patient_name,
+                           $profile,
+                           $verbose
+                         );
 
-my $is\_candinfovalid = $imaging\_upload->IsCandidateInfoValid();
+    my $is_candinfovalid = $imaging_upload->IsCandidateInfoValid();
 
-my $output = $imaging\_upload->runDicomTar();
-$imaging\_upload->updateMRIUploadTable('Inserting', 0) if ( !$output );
+    my $output = $imaging_upload->runDicomTar();
+    $imaging_upload->updateMRIUploadTable('Inserting', 0) if ( !$output );
 
-my $output = $imaging\_upload->runTarchiveLoader();
-$imaging\_upload->updateMRIUploadTable('Inserting', 0) if ( !$output);
 
-my $isCleaned = $imaging\_upload->CleanUpDataIncomingDir($uploaded\_file);
+    my $output = $imaging_upload->runTarchiveLoader();
+    $imaging_upload->updateMRIUploadTable('Inserting', 0) if ( !$output);
+
+    my $isCleaned = $imaging_upload->CleanUpDataIncomingDir($uploaded_file);
 
 # DESCRIPTION
 
 This library regroups utilities for manipulation of the uploaded imaging file
- and updates of the `mri_upload` table according to the upload status.
+and updates of the `mri_upload` table according to the upload status.
 
 ## Methods
 
-### new($dbhr, $uploaded\_temp\_folder, $upload\_id, $pname, $profile,
-$verbose) (constructor)
+### new($dbhr, $uploaded\_temp\_folder, $upload\_id, ...) (constructor)
 
 Create a new instance of this class. This constructor needs the location of
 the uploaded file. Once the uploaded file has been validated, it will be
 moved to a final destination directory.
 
 INPUT:
-  $dbhr: database handler
-  $uploaded\_temp\_folder: temporary directory of the upload
-  $upload\_id: ID of the upload in the mri\_upload table
-  $pname: patient name
-  $profile: name of the configuration file (typically `prod`)
+  - $dbhr                : database handler
+  - $uploaded\_temp\_folder: temporary directory of the upload
+  - $upload\_id           : uploadID from the mri\_upload table
+  - $pname               : patient name
+  - $profile             : name of the configuration file
+                          (typically `prod`)
 
 RETURNS: new instance of this class
 
@@ -52,8 +53,8 @@ RETURNS: new instance of this class
 
 Validates the File to be uploaded. If the validation passes, the following
 actions will happen:
-  1) Copy the file from tmp folder to the /data/incoming directory
-  2) Set the IsCandidateInfoValidated to true in the mri\_upload table
+  1) Copy the file from tmp folder to /data/incoming
+  2) Set `IsCandidateInfoValidated` to TRUE in the mri\_upload table
 
 RETURNS: 1 on success, 0 on failure
 
@@ -62,7 +63,7 @@ RETURNS: 1 on success, 0 on failure
 This method executes the following actions:
  - Runs `dicomTar.pl` with `-clobber -database -profile prod` options
  - Extracts the TarchiveID of the tarchive created by `dicomTar.pl`
- - Updates the mri\_upload table accordingly if `dicomTar.pl` ran successfully
+ - Updates the mri\_upload table if `dicomTar.pl` ran successfully
 
 RETURNS: 1 on success, 0 on failure
 
@@ -135,9 +136,10 @@ This method calls the `Notify->spool` function to log all messages
 returned by the insertion scripts.
 
 INPUT:
- $message: message to be logged in the database
- $error  : 'Y' for an error log , 'N' otherwise
- $verb   : 'N' for few main messages, 'Y' for more messages (for developers)
+ - $message: message to be logged in the database
+ - $error  : 'Y' for an error log , 'N' otherwise
+ - $verb   : 'N' for few main messages,
+             'Y' for more messages (for developers)
 
 ### updateMRIUploadTable($field, $value)
 
@@ -145,8 +147,8 @@ This method updates the `mri_upload` table with `$value` for the field
 `$field`.
 
 INPUT:
- $field: name of the column in the table to be updated
- $value: value of the column to be set
+ - $field: name of the column in the table to be updated
+ - $value: value of the column to be set
 
 # TO DO
 

--- a/docs/scripts_md/ImagingUpload.md
+++ b/docs/scripts_md/ImagingUpload.md
@@ -150,6 +150,8 @@ INPUT:
 
 # TO DO
 
+Nothing planned.
+
 # BUGS
 
 None reported

--- a/docs/scripts_md/ImagingUpload.md
+++ b/docs/scripts_md/ImagingUpload.md
@@ -1,10 +1,34 @@
 # NAME
 
-NeuroDB::ImagingUpload -- ??????????????????????
+NeuroDB::ImagingUpload -- Provides an interface to the uploaded imaging file
 
 # SYNOPSIS
 
+use NeuroDB::ImagingUpload;
+
+my $imaging\_upload = &NeuroDB::ImagingUpload->new(
+                       \\$dbh,
+                       $TmpDir\_decompressed\_folder,
+                       $upload\_id,
+                       $patient\_name,
+                       $profile,
+                       $verbose
+                     );
+
+my $is\_candinfovalid = $imaging\_upload->IsCandidateInfoValid();
+
+my $output = $imaging\_upload->runDicomTar();
+$imaging\_upload->updateMRIUploadTable('Inserting', 0) if ( !$output );
+
+my $output = $imaging\_upload->runTarchiveLoader();
+$imaging\_upload->updateMRIUploadTable('Inserting', 0) if ( !$output);
+
+my $isCleaned = $imaging\_upload->CleanUpDataIncomingDir($uploaded\_file);
+
 # DESCRIPTION
+
+This library regroups utilities for manipulation of the uploaded imaging file
+ and updates of the `mri_upload` table according to the upload status.
 
 ## Methods
 

--- a/docs/scripts_md/ImagingUpload.md
+++ b/docs/scripts_md/ImagingUpload.md
@@ -54,7 +54,7 @@ RETURNS: new instance of this class
 Validates the File to be uploaded. If the validation passes, the following
 actions will happen:
   1) Copy the file from `tmp` folder to `/data/incoming`
-  2) Set `IsCandidateInfoValidated` to TRUE in the mri\_upload table
+  2) Set `IsCandidateInfoValidated` to TRUE in the `mri_upload` table
 
 RETURNS: 1 on success, 0 on failure
 

--- a/docs/scripts_md/ImagingUpload.md
+++ b/docs/scripts_md/ImagingUpload.md
@@ -154,8 +154,10 @@ INPUT:
 
 None reported
 
-# COPYRIGHT
+# COPYRIGHT AND LICENSE
+
+License: GPLv3
 
 # AUTHORS
 
-LORIS TEAM
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/ImagingUpload.md
+++ b/docs/scripts_md/ImagingUpload.md
@@ -53,7 +53,7 @@ RETURNS: new instance of this class
 
 Validates the File to be uploaded. If the validation passes, the following
 actions will happen:
-  1) Copy the file from tmp folder to /data/incoming
+  1) Copy the file from `tmp` folder to `/data/incoming`
   2) Set `IsCandidateInfoValidated` to TRUE in the mri\_upload table
 
 RETURNS: 1 on success, 0 on failure

--- a/docs/scripts_md/ImagingUpload.md
+++ b/docs/scripts_md/ImagingUpload.md
@@ -1,0 +1,137 @@
+# NAME
+
+NeuroDB::ImagingUpload -- ??????????????????????
+
+# SYNOPSIS
+
+# DESCRIPTION
+
+## Methods
+
+### new($dbhr, $uploaded\_temp\_folder, $upload\_id, $pname, $profile,
+$verbose) (constructor)
+
+Create a new instance of this class. This constructor needs the location of
+the uploaded file. Once the uploaded file has been validated, it will be
+moved to a final destination directory.
+
+INPUT:
+  $dbhr: database handler
+  $uploaded\_temp\_folder: temporary directory of the upload
+  $upload\_id: ID of the upload in the mri\_upload table
+  $pname: patient name
+  $profile: name of the configuration file (typically `prod`)
+
+RETURNS: new instance of this class
+
+### IsCandidateInfoValid()
+
+Validates the File to be uploaded. If the validation passes, the following
+actions will happen:
+  1) Copy the file from tmp folder to the /data/incoming directory
+  2) Set the IsCandidateInfoValidated to true in the mri\_upload table
+
+RETURNS: 1 on success, 0 on failure
+
+### runDicomTar()
+
+This method executes the following actions:
+ - Runs `dicomTar.pl` with `-clobber -database -profile prod` options
+ - Extracts the TarchiveID of the tarchive created by `dicomTar.pl`
+ - Updates the mri\_upload table accordingly if `dicomTar.pl` ran successfully
+
+RETURNS: 1 on success, 0 on failure
+
+### getTarchiveFileLocation()
+
+This method fetches the location of the archive from the tarchive table of
+the database.
+
+RETURNS: the archive location
+
+### runTarchiveLoader()
+
+This methods will call `tarchiveLoader` with the `-clobber -profile prod`
+options and update the mri\_upload table accordingly if `tarchiveLoader` ran
+successfully.
+
+RETURNS: 1 on success, 0 on failure
+
+### PatientNameMatch($dicom\_file)
+
+This method extracts the patient name field from the DICOM file header using
+`dcmdump` and compares it with the patient name information stored in the
+mri\_upload table.
+
+INPUT: full path to the dicom-file
+
+RETURNS: 1 on success, 0 on failure
+
+### isDicom($dicom\_file)
+
+This method checks whether the file given as an argument is of type DICOM.
+
+INPUT: full path to the dicom-file
+
+RETURNS: 1 if file is of type DICOM, 0 if file is not of type DICOM
+
+### sourceEnvironment()
+
+This method sources the environment file.
+
+### runCommandWithExitCode($command)
+
+This method will run any linux command given as an argument using the
+`system()` method and will return the proper exit code.
+
+INPUT: the linux command to be executed
+
+RETURNS: the exit code of the command
+
+### runCommand($command)
+
+This method will run any linux command given as an argument using back-tilt
+and will return the back-tilt return value (which is STDOUT).
+
+INPUT: the linux command to be executed
+
+RETURNS: back-tilt return value (STDOUT)
+
+### CleanUpDataIncomingDir($uploaded\_file)
+
+This method cleans up and removes the uploaded file from the data directory
+once the uploaded file has been inserted into the database and saved in the
+tarchive folder.
+
+RETURNS: 1 on success, 0 on failure
+
+### spool($message, $error, $verb)
+
+This method calls the `Notify->spool` function to log all messages
+returned by the insertion scripts.
+
+INPUT:
+ $message: message to be logged in the database
+ $error  : 'Y' for an error log , 'N' otherwise
+ $verb   : 'N' for few main messages, 'Y' for more messages (for developers)
+
+### updateMRIUploadTable($field, $value)
+
+This method updates the `mri_upload` table with `$value` for the field
+`$field`.
+
+INPUT:
+ $field: name of the column in the table to be updated
+ $value: value of the column to be set
+
+# TO DO
+
+# BUGS
+
+None reported
+
+# COPYRIGHT
+
+# AUTHORS
+
+LORIS TEAM

--- a/docs/scripts_md/ImagingUpload.md
+++ b/docs/scripts_md/ImagingUpload.md
@@ -100,10 +100,6 @@ INPUT: full path to the dicom-file
 
 RETURNS: 1 if file is of type DICOM, 0 if file is not of type DICOM
 
-### sourceEnvironment()
-
-This method sources the environment file.
-
 ### runCommandWithExitCode($command)
 
 This method will run any linux command given as an argument using the

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -9,33 +9,33 @@ NeuroDB::ImagingUpload -- Provides an interface to the uploaded imaging file
 
 =head1 SYNOPSIS
 
-use NeuroDB::ImagingUpload;
+  use NeuroDB::ImagingUpload;
 
-my $imaging_upload = &NeuroDB::ImagingUpload->new(
-                       \$dbh,
-                       $TmpDir_decompressed_folder,
-                       $upload_id,
-                       $patient_name,
-                       $profile,
-                       $verbose
-                     );
+  my $imaging_upload = &NeuroDB::ImagingUpload->new(
+                         \$dbh,
+                         $TmpDir_decompressed_folder,
+                         $upload_id,
+                         $patient_name,
+                         $profile,
+                         $verbose
+                       );
 
-my $is_candinfovalid = $imaging_upload->IsCandidateInfoValid();
+  my $is_candinfovalid = $imaging_upload->IsCandidateInfoValid();
 
-my $output = $imaging_upload->runDicomTar();
-$imaging_upload->updateMRIUploadTable('Inserting', 0) if ( !$output );
+  my $output = $imaging_upload->runDicomTar();
+  $imaging_upload->updateMRIUploadTable('Inserting', 0) if ( !$output );
 
 
-my $output = $imaging_upload->runTarchiveLoader();
-$imaging_upload->updateMRIUploadTable('Inserting', 0) if ( !$output);
+  my $output = $imaging_upload->runTarchiveLoader();
+  $imaging_upload->updateMRIUploadTable('Inserting', 0) if ( !$output);
 
-my $isCleaned = $imaging_upload->CleanUpDataIncomingDir($uploaded_file);
+  my $isCleaned = $imaging_upload->CleanUpDataIncomingDir($uploaded_file);
 
 
 =head1 DESCRIPTION
 
 This library regroups utilities for manipulation of the uploaded imaging file
- and updates of the C<mri_upload> table according to the upload status.
+and updates of the C<mri_upload> table according to the upload status.
 
 =head2 Methods
 
@@ -66,19 +66,19 @@ my $notify_notsummary = 'N'; # notification_spool message flag for messages to b
 
 =pod
 
-=head3 new($dbhr, $uploaded_temp_folder, $upload_id, $pname, $profile,
-$verbose) (constructor)
+=head3 new($dbhr, $uploaded_temp_folder, $upload_id, ...) (constructor)
 
 Create a new instance of this class. This constructor needs the location of
 the uploaded file. Once the uploaded file has been validated, it will be
 moved to a final destination directory.
 
 INPUT:
-  $dbhr: database handler
-  $uploaded_temp_folder: temporary directory of the upload
-  $upload_id: ID of the upload in the mri_upload table
-  $pname: patient name
-  $profile: name of the configuration file (typically C<prod>)
+  - $dbhr                : database handler
+  - $uploaded_temp_folder: temporary directory of the upload
+  - $upload_id           : uploadID from the mri_upload table
+  - $pname               : patient name
+  - $profile             : name of the configuration file
+                          (typically C<prod>)
 
 RETURNS: new instance of this class
 
@@ -121,8 +121,8 @@ sub new {
 
 Validates the File to be uploaded. If the validation passes, the following
 actions will happen:
-  1) Copy the file from tmp folder to the /data/incoming directory
-  2) Set the IsCandidateInfoValidated to true in the mri_upload table
+  1) Copy the file from tmp folder to /data/incoming
+  2) Set C<IsCandidateInfoValidated> to TRUE in the mri_upload table
 
 RETURNS: 1 on success, 0 on failure
 
@@ -309,7 +309,7 @@ sub IsCandidateInfoValid {
 This method executes the following actions:
  - Runs C<dicomTar.pl> with C<-clobber -database -profile prod> options
  - Extracts the TarchiveID of the tarchive created by C<dicomTar.pl>
- - Updates the mri_upload table accordingly if C<dicomTar.pl> ran successfully
+ - Updates the mri_upload table if C<dicomTar.pl> ran successfully
 
 RETURNS: 1 on success, 0 on failure
 
@@ -614,9 +614,10 @@ This method calls the C<< Notify->spool >> function to log all messages
 returned by the insertion scripts.
 
 INPUT:
- $message: message to be logged in the database
- $error  : 'Y' for an error log , 'N' otherwise
- $verb   : 'N' for few main messages, 'Y' for more messages (for developers)
+ - $message: message to be logged in the database
+ - $error  : 'Y' for an error log , 'N' otherwise
+ - $verb   : 'N' for few main messages,
+             'Y' for more messages (for developers)
 
 =cut
 
@@ -640,8 +641,8 @@ This method updates the C<mri_upload> table with C<$value> for the field
 C<$field>.
 
 INPUT:
- $field: name of the column in the table to be updated
- $value: value of the column to be set
+ - $field: name of the column in the table to be updated
+ - $value: value of the column to be set
 
 =cut
 

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -491,25 +491,6 @@ sub isDicom {
     return 1;
 }
 
-
-=pod
-
-=head3 sourceEnvironment()
-
-This method sources the environment file.
-
-=cut
-
-sub sourceEnvironment {
-    my $this            = shift;
-    my $bin_dirPath = NeuroDB::DBI::getConfigSetting(
-                        $this->{dbhr},'MRICodePath'
-                        );
-    my $cmd =   "source  " . $bin_dirPath."/". "environment";
-    $this->runCommand($cmd);
-}
-
-
 =pod
 
 =head3 runCommandWithExitCode($command)

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -670,10 +670,12 @@ sub updateMRIUploadTable  {
 
 None reported
 
-=head1 COPYRIGHT
+=head1 COPYRIGHT AND LICENSE
+
+License: GPLv3
 
 =head1 AUTHORS
 
-LORIS TEAM
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
 
 =cut

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -666,6 +666,8 @@ sub updateMRIUploadTable  {
 
 =head1 TO DO
 
+Nothing planned.
+
 =head1 BUGS
 
 None reported

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -121,7 +121,7 @@ sub new {
 
 Validates the File to be uploaded. If the validation passes, the following
 actions will happen:
-  1) Copy the file from tmp folder to /data/incoming
+  1) Copy the file from C<tmp> folder to C</data/incoming>
   2) Set C<IsCandidateInfoValidated> to TRUE in the mri_upload table
 
 RETURNS: 1 on success, 0 on failure

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -1,4 +1,22 @@
 package NeuroDB::ImagingUpload;
+
+
+=pod
+
+=head1 NAME
+
+NeuroDB::ImagingUpload -- ??????????????????????
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+
+
+=head2 Methods
+
+=cut
+
 use English;
 use Carp;
 use strict;
@@ -20,19 +38,28 @@ my $notify_notsummary = 'N'; # notification_spool message flag for messages to b
 ################################################################
 #####################Constructor ###############################
 ################################################################
+
+
 =pod
-Description:
-    -The constructor needs the location of the uploaded file
-     Which will be in a uploaded_temp_folder and 
-     once the validation passes, the File will be moved to a
-     final destination directory
-Arguments:
-  $dbhr :
-  $uploaded_temp_folder:
-  $upload_id:
-  $pname: 
-  $profile:
+
+=head3 new($dbhr, $uploaded_temp_folder, $upload_id, $pname, $profile,
+$verbose) (constructor)
+
+Create a new instance of this class. This constructor needs the location of
+the uploaded file. Once the uploaded file has been validated, it will be
+moved to a final destination directory.
+
+INPUT:
+  $dbhr: database handler
+  $uploaded_temp_folder: temporary directory of the upload
+  $upload_id: ID of the upload in the mri_upload table
+  $pname: patient name
+  $profile: name of the configuration file (typically C<prod>)
+
+RETURNS: new instance of this class
+
 =cut
+
 sub new {
     my $params = shift;
     my ( $dbhr, $uploaded_temp_folder, $upload_id, $pname, $profile, $verbose ) = @_;
@@ -63,23 +90,20 @@ sub new {
     return bless $self, $params;
 }
 
-################################################################
-#####################IsCandidateInfoValid#######################
-################################################################
+
 =pod
-IsCandidateInfoValid()
-Description:
- Validates the File to be uploaded:
- If the validation passes the following will happen:
-  1) Copy the file from tmp folder to the /data/incoming
-  2) Set the IsCandidateInfoValidated to true in the 
-     mri_upload table
 
-Arguments:
- $this: reference to the class
+=head3 IsCandidateInfoValid()
 
- Returns: 0 if the validation fails and 1 if passes
+Validates the File to be uploaded. If the validation passes, the following
+actions will happen:
+  1) Copy the file from tmp folder to the /data/incoming directory
+  2) Set the IsCandidateInfoValidated to true in the mri_upload table
+
+RETURNS: 1 on success, 0 on failure
+
 =cut
+
 sub IsCandidateInfoValid {
     my $this = shift;
     my ($message,$query,$where) = '';
@@ -257,17 +281,18 @@ sub IsCandidateInfoValid {
 ############################runDicomTar#########################
 ################################################################
 =pod
-runDicomTar()
-Description:
- -Extracts tarchiveID using pname
- -Runs dicomTar.pl with -clobber -database -profile prod options
- -If successfull it updates MRI_upload table accordingly
 
-Arguments:
- $this: reference to the class
+=head3 runDicomTar()
 
- Returns: 0 if the validation fails and 1 if it passes
+This method executes the following actions:
+ - Runs C<dicomTar.pl> with C<-clobber -database -profile prod> options
+ - Extracts the TarchiveID of the tarchive created by C<dicomTar.pl>
+ - Updates the mri_upload table accordingly if C<dicomTar.pl> ran successfully
+
+RETURNS: 1 on success, 0 on failure
+
 =cut
+
 sub runDicomTar {
     my $this              = shift;
     my $tarchive_id       = undef;
@@ -319,16 +344,14 @@ sub runDicomTar {
 ###################getTarchiveFileLocation######################
 ################################################################
 =pod
-getTarchiveFileLocation()
-Description:
- -Extracts tarchiveID using pname
- -Runs dicomTar.pl with clobber -database -profile prod options
- -If successfull it updates MRI_upload Table accordingly
 
-Arguments:
- $this: reference to the class
+=head3 getTarchiveFileLocation()
 
- Returns: 0 if the validation fails and 1 if passes
+This method fetches the location of the archive from the tarchive table of
+the database.
+
+RETURNS: the archive location
+
 =cut
 sub getTarchiveFileLocation {
     my $this             = shift;
@@ -354,15 +377,15 @@ sub getTarchiveFileLocation {
 ######################runTarchiveLoader#########################
 ################################################################
 =pod
- runTarchiveLoader()
-Description:
- -Runs tarchiveLoader with clobber -profile prod option
- -If successfull it updates MRI_upload Table accordingly
 
-Arguments:
- $this: reference to the class
+=head3 runTarchiveLoader()
 
- Returns: 0 if the validation fails and 1 if passes
+This methods will call C<tarchiveLoader> with the C<-clobber -profile prod>
+options and update the mri_upload table accordingly if C<tarchiveLoader> ran
+successfully.
+
+RETURNS: 1 on success, 0 on failure
+
 =cut
 
 sub runTarchiveLoader {
@@ -390,20 +413,17 @@ sub runTarchiveLoader {
 #########################PatientNameMatch#######################
 ################################################################
 =pod
-PatientNameMatch()
-Description:
- - Extracts the patientname string from the dicom file header
-   using dcmdump
- - Uses regex to parse the string in order to the get the appropriate 
-   patientname from the obtained string
- - returns the 1 if the extracted patient-name matches
-   $this->{'pname'} object, 0 otherwise
 
-Arguments:
- $this: reference to the class
- $dicom_file: The full path to the dicom-file
+=head3 PatientNameMatch()
 
- Returns: 0 if the validation fails and 1 if passes
+This method extracts the patient name field from the DICOM file header using
+C<dcmdump> and compares it with the patient name information stored in the
+mri_upload table.
+
+INPUT: full path to the dicom-file
+
+RETURNS: 1 on success, 0 on failure
+
 =cut
 
 sub PatientNameMatch {

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -277,9 +277,7 @@ sub IsCandidateInfoValid {
 }
 
 
-################################################################
-############################runDicomTar#########################
-################################################################
+
 =pod
 
 =head3 runDicomTar()
@@ -340,9 +338,7 @@ sub runDicomTar {
     return 0;
 }
 
-################################################################
-###################getTarchiveFileLocation######################
-################################################################
+
 =pod
 
 =head3 getTarchiveFileLocation()
@@ -353,6 +349,7 @@ the database.
 RETURNS: the archive location
 
 =cut
+
 sub getTarchiveFileLocation {
     my $this             = shift;
     my $archive_location = '';
@@ -373,9 +370,7 @@ sub getTarchiveFileLocation {
     return $archive_location;
 }
 
-################################################################
-######################runTarchiveLoader#########################
-################################################################
+
 =pod
 
 =head3 runTarchiveLoader()
@@ -409,12 +404,10 @@ sub runTarchiveLoader {
     return 0;
 }
 
-################################################################
-#########################PatientNameMatch#######################
-################################################################
+
 =pod
 
-=head3 PatientNameMatch()
+=head3 PatientNameMatch($dicom_file)
 
 This method extracts the patient name field from the DICOM file header using
 C<dcmdump> and compares it with the patient name information stored in the
@@ -449,19 +442,17 @@ sub PatientNameMatch {
 
 }
 
-################################################################
-########################isDicom#################################
-################################################################
+
 =pod
-isDicom()
-Description:
- - checks to see if the file is of type DICOM 
 
-Arguments:
- $this: reference to the class
- $dicom_file: The path to the dicom-file
+=head3 isDicom($dicom_file)
 
- Returns: 0 if the file is not of type DICOM and 1 otherwise
+This method checks whether the file given as an argument is of type DICOM.
+
+INPUT: full path to the dicom-file
+
+RETURNS: 1 if file is of type DICOM, 0 if file is not of type DICOM
+
 =cut
 
 sub isDicom {
@@ -476,18 +467,13 @@ sub isDicom {
     return 1;
 }
 
-################################################################
-####################sourceEnvironment###########################
-################################################################
+
 =pod
-sourceEnvironment()
-Description:
-   - sources the environment file 
 
-Arguments:
- $this      : Reference to the class
+=head3 sourceEnvironment()
 
- Returns    : NULL
+This method sources the environment file.
+
 =cut
 
 sub sourceEnvironment {
@@ -500,20 +486,16 @@ sub sourceEnvironment {
 }
 
 
-################################################################
-#######################runCommandWithExitCode###################
-################################################################
 =pod
-runCommandWithExitCode()
-Description:
-   - Runs the linux command using system and 
-     returns the proper exit code 
 
-Arguments:
- $this      : Reference to the class
- $command   : The linux command to be executed
+=head3 runCommandWithExitCode($command)
 
- Returns    : NULL
+This method will run any linux command given as an argument using the
+C<system()> method and will return the proper exit code.
+
+INPUT: the linux command to be executed
+
+RETURNS: the exit code of the command
 
 =cut
 
@@ -525,20 +507,18 @@ sub runCommandWithExitCode {
     return $output >> 8;    ##returns the exit code
 }
 
-################################################################
-######################runCommand################################
-################################################################
+
 =pod
-runCommand()
-Description:
-   - Runs the linux command using back-tilt
-   - Note: Backtilt return value is STDOUT 
 
-Arguments:
- $this      : Reference to the class
- $command   : The linux command to be executed
+=head3 runCommand($command)
 
- Returns    : NULL
+This method will run any linux command given as an argument using back-tilt
+and will return the back-tilt return value (which is STDOUT).
+
+INPUT: the linux command to be executed
+
+RETURNS: back-tilt return value (STDOUT)
+
 =cut
 
 sub runCommand {
@@ -548,19 +528,16 @@ sub runCommand {
     return `$command`;
 }
 
-################################################################
-####################CleanUpDataIncomingDir######################
-################################################################
+
 =pod
-CleanUpDataIncomingDir()
-Description:
-   - Cleans Up and removes the uploaded file from the data  
-     directory once it is inserted into the database
 
-Arguments:
- $this      : Reference to the class
+=head3 CleanUpDataIncomingDir($uploaded_file)
 
-Returns: 1 if the uploaded file removal was successful and 0 otherwise
+This method cleans up and removes the uploaded file from the data directory
+once the uploaded file has been inserted into the database and saved in the
+tarchive folder.
+
+RETURNS: 1 on success, 0 on failure
 
 =cut
 
@@ -605,20 +582,18 @@ sub CleanUpDataIncomingDir {
 }
 
 
-################################################################
-#################spool##########################################
-################################################################
 =pod
-spool()
-Description:
-   - Calls the Notify->spool function to log all messages 
 
-Arguments:
- $this      : Reference to the class
- $message   : Message to be logged in the database 
- $error     : if 'Y' it's an error log , 'N' otherwise
- $verb      : 'N' for few main messages, 'Y' for more messages (developers)
- Returns    : NULL
+=head3 spool($message, $error, $verb)
+
+This method calls the C<< Notify->spool >> function to log all messages
+returned by the insertion scripts.
+
+INPUT:
+ $message: message to be logged in the database
+ $error  : 'Y' for an error log , 'N' otherwise
+ $verb   : 'N' for few main messages, 'Y' for more messages (for developers)
+
 =cut
 
 sub spool  {
@@ -633,19 +608,17 @@ sub spool  {
 }
 
 
-################################################################
-#################updateMRIUploadTable###########################
-################################################################
 =pod
-updateMRIUploadTable()
-Description:
-   - Update the mri_upload table 
 
-Arguments:
- $this      : Reference to the class
- $field     : Name of the column in the table 
- $value     : Value of the column to be set
- Returns    : NULL
+=head3 updateMRIUploadTable($field, $value)
+
+This method updates the C<mri_upload> table with C<$value> for the field
+C<$field>.
+
+INPUT:
+ $field: name of the column in the table to be updated
+ $value: value of the column to be set
+
 =cut
 
 sub updateMRIUploadTable  {
@@ -663,3 +636,20 @@ sub updateMRIUploadTable  {
 }
 
 1;
+
+
+=pod
+
+=head1 TO DO
+
+=head1 BUGS
+
+None reported
+
+=head1 COPYRIGHT
+
+=head1 AUTHORS
+
+LORIS TEAM
+
+=cut

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -5,13 +5,37 @@ package NeuroDB::ImagingUpload;
 
 =head1 NAME
 
-NeuroDB::ImagingUpload -- ??????????????????????
+NeuroDB::ImagingUpload -- Provides an interface to the uploaded imaging file
 
 =head1 SYNOPSIS
 
+use NeuroDB::ImagingUpload;
+
+my $imaging_upload = &NeuroDB::ImagingUpload->new(
+                       \$dbh,
+                       $TmpDir_decompressed_folder,
+                       $upload_id,
+                       $patient_name,
+                       $profile,
+                       $verbose
+                     );
+
+my $is_candinfovalid = $imaging_upload->IsCandidateInfoValid();
+
+my $output = $imaging_upload->runDicomTar();
+$imaging_upload->updateMRIUploadTable('Inserting', 0) if ( !$output );
+
+
+my $output = $imaging_upload->runTarchiveLoader();
+$imaging_upload->updateMRIUploadTable('Inserting', 0) if ( !$output);
+
+my $isCleaned = $imaging_upload->CleanUpDataIncomingDir($uploaded_file);
+
+
 =head1 DESCRIPTION
 
-
+This library regroups utilities for manipulation of the uploaded imaging file
+ and updates of the C<mri_upload> table according to the upload status.
 
 =head2 Methods
 

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -122,7 +122,7 @@ sub new {
 Validates the File to be uploaded. If the validation passes, the following
 actions will happen:
   1) Copy the file from C<tmp> folder to C</data/incoming>
-  2) Set C<IsCandidateInfoValidated> to TRUE in the mri_upload table
+  2) Set C<IsCandidateInfoValidated> to TRUE in the C<mri_upload> table
 
 RETURNS: 1 on success, 0 on failure
 


### PR DESCRIPTION
Using perldoc/perlpod to document `FileDecompress.pm` so that users can type in the terminal
`perldoc ImagingUpload.pm` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `ImagingUpload.md` file has been created so that we have a web displayed version of the documentation.
`pod2markdown ImagingUpload.pm > ImagingUpload.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage