### PR TITLE
[Documentation] NeuroDB::MRI library perldocification

### DIFF
--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -360,4 +360,5 @@ License: GPLv3
 # AUTHORS
 
 Jonathan Harlap <jharlap@bic.mni.mcgill.ca>
-LORIS team <loris.info@mcin.ca>
+LORIS community <loris.info@mcin.ca>  
+and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -23,7 +23,7 @@ files into the LORIS system)
 
 # DESCRIPTION
 
-Really a mishmash of utility functions, primarily used by process\_uploads and
+Really a mishmash of utility functions, primarily used by `process_uploads` and
 all of its children.
 
 ## Methods
@@ -33,16 +33,16 @@ all of its children.
 Determines the candidate ID and visit label for the subject based on patient
 name and (for calibration data) scannerID.
 
-INPUT: patient name, scanner ID and database handle reference
+INPUTS: patient name, scanner ID and database handle reference
 
-RETURNS: a reference to a hash containing elements including 'CandID',
-'visitLabel' and 'visitNo', or, in the case of failure, `undef`
+RETURNS: a reference to a hash containing elements including `CandID`,
+`visitLabel` and `visitNo`, or, in the case of failure, `undef`
 
 ### subjectIDIsValid($CandID, $PSCID, $dbhr)
 
 Verifies that the subject IDs match.
 
-INPUT: candidate's CandID, candidate's PSCID and the database handle reference
+INPUTS: candidate's CandID, candidate's PSCID and the database handle reference
 
 RETURNS: 1 if the ID pair matches, 0 otherwise
 
@@ -50,7 +50,7 @@ RETURNS: 1 if the ID pair matches, 0 otherwise
 
 Verifies that the subject ID (CandID) exists.
 
-INPUT: candidate's CandID and the database handle reference
+INPUTS: candidate's CandID and the database handle reference
 
 RETURNS: 1 if the ID exists, 0 otherwise
 
@@ -58,7 +58,7 @@ RETURNS: 1 if the ID exists, 0 otherwise
 
 Retrieves the candidate (CandID) for the given scanner.
 
-INPUT: the scanner ID and the database handle reference
+INPUTS: the scanner ID and the database handle reference
 
 RETURNS: the CandID or (if none exists) undef
 
@@ -82,7 +82,7 @@ simple algorithm:
 >
 > \- Otherwise, staging is not required.
 
-INPUT: hash reference of subject IDs, study date, database handle reference,
+INPUTS: hash reference of subject IDs, study date, database handle reference,
 the objective of the study and a no staging check flag.
 
 RETURNS: a list of two items, (sessionID, requiresStaging)
@@ -92,7 +92,7 @@ RETURNS: a list of two items, (sessionID, requiresStaging)
 This method tries to figure out if there may have been labelling problems which
 would put the files in a staging area that does not actually exist.
 
-INPUT: study date, database handle reference and array of fileIDs to check the
+INPUTS: study date, database handle reference and array of fileIDs to check the
 study date
 
 RETURNS: 1 if the file requires staging, 0 otherwise
@@ -102,26 +102,27 @@ RETURNS: 1 if the file requires staging, 0 otherwise
 Attempts to determine the SubprojectID  of a timepoint given the subjectIDs
 hashref `$subjectIDsref` and a database handle reference `$dbhr`
 
-INPUT: subjectIDs hashref and database handle reference
+INPUTS: subjectIDs hashref and database handle reference
 
 RETURNS: the determined objective, or 0
 
 ### identify\_scan\_db($center\_name, $objective, $fileref, $dbhr)
 
-Determines the type of the scan described by minc headers based on mri\_protocol
-table in the database.
+Determines the type of the scan described by MINC headers based on
+`mri_protocol` table in the database.
 
-INPUT: center's name, objective of the study, file hashref, database handle
+INPUTS: center's name, objective of the study, file hashref, database handle
 reference
 
-RETURNS: textual name of scan type
+RETURNS: textual name of scan type from the `mri_scan_type` table
 
 ### insert\_violated\_scans($dbhr, $series\_desc, $minc\_location, ...)
 
 Inserts scans that do not correspond to any of the defined protocol from the 
-mri\_protocol table into the mri\_protocol\_violated\_scans table of the database.
+`mri_protocol` table into the `mri_protocol_violated_scans` table of the
+database.
 
-INPUT: 
+INPUTS:
   - $dbhr           : database handle reference
   - $series\_desc    : series description of the scan
   - $minc\_location  : minc location of the file
@@ -146,7 +147,7 @@ INPUT:
 
 Will evaluate whether the scalar `$value` is in the specified `$range`.
 
-INPUT: scalar value, scalar range string
+INPUTS: scalar value, scalar range string
 
 RETURNS: 1 if in range, 0 if not in range
 
@@ -154,7 +155,7 @@ RETURNS: 1 if in range, 0 if not in range
 
 Determines the type of the scan identified by its scan type ID.
 
-INPUT: scan type ID and database handle reference
+INPUTS: scan type ID and database handle reference
 
 RETURNS: Textual name of scan type
 
@@ -162,7 +163,7 @@ RETURNS: Textual name of scan type
 
 Determines the type of the scan identified by scan type.
 
-INPUT: scan type and database handle reference
+INPUTS: scan type and database handle reference
 
 RETURNS: ID of the scan type
 
@@ -172,7 +173,7 @@ Determines whether numerical value falls within the range described by range
 string. Range string is a comma-separated list of range units. A single range
 unit follows the syntax either "X" or "X-Y".
 
-INPUT: numerical value and the range to use
+INPUTS: numerical value and the range to use
 
 RETURNS: 1 if the value is in range, 0 otherwise
 
@@ -181,7 +182,7 @@ RETURNS: 1 if the value is in range, 0 otherwise
 Checks whether f1 and f2 are equal (considers only the first nb\_decimals
 decimals).
 
-INPUT: float 1, float 2 and the number of first decimals
+INPUTS: float 1, float 2 and the number of first decimals
 
 RETURNS: 1 if the numbers are relatively equal, 0 otherwise
 
@@ -192,7 +193,7 @@ Generates a valid SQL WHERE expression to test `$field` against
 It returns a scalar range SQL string appropriate to use as a WHERE condition
 (`SELECT ... WHERE range_to_sql(...)`).
 
-INPUT: scalar field, scalar range string that follows the same format as in
+INPUTS: scalar field, scalar range string that follows the same format as in
 `&in_range()`
 
 RETURNS: scalar range SQL string
@@ -219,7 +220,7 @@ Finds the scannerID for the scanner as defined by `$manufacturer`, `$model`,
 database handle reference `$dbhr`. If no scannerID exists, one will be
 created.
 
-INPUT:
+INPUTS:
   - $manufacturer   : scanner's manufacturer
   - $model          : scanner's model
   - $serialNumber   : scanner's serial number
@@ -236,7 +237,7 @@ Registers the scanner as defined by `$manufacturer`, `$model`,
 `$serialNumber`, `$softwareVersion`, into the database attached to the DBI
 database handle reference `$dbhr`.
 
-INPUT:
+INPUTS:
   - $manufacturer   : scanner's manufacturer
   - $model          : scanner's model
   - $serialNumber   : scanner's serial number
@@ -259,7 +260,7 @@ RETURNS: (int) CandID
 Looks for the site alias in whatever field (usually patient\_name or
 patient\_id) is provided and return the MRI alias and CenterID.
 
-INPUT: patient name, database handle reference
+INPUTS: patient name, database handle reference
 
 RETURNS: a two element array:
   - first is the MRI alias of the PSC or "UNKN"
@@ -286,26 +287,26 @@ otherwise.
 
 ### make\_pics($file\_ref, $data\_dir, $dest\_dir, $horizontalPics)
 
-Generates check pics for the Imaging Browser module for the NeuroDB::File object
-referenced by `$file_ref`.
+Generates check pics for the Imaging Browser module for the `NeuroDB::File`
+object referenced by `$file_ref`.
 
-INPUT:
+INPUTS:
   - $file\_ref      : file hash ref
-  - $data\_dir      : data directory (/data/project/data typically)
-  - $dest\_dir      : destination directory (pic directory)
+  - $data\_dir      : data directory (C/data/$PROJECT/data> typically)
+  - $dest\_dir      : destination directory (`/data/$PROJECT/data` typically)
   - $horizontalPics: boolean, whether to create horizontal pics (1) or not (0)
 
 RETURNS: 1 if the pic was generated or 0 otherwise.
 
 ### make\_jiv($file\_ref, $data\_dir, $dest\_dir)
 
-Generates JIV data for the Imaging Browser module for the NeuroDB::File object
-referenced by `$file_ref`.
+Generates JIV data for the Imaging Browser module for the `NeuroDB::File`
+object referenced by `$file_ref`.
 
-INPUT:
+INPUTS:
   - $file\_ref      : file hash ref
-  - $data\_dir      : data directory (/data/project/data typically)
-  - $dest\_dir      : destination directory (jiv directory)
+  - $data\_dir      : data directory (`/data/$PROJECT/data` typically)
+  - $dest\_dir      : destination directory (`/data/$PROJECT/data` typically)
 
 RETURNS: 1 if the JIV data was generated or 0 otherwise.
 
@@ -314,13 +315,13 @@ RETURNS: 1 if the JIV data was generated or 0 otherwise.
 Creates NIfTI files associated with MINC files and append its path to the
 parameter\_file table using the parameter\_type "check\_nii\_filename".
 
-INPUT: file hashref and data directory (typically /data/project/data)
+INPUTS: file hashref and data directory (typically `/data/project/data`)
 
 ### make\_minc\_pics($dbhr, $TarchiveSource, $profile, $minFileID, ...)
 
 Creates pics associated with MINC files.
 
-INPUT:
+INPUTS:
   - $dbhr          : database handle reference
   - $TarchiveSource: tarchiveID of the DICOM study
   - $profile       : the profile (typically named `prod`)
@@ -340,7 +341,7 @@ RETURNS: a unix timestamp (integer) or 0 if something went wrong
 
 Looks up the CandID for a given PSCID.
 
-INPUT: candidate's PSCID, database handle reference
+INPUTS: candidate's PSCID, database handle reference
 
 RETURNS: the CandID or 0 if the PSCID does not exist
 
@@ -361,6 +362,6 @@ License: GPLv3
 
 # AUTHORS
 
-Jonathan Harlap <jharlap@bic.mni.mcgill.ca>
+Jonathan Harlap <jharlap@bic.mni.mcgill.ca>,
 LORIS community <loris.info@mcin.ca>  
 and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -1,0 +1,362 @@
+# NAME
+
+NeuroDB::MRI -- A set of utility functions for performing common tasks
+relating to MRI data (particularly with regards to registering MRI
+files into the LORIS system)
+
+# SYNOPSIS
+
+    use NeuroDB::File;
+    use NeuroDB::MRI;
+    use NeuroDB::DBI;
+
+    my $dbh = NeuroDB::DBI::connect_to_db();
+
+    my $file = NeuroDB::File->new(\$dbh);
+
+    $file->loadFileFromDisk('/path/to/some/file');
+    $file->setFileData('CoordinateSpace', 'nonlinear');
+    $file->setParameter('patient_name', 'Larry Wall');
+
+    my $parameterTypeID = $file->getParameterTypeID('patient_name');
+    my $parameterTypeCategoryID = $file->getParameterTypeCategoryID('MRI Header');
+
+# DESCRIPTION
+
+Really a mishmash of utility functions, primarily used by process\_uploads and
+ all of its children.
+
+## Methods
+
+### getSubjectIDs($patientName, $scannerID, $dbhr)
+
+Determines the candidate ID and visit label for the subject based on patient
+name and (for calibration data) scannerID.
+
+INPUT: patient name, scanner ID and database handle reference
+
+RETURNS: a reference to a hash containing elements including 'CandID',
+'visitLabel' and 'visitNo', or, in the case of failure, `undef`
+
+### subjectIDIsValid($CandID, $PSCID, $dbhr)
+
+Verifies that the subject IDs match.
+
+INPUT: candidate's CandID, candidate's PSCID and the database handle reference
+
+RETURNS: 1 if the ID pair matches, 0 otherwise
+
+### subjectIDExists($CandID, $dbhr)
+
+Verifies that the subject ID (CandID) exists.
+
+INPUT: candidate's CandID and the database handle reference
+
+RETURNS: 1 if the ID exists, 0 otherwise
+
+### getScannerCandID($scannerID, $dbhr)
+
+Retrieves the candidate (CandID) for the given scanner.
+
+INPUT: the scanner ID and the database handle reference
+
+RETURNS: the CandID or (if none exists) undef
+
+### getSessionID($subjectIDref, $studyDate, $dbhr, $objective,
+$noStagingCheck)
+
+Gets (or creates) the session ID, given CandID and visitLabel (contained
+inside the hashref `$subjectIDref`).  Unless `$noStagingCheck` is true, it
+also determines whether staging is required using the `$studyDate`
+(formatted YYYYMMDD) to determine whether staging is required based on a
+simple algorithm:
+
+> \- If there exists a session with the same visit label, then that is the
+>  session ID to use.  If any dates (either existing MRI data or simply a date
+>  of visit) exist associated with that session, then if they are outside of
+>  some (arbitrary) time window, staging is required.  If no dates exist, no
+>  staging is required.
+>
+> \- If no sessions exist, then if there is any other date associated with
+>  another session of the same subject within a time window, staging is required.
+>
+> \- Otherwise, staging is not required.
+
+INPUT: hash reference of subject IDs, study date, database handle reference,
+the objective of the study and a no staging check flag.
+
+RETURNS: a list of two items, (sessionID, requiresStaging)
+
+### checkMRIStudyDates($studyDateJD, $dbhr, @fileIDs)
+
+This method tries to figure out if there may have been labelling problems which
+would put the files in a staging area that does not actually exist.
+
+INPUT: study date, database handle reference and array of fileIDs to check the
+study date
+
+RETURNS: 1 if the file requires staging, 0 otherwise
+
+### getObjective($subjectIDsref, $dbhr)
+
+Attempts to determine the SubprojectID  of a timepoint given the subjectIDs
+hashref `$subjectIDsref` and a database handle reference `$dbhr`
+
+INPUT: subjectIDs hashref and database handle reference
+
+RETURNS: the determined objective, or 0
+
+### identify\_scan\_db($center\_name, $objective, $fileref, $dbhr)
+
+Determines the type of the scan described by minc headers based on mri\_protocol
+table in the database.
+
+INPUT: center's name, objective of the study, file hashref, database handle
+reference
+
+RETURNS: textual name of scan type
+
+### insert\_violated\_scans($dbhr, $series\_desc, $minc\_location, ...)
+
+Inserts scans that do not correspond to any of the defined protocol from the 
+mri\_protocol table into the mri\_protocol\_violated\_scans table of the database.
+
+INPUT: 
+  $dbhr           : database handle reference
+  $series\_desc    : series description of the scan
+  $minc\_location  : minc location of the file
+  $patient\_name   : patient name of the scan
+  $candid         : candidate's CandID
+  $pscid          : candidate's PSCID
+  $visit          : visit of the scan
+  $tr             : repetition time of the scan
+  $te             : echo time of the scan
+  $ti             : inversion time of the scan
+  $slice\_thickness: slice thickness of the image
+  $xstep          : x-step of the image
+  $ystep          : y-step of the image
+  $zstep          : z-step of the image
+  $xspace         : x-space of the image
+  $yspace         : y-space of the image
+  $zspace         : z-space of the image
+  $time           : time dimension of the scan
+  $seriesUID      : seriesUID of the scan
+
+### debug\_inrange($val, $range)
+
+Will evaluate whether the scalar `$value` is in the specified `$range`.
+
+INPUT: scalar value, scalar range string
+
+RETURNS: 1 if in range, 0 if not in range
+
+### scan\_type\_id\_to\_text($typeID, $dbhr)
+
+Determines the type of the scan identified by its scan type ID.
+
+INPUT: scan type ID and database handle reference
+
+RETURNS: Textual name of scan type
+
+### scan\_type\_text\_to\_id($type, $dbhr)
+
+Determines the type of the scan identified by scan type.
+
+INPUT: scan type and database handle reference
+
+RETURNS: ID of the scan type
+
+### in\_range($value, $range\_string)
+
+Determines whether numerical value falls within the range described by range
+string. Range string is a comma-separated list of range units. A single range
+unit follows the syntax either "X" or "X-Y"
+
+INPUT: numerical value and the range to use
+
+RETURNS: 1 if the value is in range, 0 otherwise
+
+### floats\_are\_equal($f1, $f2, $nb\_decimals)
+
+Checks whether f1 and f2 are equal (considers only the first nb\_decimals
+decimals).
+
+INPUT: float 1, float 2 and the number of first decimals
+
+RETURNS: 1 if the numbers are relatively equal, 0 otherwise
+
+### range\_to\_sql($field, $range\_string)
+
+Generates a valid SQL WHERE expression to test `$field` against
+`$range_string` using the same `$range_string` syntax as `&in_range()`.
+It returns a scalar range SQL string appropriate to use as a WHERE condition
+(`SELECT ... WHERE range_to_sql(...)`).
+
+INPUT: scalar field, scalar range string that follows the same format as in
+`&in_range()`
+
+RETURNS: scalar range SQL string
+
+### register\_db($file\_ref)
+
+Registers the NeuroDB::File object referenced by `$file_ref` into the database.
+
+INPUT: file hashref
+
+RETURNS: 0 if the file is already registered, the new FileID otherwise
+
+### mapDicomParameters($file\_ref)
+
+Maps DICOM parameters to more meaningful names in the NeuroDB::File object
+referenced by `$file_ref`.
+
+INPUT: file hashref
+
+### findScannerID($manufacturer, $model, $serialNumber, ...)
+
+Finds the scannerID for the scanner as defined by `$manufacturer`, `$model`,
+`$serialNumber`, `$softwareVersion`, using the database attached to the DBI
+database handle reference `$dbhr`. If no scannerID exists, one will be
+created.
+
+INPUT:
+  $manufacturer   : scanner's manufacturer
+  $model          : scanner's model
+  $serialNumber   : scanner's serial number
+  $softwareVersion: scanner's software version
+  $centerID       : scanner's center ID
+  $dbhr           : database handle reference
+  $register\_new   : if set, will call the function &registerScanner
+
+RETURNS: (int) scannerID
+
+### registerScanner($manufacturer, $model, $serialNumber, ...)
+
+Registers the scanner as defined by `$manufacturer`, `$model`,
+`$serialNumber`, `$softwareVersion`, into the database attached to the DBI
+database handle reference `$dbhr`.
+
+INPUT:
+  $manufacturer   : scanner's manufacturer
+  $model          : scanner's model
+  $serialNumber   : scanner's serial number
+  $softwareVersion: scanner's software version
+  $centerID       : scanner's center ID
+  $dbhr           : database handle reference
+
+RETURNS: (int) scannerID
+
+### createNewCandID($dbhr)
+
+Creates a new CandID.
+
+INPUT: database handle reference
+
+RETURNS: (int) CandID
+
+### getPSC($patientName, $dbhr)
+
+Looks for the site alias in whatever field (usually patient\_name or
+patient\_id) is provided and return the MRI alias and CenterID.
+
+INPUT: patient name, database handle reference
+
+RETURNS: a two element array:
+  - first is the MRI alias of the PSC or "UNKN"
+  - second is the centerID or 0
+
+### compute\_hash($file\_ref)
+
+Semi-intelligently generates a hash (MD5 digest) for the NeuroDB::File object
+referenced by `$file_ref`.
+
+INPUT: file hashref
+
+RETURNS: the generated MD5 hash
+
+### is\_unique\_hash($file\_ref)
+
+Determines if the file is unique using the hash (MD5 digest) from the
+NeuroDB::File object referenced by `$file_ref`.
+
+INPUT: file hashref
+
+RETURNS: 1 if the file is unique (or if hashes are not being tracked) or 0
+otherwise.
+
+### make\_pics($file\_ref, $data\_dir, $dest\_dir, $horizontalPics)
+
+Generates check pics for the Imaging Browser module for the NeuroDB::File object
+referenced by `$file_ref`.
+
+INPUT:
+  $file\_ref      : file hash ref
+  $data\_dir      : data directory (/data/project/data typically)
+  $dest\_dir      : destination directory (pic directory)
+  $horizontalPics: boolean, whether to create horizontal pics (1) or not (0)
+
+RETURNS: 1 if the pic was generated or 0 otherwise.
+
+### make\_jiv($file\_ref, $data\_dir, $dest\_dir)
+
+Generates JIV data for the Imaging Browser module for the NeuroDB::File object
+referenced by `$file_ref`.
+
+INPUT:
+  $file\_ref      : file hash ref
+  $data\_dir      : data directory (/data/project/data typically)
+  $dest\_dir      : destination directory (jiv directory)
+
+RETURNS: 1 if the JIV data was generated or 0 otherwise.
+
+### make\_nii($fileref, $data\_dir)
+
+Creates NIfTI files associated with MINC files and append its path to the
+parameter\_file table using the parameter\_type "check\_nii\_filename".
+
+INPUT: file hashref and data directory (typically /data/project/data)
+
+### make\_minc\_pics($dbhr, $TarchiveSource, $profile, $minFileID, $debug, ...)
+
+Creates pics associated with MINC files.
+
+INPUT:
+  $dbhr          : database handle reference
+  $TarchiveSource: tarchiveID of the DICOM study
+  $profile       : the profile (typically named `prod`)
+  $minFileID     : smaller FileID to be used to run `mass_pic.pl`
+  $debug         : boolean, whether in debug mode (1) or not (0)
+  $verbose       : boolean, whether in verbose mode (1) or not (0)
+
+### DICOMDateToUnixTimestamp($dicomDate>
+
+Converts a DICOM date field (YYYYMMDD) into a unix timestamp.
+
+INPUT: DICOM date to convert
+
+RETURNS: a unix timestamp (integer) or 0 if something went wrong
+
+### lookupCandIDFromPSCID($pscid, $dbhr)
+
+Looks up the CandID for a given PSCID.
+
+INPUT: candidate's PSCID, database handle reference
+
+RETURNS: the CandID or 0 if the PSCID does not exist
+
+# TO DO
+
+# BUGS
+
+None reported.
+
+# COPYRIGHT AND LICENSE
+
+Copyright (c) 2003-2004 by Jonathan Harlap, McConnell Brain Imaging Centre,
+Montreal Neurological Institute, McGill University.
+
+License: GPLv3
+
+# AUTHORS
+
+Jonathan Harlap <jharlap@bic.mni.mcgill.ca>

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -346,6 +346,8 @@ RETURNS: the CandID or 0 if the PSCID does not exist
 
 # TO DO
 
+Nothing planned.
+
 # BUGS
 
 None reported.

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -24,7 +24,7 @@ files into the LORIS system)
 # DESCRIPTION
 
 Really a mishmash of utility functions, primarily used by process\_uploads and
- all of its children.
+all of its children.
 
 ## Methods
 
@@ -62,8 +62,7 @@ INPUT: the scanner ID and the database handle reference
 
 RETURNS: the CandID or (if none exists) undef
 
-### getSessionID($subjectIDref, $studyDate, $dbhr, $objective,
-$noStagingCheck)
+### getSessionID($subjectIDref, $studyDate, $dbhr, $objective, ...)
 
 Gets (or creates) the session ID, given CandID and visitLabel (contained
 inside the hashref `$subjectIDref`).  Unless `$noStagingCheck` is true, it
@@ -71,14 +70,15 @@ also determines whether staging is required using the `$studyDate`
 (formatted YYYYMMDD) to determine whether staging is required based on a
 simple algorithm:
 
-> \- If there exists a session with the same visit label, then that is the
->  session ID to use.  If any dates (either existing MRI data or simply a date
->  of visit) exist associated with that session, then if they are outside of
->  some (arbitrary) time window, staging is required.  If no dates exist, no
->  staging is required.
+> \- If there exists a session with the same visit label, then that is
+>    the session ID to use.  If any dates (either existing MRI data or
+>    simply a date of visit) exist associated with that session, then
+>    if they are outside of some (arbitrary) time window, staging is
+>    required.  If no dates exist, no staging is required.
 >
-> \- If no sessions exist, then if there is any other date associated with
->  another session of the same subject within a time window, staging is required.
+> \- If no sessions exist, then if there is any other date associated
+>    with another session of the same subject within a time window,
+>    staging is required.
 >
 > \- Otherwise, staging is not required.
 
@@ -122,25 +122,25 @@ Inserts scans that do not correspond to any of the defined protocol from the
 mri\_protocol table into the mri\_protocol\_violated\_scans table of the database.
 
 INPUT: 
-  $dbhr           : database handle reference
-  $series\_desc    : series description of the scan
-  $minc\_location  : minc location of the file
-  $patient\_name   : patient name of the scan
-  $candid         : candidate's CandID
-  $pscid          : candidate's PSCID
-  $visit          : visit of the scan
-  $tr             : repetition time of the scan
-  $te             : echo time of the scan
-  $ti             : inversion time of the scan
-  $slice\_thickness: slice thickness of the image
-  $xstep          : x-step of the image
-  $ystep          : y-step of the image
-  $zstep          : z-step of the image
-  $xspace         : x-space of the image
-  $yspace         : y-space of the image
-  $zspace         : z-space of the image
-  $time           : time dimension of the scan
-  $seriesUID      : seriesUID of the scan
+  - $dbhr           : database handle reference
+  - $series\_desc    : series description of the scan
+  - $minc\_location  : minc location of the file
+  - $patient\_name   : patient name of the scan
+  - $candid         : candidate's CandID
+  - $pscid          : candidate's PSCID
+  - $visit          : visit of the scan
+  - $tr             : repetition time of the scan
+  - $te             : echo time of the scan
+  - $ti             : inversion time of the scan
+  - $slice\_thickness: slice thickness of the image
+  - $xstep          : x-step of the image
+  - $ystep          : y-step of the image
+  - $zstep          : z-step of the image
+  - $xspace         : x-space of the image
+  - $yspace         : y-space of the image
+  - $zspace         : z-space of the image
+  - $time           : time dimension of the scan
+  - $seriesUID      : seriesUID of the scan
 
 ### debug\_inrange($val, $range)
 
@@ -170,7 +170,7 @@ RETURNS: ID of the scan type
 
 Determines whether numerical value falls within the range described by range
 string. Range string is a comma-separated list of range units. A single range
-unit follows the syntax either "X" or "X-Y"
+unit follows the syntax either "X" or "X-Y".
 
 INPUT: numerical value and the range to use
 
@@ -220,15 +220,15 @@ database handle reference `$dbhr`. If no scannerID exists, one will be
 created.
 
 INPUT:
-  $manufacturer   : scanner's manufacturer
-  $model          : scanner's model
-  $serialNumber   : scanner's serial number
-  $softwareVersion: scanner's software version
-  $centerID       : scanner's center ID
-  $dbhr           : database handle reference
-  $register\_new   : if set, will call the function &registerScanner
+  - $manufacturer   : scanner's manufacturer
+  - $model          : scanner's model
+  - $serialNumber   : scanner's serial number
+  - $softwareVersion: scanner's software version
+  - $centerID       : scanner's center ID
+  - $dbhr           : database handle reference
+  - $register\_new   : if set, will call the function `&registerScanner`
 
-RETURNS: (int) scannerID
+RETURNS: (int) scanner ID
 
 ### registerScanner($manufacturer, $model, $serialNumber, ...)
 
@@ -237,14 +237,14 @@ Registers the scanner as defined by `$manufacturer`, `$model`,
 database handle reference `$dbhr`.
 
 INPUT:
-  $manufacturer   : scanner's manufacturer
-  $model          : scanner's model
-  $serialNumber   : scanner's serial number
-  $softwareVersion: scanner's software version
-  $centerID       : scanner's center ID
-  $dbhr           : database handle reference
+  - $manufacturer   : scanner's manufacturer
+  - $model          : scanner's model
+  - $serialNumber   : scanner's serial number
+  - $softwareVersion: scanner's software version
+  - $centerID       : scanner's center ID
+  - $dbhr           : database handle reference
 
-RETURNS: (int) scannerID
+RETURNS: (int) scanner ID
 
 ### createNewCandID($dbhr)
 
@@ -290,10 +290,10 @@ Generates check pics for the Imaging Browser module for the NeuroDB::File object
 referenced by `$file_ref`.
 
 INPUT:
-  $file\_ref      : file hash ref
-  $data\_dir      : data directory (/data/project/data typically)
-  $dest\_dir      : destination directory (pic directory)
-  $horizontalPics: boolean, whether to create horizontal pics (1) or not (0)
+  - $file\_ref      : file hash ref
+  - $data\_dir      : data directory (/data/project/data typically)
+  - $dest\_dir      : destination directory (pic directory)
+  - $horizontalPics: boolean, whether to create horizontal pics (1) or not (0)
 
 RETURNS: 1 if the pic was generated or 0 otherwise.
 
@@ -303,9 +303,9 @@ Generates JIV data for the Imaging Browser module for the NeuroDB::File object
 referenced by `$file_ref`.
 
 INPUT:
-  $file\_ref      : file hash ref
-  $data\_dir      : data directory (/data/project/data typically)
-  $dest\_dir      : destination directory (jiv directory)
+  - $file\_ref      : file hash ref
+  - $data\_dir      : data directory (/data/project/data typically)
+  - $dest\_dir      : destination directory (jiv directory)
 
 RETURNS: 1 if the JIV data was generated or 0 otherwise.
 
@@ -316,17 +316,17 @@ parameter\_file table using the parameter\_type "check\_nii\_filename".
 
 INPUT: file hashref and data directory (typically /data/project/data)
 
-### make\_minc\_pics($dbhr, $TarchiveSource, $profile, $minFileID, $debug, ...)
+### make\_minc\_pics($dbhr, $TarchiveSource, $profile, $minFileID, ...)
 
 Creates pics associated with MINC files.
 
 INPUT:
-  $dbhr          : database handle reference
-  $TarchiveSource: tarchiveID of the DICOM study
-  $profile       : the profile (typically named `prod`)
-  $minFileID     : smaller FileID to be used to run `mass_pic.pl`
-  $debug         : boolean, whether in debug mode (1) or not (0)
-  $verbose       : boolean, whether in verbose mode (1) or not (0)
+  - $dbhr          : database handle reference
+  - $TarchiveSource: tarchiveID of the DICOM study
+  - $profile       : the profile (typically named `prod`)
+  - $minFileID     : smaller FileID to be used to run `mass_pic.pl`
+  - $debug         : boolean, whether in debug mode (1) or not (0)
+  - $verbose       : boolean, whether in verbose mode (1) or not (0)
 
 ### DICOMDateToUnixTimestamp($dicomDate>
 

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -292,8 +292,9 @@ object referenced by `$file_ref`.
 
 INPUTS:
   - $file\_ref      : file hash ref
-  - $data\_dir      : data directory (C/data/$PROJECT/data> typically)
-  - $dest\_dir      : destination directory (`/data/$PROJECT/data` typically)
+  - $data\_dir      : data directory (`/data/$PROJECT/data` typically)
+  - $dest\_dir      : destination directory (`/data/$PROJECT/data/pics`
+                     typically)
   - $horizontalPics: boolean, whether to create horizontal pics (1) or not (0)
 
 RETURNS: 1 if the pic was generated or 0 otherwise.
@@ -306,7 +307,8 @@ object referenced by `$file_ref`.
 INPUTS:
   - $file\_ref      : file hash ref
   - $data\_dir      : data directory (`/data/$PROJECT/data` typically)
-  - $dest\_dir      : destination directory (`/data/$PROJECT/data` typically)
+  - $dest\_dir      : destination directory (`/data/$PROJECT/data/jiv`
+                     typically)
 
 RETURNS: 1 if the JIV data was generated or 0 otherwise.
 

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -360,3 +360,4 @@ License: GPLv3
 # AUTHORS
 
 Jonathan Harlap <jharlap@bic.mni.mcgill.ca>
+LORIS team <loris.info@mcin.ca>

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -293,7 +293,7 @@ object referenced by `$file_ref`.
 INPUTS:
   - $file\_ref      : file hash ref
   - $data\_dir      : data directory (`/data/$PROJECT/data` typically)
-  - $dest\_dir      : destination directory (`/data/$PROJECT/data/pics`
+  - $dest\_dir      : destination directory (`/data/$PROJECT/data/pic`
                      typically)
   - $horizontalPics: boolean, whether to create horizontal pics (1) or not (0)
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1503,6 +1503,8 @@ __END__
 
 =head1 TO DO
 
+Nothing planned.
+
 =head1 BUGS
 
 None reported.

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1261,8 +1261,9 @@ object referenced by C<$file_ref>.
 
 INPUTS:
   - $file_ref      : file hash ref
-  - $data_dir      : data directory (C/data/$PROJECT/data> typically)
-  - $dest_dir      : destination directory (C</data/$PROJECT/data> typically)
+  - $data_dir      : data directory (C</data/$PROJECT/data> typically)
+  - $dest_dir      : destination directory (C</data/$PROJECT/data/pics>
+                     typically)
   - $horizontalPics: boolean, whether to create horizontal pics (1) or not (0)
 
 RETURNS: 1 if the pic was generated or 0 otherwise.
@@ -1311,7 +1312,8 @@ object referenced by C<$file_ref>.
 INPUTS:
   - $file_ref      : file hash ref
   - $data_dir      : data directory (C</data/$PROJECT/data> typically)
-  - $dest_dir      : destination directory (C</data/$PROJECT/data> typically)
+  - $dest_dir      : destination directory (C</data/$PROJECT/data/jiv>
+                     typically)
 
 RETURNS: 1 if the JIV data was generated or 0 otherwise.
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1517,6 +1517,6 @@ License: GPLv3
 =head1 AUTHORS
 
 Jonathan Harlap <jharlap@bic.mni.mcgill.ca>
-LORIS team <loris.info@mcin.ca>
-
+LORIS community <loris.info@mcin.ca>  
+and McGill Centre for Integrative Neuroscience
 =cut    

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -28,7 +28,7 @@ files into the LORIS system)
 =head1 DESCRIPTION
 
 Really a mishmash of utility functions, primarily used by process_uploads and
- all of its children.
+all of its children.
 
 =head2 Methods
 
@@ -178,8 +178,7 @@ sub getScannerCandID {
 
 =pod
 
-=head3 getSessionID($subjectIDref, $studyDate, $dbhr, $objective,
-$noStagingCheck)
+=head3 getSessionID($subjectIDref, $studyDate, $dbhr, $objective, ...)
 
 Gets (or creates) the session ID, given CandID and visitLabel (contained
 inside the hashref C<$subjectIDref>).  Unless C<$noStagingCheck> is true, it
@@ -189,14 +188,15 @@ simple algorithm:
 
 =over 3
 
-- If there exists a session with the same visit label, then that is the
- session ID to use.  If any dates (either existing MRI data or simply a date
- of visit) exist associated with that session, then if they are outside of
- some (arbitrary) time window, staging is required.  If no dates exist, no
- staging is required.
+- If there exists a session with the same visit label, then that is
+   the session ID to use.  If any dates (either existing MRI data or
+   simply a date of visit) exist associated with that session, then
+   if they are outside of some (arbitrary) time window, staging is
+   required.  If no dates exist, no staging is required.
     
-- If no sessions exist, then if there is any other date associated with
- another session of the same subject within a time window, staging is required.
+- If no sessions exist, then if there is any other date associated
+   with another session of the same subject within a time window,
+   staging is required.
     
 - Otherwise, staging is not required.
 
@@ -600,25 +600,25 @@ Inserts scans that do not correspond to any of the defined protocol from the
 mri_protocol table into the mri_protocol_violated_scans table of the database.
 
 INPUT: 
-  $dbhr           : database handle reference
-  $series_desc    : series description of the scan
-  $minc_location  : minc location of the file
-  $patient_name   : patient name of the scan
-  $candid         : candidate's CandID
-  $pscid          : candidate's PSCID
-  $visit          : visit of the scan
-  $tr             : repetition time of the scan
-  $te             : echo time of the scan
-  $ti             : inversion time of the scan
-  $slice_thickness: slice thickness of the image
-  $xstep          : x-step of the image
-  $ystep          : y-step of the image
-  $zstep          : z-step of the image
-  $xspace         : x-space of the image
-  $yspace         : y-space of the image
-  $zspace         : z-space of the image
-  $time           : time dimension of the scan
-  $seriesUID      : seriesUID of the scan
+  - $dbhr           : database handle reference
+  - $series_desc    : series description of the scan
+  - $minc_location  : minc location of the file
+  - $patient_name   : patient name of the scan
+  - $candid         : candidate's CandID
+  - $pscid          : candidate's PSCID
+  - $visit          : visit of the scan
+  - $tr             : repetition time of the scan
+  - $te             : echo time of the scan
+  - $ti             : inversion time of the scan
+  - $slice_thickness: slice thickness of the image
+  - $xstep          : x-step of the image
+  - $ystep          : y-step of the image
+  - $zstep          : z-step of the image
+  - $xspace         : x-space of the image
+  - $yspace         : y-space of the image
+  - $zspace         : z-space of the image
+  - $time           : time dimension of the scan
+  - $seriesUID      : seriesUID of the scan
 
 =cut
 
@@ -714,7 +714,7 @@ sub scan_type_text_to_id {
 
 Determines whether numerical value falls within the range described by range
 string. Range string is a comma-separated list of range units. A single range
-unit follows the syntax either "X" or "X-Y"
+unit follows the syntax either "X" or "X-Y".
 
 INPUT: numerical value and the range to use
 
@@ -1011,15 +1011,15 @@ database handle reference C<$dbhr>. If no scannerID exists, one will be
 created.
 
 INPUT:
-  $manufacturer   : scanner's manufacturer
-  $model          : scanner's model
-  $serialNumber   : scanner's serial number
-  $softwareVersion: scanner's software version
-  $centerID       : scanner's center ID
-  $dbhr           : database handle reference
-  $register_new   : if set, will call the function &registerScanner
+  - $manufacturer   : scanner's manufacturer
+  - $model          : scanner's model
+  - $serialNumber   : scanner's serial number
+  - $softwareVersion: scanner's software version
+  - $centerID       : scanner's center ID
+  - $dbhr           : database handle reference
+  - $register_new   : if set, will call the function C<&registerScanner>
 
-RETURNS: (int) scannerID
+RETURNS: (int) scanner ID
 
 =cut
 
@@ -1050,14 +1050,14 @@ C<$serialNumber>, C<$softwareVersion>, into the database attached to the DBI
 database handle reference C<$dbhr>.
 
 INPUT:
-  $manufacturer   : scanner's manufacturer
-  $model          : scanner's model
-  $serialNumber   : scanner's serial number
-  $softwareVersion: scanner's software version
-  $centerID       : scanner's center ID
-  $dbhr           : database handle reference
+  - $manufacturer   : scanner's manufacturer
+  - $model          : scanner's model
+  - $serialNumber   : scanner's serial number
+  - $softwareVersion: scanner's software version
+  - $centerID       : scanner's center ID
+  - $dbhr           : database handle reference
 
-RETURNS: (int) scannerID
+RETURNS: (int) scanner ID
 
 =cut
 
@@ -1259,10 +1259,10 @@ Generates check pics for the Imaging Browser module for the NeuroDB::File object
 referenced by C<$file_ref>.
 
 INPUT:
-  $file_ref      : file hash ref
-  $data_dir      : data directory (/data/project/data typically)
-  $dest_dir      : destination directory (pic directory)
-  $horizontalPics: boolean, whether to create horizontal pics (1) or not (0)
+  - $file_ref      : file hash ref
+  - $data_dir      : data directory (/data/project/data typically)
+  - $dest_dir      : destination directory (pic directory)
+  - $horizontalPics: boolean, whether to create horizontal pics (1) or not (0)
 
 RETURNS: 1 if the pic was generated or 0 otherwise.
 
@@ -1308,9 +1308,9 @@ Generates JIV data for the Imaging Browser module for the NeuroDB::File object
 referenced by C<$file_ref>.
 
 INPUT:
-  $file_ref      : file hash ref
-  $data_dir      : data directory (/data/project/data typically)
-  $dest_dir      : destination directory (jiv directory)
+  - $file_ref      : file hash ref
+  - $data_dir      : data directory (/data/project/data typically)
+  - $dest_dir      : destination directory (jiv directory)
 
 RETURNS: 1 if the JIV data was generated or 0 otherwise.
 
@@ -1388,17 +1388,17 @@ sub make_nii {
 
 =pod
 
-=head3 make_minc_pics($dbhr, $TarchiveSource, $profile, $minFileID, $debug, ...)
+=head3 make_minc_pics($dbhr, $TarchiveSource, $profile, $minFileID, ...)
 
 Creates pics associated with MINC files.
 
 INPUT:
-  $dbhr          : database handle reference
-  $TarchiveSource: tarchiveID of the DICOM study
-  $profile       : the profile (typically named C<prod>)
-  $minFileID     : smaller FileID to be used to run C<mass_pic.pl>
-  $debug         : boolean, whether in debug mode (1) or not (0)
-  $verbose       : boolean, whether in verbose mode (1) or not (0)
+  - $dbhr          : database handle reference
+  - $TarchiveSource: tarchiveID of the DICOM study
+  - $profile       : the profile (typically named C<prod>)
+  - $minFileID     : smaller FileID to be used to run C<mass_pic.pl>
+  - $debug         : boolean, whether in debug mode (1) or not (0)
+  - $verbose       : boolean, whether in verbose mode (1) or not (0)
 
 =cut
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -27,7 +27,7 @@ files into the LORIS system)
 
 =head1 DESCRIPTION
 
-Really a mishmash of utility functions, primarily used by process_uploads and
+Really a mishmash of utility functions, primarily used by C<process_uploads> and
 all of its children.
 
 =head2 Methods
@@ -61,10 +61,10 @@ $FLOAT_EQUALS_NB_DECIMALS = 4;
 Determines the candidate ID and visit label for the subject based on patient
 name and (for calibration data) scannerID.
 
-INPUT: patient name, scanner ID and database handle reference
+INPUTS: patient name, scanner ID and database handle reference
 
-RETURNS: a reference to a hash containing elements including 'CandID',
-'visitLabel' and 'visitNo', or, in the case of failure, C<undef>
+RETURNS: a reference to a hash containing elements including C<CandID>,
+C<visitLabel> and C<visitNo>, or, in the case of failure, C<undef>
 
 =cut
 
@@ -100,7 +100,7 @@ sub getSubjectIDs {
 
 Verifies that the subject IDs match.
 
-INPUT: candidate's CandID, candidate's PSCID and the database handle reference
+INPUTS: candidate's CandID, candidate's PSCID and the database handle reference
 
 RETURNS: 1 if the ID pair matches, 0 otherwise
 
@@ -131,7 +131,7 @@ sub subjectIDIsValid {
 
 Verifies that the subject ID (CandID) exists.
 
-INPUT: candidate's CandID and the database handle reference
+INPUTS: candidate's CandID and the database handle reference
 
 RETURNS: 1 if the ID exists, 0 otherwise
 
@@ -154,7 +154,7 @@ sub subjectIDExists {
 
 Retrieves the candidate (CandID) for the given scanner.
 
-INPUT: the scanner ID and the database handle reference
+INPUTS: the scanner ID and the database handle reference
 
 RETURNS: the CandID or (if none exists) undef
 
@@ -202,7 +202,7 @@ simple algorithm:
 
 =back
 
-INPUT: hash reference of subject IDs, study date, database handle reference,
+INPUTS: hash reference of subject IDs, study date, database handle reference,
 the objective of the study and a no staging check flag.
 
 RETURNS: a list of two items, (sessionID, requiresStaging)
@@ -354,7 +354,7 @@ sub getSessionID {
 This method tries to figure out if there may have been labelling problems which
 would put the files in a staging area that does not actually exist.
 
-INPUT: study date, database handle reference and array of fileIDs to check the
+INPUTS: study date, database handle reference and array of fileIDs to check the
 study date
 
 RETURNS: 1 if the file requires staging, 0 otherwise
@@ -402,7 +402,7 @@ sub checkMRIStudyDates {
 Attempts to determine the SubprojectID  of a timepoint given the subjectIDs
 hashref C<$subjectIDsref> and a database handle reference C<$dbhr>
 
-INPUT: subjectIDs hashref and database handle reference
+INPUTS: subjectIDs hashref and database handle reference
 
 RETURNS: the determined objective, or 0
 
@@ -448,13 +448,13 @@ sub getObjective
 
 =head3 identify_scan_db($center_name, $objective, $fileref, $dbhr)
 
-Determines the type of the scan described by minc headers based on mri_protocol
-table in the database.
+Determines the type of the scan described by MINC headers based on
+C<mri_protocol> table in the database.
 
-INPUT: center's name, objective of the study, file hashref, database handle
+INPUTS: center's name, objective of the study, file hashref, database handle
 reference
 
-RETURNS: textual name of scan type
+RETURNS: textual name of scan type from the C<mri_scan_type> table
 
 =cut
 
@@ -597,9 +597,10 @@ sub identify_scan_db {
 =head3 insert_violated_scans($dbhr, $series_desc, $minc_location, ...)
 
 Inserts scans that do not correspond to any of the defined protocol from the 
-mri_protocol table into the mri_protocol_violated_scans table of the database.
+C<mri_protocol> table into the C<mri_protocol_violated_scans> table of the
+database.
 
-INPUT: 
+INPUTS:
   - $dbhr           : database handle reference
   - $series_desc    : series description of the scan
   - $minc_location  : minc location of the file
@@ -640,7 +641,7 @@ sub insert_violated_scans {
 
 Will evaluate whether the scalar C<$value> is in the specified C<$range>.
 
-INPUT: scalar value, scalar range string
+INPUTS: scalar value, scalar range string
 
 RETURNS: 1 if in range, 0 if not in range
 
@@ -666,7 +667,7 @@ sub debug_inrange {
 
 Determines the type of the scan identified by its scan type ID.
 
-INPUT: scan type ID and database handle reference
+INPUTS: scan type ID and database handle reference
 
 RETURNS: Textual name of scan type
 
@@ -689,7 +690,7 @@ sub scan_type_id_to_text {
 
 Determines the type of the scan identified by scan type.
 
-INPUT: scan type and database handle reference
+INPUTS: scan type and database handle reference
 
 RETURNS: ID of the scan type
 
@@ -716,7 +717,7 @@ Determines whether numerical value falls within the range described by range
 string. Range string is a comma-separated list of range units. A single range
 unit follows the syntax either "X" or "X-Y".
 
-INPUT: numerical value and the range to use
+INPUTS: numerical value and the range to use
 
 RETURNS: 1 if the value is in range, 0 otherwise
 
@@ -756,7 +757,7 @@ sub in_range
 Checks whether f1 and f2 are equal (considers only the first nb_decimals
 decimals).
 
-INPUT: float 1, float 2 and the number of first decimals
+INPUTS: float 1, float 2 and the number of first decimals
 
 RETURNS: 1 if the numbers are relatively equal, 0 otherwise
 
@@ -777,7 +778,7 @@ C<$range_string> using the same C<$range_string> syntax as C<&in_range()>.
 It returns a scalar range SQL string appropriate to use as a WHERE condition
 (C<SELECT ... WHERE range_to_sql(...)>).
 
-INPUT: scalar field, scalar range string that follows the same format as in
+INPUTS: scalar field, scalar range string that follows the same format as in
 C<&in_range()>
 
 RETURNS: scalar range SQL string
@@ -1010,7 +1011,7 @@ C<$serialNumber>, C<$softwareVersion>, using the database attached to the DBI
 database handle reference C<$dbhr>. If no scannerID exists, one will be
 created.
 
-INPUT:
+INPUTS:
   - $manufacturer   : scanner's manufacturer
   - $model          : scanner's model
   - $serialNumber   : scanner's serial number
@@ -1049,7 +1050,7 @@ Registers the scanner as defined by C<$manufacturer>, C<$model>,
 C<$serialNumber>, C<$softwareVersion>, into the database attached to the DBI
 database handle reference C<$dbhr>.
 
-INPUT:
+INPUTS:
   - $manufacturer   : scanner's manufacturer
   - $model          : scanner's model
   - $serialNumber   : scanner's serial number
@@ -1125,7 +1126,7 @@ sub createNewCandID {
 Looks for the site alias in whatever field (usually patient_name or
 patient_id) is provided and return the MRI alias and CenterID.
 
-INPUT: patient name, database handle reference
+INPUTS: patient name, database handle reference
 
 RETURNS: a two element array:
   - first is the MRI alias of the PSC or "UNKN"
@@ -1255,13 +1256,13 @@ sub is_unique_hash {
 
 =head3 make_pics($file_ref, $data_dir, $dest_dir, $horizontalPics)
 
-Generates check pics for the Imaging Browser module for the NeuroDB::File object
-referenced by C<$file_ref>.
+Generates check pics for the Imaging Browser module for the C<NeuroDB::File>
+object referenced by C<$file_ref>.
 
-INPUT:
+INPUTS:
   - $file_ref      : file hash ref
-  - $data_dir      : data directory (/data/project/data typically)
-  - $dest_dir      : destination directory (pic directory)
+  - $data_dir      : data directory (C/data/$PROJECT/data> typically)
+  - $dest_dir      : destination directory (C</data/$PROJECT/data> typically)
   - $horizontalPics: boolean, whether to create horizontal pics (1) or not (0)
 
 RETURNS: 1 if the pic was generated or 0 otherwise.
@@ -1304,13 +1305,13 @@ sub make_pics {
 
 =head3 make_jiv($file_ref, $data_dir, $dest_dir)
 
-Generates JIV data for the Imaging Browser module for the NeuroDB::File object
-referenced by C<$file_ref>.
+Generates JIV data for the Imaging Browser module for the C<NeuroDB::File>
+object referenced by C<$file_ref>.
 
-INPUT:
+INPUTS:
   - $file_ref      : file hash ref
-  - $data_dir      : data directory (/data/project/data typically)
-  - $dest_dir      : destination directory (jiv directory)
+  - $data_dir      : data directory (C</data/$PROJECT/data> typically)
+  - $dest_dir      : destination directory (C</data/$PROJECT/data> typically)
 
 RETURNS: 1 if the JIV data was generated or 0 otherwise.
 
@@ -1363,7 +1364,7 @@ sub make_jiv {
 Creates NIfTI files associated with MINC files and append its path to the
 parameter_file table using the parameter_type "check_nii_filename".
 
-INPUT: file hashref and data directory (typically /data/project/data)
+INPUTS: file hashref and data directory (typically C</data/project/data>)
 
 =cut
 
@@ -1392,7 +1393,7 @@ sub make_nii {
 
 Creates pics associated with MINC files.
 
-INPUT:
+INPUTS:
   - $dbhr          : database handle reference
   - $TarchiveSource: tarchiveID of the DICOM study
   - $profile       : the profile (typically named C<prod>)
@@ -1468,7 +1469,7 @@ sub DICOMDateToUnixTimestamp {
 
 Looks up the CandID for a given PSCID.
 
-INPUT: candidate's PSCID, database handle reference
+INPUTS: candidate's PSCID, database handle reference
 
 RETURNS: the CandID or 0 if the PSCID does not exist
 
@@ -1518,7 +1519,7 @@ License: GPLv3
 
 =head1 AUTHORS
 
-Jonathan Harlap <jharlap@bic.mni.mcgill.ca>
+Jonathan Harlap <jharlap@bic.mni.mcgill.ca>,
 LORIS community <loris.info@mcin.ca>  
 and McGill Centre for Integrative Neuroscience
 =cut    

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1517,5 +1517,6 @@ License: GPLv3
 =head1 AUTHORS
 
 Jonathan Harlap <jharlap@bic.mni.mcgill.ca>
+LORIS team <loris.info@mcin.ca>
 
 =cut    

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1262,7 +1262,7 @@ object referenced by C<$file_ref>.
 INPUTS:
   - $file_ref      : file hash ref
   - $data_dir      : data directory (C</data/$PROJECT/data> typically)
-  - $dest_dir      : destination directory (C</data/$PROJECT/data/pics>
+  - $dest_dir      : destination directory (C</data/$PROJECT/data/pic>
                      typically)
   - $horizontalPics: boolean, whether to create horizontal pics (1) or not (0)
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1,10 +1,12 @@
+package NeuroDB::MRI;
+
 =pod
 
 =head1 NAME
 
 NeuroDB::MRI -- A set of utility functions for performing common tasks
 relating to MRI data (particularly with regards to registering MRI
-files into the NeuroDB system)
+files into the LORIS system)
 
 =head1 SYNOPSIS
 
@@ -25,14 +27,13 @@ files into the NeuroDB system)
 
 =head1 DESCRIPTION
 
-Really a mishmash of utility functions, primarily used by
-process_uploads and all of its children
+Really a mishmash of utility functions, primarily used by process_uploads and
+ all of its children.
 
-=head1 METHODS
+=head2 Methods
 
 =cut
 
-package NeuroDB::MRI;
 
 use Exporter();
 use Math::Round;
@@ -54,10 +55,19 @@ $FLOAT_EQUALS_NB_DECIMALS = 4;
 @EXPORT_OK = qw(identify_scan in_range get_headers get_info get_ids get_objective identify_scan_db scan_type_text_to_id scan_type_id_to_text register_db get_header_hash get_scanner_id get_psc compute_hash is_unique_hash make_pics select_volume);
 
 =pod
-B<getSubjectIDs( C<$patientName>, C<$scannerID>, C<$dbhr> )>
-Determines the cand id and visit label for the subject based on patient name and (for calibration data) scannerid.
-Returns: a reference to a hash containing elements including 'CandID', 'visitLabel' and 'visitNo', or, in the case of failure, undef
+
+=head3 getSubjectIDs($patientName, $scannerID, $dbhr)
+
+Determines the candidate ID and visit label for the subject based on patient
+name and (for calibration data) scannerID.
+
+INPUT: patient name, scanner ID and database handle reference
+
+RETURNS: a reference to a hash containing elements including 'CandID',
+'visitLabel' and 'visitNo', or, in the case of failure, C<undef>
+
 =cut
+
 sub getSubjectIDs {
     my ($patientName, $scannerID, $dbhr) = @_;
     my %subjectID;
@@ -85,10 +95,17 @@ sub getSubjectIDs {
 }
 
 =pod
-B<subjectIDIsValid( C<$CandID>, C<$PSCID>, C<$dbhr> )>
-    Verifies that the subject IDs match.
-    Returns: 1 if the ID pair matches, 0 otherwise
+
+=head3 subjectIDIsValid($CandID, $PSCID, $dbhr)
+
+Verifies that the subject IDs match.
+
+INPUT: candidate's CandID, candidate's PSCID and the database handle reference
+
+RETURNS: 1 if the ID pair matches, 0 otherwise
+
 =cut
+
 sub subjectIDIsValid {
     my ($candID, $pscid, $visit_label, $dbhr, $create_visit_label) = @_;
     my $query = "SELECT COUNT(*) AS isValid FROM candidate WHERE CandID=".$${dbhr}->quote($candID)." AND PSCID=".$${dbhr}->quote($pscid);
@@ -109,10 +126,17 @@ sub subjectIDIsValid {
 }
 
 =pod
-B<subjectIDExists( C<$CandID>, C<$dbhr> )>
-    Verifies that the subject ID (CandID) exists.
-    Returns: 1 if the ID exists, 0 otherwise
+
+=head3 subjectIDExists($CandID, $dbhr)
+
+Verifies that the subject ID (CandID) exists.
+
+INPUT: candidate's CandID and the database handle reference
+
+RETURNS: 1 if the ID exists, 0 otherwise
+
 =cut
+
 sub subjectIDExists {
     my ($candID, $dbhr) = @_;
     
@@ -125,10 +149,17 @@ sub subjectIDExists {
 }
 
 =pod
-B<getScannerCandID( C<$scannerID>, C<$dbhr> )>
-    Retrieves the candidate id for the given scanner
-    Returns: the CandID or (if none exists) undef
+
+=head3 getScannerCandID($scannerID, $dbhr)
+
+Retrieves the candidate (CandID) for the given scanner.
+
+INPUT: the scanner ID and the database handle reference
+
+RETURNS: the CandID or (if none exists) undef
+
 =cut
+
 sub getScannerCandID {
     my ($scannerID, $dbhr) = @_;
     my $candID;
@@ -146,28 +177,38 @@ sub getScannerCandID {
 }
 
 =pod
-B<getSessionID( C<$subjectIDref>, C<$studyDate>, C<$dbhr>, C<$objective>, C<$noStagingCheck> )>
 
-    Gets (or creates) the session ID, given CandID and visitLabel
-    (contained inside the hashref C<$subjectIDref>).  Unless
-    C<$noStagingCheck> is true, it also determines whether staging is
-    required using the C<$studyDate> (formatted YYYYMMDD) to determine
-    whether staging is required based on a simple algorithm:
-    
-    If there exists a session with the same visit label, then that is the
-    session ID to use.  If any dates (either existing MRI data or simply a
-    date of visit) exist associated with that session, then if they are
-    outside of some (arbitrary) time window, staging is required.  If no
-    dates exist, no staging is required.
-    
-    If no sessions exist, then if there is any other date associated with
-    another session of the same subject within a time window, staging is
-    required.
-    
-    Otherwise, staging is not required.
+=head3 getSessionID($subjectIDref, $studyDate, $dbhr, $objective,
+$noStagingCheck)
 
-    Returns: a list of two items, (sessionID, requiresStaging)
+Gets (or creates) the session ID, given CandID and visitLabel (contained
+inside the hashref C<$subjectIDref>).  Unless C<$noStagingCheck> is true, it
+also determines whether staging is required using the C<$studyDate>
+(formatted YYYYMMDD) to determine whether staging is required based on a
+simple algorithm:
+
+=over 3
+
+- If there exists a session with the same visit label, then that is the
+ session ID to use.  If any dates (either existing MRI data or simply a date
+ of visit) exist associated with that session, then if they are outside of
+ some (arbitrary) time window, staging is required.  If no dates exist, no
+ staging is required.
+    
+- If no sessions exist, then if there is any other date associated with
+ another session of the same subject within a time window, staging is required.
+    
+- Otherwise, staging is not required.
+
+=back
+
+INPUT: hash reference of subject IDs, study date, database handle reference,
+the objective of the study and a no staging check flag.
+
+RETURNS: a list of two items, (sessionID, requiresStaging)
+
 =cut
+
 sub getSessionID {
     my ($subjectIDref, $studyDate, $dbhr, $objective, $noStagingCheck) = @_;
     my ($sessionID, $requiresStaging, $studyDateJD);
@@ -306,7 +347,20 @@ sub getSessionID {
     return ($sessionID, $requiresStaging);
 }
 
-# tries to figure out if there may have been labelling problems which would put this file in a staging area that does not actually exist.
+=pod
+
+=head3 checkMRIStudyDates($studyDateJD, $dbhr, @fileIDs)
+
+This method tries to figure out if there may have been labelling problems which
+would put the files in a staging area that does not actually exist.
+
+INPUT: study date, database handle reference and array of fileIDs to check the
+study date
+
+RETURNS: 1 if the file requires staging, 0 otherwise
+
+=cut
+
 sub checkMRIStudyDates {
     my ($studyDateJD, $dbhr, @fileIDs) = @_;
 
@@ -343,13 +397,14 @@ sub checkMRIStudyDates {
 
 =pod
 
-B<getObjective( C<$subjectIDsref>, C<$dbhr> )>
+=head3 getObjective($subjectIDsref, $dbhr)
 
-Attempts to determine the SubprojectID  of a timepoint given the
-subjectIDs hashref C<$subjectIDsref> and a database handle reference
-C<$dbhr>
+Attempts to determine the SubprojectID  of a timepoint given the subjectIDs
+hashref C<$subjectIDsref> and a database handle reference C<$dbhr>
 
-Returns: the determined objective, or 0
+INPUT: subjectIDs hashref and database handle reference
+
+RETURNS: the determined objective, or 0
 
 =cut
 
@@ -391,11 +446,15 @@ sub getObjective
 
 =pod
 
-B<identify_scan_db( C<$center_name>, C<$objective>, C<$fileref>, C<$dbhr> )>
+=head3 identify_scan_db($center_name, $objective, $fileref, $dbhr)
 
-Determines the type of the scan described by minc headers based on mri_protocol in the database
+Determines the type of the scan described by minc headers based on mri_protocol
+table in the database.
 
-Returns: Textual name of scan type
+INPUT: center's name, objective of the study, file hashref, database handle
+reference
+
+RETURNS: textual name of scan type
 
 =cut
 
@@ -533,6 +592,35 @@ sub identify_scan_db {
     return 'unknown';
 }    
 
+=pod
+
+=head3 insert_violated_scans($dbhr, $series_desc, $minc_location, ...)
+
+Inserts scans that do not correspond to any of the defined protocol from the 
+mri_protocol table into the mri_protocol_violated_scans table of the database.
+
+INPUT: 
+  $dbhr           : database handle reference
+  $series_desc    : series description of the scan
+  $minc_location  : minc location of the file
+  $patient_name   : patient name of the scan
+  $candid         : candidate's CandID
+  $pscid          : candidate's PSCID
+  $visit          : visit of the scan
+  $tr             : repetition time of the scan
+  $te             : echo time of the scan
+  $ti             : inversion time of the scan
+  $slice_thickness: slice thickness of the image
+  $xstep          : x-step of the image
+  $ystep          : y-step of the image
+  $zstep          : z-step of the image
+  $xspace         : x-space of the image
+  $yspace         : y-space of the image
+  $zspace         : z-space of the image
+  $time           : time dimension of the scan
+  $seriesUID      : seriesUID of the scan
+
+=cut
 
 sub insert_violated_scans {
 
@@ -544,18 +632,20 @@ sub insert_violated_scans {
    my $success = $sth->execute($candid,$pscid,$series_description,$minc_location,$patient_name,$tr,$te,$ti,$slice_thickness,$xspace,$yspace,$zspace,$xstep,$ystep,$zstep,$time,$seriesUID);
 
 }
-# ------------------------------ MNI Header ----------------------------------
-#@NAME       : debug_inrange
-#@INPUT      : scalar value, scalar range string
-#@OUTPUT     : prints $value [NOT] IN $range as appropriate
-#@RETURNS    : 
-#@DESCRIPTION: Debugging tool wrapped around &in_range()
-#@METHOD     : 
-#@GLOBALS    : 
-#@CALLS      : 
-#@CREATED    : 2003/03/18, Jonathan Harlap
-#@MODIFIED   : 
-#-----------------------------------------------------------------------------
+
+
+=pod
+
+=head3 debug_inrange($val, $range)
+
+Will evaluate whether the scalar C<$value> is in the specified C<$range>.
+
+INPUT: scalar value, scalar range string
+
+RETURNS: 1 if in range, 0 if not in range
+
+=cut
+
 sub debug_inrange {
     my $val = shift;
     my $range = shift;
@@ -569,13 +659,16 @@ sub debug_inrange {
     }
 }
 
+
 =pod
 
-B<scan_type_id_to_text( C<$typeID>, C<$dbhr> )>
+=head3 scan_type_id_to_text($typeID, $dbhr)
 
-Determines the type of the scan identified by scan type id
+Determines the type of the scan identified by its scan type ID.
 
-Returns: Textual name of scan type
+INPUT: scan type ID and database handle reference
+
+RETURNS: Textual name of scan type
 
 =cut
 
@@ -592,11 +685,13 @@ sub scan_type_id_to_text {
 
 =pod
 
-B<scan_type_text_to_id( C<$type>, C<$dbhr> )>
+=head3 scan_type_text_to_id($type, $dbhr)
 
-Determines the type of the scan identified by scan type
+Determines the type of the scan identified by scan type.
 
-Returns: ID of the scan type
+INPUT: scan type and database handle reference
+
+RETURNS: ID of the scan type
 
 =cut
 
@@ -612,15 +707,18 @@ sub scan_type_text_to_id {
     return $results[0];
 }
 
+
 =pod
 
-B<in_range( C<$value>, C<$range_string> )>
+=head3 in_range($value, $range_string)
 
-determines whether numerical value falls within the range described by
-range string.  range string is a comma-seperated list of range units.
-a single range unit follows the syntax either "X" or "X-Y"
+Determines whether numerical value falls within the range described by range
+string. Range string is a comma-separated list of range units. A single range
+unit follows the syntax either "X" or "X-Y"
 
-Returns: 1 if the value is in range, 0 otherwise
+INPUT: numerical value and the range to use
+
+RETURNS: 1 if the value is in range, 0 otherwise
 
 =cut
 
@@ -653,11 +751,14 @@ sub in_range
 
 =pod
 
-B<floats_are_equal( C<$f1>, C<$f2>, C<$nb_decimals> )>
+=head3 floats_are_equal($f1, $f2, $nb_decimals)
 
-Checks whether f1 and f2 are equal (considers only the first nb_decimals decimals).
+Checks whether f1 and f2 are equal (considers only the first nb_decimals
+decimals).
 
-Returns: 1 if the numbers are relatively equal, 0 otherwise
+INPUT: float 1, float 2 and the number of first decimals
+
+RETURNS: 1 if the numbers are relatively equal, 0 otherwise
 
 =cut
 sub floats_are_equal {
@@ -666,21 +767,23 @@ sub floats_are_equal {
     return sprintf("%.${nb_decimals}g", $f1) eq sprintf("%.${nb_decimals}g", $f2);
 }
 
-## string range_to_sql($field, $range_string) where $range_string follows the same format as in in_range
-## returns SQL appropriate to use as a WHERE condition. (SELECT ... WHERE range_to_sql(...))
-# ------------------------------ MNI Header ----------------------------------
-#@NAME       : range_to_sql
-#@INPUT      : scalar field, scalar range string
-#@OUTPUT     : 
-#@RETURNS    : scalar range sql string
-#@DESCRIPTION: generates a valid SQL WHERE expression to test $field against $range_string
-#              using the same $range_string syntax as &in_range()
-#@METHOD     : 
-#@GLOBALS    : 
-#@CALLS      : 
-#@CREATED    : 2003/01/18, Jonathan Harlap
-#@MODIFIED   : 
-#-----------------------------------------------------------------------------
+
+=pod
+
+=head3 range_to_sql($field, $range_string)
+
+Generates a valid SQL WHERE expression to test C<$field> against
+C<$range_string> using the same C<$range_string> syntax as C<&in_range()>.
+It returns a scalar range SQL string appropriate to use as a WHERE condition
+(C<SELECT ... WHERE range_to_sql(...)>).
+
+INPUT: scalar field, scalar range string that follows the same format as in
+C<&in_range()>
+
+RETURNS: scalar range SQL string
+
+=cut
+
 sub range_to_sql {
     my ($field, $range_string) = @_;
     chomp($field);
@@ -712,11 +815,13 @@ sub range_to_sql {
 
 =pod
 
-B<register_db( C<$file_ref> )>
+=head3 register_db($file_ref)
 
-Registers the NeuroDB::File object referenced by C<$file_ref> into the database
+Registers the NeuroDB::File object referenced by C<$file_ref> into the database.
 
-Returns: 0 if the file is already registered, the new FileID otherwise
+INPUT: file hashref
+
+RETURNS: 0 if the file is already registered, the new FileID otherwise
 
 =cut
 
@@ -777,10 +882,12 @@ sub register_db {
 
 =pod
 
-B<mapDicomParameters( C<$file_ref> )>
+=head3 mapDicomParameters($file_ref)
 
-Maps dicom parameters to more meaningful names in the NeuroDB::File
-object referenced by C<$file_ref>.
+Maps DICOM parameters to more meaningful names in the NeuroDB::File object
+referenced by C<$file_ref>.
+
+INPUT: file hashref
 
 =cut
 
@@ -896,14 +1003,23 @@ sub mapDicomParameters {
 }
 =pod
 
-B<findScannerID( C<$manufacturer>, C<$model>, C<$serialNumber>, C<$softwareVersion>, C<$dbhr> )>
+=head3 findScannerID($manufacturer, $model, $serialNumber, ...)
 
-Finds the scannerID for the scanner as defined by C<$manufacturer>,
-C<$model>, C<$serialNumber>, C<$softwareVersion>, using the database
-attached to the DBI database handle reference C<$dbhr>.  If no
-scannerID exists, one will be created.
+Finds the scannerID for the scanner as defined by C<$manufacturer>, C<$model>,
+C<$serialNumber>, C<$softwareVersion>, using the database attached to the DBI
+database handle reference C<$dbhr>. If no scannerID exists, one will be
+created.
 
-Returns: (int) scannerID
+INPUT:
+  $manufacturer   : scanner's manufacturer
+  $model          : scanner's model
+  $serialNumber   : scanner's serial number
+  $softwareVersion: scanner's software version
+  $centerID       : scanner's center ID
+  $dbhr           : database handle reference
+  $register_new   : if set, will call the function &registerScanner
+
+RETURNS: (int) scannerID
 
 =cut
 
@@ -927,13 +1043,21 @@ sub findScannerID {
 
 =pod
 
-B<registerScanner( C<$manufacturer>, C<$model>, C<$serialNumber>, C<$softwareVersion>, C<$dbhr> )>
+=head3 registerScanner($manufacturer, $model, $serialNumber, ...)
 
 Registers the scanner as defined by C<$manufacturer>, C<$model>,
-C<$serialNumber>, C<$softwareVersion>, into the database attached to
-the DBI database handle reference C<$dbhr>.
+C<$serialNumber>, C<$softwareVersion>, into the database attached to the DBI
+database handle reference C<$dbhr>.
 
-Returns: (int) scannerID
+INPUT:
+  $manufacturer   : scanner's manufacturer
+  $model          : scanner's model
+  $serialNumber   : scanner's serial number
+  $softwareVersion: scanner's software version
+  $centerID       : scanner's center ID
+  $dbhr           : database handle reference
+
+RETURNS: (int) scannerID
 
 =cut
 
@@ -970,10 +1094,13 @@ sub registerScanner {
 
 =pod
 
-B<createNewCandID
+=head3 createNewCandID($dbhr)
 
+Creates a new CandID.
 
-Returns: (int) CandID
+INPUT: database handle reference
+
+RETURNS: (int) CandID
 
 =cut
 
@@ -993,12 +1120,16 @@ sub createNewCandID {
 
 =pod
 
-B<getPSC( C<$patientName>, C<$dbhr> )>
+=head3 getPSC($patientName, $dbhr)
 
-Look for the site alias in whatever field (usually patient name or patient_id) is provided 
-and return the MRI alias and CenterID
+Looks for the site alias in whatever field (usually patient_name or
+patient_id) is provided and return the MRI alias and CenterID.
 
-Returns: two element array: first is UNKN or the MRI alias of the PSC, second is the centerID or 0
+INPUT: patient name, database handle reference
+
+RETURNS: a two element array:
+  - first is the MRI alias of the PSC or "UNKN"
+  - second is the centerID or 0
 
 =cut
 
@@ -1038,10 +1169,14 @@ sub getPSC {
 
 =pod
 
-B<compute_hash( C<$file_ref> )>
+=head3 compute_hash($file_ref)
 
-Semi-intelligently generates a hash (MD5 digest) for the NeuroDB::File object referenced
-by C<$file_ref>.
+Semi-intelligently generates a hash (MD5 digest) for the NeuroDB::File object
+referenced by C<$file_ref>.
+
+INPUT: file hashref
+
+RETURNS: the generated MD5 hash
 
 =cut
 
@@ -1084,12 +1219,15 @@ sub compute_hash {
 
 =pod
 
-B<is_unique_hash( C<$file_ref> )>
+=head3 is_unique_hash($file_ref)
 
 Determines if the file is unique using the hash (MD5 digest) from the
 NeuroDB::File object referenced by C<$file_ref>.
 
-Returns: 1 if the file is unique (or if hashes are not being tracked) or 0 otherwise.
+INPUT: file hashref
+
+RETURNS: 1 if the file is unique (or if hashes are not being tracked) or 0
+otherwise.
 
 =cut
 
@@ -1115,12 +1253,18 @@ sub is_unique_hash {
 
 =pod
 
-B<make_pics( C<$file_ref> )>
+=head3 make_pics($file_ref, $data_dir, $dest_dir, $horizontalPics)
 
-Generates check pics for the MRI browser for the NeuroDB::File object
+Generates check pics for the Imaging Browser module for the NeuroDB::File object
 referenced by C<$file_ref>.
 
-Returns: 1 if the pic was generated or 0 otherwise.
+INPUT:
+  $file_ref      : file hash ref
+  $data_dir      : data directory (/data/project/data typically)
+  $dest_dir      : destination directory (pic directory)
+  $horizontalPics: boolean, whether to create horizontal pics (1) or not (0)
+
+RETURNS: 1 if the pic was generated or 0 otherwise.
 
 =cut
 
@@ -1158,11 +1302,20 @@ sub make_pics {
 
 =pod
 
-B<make_jiv( C<$file_ref> )>
-Generates JIV data for the MRI browser for the NeuroDB::File object
+=head3 make_jiv($file_ref, $data_dir, $dest_dir)
+
+Generates JIV data for the Imaging Browser module for the NeuroDB::File object
 referenced by C<$file_ref>.
-Returns: 1 if the JIV data was generated or 0 otherwise.
+
+INPUT:
+  $file_ref      : file hash ref
+  $data_dir      : data directory (/data/project/data typically)
+  $dest_dir      : destination directory (jiv directory)
+
+RETURNS: 1 if the JIV data was generated or 0 otherwise.
+
 =cut
+
 sub make_jiv {
     my ($fileref, $data_dir, $dest_dir) = @_;
     my $file = $$fileref;
@@ -1204,10 +1357,16 @@ sub make_jiv {
 }
 
 =pod
-Creates NIfTI files associated with MINC files and append
-its path to the parameter_file table using the parameter_type
-"check_nii_filename".
+
+=head3 make_nii($fileref, $data_dir)
+
+Creates NIfTI files associated with MINC files and append its path to the
+parameter_file table using the parameter_type "check_nii_filename".
+
+INPUT: file hashref and data directory (typically /data/project/data)
+
 =cut
+
 sub make_nii {
     my ($fileref, $data_dir)  = @_;
    
@@ -1228,8 +1387,21 @@ sub make_nii {
 }
 
 =pod
-Creates pics associated with MINC files
+
+=head3 make_minc_pics($dbhr, $TarchiveSource, $profile, $minFileID, $debug, ...)
+
+Creates pics associated with MINC files.
+
+INPUT:
+  $dbhr          : database handle reference
+  $TarchiveSource: tarchiveID of the DICOM study
+  $profile       : the profile (typically named C<prod>)
+  $minFileID     : smaller FileID to be used to run C<mass_pic.pl>
+  $debug         : boolean, whether in debug mode (1) or not (0)
+  $verbose       : boolean, whether in verbose mode (1) or not (0)
+
 =cut
+
 sub make_minc_pics {
     my ($dbhr, $TarchiveSource, $profile, $minFileID, $debug, $verbose) = @_;
     my $where = "WHERE TarchiveSource = ? ";
@@ -1263,10 +1435,17 @@ sub make_minc_pics {
 }
 
 =pod
-B<DICOMDateToUnixTimestamp( C<$dicomDate> )>
-Converts a DICOM date field (YYYYMMDD) into a unix timestamp
-Returns: a unix timestamp (integer) or 0 if something went wrong
+
+=head3 DICOMDateToUnixTimestamp($dicomDate>
+
+Converts a DICOM date field (YYYYMMDD) into a unix timestamp.
+
+INPUT: DICOM date to convert
+
+RETURNS: a unix timestamp (integer) or 0 if something went wrong
+
 =cut
+
 sub DICOMDateToUnixTimestamp {
     my ($dicomDate) = @_;
 
@@ -1284,10 +1463,17 @@ sub DICOMDateToUnixTimestamp {
 }
 
 =pod
-B<lookupCandIDFromPSCID( C<$pscid> )>
-Looks up the CandID for a given PSCID
-Returns: the CandID or 0 if the PSCID does not exist
+
+=head3 lookupCandIDFromPSCID($pscid, $dbhr)
+
+Looks up the CandID for a given PSCID.
+
+INPUT: candidate's PSCID, database handle reference
+
+RETURNS: the CandID or 0 if the PSCID does not exist
+
 =cut
+
 sub lookupCandIDFromPSCID {
     my ($pscid, $dbhr) = @_;
     my $candid = 0;
@@ -1316,13 +1502,17 @@ __END__
 =pod
 
 =head1 TO DO
-Update all subs without pod...
+
 =head1 BUGS
+
 None reported.
-=head1 COPYRIGHT
+
+=head1 COPYRIGHT AND LICENSE
 
 Copyright (c) 2003-2004 by Jonathan Harlap, McConnell Brain Imaging Centre,
 Montreal Neurological Institute, McGill University.
+
+License: GPLv3
 
 =head1 AUTHORS
 


### PR DESCRIPTION
Using perldoc/perlpod to document `MRI.pm` so that users can type in the terminal
`perldoc MRI.pm` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `MRI.md` file has been created so that we have a web displayed version of the documentation.
`pod2markdown MRI.pm > MRI.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage