### PR TITLE
[Documentation] NeuroDB::Notification perldocification

### DIFF
--- a/docs/scripts_md/Notify.md
+++ b/docs/scripts_md/Notify.md
@@ -1,0 +1,112 @@
+# NAME
+
+NeuroDB::Notify -- Provides an interface to the email notification subsystem
+of LORIS
+
+# SYNOPSIS
+
+use NeuroDB::Notify;
+
+my $notifier = NeuroDB::Notify->new(\\$dbh);
+
+my $message           = "Some kind of message from tarchive validation";
+my $upload\_id         = 123456;
+my $notify\_notsummary = 'N';
+$notifier->spool('tarchive validation', $message,   0,
+		         'tarchiveLoader',      $upload\_id, 'Y',
+		         $notify\_notsummary
+		        );
+
+# DESCRIPTION
+
+This class defines an interface into the email notification subsystem of
+LORIS - particularly with regards to spooling new messages.
+
+## Methods
+
+### new($dbh) (constructor)
+
+Creates a new instance of this class. The parameter `\$dbh` is a
+reference to a DBI database handle, used to set the object's database
+handle, so that all the DB-driven methods will work.
+
+INPUT: DBI database handle
+
+RETURNS: new instance of this class.
+
+### spool($type, $message, $centerID, $origin, $processID, $isError, $isVerb)
+
+Spools a new notification message, `$message`, into the spool for notification
+type `$type`. If `$centerID` is specified, only recipients in that site will
+receive the message.
+
+INPUT:
+  $type     : notification type
+  $message  : notification message
+  $centerID : center ID
+  $origin   : notification origin
+  $processID: process ID
+  $isError  : if the notification is an error
+  $isVerb   : if verbose is set
+
+RETURNS: 1 on success, 0 on failure
+
+### getTypeID($type)
+
+Gets the notification typeID for the notification of type `$type`.
+
+INPUT: notification type
+
+RETURNS: the notification typeID, or undef is none exists
+
+### getSpooledTypes()
+
+Gets the notification types for which there are unsent messages spooled.
+
+RETURNS: an array of hashrefs, each of which has keys NotificationTypeID and
+SubjectLine and CenterID
+
+### getSpooledMessagesByTypeID($typeID, $centerID)
+
+Gets the spooled messages for a given NotificationTypeID specified by
+`$typeID`, optionally directed to the center specified by `$centerID`.
+
+INPUT: notification type ID, (optionally the center ID)
+
+RETURNS: an array of hashrefs, each of which has keys TimeSpooled and Message
+
+### getRecipientsByTypeID($typeID, $centerID)
+
+Gets the recipient list for a given NotificationTypeID specified by
+`$typeID`, optionally directed to the center specified by `$centerID`.
+
+INPUT: notification type ID, (optionally the center ID)
+
+RETURNS: an array of email addresses
+
+### markMessagesAsSentByTypeID($typeID, $centerID)
+
+Marks all messages as sent with a given NotificationTypeID specified by
+`$typeID` and optionally `$centerID`.
+
+INPUT: notification type ID, (optionally the center ID)
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# COPYRIGHT
+
+Copyright (c) 2004 by Jonathan Harlap, McConnell Brain Imaging Centre,
+Montreal Neurological Institute, McGill University.
+
+License: GPLv3
+
+# AUTHORS
+
+Jonathan Harlap <jharlap@bic.mni.mcgill.ca>,
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/Notify.md
+++ b/docs/scripts_md/Notify.md
@@ -13,9 +13,9 @@ of LORIS
     my $upload_id         = 123456;
     my $notify_notsummary = 'N';
     $notifier->spool('tarchive validation', $message,   0,
-                             'tarchiveLoader',      $upload_id, 'Y',
-                             $notify_notsummary
-                            );
+                     'tarchiveLoader',      $upload_id, 'Y',
+                     $notify_notsummary
+                    );
 
 # DESCRIPTION
 
@@ -57,7 +57,7 @@ Gets the notification typeID for the notification of type `$type`.
 
 INPUT: notification type
 
-RETURNS: the notification typeID, or undef is none exists
+RETURNS: the notification typeID, or undef if none exists
 
 ### getSpooledTypes()
 

--- a/docs/scripts_md/Notify.md
+++ b/docs/scripts_md/Notify.md
@@ -5,17 +5,17 @@ of LORIS
 
 # SYNOPSIS
 
-use NeuroDB::Notify;
+    use NeuroDB::Notify;
 
-my $notifier = NeuroDB::Notify->new(\\$dbh);
+    my $notifier = NeuroDB::Notify->new(\$dbh);
 
-my $message           = "Some kind of message from tarchive validation";
-my $upload\_id         = 123456;
-my $notify\_notsummary = 'N';
-$notifier->spool('tarchive validation', $message,   0,
-		         'tarchiveLoader',      $upload\_id, 'Y',
-		         $notify\_notsummary
-		        );
+    my $message           = "Some kind of message from tarchive validation";
+    my $upload_id         = 123456;
+    my $notify_notsummary = 'N';
+    $notifier->spool('tarchive validation', $message,   0,
+                             'tarchiveLoader',      $upload_id, 'Y',
+                             $notify_notsummary
+                            );
 
 # DESCRIPTION
 
@@ -34,7 +34,7 @@ INPUT: DBI database handle
 
 RETURNS: new instance of this class.
 
-### spool($type, $message, $centerID, $origin, $processID, $isError, $isVerb)
+### spool($type, $message, $centerID, $origin, $processID, ...)
 
 Spools a new notification message, `$message`, into the spool for notification
 type `$type`. If `$centerID` is specified, only recipients in that site will

--- a/docs/scripts_md/Notify.md
+++ b/docs/scripts_md/Notify.md
@@ -24,7 +24,7 @@ LORIS - particularly with regards to spooling new messages.
 
 ## Methods
 
-### new($dbh) (constructor)
+### new($dbh) >> (constructor)
 
 Creates a new instance of this class. The parameter `\$dbh` is a
 reference to a DBI database handle, used to set the object's database
@@ -36,18 +36,18 @@ RETURNS: new instance of this class.
 
 ### spool($type, $message, $centerID, $origin, $processID, ...)
 
-Spools a new notification message, `$message`, into the spool for notification
-type `$type`. If `$centerID` is specified, only recipients in that site will
-receive the message.
+Spools a new notification message, `$message`, into the `notification_spool`
+table for notification type `$type`. If `$centerID` is specified, only
+recipients in that site will receive the message.
 
-INPUT:
-  $type     : notification type
-  $message  : notification message
-  $centerID : center ID
-  $origin   : notification origin
-  $processID: process ID
-  $isError  : if the notification is an error
-  $isVerb   : if verbose is set
+INPUTS:
+  - $type     : notification type
+  - $message  : notification message
+  - $centerID : center ID
+  - $origin   : notification origin
+  - $processID: process ID
+  - $isError  : if the notification is an error
+  - $isVerb   : if verbose is set
 
 RETURNS: 1 on success, 0 on failure
 
@@ -63,24 +63,25 @@ RETURNS: the notification typeID, or undef is none exists
 
 Gets the notification types for which there are unsent messages spooled.
 
-RETURNS: an array of hashrefs, each of which has keys NotificationTypeID and
-SubjectLine and CenterID
+RETURNS: an array of hashrefs, each of which has keys `NotificationTypeID` and
+`SubjectLine` and `CenterID`
 
 ### getSpooledMessagesByTypeID($typeID, $centerID)
 
-Gets the spooled messages for a given NotificationTypeID specified by
+Gets the spooled messages for a given `NotificationTypeID` specified by
 `$typeID`, optionally directed to the center specified by `$centerID`.
 
-INPUT: notification type ID, (optionally the center ID)
+INPUTS: notification type ID, (optionally the center ID)
 
-RETURNS: an array of hashrefs, each of which has keys TimeSpooled and Message
+RETURNS: an array of hashrefs, each of which has keys `TimeSpooled` and
+`Message`
 
 ### getRecipientsByTypeID($typeID, $centerID)
 
 Gets the recipient list for a given NotificationTypeID specified by
 `$typeID`, optionally directed to the center specified by `$centerID`.
 
-INPUT: notification type ID, (optionally the center ID)
+INPUTS: notification type ID, (optionally the center ID)
 
 RETURNS: an array of email addresses
 
@@ -89,7 +90,7 @@ RETURNS: an array of email addresses
 Marks all messages as sent with a given NotificationTypeID specified by
 `$typeID` and optionally `$centerID`.
 
-INPUT: notification type ID, (optionally the center ID)
+INPUTS: notification type ID, (optionally the center ID)
 
 # TO DO
 

--- a/uploadNeuroDB/NeuroDB/Notify.pm
+++ b/uploadNeuroDB/NeuroDB/Notify.pm
@@ -10,17 +10,17 @@ of LORIS
 
 =head1 SYNOPSIS
 
-use NeuroDB::Notify;
+  use NeuroDB::Notify;
 
-my $notifier = NeuroDB::Notify->new(\$dbh);
+  my $notifier = NeuroDB::Notify->new(\$dbh);
 
-my $message           = "Some kind of message from tarchive validation";
-my $upload_id         = 123456;
-my $notify_notsummary = 'N';
-$notifier->spool('tarchive validation', $message,   0,
-		         'tarchiveLoader',      $upload_id, 'Y',
-		         $notify_notsummary
-		        );
+  my $message           = "Some kind of message from tarchive validation";
+  my $upload_id         = 123456;
+  my $notify_notsummary = 'N';
+  $notifier->spool('tarchive validation', $message,   0,
+  		           'tarchiveLoader',      $upload_id, 'Y',
+  		           $notify_notsummary
+  		          );
 
 
 =head1 DESCRIPTION
@@ -67,7 +67,7 @@ sub new {
 
 =pod
 
-=head3 spool($type, $message, $centerID, $origin, $processID, $isError, $isVerb)
+=head3 spool($type, $message, $centerID, $origin, $processID, ...)
 
 Spools a new notification message, C<$message>, into the spool for notification
 type C<$type>. If C<$centerID> is specified, only recipients in that site will

--- a/uploadNeuroDB/NeuroDB/Notify.pm
+++ b/uploadNeuroDB/NeuroDB/Notify.pm
@@ -18,9 +18,9 @@ of LORIS
   my $upload_id         = 123456;
   my $notify_notsummary = 'N';
   $notifier->spool('tarchive validation', $message,   0,
-  		           'tarchiveLoader',      $upload_id, 'Y',
-  		           $notify_notsummary
-  		          );
+  		   'tarchiveLoader',      $upload_id, 'Y',
+  		   $notify_notsummary
+  	          );
 
 
 =head1 DESCRIPTION
@@ -141,7 +141,7 @@ Gets the notification typeID for the notification of type C<$type>.
 
 INPUT: notification type
 
-RETURNS: the notification typeID, or undef is none exists
+RETURNS: the notification typeID, or undef if none exists
 
 =cut
 

--- a/uploadNeuroDB/NeuroDB/Notify.pm
+++ b/uploadNeuroDB/NeuroDB/Notify.pm
@@ -40,7 +40,7 @@ my $VERSION = sprintf "%d.%03d", q$Revision: 1.1.1.1 $ =~ /: (\d+)\.(\d+)/;
 
 =pod
 
-=head3 new($dbh) (constructor)
+=head3 new($dbh) >> (constructor)
 
 Creates a new instance of this class. The parameter C<\$dbh> is a
 reference to a DBI database handle, used to set the object's database
@@ -69,18 +69,18 @@ sub new {
 
 =head3 spool($type, $message, $centerID, $origin, $processID, ...)
 
-Spools a new notification message, C<$message>, into the spool for notification
-type C<$type>. If C<$centerID> is specified, only recipients in that site will
-receive the message.
+Spools a new notification message, C<$message>, into the C<notification_spool>
+table for notification type C<$type>. If C<$centerID> is specified, only
+recipients in that site will receive the message.
 
-INPUT:
-  $type     : notification type
-  $message  : notification message
-  $centerID : center ID
-  $origin   : notification origin
-  $processID: process ID
-  $isError  : if the notification is an error
-  $isVerb   : if verbose is set
+INPUTS:
+  - $type     : notification type
+  - $message  : notification message
+  - $centerID : center ID
+  - $origin   : notification origin
+  - $processID: process ID
+  - $isError  : if the notification is an error
+  - $isVerb   : if verbose is set
 
 RETURNS: 1 on success, 0 on failure
 
@@ -170,8 +170,8 @@ sub getTypeID {
 
 Gets the notification types for which there are unsent messages spooled.
 
-RETURNS: an array of hashrefs, each of which has keys NotificationTypeID and
-SubjectLine and CenterID
+RETURNS: an array of hashrefs, each of which has keys C<NotificationTypeID> and
+C<SubjectLine> and C<CenterID>
 
 =cut
 
@@ -198,12 +198,13 @@ sub getSpooledTypes {
 
 =head3 getSpooledMessagesByTypeID($typeID, $centerID)
 
-Gets the spooled messages for a given NotificationTypeID specified by
+Gets the spooled messages for a given C<NotificationTypeID> specified by
 C<$typeID>, optionally directed to the center specified by C<$centerID>.
 
-INPUT: notification type ID, (optionally the center ID)
+INPUTS: notification type ID, (optionally the center ID)
 
-RETURNS: an array of hashrefs, each of which has keys TimeSpooled and Message
+RETURNS: an array of hashrefs, each of which has keys C<TimeSpooled> and
+C<Message>
 
 =cut
 
@@ -237,7 +238,7 @@ sub getSpooledMessagesByTypeID {
 Gets the recipient list for a given NotificationTypeID specified by
 C<$typeID>, optionally directed to the center specified by C<$centerID>.
 
-INPUT: notification type ID, (optionally the center ID)
+INPUTS: notification type ID, (optionally the center ID)
 
 RETURNS: an array of email addresses
 
@@ -272,7 +273,7 @@ sub getRecipientsByTypeID {
 Marks all messages as sent with a given NotificationTypeID specified by
 C<$typeID> and optionally C<$centerID>.
 
-INPUT: notification type ID, (optionally the center ID)
+INPUTS: notification type ID, (optionally the center ID)
 
 =cut
 

--- a/uploadNeuroDB/NeuroDB/Notify.pm
+++ b/uploadNeuroDB/NeuroDB/Notify.pm
@@ -1,21 +1,34 @@
 package NeuroDB::Notify;
 
+
 =pod
 
 =head1 NAME
 
-NeuroDB::Notify -- Provides an interface to the email notification subsystem of NeuroDB
+NeuroDB::Notify -- Provides an interface to the email notification subsystem
+of LORIS
 
 =head1 SYNOPSIS
 
-TBD
+use NeuroDB::Notify;
+
+my $notifier = NeuroDB::Notify->new(\$dbh);
+
+my $message           = "Some kind of message from tarchive validation";
+my $upload_id         = 123456;
+my $notify_notsummary = 'N';
+$notifier->spool('tarchive validation', $message,   0,
+		         'tarchiveLoader',      $upload_id, 'Y',
+		         $notify_notsummary
+		        );
+
 
 =head1 DESCRIPTION
 
-This class defines an interface into the email notification subsystem
-of NeuroDB - particularly with regards to spooling new messages.
+This class defines an interface into the email notification subsystem of
+LORIS - particularly with regards to spooling new messages.
 
-=head1 METHODS
+=head2 Methods
 
 =cut
 
@@ -24,15 +37,18 @@ use Carp;
 use Data::Dumper;
 my $VERSION = sprintf "%d.%03d", q$Revision: 1.1.1.1 $ =~ /: (\d+)\.(\d+)/;
 
+
 =pod
 
-B<new( \$dbh )> (constructor)
+=head3 new($dbh) (constructor)
 
-Create a new instance of this class.  The parameter C<\$dbh> is a
+Creates a new instance of this class. The parameter C<\$dbh> is a
 reference to a DBI database handle, used to set the object's database
 handle, so that all the DB-driven methods will work.
 
-Returns: new instance of this class.
+INPUT: DBI database handle
+
+RETURNS: new instance of this class.
 
 =cut
 
@@ -48,15 +64,25 @@ sub new {
     return bless $self, $params;
 }
 
+
 =pod
 
-B<spool( C<$type>, C<$message>, C<$centerID>, C<$origin>, C<$processID>, C<$isError>, C<$isVerb> )>
+=head3 spool($type, $message, $centerID, $origin, $processID, $isError, $isVerb)
 
-Spools a new notification message, C<$message>, into the spool for
-notification type C<$type>.  If C<$centerID> is specified, only
-recipients in that site will receive the message.
+Spools a new notification message, C<$message>, into the spool for notification
+type C<$type>. If C<$centerID> is specified, only recipients in that site will
+receive the message.
 
-Returns: 1 on success, 0 on failure
+INPUT:
+  $type     : notification type
+  $message  : notification message
+  $centerID : center ID
+  $origin   : notification origin
+  $processID: process ID
+  $isError  : if the notification is an error
+  $isVerb   : if verbose is set
+
+RETURNS: 1 on success, 0 on failure
 
 =cut
 
@@ -106,13 +132,16 @@ sub spool {
     return 1;
 }
 
+
 =pod
 
-B<getTypeID( C<$type> )>
+=head3 getTypeID($type)
 
 Gets the notification typeID for the notification of type C<$type>.
 
-Returns: the notification typeID, or undef is none exists
+INPUT: notification type
+
+RETURNS: the notification typeID, or undef is none exists
 
 =cut
 
@@ -134,13 +163,15 @@ sub getTypeID {
     }
 }
 
+
 =pod
 
-B<getSpooledTypes()>
+=head3 getSpooledTypes()
 
 Gets the notification types for which there are unsent messages spooled.
 
-Returns: an array of hashrefs, each of which has keys NotificationTypeID and SubjectLine and CenterID
+RETURNS: an array of hashrefs, each of which has keys NotificationTypeID and
+SubjectLine and CenterID
 
 =cut
 
@@ -162,15 +193,17 @@ sub getSpooledTypes {
     return @types;
 }
 
+
 =pod
 
-B<getSpooledMessagesByTypeID( C<$typeID> )>
+=head3 getSpooledMessagesByTypeID($typeID, $centerID)
 
 Gets the spooled messages for a given NotificationTypeID specified by
-C<$typeID>, optionally directed to the center specified by
-C<$centerID>.
+C<$typeID>, optionally directed to the center specified by C<$centerID>.
 
-Returns: an array of hashrefs, each of which has keys TimeSpooled and Message
+INPUT: notification type ID, (optionally the center ID)
+
+RETURNS: an array of hashrefs, each of which has keys TimeSpooled and Message
 
 =cut
 
@@ -196,14 +229,17 @@ sub getSpooledMessagesByTypeID {
     return @messages;
 }
 
+
 =pod
 
-B<getRecipientsByTypeID( C<$typeID>, C<$centerID> )>
+=head3 getRecipientsByTypeID($typeID, $centerID)
 
 Gets the recipient list for a given NotificationTypeID specified by
 C<$typeID>, optionally directed to the center specified by C<$centerID>.
- 
-Returns: an array of email addresses
+
+INPUT: notification type ID, (optionally the center ID)
+
+RETURNS: an array of email addresses
 
 =cut
 
@@ -228,11 +264,15 @@ sub getRecipientsByTypeID {
     return @recipients;
 }
 
+
 =pod
 
-B<markMessagesAsSentByTypeID( C<$typeID>, C<$centerID> )>
+=head3 markMessagesAsSentByTypeID($typeID, $centerID)
 
-Marks all messages as sent with a given NotificationTypeID specified by C<$typeID> and optionally C<$centerID>.
+Marks all messages as sent with a given NotificationTypeID specified by
+C<$typeID> and optionally C<$centerID>.
+
+INPUT: notification type ID, (optionally the center ID)
 
 =cut
 
@@ -266,8 +306,11 @@ None reported.
 Copyright (c) 2004 by Jonathan Harlap, McConnell Brain Imaging Centre,
 Montreal Neurological Institute, McGill University.
 
+License: GPLv3
+
 =head1 AUTHORS
 
-Jonathan Harlap <jharlap@bic.mni.mcgill.ca>
+Jonathan Harlap <jharlap@bic.mni.mcgill.ca>,
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
 
 =cut    


### PR DESCRIPTION
Using perldoc/perlpod to document `Notify.pm` so that users can type in the terminal
`perldoc Notify.pm` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `Notify.md` file has been created so that we have a web displayed version of the documentation.
`pod2markdown Notify.pm > Notify.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage