### PR TITLE
[Documentation] NeuroDB::MRIProcessingUtility library perldocification

### DIFF
--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -129,17 +129,17 @@ RETURNS: array of two elements: center name and center ID
 Determines which scanner ID was used for DICOM acquisitions.
 
 INPUTS:
-  $tarchiveInfo: tarchive information hashref
-  $to\_log      : whether this step should be logged
-  $centerID    : center ID
-  $NewScanner  : whether a new scanner entry should be created if the scanner
-  used is a new scanner for the study
+  - $tarchiveInfo: tarchive information hashref
+  - $to\_log      : whether this step should be logged
+  - $centerID    : center ID
+  - $NewScanner  : whether a new scanner entry should be created if the scanner
+                   used is a new scanner for the study
 
 RETURNS: scanner ID
 
 ### get\_acqusitions($study\_dir, \\@acquisitions)
 
-UNUSED FUNCTION TO BE CLEANED UP IN ANOTHER PULL REQUEST
+UNUSED
 
 ### computeMd5Hash($file, $tarchive\_srcloc)
 
@@ -159,13 +159,13 @@ true, then it will bypass the additional protocol checks from the
 `mri_protocol_checks` table using `&extra_file_checks`.
 
 INPUTS:
-  $file                    : file's information hashref
-  $subjectIDsref           : subject's information hashref
-  $tarchiveInfo            : tarchive's information hashref
-  $center\_name             : center name
-  $minc                    : absolute path to the MINC file
-  $acquisitionProtocol     : acquisition protocol if already knows it
-  $bypass\_extra\_file\_checks: boolean, if set bypass the extra checks
+  - $file                    : file's information hashref
+  - $subjectIDsref           : subject's information hashref
+  - $tarchiveInfo            : tarchive's information hashref
+  - $center\_name             : center name
+  - $minc                    : absolute path to the MINC file
+  - $acquisitionProtocol     : acquisition protocol if already knows it
+  - $bypass\_extra\_file\_checks: boolean, if set bypass the extra checks
 
 RETURNS: acquisition protocol, acquisition protocol ID, array of extra checks
 
@@ -175,11 +175,11 @@ Returns the list of MRI protocol checks that failed. Can't directly insert
 this information here since the file isn't registered in the database yet.
 
 INPUTS:
-  $scan\_type  : scan type of the file
-  $file       : file information hashref
-  $CandID     : candidate's CandID
-  $Visit\_Label: visit label of the scan
-  $PatientName: patient name of the scan
+  - $scan\_type  : scan type of the file
+  - $file       : file information hashref
+  - $CandID     : candidate's CandID
+  - $Visit\_Label: visit label of the scan
+  - $PatientName: patient name of the scan
 
 RETURNS:
   - pass, warn or exclude flag depending on the worst failed check
@@ -204,13 +204,13 @@ RETURNS: file information hashref
 Renames and moves the MINC file.
 
 INPUTS:
-  $minc           : path to the MINC file
-  $subjectIDsref  : subject's ID hashref
-  $minc\_type      : MINC file information hashref
-  $fileref        : file information hashref
-  $prefix         : study prefix
-  $data\_dir       : data directory (typically /data/project/data)
-  $tarchive\_srcloc: tarchive source location
+  - $minc           : path to the MINC file
+  - $subjectIDsref  : subject's ID hashref
+  - $minc\_type      : MINC file information hashref
+  - $fileref        : file information hashref
+  - $prefix         : study prefix
+  - $data\_dir       : data directory (typically /data/project/data)
+  - $tarchive\_srcloc: tarchive source location
 
 RETURNS: new name of the MINC file with path relative to `$data_dir`
 
@@ -219,15 +219,15 @@ RETURNS: new name of the MINC file with path relative to `$data_dir`
 Registers the scan into the database.
 
 INPUTS:
-  $minc\_file          : MINC file information hashref
-  $tarchiveInfo       : tarchive information hashref
-  $subjectIDsref      : subject's ID information hashref
-  $acquisitionProtocol: acquisition protocol
-  $minc               : MINC file to register into the database
-  $checks             : failed checks to register with the file
-  $reckless           : boolean, if reckless or not
-  $tarchive           : tarchive path
-  $sessionID          : session ID of the MINC file
+  - $minc\_file          : MINC file information hashref
+  - $tarchiveInfo       : tarchive information hashref
+  - $subjectIDsref      : subject's ID information hashref
+  - $acquisitionProtocol: acquisition protocol
+  - $minc               : MINC file to register into the database
+  - $checks             : failed checks to register with the file
+  - $reckless           : boolean, if reckless or not
+  - $tarchive           : tarchive path
+  - $sessionID          : session ID of the MINC file
 
 RETURNS: acquisition protocol ID of the MINC file
 
@@ -236,12 +236,12 @@ RETURNS: acquisition protocol ID of the MINC file
 Converts a DICOM study into MINC files.
 
 INPUTS:
-  $study\_dir      : DICOM study directory to convert
-  $converter      : converter to be used
-  $get\_dicom\_info : get DICOM information setting from the Config table
-  $exclude        : which files to exclude from the dcm2mnc command
-  $mail\_user      : mail of the user
-  $tarchive\_srcloc: tarchive source location
+  - $study\_dir      : DICOM study directory to convert
+  - $converter      : converter to be used
+  - $get\_dicom\_info : get DICOM information setting from the Config table
+  - $exclude        : which files to exclude from the dcm2mnc command
+  - $mail\_user      : mail of the user
+  - $tarchive\_srcloc: tarchive source location
 
 ### get\_mincs($minc\_files, $tarchive\_srcloc)
 
@@ -274,11 +274,11 @@ RETURNS: the new tarchive location
 Registers a new candidate in the candidate table.
 
 INPUTS:
-  $subjectIDsref: subject's ID information hashref
-  $gender       : gender of the candidate
-  $tarchiveInfo : tarchive information hashref
-  $User         : user that is running the pipeline
-  $centerID     : center ID
+  - $subjectIDsref: subject's ID information hashref
+  - $gender       : gender of the candidate
+  - $tarchiveInfo : tarchive information hashref
+  - $User         : user that is running the pipeline
+  - $centerID     : center ID
 
 ### setMRISession($subjectIDsref, $tarchiveInfo)
 
@@ -349,12 +349,12 @@ RETURNS: the found upload ID
 Calls the Notify->spool function to log all messages.
 
 INPUTS:
-  $message   : message to be logged in the database
-  $error     : if 'Y' it's an error log,
-               'N' otherwise
-  $upload\_id : the upload\_id
-  $verb      : 'N' for few main messages,
-               'Y' for more messages (developers)
+  - $message   : message to be logged in the database
+  - $error     : if 'Y' it's an error log,
+                 'N' otherwise
+  - $upload\_id : the upload\_id
+  - $verb      : 'N' for few main messages,
+                 'Y' for more messages (developers)
 
 # TO DO
 
@@ -362,6 +362,8 @@ Document the following functions:
   - get\_acqusitions($study\_dir, \\@acquisitions)
   - concat\_mri($minc\_files)
   - registerProgs(@toregister)
+
+Remove function get\_acqusitions($study\_dir, \\@acquisitions) that is not used
 
 # BUGS
 
@@ -373,4 +375,5 @@ License: GPLv3
 
 # AUTHORS
 
-LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -7,32 +7,32 @@ utilities
 
     use NeuroDB::ProcessingUtility;
 
-    my $utility = NeuroDB::MRIProcessingUtility->new(
-                      \$dbh,    $debug,  $TmpDir,
-                      $logfile, $LogDir, $verbose
-                  );
+    my $utility       = NeuroDB::MRIProcessingUtility->new(
+                          \$dbh,    $debug,  $TmpDir,
+                          $logfile, $LogDir, $verbose
+                        );
 
-    %tarchiveInfo = $utility->createTarchiveArray(
-                      $ArchiveLocation, $globArchiveLocation
-                    );
+    %tarchiveInfo     = $utility->createTarchiveArray(
+                          $ArchiveLocation, $globArchiveLocation
+                        );
 
     my ($center_name, $centerID) = $utility->determinePSC(\%tarchiveInfo,0);
 
-    my $scannerID = $utility->determineScannerID(
-                        \%tarchiveInfo, 0,
-                        $centerID,      $NewScanner
-                    );
-
-    my $subjectIDsref = $utility->determineSubjectID(
-                            $scannerID,
-                            \%tarchiveInfo,
-                            0
+    my $scannerID     = $utility->determineScannerID(
+                          \%tarchiveInfo, 0,
+                          $centerID,      $NewScanner
                         );
 
-    my $CandMismatchError= $utility->validateCandidate(
-                                    $subjectIDsref,
-                                    $tarchiveInfo{'SourceLocation'}
-                           );
+    my $subjectIDsref = $utility->determineSubjectID(
+                          $scannerID,
+                          \%tarchiveInfo,
+                          0
+                        );
+
+    my $CandMismatchError = $utility->validateCandidate(
+                              $subjectIDsref,
+                              $tarchiveInfo{'SourceLocation'}
+                            );
 
     $utility->computeSNR($TarchiveID, $ArchLoc, $profile);
     $utility->orderModalitiesByAcq($TarchiveID, $ArchLoc);
@@ -44,7 +44,7 @@ scripts of LORIS.
 
 ## Methods
 
-### new($dbhr, $debug, $TmpDir, $logfile, $verbose) (constructor)
+### new($dbhr, $debug, $TmpDir, $logfile, $verbose) >> (constructor)
 
 Creates a new instance of this class. The parameter \`\\$dbhr\` is a reference
 to a DBI database handle, used to set the object's database handle, so that all
@@ -59,30 +59,31 @@ RETURNS: new instance of this class.
 Writes error log. This is a useful function that will close the log and write
 error messages in case of abnormal program termination.
 
-INPUT: notification message, fail status of the process, log directory
+INPUTS: notification message, fail status of the process, log directory
 
 ### lookupNextVisitLabel($candID, $dbhr)
 
 Will look up for the next visit label of candidate `CandID`. Useful only if
 the visit label IS NOT encoded somewhere in the patient ID or patient name.
 
-INPUT: candidate's CandID, database handle reference
+INPUTS: candidate's CandID, database handle reference
 
 RETURNS: next visit label found for the candidate
 
 ### getFileNamesfromSeriesUID($seriesuid, @alltarfiles)
 
-?????????????????????????????
+Will extract from the `tarchive_files` table a list of DICOM files
+matching a given SeriesUID.
 
-INPUT: seriesUID, list of tar files
+INPUTS: seriesUID, list of tar files
 
-RETURNS: ???????????????????
+RETURNS: list of DICOM files corresponding to the seriesUID
 
 ### extract\_tarchive($tarchive, $tarchive\_srcloc, $seriesuid)
 
-Extracts the tarchive so that data can actually be uploaded.
+Extracts the DICOM archive so that data can actually be uploaded.
 
-INPUT: path to the tarchive, source location from the tarchive table,
+INPUTS: path to the DICOM archive, source location from the `tarchive` table,
 (optionally seriesUID)
 
 RETURNS: the extracted DICOM directory
@@ -91,7 +92,7 @@ RETURNS: the extracted DICOM directory
 
 Extracts and parses the tarchive.
 
-INPUT: path to the tarchive, source location from the tarchive table,
+INPUTS: path to the tarchive, source location from the tarchive table,
 (optionally seriesUID)
 
 RETURNS: extract suffix, extracted DICOM directory, tarchive meta data header
@@ -100,16 +101,18 @@ RETURNS: extract suffix, extracted DICOM directory, tarchive meta data header
 
 Determines subject's ID based on scanner ID and tarchive information.
 
-INPUT: scanner ID, tarchive information hashref, boolean if this step should be
-logged
+INPUTS: scanner ID, tarchive information hashref, boolean if this step should
+be logged
 
-RETURNS: subject's ID hashref
+RETURNS: subject's ID hashref containing CandID, PSCID and Visit Label
+information
 
 ### createTarchiveArray($tarchive, $globArchiveLocation)
 
 Creates the tarchive information hashref.
 
-INPUT: tarchive's path, globArchiveLocation option
+INPUTS: tarchive's path, globArchiveLocation argument specified when running
+the insertion scripts
 
 RETURNS: tarchive information hashref
 
@@ -117,7 +120,7 @@ RETURNS: tarchive information hashref
 
 Determines the PSC based on the tarchive information hashref.
 
-INPUT: tarchive information hashref, whether this step should be logged
+INPUTS: tarchive information hashref, whether this step should be logged
 
 RETURNS: array of two elements: center name and center ID
 
@@ -125,7 +128,7 @@ RETURNS: array of two elements: center name and center ID
 
 Determines which scanner ID was used for DICOM acquisitions.
 
-INPUT:
+INPUTS:
   $tarchiveInfo: tarchive information hashref
   $to\_log      : whether this step should be logged
   $centerID    : center ID
@@ -136,16 +139,13 @@ RETURNS: scanner ID
 
 ### get\_acqusitions($study\_dir, \\@acquisitions)
 
-Greps the list of acquisitions in the study directory from array
-`@acquisitions`. ?????????????????????????????????????
-
-INPUT: study directory, array of acquisitions ??????????????????
+UNUSED FUNCTION TO BE CLEANED UP IN ANOTHER PULL REQUEST
 
 ### computeMd5Hash($file, $tarchive\_srcloc)
 
 Computes the MD5 hash of a file and makes sure it is unique.
 
-INPUT: file to use to compute the MD5 hash, tarchive source location
+INPUTS: file to use to compute the MD5 hash, tarchive source location
 
 RETURNS: 1 if the file is unique, 0 otherwise
 
@@ -153,12 +153,12 @@ RETURNS: 1 if the file is unique, 0 otherwise
 
 Determines the acquisition protocol and acquisition protocol ID for the MINC
 file. If `$acquisitionProtocol` is not set, it will look for the acquisition
-protocol in the mri\_protocol table based on the mincheader information using
-`&NeuroDB::MRI::identify_scan_db`. If `$bypass_extra_file_checks` is
+protocol in the `mri_protocol` table based on the MINC header information
+using `&NeuroDB::MRI::identify_scan_db`. If `$bypass_extra_file_checks` is
 true, then it will bypass the additional protocol checks from the
-mri\_protocol\_checks table using `&extra_file_checks`.
+`mri_protocol_checks` table using `&extra_file_checks`.
 
-INPUT:
+INPUTS:
   $file                    : file's information hashref
   $subjectIDsref           : subject's information hashref
   $tarchiveInfo            : tarchive's information hashref
@@ -174,7 +174,7 @@ RETURNS: acquisition protocol, acquisition protocol ID, array of extra checks
 Returns the list of MRI protocol checks that failed. Can't directly insert
 this information here since the file isn't registered in the database yet.
 
-INPUT:
+INPUTS:
   $scan\_type  : scan type of the file
   $file       : file information hashref
   $CandID     : candidate's CandID
@@ -189,13 +189,13 @@ RETURNS:
 
 Updates the mri\_acquisition\_dates table by a new acquisition date `$acq_date`.
 
-INPUT: session ID, acquisition date
+INPUTS: session ID, acquisition date
 
 ### loadAndCreateObjectFile($minc, $tarchive\_srcloc)
 
 Loads and creates the object file.
 
-INPUT: location of the minc file, tarchive source location
+INPUTS: location of the minc file, tarchive source location
 
 RETURNS: file information hashref
 
@@ -203,7 +203,7 @@ RETURNS: file information hashref
 
 Renames and moves the MINC file.
 
-INPUT:
+INPUTS:
   $minc           : path to the MINC file
   $subjectIDsref  : subject's ID hashref
   $minc\_type      : MINC file information hashref
@@ -218,7 +218,7 @@ RETURNS: new name of the MINC file with path relative to `$data_dir`
 
 Registers the scan into the database.
 
-INPUT:
+INPUTS:
   $minc\_file          : MINC file information hashref
   $tarchiveInfo       : tarchive information hashref
   $subjectIDsref      : subject's ID information hashref
@@ -235,7 +235,7 @@ RETURNS: acquisition protocol ID of the MINC file
 
 Converts a DICOM study into MINC files.
 
-INPUT:
+INPUTS:
   $study\_dir      : DICOM study directory to convert
   $converter      : converter to be used
   $get\_dicom\_info : get DICOM information setting from the Config table
@@ -247,17 +247,17 @@ INPUT:
 
 Greps the created MINC files and returns a sorted list of those MINC files.
 
-INPUT: empty array to store the list of MINC files, tarchive source location
+INPUTS: empty array to store the list of MINC files, tarchive source location
 
 ### concat\_mri($minc\_files)
 
-Concats and removes pre-concat MINC files. ?????????????????
+Concats and removes pre-concat MINC files.
 
 INPUT: list of MINC files to concat
 
 ### registerProgs(@toregister)
 
-Register programs ???????????????????????
+Register programs.
 
 INPUT: program to register
 
@@ -265,7 +265,7 @@ INPUT: program to register
 
 Moves and updates the tarchive table with the new location of the tarchive.
 
-INPUT: tarchive location, tarchive information hashref
+INPUTS: tarchive location, tarchive information hashref
 
 RETURNS: the new tarchive location
 
@@ -273,7 +273,7 @@ RETURNS: the new tarchive location
 
 Registers a new candidate in the candidate table.
 
-INPUT:
+INPUTS:
   $subjectIDsref: subject's ID information hashref
   $gender       : gender of the candidate
   $tarchiveInfo : tarchive information hashref
@@ -288,7 +288,7 @@ Sets the imaging session ID. This function will call
   - create a new session if visit label does not exist for that
      candidate yet
 
-INPUT: subject's ID information hashref, tarchive information hashref
+INPUTS: subject's ID information hashref, tarchive information hashref
 
 RETURNS: session ID, if the new session requires staging
 
@@ -299,13 +299,13 @@ the one stored in the tarchive information hashref `$tarchiveInfo` derived
 from the database. The function will exits with an error message if the
 tarchive is not validated.
 
-INPUT: tarchive file, tarchive information hashref
+INPUTS: tarchive file, tarchive information hashref
 
 ### which\_directory($subjectIDsref, $data\_dir)
 
 Determines where the MINC files to be registered into the database will go.
 
-INPUT: subject's ID information hashref, data directory (typically
+INPUTS: subject's ID information hashref, data directory (typically
 /data/project/data)
 
 RETURNS: the final directory in which the registered MINC files will go
@@ -317,29 +317,30 @@ Check that the candidate's information derived from the patient name field of
 the DICOM files is valid (CandID and PSCID of the candidate should correspond
 to the same subject in the database).
 
-INPUT: subject's ID information hashref, tarchive source location
+INPUTS: subject's ID information hashref, tarchive source location
 
 RETURNS: the candidate mismatch error, or undef if the candidate is validated
- or a phantom
+or a phantom
 
 ### computeSNR($tarchiveID, $tarchive\_srcloc, $profile)
 
-Computes the SNR on the modalities specified in the Config table for a given
-tarchive.
+Computes the SNR on the modalities specified in the `getSNRModalities()`
+routine of the `$profile` file.
 
-INPUT: tarchive ID, tarchive source location, configuration file (usually prod)
+INPUTS: tarchive ID, tarchive source location, configuration file (usually prod)
 
 ### orderModalitiesByAcq($tarchiveID, $tarchive\_srcloc)
 
 Order imaging modalities by acquisition number.
 
-INPUT: tarchive ID, tarchive source location
+INPUTS: tarchive ID, tarchive source location
 
 ### getUploadIDUsingTarchiveSrcLoc($tarchive\_srcloc)
 
-Gets the upload ID form the mri\_upload table using tarchive's SourceLocation
+Gets the upload ID form the `mri_upload` table using the DICOM archive
+`SourceLocation` specified in the `tarchive` table.
 
-INPUT: tarchive's source location
+INPUT: DICOM archive's source location
 
 RETURNS: the found upload ID
 
@@ -347,9 +348,10 @@ RETURNS: the found upload ID
 
 Calls the Notify->spool function to log all messages.
 
-INPUT:
+INPUTS:
   $message   : message to be logged in the database
-  $error     : if 'Y' it's an error log , 'N' otherwise
+  $error     : if 'Y' it's an error log,
+               'N' otherwise
   $upload\_id : the upload\_id
   $verb      : 'N' for few main messages,
                'Y' for more messages (developers)
@@ -357,7 +359,6 @@ INPUT:
 # TO DO
 
 Document the following functions:
-  - getFileNamesfromSeriesUID($seriesuid, @alltarfiles)
   - get\_acqusitions($study\_dir, \\@acquisitions)
   - concat\_mri($minc\_files)
   - registerProgs(@toregister)

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -5,33 +5,37 @@ utilities
 
 # SYNOPSIS
 
-use NeuroDB::ProcessingUtility;
+    use NeuroDB::ProcessingUtility;
 
-my $utility = NeuroDB::MRIProcessingUtility->new(
-                  \\$dbh,    $debug,  $TmpDir,
-                  $logfile, $LogDir, $verbose
-              );
+    my $utility = NeuroDB::MRIProcessingUtility->new(
+                      \$dbh,    $debug,  $TmpDir,
+                      $logfile, $LogDir, $verbose
+                  );
 
-%tarchiveInfo = $utility->createTarchiveArray(
-                  $ArchiveLocation, $globArchiveLocation
-                );
+    %tarchiveInfo = $utility->createTarchiveArray(
+                      $ArchiveLocation, $globArchiveLocation
+                    );
 
-my ($center\_name, $centerID) = $utility->determinePSC(\\%tarchiveInfo,0);
+    my ($center_name, $centerID) = $utility->determinePSC(\%tarchiveInfo,0);
 
-my $scannerID = $utility->determineScannerID(
-                    \\%tarchiveInfo, 0,
-                    $centerID,      $NewScanner
-                );
+    my $scannerID = $utility->determineScannerID(
+                        \%tarchiveInfo, 0,
+                        $centerID,      $NewScanner
+                    );
 
-my $subjectIDsref = $utility->determineSubjectID($scannerID, \\%tarchiveInfo, 0);
+    my $subjectIDsref = $utility->determineSubjectID(
+                            $scannerID,
+                            \%tarchiveInfo,
+                            0
+                        );
 
-my $CandMismatchError= $utility->validateCandidate(
-                                $subjectIDsref,
-                                $tarchiveInfo{'SourceLocation'}
-                       );
+    my $CandMismatchError= $utility->validateCandidate(
+                                    $subjectIDsref,
+                                    $tarchiveInfo{'SourceLocation'}
+                           );
 
-$utility->computeSNR($TarchiveID, $ArchLoc, $profile);
-$utility->orderModalitiesByAcq($TarchiveID, $ArchLoc);
+    $utility->computeSNR($TarchiveID, $ArchLoc, $profile);
+    $utility->orderModalitiesByAcq($TarchiveID, $ArchLoc);
 
 # DESCRIPTION
 

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -161,7 +161,7 @@ INPUT:
   $center\_name             : center name
   $minc                    : absolute path to the MINC file
   $acquisitionProtocol     : acquisition protocol if already knows it
-  $bypass\_extra\_file\_checks: boolean, if should bypass the extra file checks
+  $bypass\_extra\_file\_checks: boolean, if set bypass the extra checks
 
 RETURNS: acquisition protocol, acquisition protocol ID, array of extra checks
 
@@ -280,8 +280,9 @@ INPUT:
 
 Sets the imaging session ID. This function will call
 `&NeuroDB::MRI::getSessionID` which in turn will either:
-  - grep the sessionID if the visit label for that candidate already exists, or
-  - create a new session if the visit label doesn't exist for that candidate yet
+  - grep sessionID if visit for that candidate already exists, or
+  - create a new session if visit label does not exist for that
+     candidate yet
 
 INPUT: subject's ID information hashref, tarchive information hashref
 
@@ -346,7 +347,8 @@ INPUT:
   $message   : message to be logged in the database
   $error     : if 'Y' it's an error log , 'N' otherwise
   $upload\_id : the upload\_id
-  $verb      : 'N' for few main messages, 'Y' for more messages (developers)
+  $verb      : 'N' for few main messages,
+               'Y' for more messages (developers)
 
 # TO DO
 

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -359,7 +359,6 @@ INPUTS:
 # TO DO
 
 Document the following functions:
-  - get\_acqusitions($study\_dir, \\@acquisitions)
   - concat\_mri($minc\_files)
   - registerProgs(@toregister)
 

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -1,0 +1,369 @@
+# NAME
+
+NeuroDB::MRIProcessingUtility -- Provides an interface for MRI processing
+utilities
+
+# SYNOPSIS
+
+use NeuroDB::ProcessingUtility;
+
+my $utility = NeuroDB::MRIProcessingUtility->new(
+                  \\$dbh,    $debug,  $TmpDir,
+                  $logfile, $LogDir, $verbose
+              );
+
+%tarchiveInfo = $utility->createTarchiveArray(
+                  $ArchiveLocation, $globArchiveLocation
+                );
+
+my ($center\_name, $centerID) = $utility->determinePSC(\\%tarchiveInfo,0);
+
+my $scannerID = $utility->determineScannerID(
+                    \\%tarchiveInfo, 0,
+                    $centerID,      $NewScanner
+                );
+
+my $subjectIDsref = $utility->determineSubjectID($scannerID, \\%tarchiveInfo, 0);
+
+my $CandMismatchError= $utility->validateCandidate(
+                                $subjectIDsref,
+                                $tarchiveInfo{'SourceLocation'}
+                       );
+
+$utility->computeSNR($TarchiveID, $ArchLoc, $profile);
+$utility->orderModalitiesByAcq($TarchiveID, $ArchLoc);
+
+# DESCRIPTION
+
+Mishmash of MRI processing utility functions used mainly by the insertion
+scripts of LORIS.
+
+## Methods
+
+### new($dbhr, $debug, $TmpDir, $logfile, $verbose) (constructor)
+
+Creates a new instance of this class. The parameter \`\\$dbhr\` is a reference
+to a DBI database handle, used to set the object's database handle, so that all
+the DB-driven methods will work.
+
+INPUT: DBI database handle
+
+RETURNS: new instance of this class.
+
+### writeErrorLog($message, $failStatus, $LogDir)
+
+Writes error log. This is a useful function that will close the log and write
+error messages in case of abnormal program termination.
+
+INPUT: notification message, fail status of the process, log directory
+
+### lookupNextVisitLabel($candID, $dbhr)
+
+Will look up for the next visit label of candidate `CandID`. Useful only if
+the visit label IS NOT encoded somewhere in the patient ID or patient name.
+
+INPUT: candidate's CandID, database handle reference
+
+RETURNS: next visit label found for the candidate
+
+### getFileNamesfromSeriesUID($seriesuid, @alltarfiles)
+
+?????????????????????????????
+
+INPUT: seriesUID, list of tar files
+
+RETURNS: ???????????????????
+
+### extract\_tarchive($tarchive, $tarchive\_srcloc, $seriesuid)
+
+Extracts the tarchive so that data can actually be uploaded.
+
+INPUT: path to the tarchive, source location from the tarchive table,
+(optionally seriesUID)
+
+RETURNS: the extracted DICOM directory
+
+### extractAndParseTarchive($tarchive, $tarchive\_srcloc, $seriesuid)
+
+Extracts and parses the tarchive.
+
+INPUT: path to the tarchive, source location from the tarchive table,
+(optionally seriesUID)
+
+RETURNS: extract suffix, extracted DICOM directory, tarchive meta data header
+
+### determineSubjectID($scannerID, $tarchiveInfo, $to\_log)
+
+Determines subject's ID based on scanner ID and tarchive information.
+
+INPUT: scanner ID, tarchive information hashref, boolean if this step should be
+logged
+
+RETURNS: subject's ID hashref
+
+### createTarchiveArray($tarchive, $globArchiveLocation)
+
+Creates the tarchive information hashref.
+
+INPUT: tarchive's path, globArchiveLocation option
+
+RETURNS: tarchive information hashref
+
+### determinePSC($tarchiveInfo, $to\_log)
+
+Determines the PSC based on the tarchive information hashref.
+
+INPUT: tarchive information hashref, whether this step should be logged
+
+RETURNS: array of two elements: center name and center ID
+
+### determineScannerID($tarchiveInfo, $to\_log, $centerID, $NewScanner)
+
+Determines which scanner ID was used for DICOM acquisitions.
+
+INPUT:
+  $tarchiveInfo: tarchive information hashref
+  $to\_log      : whether this step should be logged
+  $centerID    : center ID
+  $NewScanner  : whether a new scanner entry should be created if the scanner
+  used is a new scanner for the study
+
+RETURNS: scanner ID
+
+### get\_acqusitions($study\_dir, \\@acquisitions)
+
+Greps the list of acquisitions in the study directory from array
+`@acquisitions`. ?????????????????????????????????????
+
+INPUT: study directory, array of acquisitions ??????????????????
+
+### computeMd5Hash($file, $tarchive\_srcloc)
+
+Computes the MD5 hash of a file and makes sure it is unique.
+
+INPUT: file to use to compute the MD5 hash, tarchive source location
+
+RETURNS: 1 if the file is unique, 0 otherwise
+
+### getAcquisitionProtocol($file, $subjectIDsref, $tarchiveInfo, ...)
+
+Determines the acquisition protocol and acquisition protocol ID for the MINC
+file. If `$acquisitionProtocol` is not set, it will look for the acquisition
+protocol in the mri\_protocol table based on the mincheader information using
+`&NeuroDB::MRI::identify_scan_db`. If `$bypass_extra_file_checks` is
+true, then it will bypass the additional protocol checks from the
+mri\_protocol\_checks table using `&extra_file_checks`.
+
+INPUT:
+  $file                    : file's information hashref
+  $subjectIDsref           : subject's information hashref
+  $tarchiveInfo            : tarchive's information hashref
+  $center\_name             : center name
+  $minc                    : absolute path to the MINC file
+  $acquisitionProtocol     : acquisition protocol if already knows it
+  $bypass\_extra\_file\_checks: boolean, if should bypass the extra file checks
+
+RETURNS: acquisition protocol, acquisition protocol ID, array of extra checks
+
+### extra\_file\_checks($scan\_type, $file, $CandID, $Visit\_Label, $PatientName)
+
+Returns the list of MRI protocol checks that failed. Can't directly insert
+this information here since the file isn't registered in the database yet.
+
+INPUT:
+  $scan\_type  : scan type of the file
+  $file       : file information hashref
+  $CandID     : candidate's CandID
+  $Visit\_Label: visit label of the scan
+  $PatientName: patient name of the scan
+
+RETURNS:
+  - pass, warn or exclude flag depending on the worst failed check
+  - array of failed checks if any were failed
+
+### update\_mri\_acquisition\_dates($sessionID, $acq\_date)
+
+Updates the mri\_acquisition\_dates table by a new acquisition date `$acq_date`.
+
+INPUT: session ID, acquisition date
+
+### loadAndCreateObjectFile($minc, $tarchive\_srcloc)
+
+Loads and creates the object file.
+
+INPUT: location of the minc file, tarchive source location
+
+RETURNS: file information hashref
+
+### move\_minc($minc, $subjectIDsref, $minc\_type, $fileref, $prefix, ...)
+
+Renames and moves the MINC file.
+
+INPUT:
+  $minc           : path to the MINC file
+  $subjectIDsref  : subject's ID hashref
+  $minc\_type      : MINC file information hashref
+  $fileref        : file information hashref
+  $prefix         : study prefix
+  $data\_dir       : data directory (typically /data/project/data)
+  $tarchive\_srcloc: tarchive source location
+
+RETURNS: new name of the MINC file with path relative to `$data_dir`
+
+### registerScanIntoDB($minc\_file, $tarchiveInfo, $subjectIDsref, ...)
+
+Registers the scan into the database.
+
+INPUT:
+  $minc\_file          : MINC file information hashref
+  $tarchiveInfo       : tarchive information hashref
+  $subjectIDsref      : subject's ID information hashref
+  $acquisitionProtocol: acquisition protocol
+  $minc               : MINC file to register into the database
+  $checks             : failed checks to register with the file
+  $reckless           : boolean, if reckless or not
+  $tarchive           : tarchive path
+  $sessionID          : session ID of the MINC file
+
+RETURNS: acquisition protocol ID of the MINC file
+
+### dicom\_to\_minc($study\_dir, $converter, $get\_dicom\_info, $exclude, ...)
+
+Converts a DICOM study into MINC files.
+
+INPUT:
+  $study\_dir      : DICOM study directory to convert
+  $converter      : converter to be used
+  $get\_dicom\_info : get DICOM information setting from the Config table
+  $exclude        : which files to exclude from the dcm2mnc command
+  $mail\_user      : mail of the user
+  $tarchive\_srcloc: tarchive source location
+
+### get\_mincs($minc\_files, $tarchive\_srcloc)
+
+Greps the created MINC files and returns a sorted list of those MINC files.
+
+INPUT: empty array to store the list of MINC files, tarchive source location
+
+### concat\_mri($minc\_files)
+
+Concats and removes pre-concat MINC files. ?????????????????
+
+INPUT: list of MINC files to concat
+
+### registerProgs(@toregister)
+
+Register programs ???????????????????????
+
+INPUT: program to register
+
+### moveAndUpdateTarchive($tarchive\_location, $tarchiveInfo)
+
+Moves and updates the tarchive table with the new location of the tarchive.
+
+INPUT: tarchive location, tarchive information hashref
+
+RETURNS: the new tarchive location
+
+### CreateMRICandidates($subjectIDsref, $gender, $tarchiveInfo, $User, ...)
+
+Registers a new candidate in the candidate table.
+
+INPUT:
+  $subjectIDsref: subject's ID information hashref
+  $gender       : gender of the candidate
+  $tarchiveInfo : tarchive information hashref
+  $User         : user that is running the pipeline
+  $centerID     : center ID
+
+### setMRISession($subjectIDsref, $tarchiveInfo)
+
+Sets the imaging session ID. This function will call
+`&NeuroDB::MRI::getSessionID` which in turn will either:
+  - grep the sessionID if the visit label for that candidate already exists, or
+  - create a new session if the visit label doesn't exist for that candidate yet
+
+INPUT: subject's ID information hashref, tarchive information hashref
+
+RETURNS: session ID, if the new session requires staging
+
+### validateArchive($tarchive, $tarchiveInfo)
+
+Validates the DICOM archive by comparing the MD5 of the `$tarchive file` and
+the one stored in the tarchive information hashref `$tarchiveInfo` derived
+from the database. The function will exits with an error message if the
+tarchive is not validated.
+
+INPUT: tarchive file, tarchive information hashref
+
+### which\_directory($subjectIDsref, $data\_dir)
+
+Determines where the MINC files to be registered into the database will go.
+
+INPUT: subject's ID information hashref, data directory (typically
+/data/project/data)
+
+RETURNS: the final directory in which the registered MINC files will go
+(typically /data/project/data/assembly/CandID/visit/mri/)
+
+### validateCandidate($subjectIDsref, $tarchive\_srcloc)
+
+Check that the candidate's information derived from the patient name field of
+the DICOM files is valid (CandID and PSCID of the candidate should correspond
+to the same subject in the database).
+
+INPUT: subject's ID information hashref, tarchive source location
+
+RETURNS: the candidate mismatch error, or undef if the candidate is validated
+ or a phantom
+
+### computeSNR($tarchiveID, $tarchive\_srcloc, $profile)
+
+Computes the SNR on the modalities specified in the Config table for a given
+tarchive.
+
+INPUT: tarchive ID, tarchive source location, configuration file (usually prod)
+
+### orderModalitiesByAcq($tarchiveID, $tarchive\_srcloc)
+
+Order imaging modalities by acquisition number.
+
+INPUT: tarchive ID, tarchive source location
+
+### getUploadIDUsingTarchiveSrcLoc($tarchive\_srcloc)
+
+Gets the upload ID form the mri\_upload table using tarchive's SourceLocation
+
+INPUT: tarchive's source location
+
+RETURNS: the found upload ID
+
+### spool($message, $error, $upload\_id, $verb)
+
+Calls the Notify->spool function to log all messages.
+
+INPUT:
+  $message   : message to be logged in the database
+  $error     : if 'Y' it's an error log , 'N' otherwise
+  $upload\_id : the upload\_id
+  $verb      : 'N' for few main messages, 'Y' for more messages (developers)
+
+# TO DO
+
+Document the following functions:
+  - getFileNamesfromSeriesUID($seriesuid, @alltarfiles)
+  - get\_acqusitions($study\_dir, \\@acquisitions)
+  - concat\_mri($minc\_files)
+  - registerProgs(@toregister)
+
+# BUGS
+
+None reported (or list of bugs)
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -12,32 +12,32 @@ utilities
 
   use NeuroDB::ProcessingUtility;
 
-  my $utility = NeuroDB::MRIProcessingUtility->new(
-                    \$dbh,    $debug,  $TmpDir,
-                    $logfile, $LogDir, $verbose
-                );
+  my $utility       = NeuroDB::MRIProcessingUtility->new(
+                        \$dbh,    $debug,  $TmpDir,
+                        $logfile, $LogDir, $verbose
+                      );
 
-  %tarchiveInfo = $utility->createTarchiveArray(
-                    $ArchiveLocation, $globArchiveLocation
-                  );
+  %tarchiveInfo     = $utility->createTarchiveArray(
+                        $ArchiveLocation, $globArchiveLocation
+                      );
 
   my ($center_name, $centerID) = $utility->determinePSC(\%tarchiveInfo,0);
 
-  my $scannerID = $utility->determineScannerID(
-                      \%tarchiveInfo, 0,
-                      $centerID,      $NewScanner
-                  );
-
-  my $subjectIDsref = $utility->determineSubjectID(
-                          $scannerID,
-                          \%tarchiveInfo,
-                          0
+  my $scannerID     = $utility->determineScannerID(
+                        \%tarchiveInfo, 0,
+                        $centerID,      $NewScanner
                       );
 
-  my $CandMismatchError= $utility->validateCandidate(
-                                  $subjectIDsref,
-                                  $tarchiveInfo{'SourceLocation'}
-                         );
+  my $subjectIDsref = $utility->determineSubjectID(
+                        $scannerID,
+                        \%tarchiveInfo,
+                        0
+                      );
+
+  my $CandMismatchError = $utility->validateCandidate(
+                            $subjectIDsref,
+                            $tarchiveInfo{'SourceLocation'}
+                          );
 
   $utility->computeSNR($TarchiveID, $ArchLoc, $profile);
   $utility->orderModalitiesByAcq($TarchiveID, $ArchLoc);
@@ -74,7 +74,7 @@ my $notify_notsummary = 'N'; # notification_spool message flag for messages to b
 
 =pod
 
-=head3 new($dbhr, $debug, $TmpDir, $logfile, $verbose) (constructor)
+=head3 new($dbhr, $debug, $TmpDir, $logfile, $verbose) >> (constructor)
 
 Creates a new instance of this class. The parameter `\$dbhr` is a reference
 to a DBI database handle, used to set the object's database handle, so that all
@@ -134,7 +134,7 @@ sub new {
 Writes error log. This is a useful function that will close the log and write
 error messages in case of abnormal program termination.
 
-INPUT: notification message, fail status of the process, log directory
+INPUTS: notification message, fail status of the process, log directory
 
 =cut
 
@@ -159,7 +159,7 @@ sub writeErrorLog {
 Will look up for the next visit label of candidate C<CandID>. Useful only if
 the visit label IS NOT encoded somewhere in the patient ID or patient name.
 
-INPUT: candidate's CandID, database handle reference
+INPUTS: candidate's CandID, database handle reference
 
 RETURNS: next visit label found for the candidate
 
@@ -189,11 +189,12 @@ sub lookupNextVisitLabel {
 
 =head3 getFileNamesfromSeriesUID($seriesuid, @alltarfiles)
 
-?????????????????????????????
+Will extract from the C<tarchive_files> table a list of DICOM files
+matching a given SeriesUID.
 
-INPUT: seriesUID, list of tar files
+INPUTS: seriesUID, list of tar files
 
-RETURNS: ???????????????????
+RETURNS: list of DICOM files corresponding to the seriesUID
 
 =cut
 
@@ -235,9 +236,9 @@ sub getFileNamesfromSeriesUID {
 
 =head3 extract_tarchive($tarchive, $tarchive_srcloc, $seriesuid)
 
-Extracts the tarchive so that data can actually be uploaded.
+Extracts the DICOM archive so that data can actually be uploaded.
 
-INPUT: path to the tarchive, source location from the tarchive table,
+INPUTS: path to the DICOM archive, source location from the C<tarchive> table,
 (optionally seriesUID)
 
 RETURNS: the extracted DICOM directory
@@ -294,7 +295,7 @@ sub extract_tarchive {
 
 Extracts and parses the tarchive.
 
-INPUT: path to the tarchive, source location from the tarchive table,
+INPUTS: path to the tarchive, source location from the tarchive table,
 (optionally seriesUID)
 
 RETURNS: extract suffix, extracted DICOM directory, tarchive meta data header
@@ -328,10 +329,11 @@ sub extractAndParseTarchive {
 
 Determines subject's ID based on scanner ID and tarchive information.
 
-INPUT: scanner ID, tarchive information hashref, boolean if this step should be
-logged
+INPUTS: scanner ID, tarchive information hashref, boolean if this step should
+be logged
 
-RETURNS: subject's ID hashref
+RETURNS: subject's ID hashref containing CandID, PSCID and Visit Label
+information
 
 =cut
 
@@ -376,7 +378,8 @@ sub determineSubjectID {
 
 Creates the tarchive information hashref.
 
-INPUT: tarchive's path, globArchiveLocation option
+INPUTS: tarchive's path, globArchiveLocation argument specified when running
+the insertion scripts
 
 RETURNS: tarchive information hashref
 
@@ -426,7 +429,7 @@ sub createTarchiveArray {
 
 Determines the PSC based on the tarchive information hashref.
 
-INPUT: tarchive information hashref, whether this step should be logged
+INPUTS: tarchive information hashref, whether this step should be logged
 
 RETURNS: array of two elements: center name and center ID
 
@@ -473,7 +476,7 @@ sub determinePSC {
 
 Determines which scanner ID was used for DICOM acquisitions.
 
-INPUT:
+INPUTS:
   $tarchiveInfo: tarchive information hashref
   $to_log      : whether this step should be logged
   $centerID    : center ID
@@ -532,10 +535,7 @@ sub determineScannerID {
 
 =head3 get_acqusitions($study_dir, \@acquisitions)
 
-Greps the list of acquisitions in the study directory from array
-C<@acquisitions>. ?????????????????????????????????????
-
-INPUT: study directory, array of acquisitions ??????????????????
+UNUSED FUNCTION TO BE CLEANED UP IN ANOTHER PULL REQUEST
 
 =cut
 
@@ -557,7 +557,7 @@ sub get_acquisitions {
 
 Computes the MD5 hash of a file and makes sure it is unique.
 
-INPUT: file to use to compute the MD5 hash, tarchive source location
+INPUTS: file to use to compute the MD5 hash, tarchive source location
 
 RETURNS: 1 if the file is unique, 0 otherwise
 
@@ -587,12 +587,12 @@ sub computeMd5Hash {
 
 Determines the acquisition protocol and acquisition protocol ID for the MINC
 file. If C<$acquisitionProtocol> is not set, it will look for the acquisition
-protocol in the mri_protocol table based on the mincheader information using
-C<&NeuroDB::MRI::identify_scan_db>. If C<$bypass_extra_file_checks> is
+protocol in the C<mri_protocol> table based on the MINC header information
+using C<&NeuroDB::MRI::identify_scan_db>. If C<$bypass_extra_file_checks> is
 true, then it will bypass the additional protocol checks from the
-mri_protocol_checks table using C<&extra_file_checks>.
+C<mri_protocol_checks> table using C<&extra_file_checks>.
 
-INPUT:
+INPUTS:
   $file                    : file's information hashref
   $subjectIDsref           : subject's information hashref
   $tarchiveInfo            : tarchive's information hashref
@@ -675,7 +675,7 @@ sub getAcquisitionProtocol {
 Returns the list of MRI protocol checks that failed. Can't directly insert
 this information here since the file isn't registered in the database yet.
 
-INPUT:
+INPUTS:
   $scan_type  : scan type of the file
   $file       : file information hashref
   $CandID     : candidate's CandID
@@ -761,7 +761,7 @@ sub extra_file_checks() {
 
 Updates the mri_acquisition_dates table by a new acquisition date C<$acq_date>.
 
-INPUT: session ID, acquisition date
+INPUTS: session ID, acquisition date
 
 =cut
 
@@ -803,7 +803,7 @@ sub update_mri_acquisition_dates {
 
 Loads and creates the object file.
 
-INPUT: location of the minc file, tarchive source location
+INPUTS: location of the minc file, tarchive source location
 
 RETURNS: file information hashref
 
@@ -846,7 +846,7 @@ sub loadAndCreateObjectFile {
 
 Renames and moves the MINC file.
 
-INPUT:
+INPUTS:
   $minc           : path to the MINC file
   $subjectIDsref  : subject's ID hashref
   $minc_type      : MINC file information hashref
@@ -915,7 +915,7 @@ sub move_minc {
 
 Registers the scan into the database.
 
-INPUT:
+INPUTS:
   $minc_file          : MINC file information hashref
   $tarchiveInfo       : tarchive information hashref
   $subjectIDsref      : subject's ID information hashref
@@ -1050,7 +1050,7 @@ sub registerScanIntoDB {
 
 Converts a DICOM study into MINC files.
 
-INPUT:
+INPUTS:
   $study_dir      : DICOM study directory to convert
   $converter      : converter to be used
   $get_dicom_info : get DICOM information setting from the Config table
@@ -1112,7 +1112,7 @@ sub dicom_to_minc {
 
 Greps the created MINC files and returns a sorted list of those MINC files.
 
-INPUT: empty array to store the list of MINC files, tarchive source location
+INPUTS: empty array to store the list of MINC files, tarchive source location
 
 =cut
 
@@ -1154,7 +1154,7 @@ sub get_mincs {
 
 =head3 concat_mri($minc_files)
 
-Concats and removes pre-concat MINC files. ?????????????????
+Concats and removes pre-concat MINC files.
 
 INPUT: list of MINC files to concat
 
@@ -1204,7 +1204,7 @@ sub concat_mri {
 
 =head3 registerProgs(@toregister)
 
-Register programs ???????????????????????
+Register programs.
 
 INPUT: program to register
 
@@ -1228,7 +1228,7 @@ sub registerProgs() {
 
 Moves and updates the tarchive table with the new location of the tarchive.
 
-INPUT: tarchive location, tarchive information hashref
+INPUTS: tarchive location, tarchive information hashref
 
 RETURNS: the new tarchive location
 
@@ -1294,7 +1294,7 @@ sub moveAndUpdateTarchive {
 
 Registers a new candidate in the candidate table.
 
-INPUT:
+INPUTS:
   $subjectIDsref: subject's ID information hashref
   $gender       : gender of the candidate
   $tarchiveInfo : tarchive information hashref
@@ -1384,7 +1384,7 @@ C<&NeuroDB::MRI::getSessionID> which in turn will either:
   - create a new session if visit label does not exist for that
      candidate yet
 
-INPUT: subject's ID information hashref, tarchive information hashref
+INPUTS: subject's ID information hashref, tarchive information hashref
 
 RETURNS: session ID, if the new session requires staging
 
@@ -1450,7 +1450,7 @@ the one stored in the tarchive information hashref C<$tarchiveInfo> derived
 from the database. The function will exits with an error message if the
 tarchive is not validated.
 
-INPUT: tarchive file, tarchive information hashref
+INPUTS: tarchive file, tarchive information hashref
 
 =cut
 
@@ -1490,7 +1490,7 @@ sub validateArchive {
 
 Determines where the MINC files to be registered into the database will go.
 
-INPUT: subject's ID information hashref, data directory (typically
+INPUTS: subject's ID information hashref, data directory (typically
 /data/project/data)
 
 RETURNS: the final directory in which the registered MINC files will go
@@ -1517,10 +1517,10 @@ Check that the candidate's information derived from the patient name field of
 the DICOM files is valid (CandID and PSCID of the candidate should correspond
 to the same subject in the database).
 
-INPUT: subject's ID information hashref, tarchive source location
+INPUTS: subject's ID information hashref, tarchive source location
 
 RETURNS: the candidate mismatch error, or undef if the candidate is validated
- or a phantom
+or a phantom
 
 =cut
 
@@ -1592,10 +1592,10 @@ sub validateCandidate {
 
 =head3 computeSNR($tarchiveID, $tarchive_srcloc, $profile)
 
-Computes the SNR on the modalities specified in the Config table for a given
-tarchive.
+Computes the SNR on the modalities specified in the C<getSNRModalities()>
+routine of the C<$profile> file.
 
-INPUT: tarchive ID, tarchive source location, configuration file (usually prod)
+INPUTS: tarchive ID, tarchive source location, configuration file (usually prod)
 
 =cut
 
@@ -1663,7 +1663,7 @@ sub computeSNR {
 
 Order imaging modalities by acquisition number.
 
-INPUT: tarchive ID, tarchive source location
+INPUTS: tarchive ID, tarchive source location
 
 =cut
 
@@ -1733,9 +1733,10 @@ sub orderModalitiesByAcq {
 
 =head3 getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc)
 
-Gets the upload ID form the mri_upload table using tarchive's SourceLocation
+Gets the upload ID form the C<mri_upload> table using the DICOM archive
+C<SourceLocation> specified in the C<tarchive> table.
 
-INPUT: tarchive's source location
+INPUT: DICOM archive's source location
 
 RETURNS: the found upload ID
 
@@ -1775,9 +1776,10 @@ sub getUploadIDUsingTarchiveSrcLoc {
 
 Calls the Notify->spool function to log all messages.
 
-INPUT:
+INPUTS:
   $message   : message to be logged in the database
-  $error     : if 'Y' it's an error log , 'N' otherwise
+  $error     : if 'Y' it's an error log,
+               'N' otherwise
   $upload_id : the upload_id
   $verb      : 'N' for few main messages,
                'Y' for more messages (developers)
@@ -1804,7 +1806,6 @@ sub spool  {
 =head1 TO DO
 
 Document the following functions:
-  - getFileNamesfromSeriesUID($seriesuid, @alltarfiles)
   - get_acqusitions($study_dir, \@acquisitions)
   - concat_mri($minc_files)
   - registerProgs(@toregister)

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -595,7 +595,7 @@ INPUT:
   $center_name             : center name
   $minc                    : absolute path to the MINC file
   $acquisitionProtocol     : acquisition protocol if already knows it
-  $bypass_extra_file_checks: boolean, if should bypass the extra file checks
+  $bypass_extra_file_checks: boolean, if set bypass the extra checks
 
 RETURNS: acquisition protocol, acquisition protocol ID, array of extra checks
 
@@ -1376,8 +1376,9 @@ sub CreateMRICandidates {
 
 Sets the imaging session ID. This function will call
 C<&NeuroDB::MRI::getSessionID> which in turn will either:
-  - grep the sessionID if the visit label for that candidate already exists, or
-  - create a new session if the visit label doesn't exist for that candidate yet
+  - grep sessionID if visit for that candidate already exists, or
+  - create a new session if visit label does not exist for that
+     candidate yet
 
 INPUT: subject's ID information hashref, tarchive information hashref
 
@@ -1724,9 +1725,6 @@ sub orderModalitiesByAcq {
     }
 }
 
-################################################################
-################ getUploadIDUsingTarchiveSrcLoc#################
-################################################################
 =pod
 
 =head3 getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc)
@@ -1777,7 +1775,8 @@ INPUT:
   $message   : message to be logged in the database
   $error     : if 'Y' it's an error log , 'N' otherwise
   $upload_id : the upload_id
-  $verb      : 'N' for few main messages, 'Y' for more messages (developers)
+  $verb      : 'N' for few main messages,
+               'Y' for more messages (developers)
 
 =cut
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1806,7 +1806,6 @@ sub spool  {
 =head1 TO DO
 
 Document the following functions:
-  - get_acqusitions($study_dir, \@acquisitions)
   - concat_mri($minc_files)
   - registerProgs(@toregister)
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1,4 +1,53 @@
 package NeuroDB::MRIProcessingUtility;
+
+
+=pod
+
+=head1 NAME
+
+NeuroDB::MRIProcessingUtility -- Provides an interface for MRI processing
+utilities
+
+=head1 SYNOPSIS
+
+use NeuroDB::ProcessingUtility;
+
+my $utility = NeuroDB::MRIProcessingUtility->new(
+                  \$dbh,    $debug,  $TmpDir,
+                  $logfile, $LogDir, $verbose
+              );
+
+%tarchiveInfo = $utility->createTarchiveArray(
+                  $ArchiveLocation, $globArchiveLocation
+                );
+
+my ($center_name, $centerID) = $utility->determinePSC(\%tarchiveInfo,0);
+
+my $scannerID = $utility->determineScannerID(
+                    \%tarchiveInfo, 0,
+                    $centerID,      $NewScanner
+                );
+
+my $subjectIDsref = $utility->determineSubjectID($scannerID, \%tarchiveInfo, 0);
+
+my $CandMismatchError= $utility->validateCandidate(
+                                $subjectIDsref,
+                                $tarchiveInfo{'SourceLocation'}
+                       );
+
+$utility->computeSNR($TarchiveID, $ArchLoc, $profile);
+$utility->orderModalitiesByAcq($TarchiveID, $ArchLoc);
+
+=head1 DESCRIPTION
+
+Mishmash of MRI processing utility functions used mainly by the insertion
+scripts of LORIS.
+
+=head2 Methods
+
+=cut
+
+
 use English;
 use Carp;
 use strict;
@@ -18,9 +67,21 @@ my $notify_detailed   = 'Y'; # notification_spool message flag for messages to b
 my $notify_notsummary = 'N'; # notification_spool message flag for messages to be displayed 
                              # with SUMMARY Option in the front-end/imaging_uploader 
 
-################################################################
-#####################Constructor ###############################
-################################################################
+
+=pod
+
+=head3 new($dbhr, $debug, $TmpDir, $logfile, $verbose) (constructor)
+
+Creates a new instance of this class. The parameter `\$dbhr` is a reference
+to a DBI database handle, used to set the object's database handle, so that all
+the DB-driven methods will work.
+
+INPUT: DBI database handle
+
+RETURNS: new instance of this class.
+
+=cut
+
 sub new {
     my $params = shift;
     my ($dbhr,$debug,$TmpDir,$logfile,$verbose) = @_;
@@ -61,11 +122,18 @@ sub new {
     return bless $self, $params;
 }
 
-################################################################
-## writeErrorLog and update Notification Table##################
-## this is a useful function that will close the log and write #
-## error messages in case of abnormal program termination ######
-################################################################
+
+=pod
+
+=head3 writeErrorLog($message, $failStatus, $LogDir)
+
+Writes error log. This is a useful function that will close the log and write
+error messages in case of abnormal program termination.
+
+INPUT: notification message, fail status of the process, log directory
+
+=cut
+
 sub writeErrorLog {
     my $this = shift;
     my ($message, $failStatus,$LogDir) = @_;
@@ -80,10 +148,18 @@ sub writeErrorLog {
 }
 
 
-#################################################################    
-## useful only if the visit label IS NOT encoded somewhere in ###
-## the patient ID or patient Name ###############################
-#################################################################    
+=pod
+
+=head3 lookupNextVisitLabel($candID, $dbhr)
+
+Will look up for the next visit label of candidate C<CandID>. Useful only if
+the visit label IS NOT encoded somewhere in the patient ID or patient name.
+
+INPUT: candidate's CandID, database handle reference
+
+RETURNS: next visit label found for the candidate
+
+=cut
 
 sub lookupNextVisitLabel {
     my $this = shift;
@@ -104,9 +180,19 @@ sub lookupNextVisitLabel {
     return $visitLabel;
 }
 
-################################################################
-########### getFileNamesfromSeriesUID  #########################
-################################################################
+
+=pod
+
+=head3 getFileNamesfromSeriesUID($seriesuid, @alltarfiles)
+
+?????????????????????????????
+
+INPUT: seriesUID, list of tar files
+
+RETURNS: ???????????????????
+
+=cut
+
 sub getFileNamesfromSeriesUID {
 
     # longest common prefix
@@ -140,13 +226,20 @@ sub getFileNamesfromSeriesUID {
     return $tarstring;
 }
 
-################################################################
-##################### extract_tarchive #########################
-################################################################
+
 =pod
-Most important function now. Gets the tarchive and
-extracts it so data can actually be uploaded
+
+=head3 extract_tarchive($tarchive, $tarchive_srcloc, $seriesuid)
+
+Extracts the tarchive so that data can actually be uploaded.
+
+INPUT: path to the tarchive, source location from the tarchive table,
+(optionally seriesUID)
+
+RETURNS: the extracted DICOM directory
+
 =cut
+
 sub extract_tarchive {
     my $this = shift;
     my ($tarchive, $tarchive_srcloc, $seriesuid) = @_;
@@ -191,9 +284,19 @@ sub extract_tarchive {
 }
 
 
-################################################################
-############ sub extractAndParseTarchive #######################
-################################################################
+=pod
+
+=head3 extractAndParseTarchive($tarchive, $tarchive_srcloc, $seriesuid)
+
+Extracts and parses the tarchive.
+
+INPUT: path to the tarchive, source location from the tarchive table,
+(optionally seriesUID)
+
+RETURNS: extract suffix, extracted DICOM directory, tarchive meta data header
+
+=cut
+
 sub extractAndParseTarchive {
 
     my $this = shift;
@@ -214,9 +317,20 @@ sub extractAndParseTarchive {
     return ($ExtractSuffix, $study_dir, $header);
 }
 
-################################################################
-################## determineSubjectID ##########################
-################################################################
+
+=pod
+
+=head3 determineSubjectID($scannerID, $tarchiveInfo, $to_log)
+
+Determines subject's ID based on scanner ID and tarchive information.
+
+INPUT: scanner ID, tarchive information hashref, boolean if this step should be
+logged
+
+RETURNS: subject's ID hashref
+
+=cut
+
 sub determineSubjectID {
 
     my $this = shift;
@@ -252,9 +366,17 @@ sub determineSubjectID {
 }
 
 
-################################################################
-################### createTarchiveArray ########################
-################################################################
+=pod
+
+=head3 createTarchiveArray($tarchive, $globArchiveLocation)
+
+Creates the tarchive information hashref.
+
+INPUT: tarchive's path, globArchiveLocation option
+
+RETURNS: tarchive information hashref
+
+=cut
 
 sub createTarchiveArray {
 
@@ -293,9 +415,19 @@ sub createTarchiveArray {
     return %tarchiveInfo;
 }
 
-################################################################
-#################### determinePSC ##############################
-################################################################
+
+=pod
+
+=head3 determinePSC($tarchiveInfo, $to_log)
+
+Determines the PSC based on the tarchive information hashref.
+
+INPUT: tarchive information hashref, whether this step should be logged
+
+RETURNS: array of two elements: center name and center ID
+
+=cut
+
 sub determinePSC {
 
     my $this = shift;
@@ -330,9 +462,24 @@ sub determinePSC {
     return ($center_name, $centerID);
 }
 
-################################################################
-################## determineScannerID ##########################
-################################################################
+
+=pod
+
+=head3 determineScannerID($tarchiveInfo, $to_log, $centerID, $NewScanner)
+
+Determines which scanner ID was used for DICOM acquisitions.
+
+INPUT:
+  $tarchiveInfo: tarchive information hashref
+  $to_log      : whether this step should be logged
+  $centerID    : center ID
+  $NewScanner  : whether a new scanner entry should be created if the scanner
+  used is a new scanner for the study
+
+RETURNS: scanner ID
+
+=cut
+
 sub determineScannerID {
 
     my $this = shift;
@@ -376,10 +523,18 @@ sub determineScannerID {
     return $scannerID;
 }
 
-################################################################
-####### get_acqusitions($study_dir, \@acquisitions) ############ 
-####### puts list of acq dirs in @acquisitions #################
-################################################################
+
+=pod
+
+=head3 get_acqusitions($study_dir, \@acquisitions)
+
+Greps the list of acquisitions in the study directory from array
+C<@acquisitions>. ?????????????????????????????????????
+
+INPUT: study directory, array of acquisitions ??????????????????
+
+=cut
+
 sub get_acquisitions {
     my $this = shift;
     my ($study_dir, $acquisitions) = @_;
@@ -391,9 +546,19 @@ sub get_acquisitions {
     }
 }
 
-################################################################
-################### compute the md5 hash #######################
-################################################################
+
+=pod
+
+=head3 computeMd5Hash($file, $tarchive_srcloc)
+
+Computes the MD5 hash of a file and makes sure it is unique.
+
+INPUT: file to use to compute the MD5 hash, tarchive source location
+
+RETURNS: 1 if the file is unique, 0 otherwise
+
+=cut
+
 sub computeMd5Hash {
     my $this = shift;
     my ($file, $tarchive_srcloc) = @_;
@@ -411,9 +576,30 @@ sub computeMd5Hash {
     return $unique;
 }
 
-################################################################
-#################### getAcquisitionProtocol ####################
-################################################################
+
+=pod
+
+=head3 getAcquisitionProtocol($file, $subjectIDsref, $tarchiveInfo, ...)
+
+Determines the acquisition protocol and acquisition protocol ID for the MINC
+file. If C<$acquisitionProtocol> is not set, it will look for the acquisition
+protocol in the mri_protocol table based on the mincheader information using
+C<&NeuroDB::MRI::identify_scan_db>. If C<$bypass_extra_file_checks> is
+true, then it will bypass the additional protocol checks from the
+mri_protocol_checks table using C<&extra_file_checks>.
+
+INPUT:
+  $file                    : file's information hashref
+  $subjectIDsref           : subject's information hashref
+  $tarchiveInfo            : tarchive's information hashref
+  $center_name             : center name
+  $minc                    : absolute path to the MINC file
+  $acquisitionProtocol     : acquisition protocol if already knows it
+  $bypass_extra_file_checks: boolean, if should bypass the extra file checks
+
+RETURNS: acquisition protocol, acquisition protocol ID, array of extra checks
+
+=cut
 
 sub getAcquisitionProtocol {
    
@@ -477,12 +663,26 @@ sub getAcquisitionProtocol {
     return ($acquisitionProtocol, $acquisitionProtocolID, @checks);
 }
 
-################################################################
-######## extra_file_checks () ##################################
-######## Returns list of checks that failed, ###################
-######## We can't directly insert here because #################
-######## The file isn't registered in the database yet #########
-################################################################
+
+=pod
+
+=head3 extra_file_checks($scan_type, $file, $CandID, $Visit_Label, $PatientName)
+
+Returns the list of MRI protocol checks that failed. Can't directly insert
+this information here since the file isn't registered in the database yet.
+
+INPUT:
+  $scan_type  : scan type of the file
+  $file       : file information hashref
+  $CandID     : candidate's CandID
+  $Visit_Label: visit label of the scan
+  $PatientName: patient name of the scan
+
+RETURNS:
+  - pass, warn or exclude flag depending on the worst failed check
+  - array of failed checks if any were failed
+
+=cut
 
 sub extra_file_checks() {
       
@@ -549,9 +749,18 @@ sub extra_file_checks() {
     return ('pass', \@faillist);
 }
 
-################################################################
-################## update_mri_acquisition_dates ################
-################################################################
+
+
+=pod
+
+=head3 update_mri_acquisition_dates($sessionID, $acq_date)
+
+Updates the mri_acquisition_dates table by a new acquisition date C<$acq_date>.
+
+INPUT: session ID, acquisition date
+
+=cut
+
 sub update_mri_acquisition_dates {
    
     my $this = shift;
@@ -583,9 +792,18 @@ sub update_mri_acquisition_dates {
     }
 }
 
-################################################################
-#################### loadAndCreateObjectFile ###################
-################################################################
+
+=pod
+
+=head3 loadAndCreateObjectFile($minc, $tarchive_srcloc)
+
+Loads and creates the object file.
+
+INPUT: location of the minc file, tarchive source location
+
+RETURNS: file information hashref
+
+=cut
 
 sub loadAndCreateObjectFile {
 
@@ -617,10 +835,26 @@ sub loadAndCreateObjectFile {
     return $file;
 }
 
-################################################################
-#################### move_minc #################################
-#################### renames and moves $minc ###################
-################################################################
+
+=pod
+
+=head3 move_minc($minc, $subjectIDsref, $minc_type, $fileref, $prefix, ...)
+
+Renames and moves the MINC file.
+
+INPUT:
+  $minc           : path to the MINC file
+  $subjectIDsref  : subject's ID hashref
+  $minc_type      : MINC file information hashref
+  $fileref        : file information hashref
+  $prefix         : study prefix
+  $data_dir       : data directory (typically /data/project/data)
+  $tarchive_srcloc: tarchive source location
+
+RETURNS: new name of the MINC file with path relative to C<$data_dir>
+
+=cut
+
 sub move_minc {
     
     my $this = shift;
@@ -671,9 +905,27 @@ sub move_minc {
 }
 
 
-################################################################
-###################### registerScanIntoDB ######################
-################################################################
+=pod
+
+=head3 registerScanIntoDB($minc_file, $tarchiveInfo, $subjectIDsref, ...)
+
+Registers the scan into the database.
+
+INPUT:
+  $minc_file          : MINC file information hashref
+  $tarchiveInfo       : tarchive information hashref
+  $subjectIDsref      : subject's ID information hashref
+  $acquisitionProtocol: acquisition protocol
+  $minc               : MINC file to register into the database
+  $checks             : failed checks to register with the file
+  $reckless           : boolean, if reckless or not
+  $tarchive           : tarchive path
+  $sessionID          : session ID of the MINC file
+
+RETURNS: acquisition protocol ID of the MINC file
+
+=cut
+
 sub registerScanIntoDB {
 
     my $this = shift;
@@ -787,9 +1039,22 @@ sub registerScanIntoDB {
     return $acquisitionProtocolID;
 }
 
-################################################################
-################## dicom_to_minc ###############################
-################################################################
+
+=pod
+
+=head3 dicom_to_minc($study_dir, $converter, $get_dicom_info, $exclude, ...)
+
+Converts a DICOM study into MINC files.
+
+INPUT:
+  $study_dir      : DICOM study directory to convert
+  $converter      : converter to be used
+  $get_dicom_info : get DICOM information setting from the Config table
+  $exclude        : which files to exclude from the dcm2mnc command
+  $mail_user      : mail of the user
+  $tarchive_srcloc: tarchive source location
+
+=cut
 
 sub dicom_to_minc {
 
@@ -835,10 +1100,18 @@ sub dicom_to_minc {
     "### Dicom to MINC:\n$d2m_log");
     $this->spool($message, 'N', $upload_id, $notify_detailed);
 }
-################################################################
-####### get_mincs ##############################################
-######## returns a sorted list of mincfiles ####################
-################################################################
+
+
+=pod
+
+=head3 get_mincs($minc_files, $tarchive_srcloc)
+
+Greps the created MINC files and returns a sorted list of those MINC files.
+
+INPUT: empty array to store the list of MINC files, tarchive source location
+
+=cut
+
 sub get_mincs {
   
     my $this = shift;
@@ -872,12 +1145,17 @@ sub get_mincs {
     $this->spool($message, 'N', $upload_id, $notify_detailed);
 }  
 
-################################################################
-########################## concat_mri ##########################
-################################################################
-## concat_mri(\@minc_files, $psc) -> concats & removes #########
-## pre-concat mincs ############################################
-################################################################
+
+=pod
+
+=head3 concat_mri($minc_files)
+
+Concats and removes pre-concat MINC files. ?????????????????
+
+INPUT: list of MINC files to concat
+
+=cut
+
 sub concat_mri {
   
     my $this = shift;
@@ -917,9 +1195,17 @@ sub concat_mri {
     );
 }
 
-################################################################
-###################### registerProgs ###########################
-################################################################
+
+=pod
+
+=head3 registerProgs(@toregister)
+
+Register programs ???????????????????????
+
+INPUT: program to register
+
+=cut
+
 sub registerProgs() {
     my $this = shift;
     my @toregister = @_;
@@ -931,9 +1217,19 @@ sub registerProgs() {
     }
 }
 
-################################################################
-############ moveAndUpdateTarchive #############################
-################################################################
+
+=pod
+
+=head3 moveAndUpdateTarchive($tarchive_location, $tarchiveInfo)
+
+Moves and updates the tarchive table with the new location of the tarchive.
+
+INPUT: tarchive location, tarchive information hashref
+
+RETURNS: the new tarchive location
+
+=cut
+
 sub moveAndUpdateTarchive {
 
     my $this = shift;
@@ -987,9 +1283,22 @@ sub moveAndUpdateTarchive {
     return $newTarchiveLocation;
 }
 
-################################################################
-###################### CreateMRICandidates #####################
-################################################################
+
+=pod
+
+=head3 CreateMRICandidates($subjectIDsref, $gender, $tarchiveInfo, $User, ...)
+
+Registers a new candidate in the candidate table.
+
+INPUT:
+  $subjectIDsref: subject's ID information hashref
+  $gender       : gender of the candidate
+  $tarchiveInfo : tarchive information hashref
+  $User         : user that is running the pipeline
+  $centerID     : center ID
+
+=cut
+
 sub CreateMRICandidates {
     ############################################################
     ### Standardize gender (DICOM uses M/F, DB uses Male/Female)
@@ -1060,9 +1369,22 @@ sub CreateMRICandidates {
      }
 }
 
-################################################################
-###############################setMRISession####################
-################################################################
+
+=pod
+
+=head3 setMRISession($subjectIDsref, $tarchiveInfo)
+
+Sets the imaging session ID. This function will call
+C<&NeuroDB::MRI::getSessionID> which in turn will either:
+  - grep the sessionID if the visit label for that candidate already exists, or
+  - create a new session if the visit label doesn't exist for that candidate yet
+
+INPUT: subject's ID information hashref, tarchive information hashref
+
+RETURNS: session ID, if the new session requires staging
+
+=cut
+
 sub setMRISession {
     my $this = shift;
     my $query = '';
@@ -1113,9 +1435,19 @@ sub setMRISession {
     return ($sessionID, $requiresStaging);
 }
 
-################################################################
-###################### validateArchive #########################
-################################################################
+
+=pod
+
+=head3 validateArchive($tarchive, $tarchiveInfo)
+
+Validates the DICOM archive by comparing the MD5 of the C<$tarchive file> and
+the one stored in the tarchive information hashref C<$tarchiveInfo> derived
+from the database. The function will exits with an error message if the
+tarchive is not validated.
+
+INPUT: tarchive file, tarchive information hashref
+
+=cut
 
 sub validateArchive {
     my $this = shift;
@@ -1146,9 +1478,21 @@ sub validateArchive {
     }
 }
 
-################################################################
-############## determines where the mincs will go... ###########
-################################################################
+
+=pod
+
+=head3 which_directory($subjectIDsref, $data_dir)
+
+Determines where the MINC files to be registered into the database will go.
+
+INPUT: subject's ID information hashref, data directory (typically
+/data/project/data)
+
+RETURNS: the final directory in which the registered MINC files will go
+(typically /data/project/data/assembly/CandID/visit/mri/)
+
+=cut
+
 sub which_directory {
     my $this = shift;
     my ($subjectIDsref,$data_dir) = @_;
@@ -1158,9 +1502,22 @@ sub which_directory {
     $dir =~ s/ //;
     return $dir;
 }
-################################################################
-############# validateCandidate ################################
-################################################################
+
+
+=pod
+
+=head3 validateCandidate($subjectIDsref, $tarchive_srcloc)
+
+Check that the candidate's information derived from the patient name field of
+the DICOM files is valid (CandID and PSCID of the candidate should correspond
+to the same subject in the database).
+
+INPUT: subject's ID information hashref, tarchive source location
+
+RETURNS: the candidate mismatch error, or undef if the candidate is validated
+ or a phantom
+
+=cut
 
 sub validateCandidate {
     my $this = shift;
@@ -1225,9 +1582,17 @@ sub validateCandidate {
    return $CandMismatchError;
 }
 
-################################################################
-#################### computeSNR ################################
-################################################################
+
+=pod
+
+=head3 computeSNR($tarchiveID, $tarchive_srcloc, $profile)
+
+Computes the SNR on the modalities specified in the Config table for a given
+tarchive.
+
+INPUT: tarchive ID, tarchive source location, configuration file (usually prod)
+
+=cut
 
 sub computeSNR {
 
@@ -1286,9 +1651,16 @@ sub computeSNR {
     }
 }
 
-################################################################
-##########  Order Imaging Modalities By Acquisition ############
-################################################################
+
+=pod
+
+=head3 orderModalitiesByAcq($tarchiveID, $tarchive_srcloc)
+
+Order imaging modalities by acquisition number.
+
+INPUT: tarchive ID, tarchive source location
+
+=cut
 
 sub orderModalitiesByAcq {
 
@@ -1356,14 +1728,15 @@ sub orderModalitiesByAcq {
 ################ getUploadIDUsingTarchiveSrcLoc#################
 ################################################################
 =pod
-getUploadIDUsingTarchiveSrcLoc()
-Description:
-  - Get upload_id form the mri_upload table using tarchive SourceLocation
 
-Arguments:
-  $tarchive_srcloc: The Tarchive SourceLocation
+=head3 getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc)
 
-  Returns: $upload_id : The upload_id from the mri_upload table
+Gets the upload ID form the mri_upload table using tarchive's SourceLocation
+
+INPUT: tarchive's source location
+
+RETURNS: the found upload ID
+
 =cut
 
 
@@ -1393,21 +1766,19 @@ sub getUploadIDUsingTarchiveSrcLoc {
     return $upload_id;
 }
 
-################################################################
-#################spool##########################################
-################################################################
-=pod
-spool()
-Description:
-   - Calls the Notify->spool function to log all messages
 
-Arguments:
- $this      : Reference to the class
- $message   : Message to be logged in the database
- $error     : if 'Y' it's an error log , 'N' otherwise
- $upload_id: The upload_id
- $verb      : 'N' for few main messages, 'Y' for more messages (developers)
- Returns    : NULL
+=pod
+
+=head3 spool($message, $error, $upload_id, $verb)
+
+Calls the Notify->spool function to log all messages.
+
+INPUT:
+  $message   : message to be logged in the database
+  $error     : if 'Y' it's an error log , 'N' otherwise
+  $upload_id : the upload_id
+  $verb      : 'N' for few main messages, 'Y' for more messages (developers)
+
 =cut
 
 sub spool  {
@@ -1423,3 +1794,28 @@ sub spool  {
 
 
 1;
+
+
+=pod
+
+=head1 TO DO
+
+Document the following functions:
+  - getFileNamesfromSeriesUID($seriesuid, @alltarfiles)
+  - get_acqusitions($study_dir, \@acquisitions)
+  - concat_mri($minc_files)
+  - registerProgs(@toregister)
+
+=head1 BUGS
+
+None reported (or list of bugs)
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -10,33 +10,37 @@ utilities
 
 =head1 SYNOPSIS
 
-use NeuroDB::ProcessingUtility;
+  use NeuroDB::ProcessingUtility;
 
-my $utility = NeuroDB::MRIProcessingUtility->new(
-                  \$dbh,    $debug,  $TmpDir,
-                  $logfile, $LogDir, $verbose
-              );
-
-%tarchiveInfo = $utility->createTarchiveArray(
-                  $ArchiveLocation, $globArchiveLocation
+  my $utility = NeuroDB::MRIProcessingUtility->new(
+                    \$dbh,    $debug,  $TmpDir,
+                    $logfile, $LogDir, $verbose
                 );
 
-my ($center_name, $centerID) = $utility->determinePSC(\%tarchiveInfo,0);
+  %tarchiveInfo = $utility->createTarchiveArray(
+                    $ArchiveLocation, $globArchiveLocation
+                  );
 
-my $scannerID = $utility->determineScannerID(
-                    \%tarchiveInfo, 0,
-                    $centerID,      $NewScanner
-                );
+  my ($center_name, $centerID) = $utility->determinePSC(\%tarchiveInfo,0);
 
-my $subjectIDsref = $utility->determineSubjectID($scannerID, \%tarchiveInfo, 0);
+  my $scannerID = $utility->determineScannerID(
+                      \%tarchiveInfo, 0,
+                      $centerID,      $NewScanner
+                  );
 
-my $CandMismatchError= $utility->validateCandidate(
-                                $subjectIDsref,
-                                $tarchiveInfo{'SourceLocation'}
-                       );
+  my $subjectIDsref = $utility->determineSubjectID(
+                          $scannerID,
+                          \%tarchiveInfo,
+                          0
+                      );
 
-$utility->computeSNR($TarchiveID, $ArchLoc, $profile);
-$utility->orderModalitiesByAcq($TarchiveID, $ArchLoc);
+  my $CandMismatchError= $utility->validateCandidate(
+                                  $subjectIDsref,
+                                  $tarchiveInfo{'SourceLocation'}
+                         );
+
+  $utility->computeSNR($TarchiveID, $ArchLoc, $profile);
+  $utility->orderModalitiesByAcq($TarchiveID, $ArchLoc);
 
 =head1 DESCRIPTION
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -477,11 +477,11 @@ sub determinePSC {
 Determines which scanner ID was used for DICOM acquisitions.
 
 INPUTS:
-  $tarchiveInfo: tarchive information hashref
-  $to_log      : whether this step should be logged
-  $centerID    : center ID
-  $NewScanner  : whether a new scanner entry should be created if the scanner
-  used is a new scanner for the study
+  - $tarchiveInfo: tarchive information hashref
+  - $to_log      : whether this step should be logged
+  - $centerID    : center ID
+  - $NewScanner  : whether a new scanner entry should be created if the scanner
+                   used is a new scanner for the study
 
 RETURNS: scanner ID
 
@@ -535,7 +535,7 @@ sub determineScannerID {
 
 =head3 get_acqusitions($study_dir, \@acquisitions)
 
-UNUSED FUNCTION TO BE CLEANED UP IN ANOTHER PULL REQUEST
+UNUSED
 
 =cut
 
@@ -593,13 +593,13 @@ true, then it will bypass the additional protocol checks from the
 C<mri_protocol_checks> table using C<&extra_file_checks>.
 
 INPUTS:
-  $file                    : file's information hashref
-  $subjectIDsref           : subject's information hashref
-  $tarchiveInfo            : tarchive's information hashref
-  $center_name             : center name
-  $minc                    : absolute path to the MINC file
-  $acquisitionProtocol     : acquisition protocol if already knows it
-  $bypass_extra_file_checks: boolean, if set bypass the extra checks
+  - $file                    : file's information hashref
+  - $subjectIDsref           : subject's information hashref
+  - $tarchiveInfo            : tarchive's information hashref
+  - $center_name             : center name
+  - $minc                    : absolute path to the MINC file
+  - $acquisitionProtocol     : acquisition protocol if already knows it
+  - $bypass_extra_file_checks: boolean, if set bypass the extra checks
 
 RETURNS: acquisition protocol, acquisition protocol ID, array of extra checks
 
@@ -676,11 +676,11 @@ Returns the list of MRI protocol checks that failed. Can't directly insert
 this information here since the file isn't registered in the database yet.
 
 INPUTS:
-  $scan_type  : scan type of the file
-  $file       : file information hashref
-  $CandID     : candidate's CandID
-  $Visit_Label: visit label of the scan
-  $PatientName: patient name of the scan
+  - $scan_type  : scan type of the file
+  - $file       : file information hashref
+  - $CandID     : candidate's CandID
+  - $Visit_Label: visit label of the scan
+  - $PatientName: patient name of the scan
 
 RETURNS:
   - pass, warn or exclude flag depending on the worst failed check
@@ -847,13 +847,13 @@ sub loadAndCreateObjectFile {
 Renames and moves the MINC file.
 
 INPUTS:
-  $minc           : path to the MINC file
-  $subjectIDsref  : subject's ID hashref
-  $minc_type      : MINC file information hashref
-  $fileref        : file information hashref
-  $prefix         : study prefix
-  $data_dir       : data directory (typically /data/project/data)
-  $tarchive_srcloc: tarchive source location
+  - $minc           : path to the MINC file
+  - $subjectIDsref  : subject's ID hashref
+  - $minc_type      : MINC file information hashref
+  - $fileref        : file information hashref
+  - $prefix         : study prefix
+  - $data_dir       : data directory (typically /data/project/data)
+  - $tarchive_srcloc: tarchive source location
 
 RETURNS: new name of the MINC file with path relative to C<$data_dir>
 
@@ -916,15 +916,15 @@ sub move_minc {
 Registers the scan into the database.
 
 INPUTS:
-  $minc_file          : MINC file information hashref
-  $tarchiveInfo       : tarchive information hashref
-  $subjectIDsref      : subject's ID information hashref
-  $acquisitionProtocol: acquisition protocol
-  $minc               : MINC file to register into the database
-  $checks             : failed checks to register with the file
-  $reckless           : boolean, if reckless or not
-  $tarchive           : tarchive path
-  $sessionID          : session ID of the MINC file
+  - $minc_file          : MINC file information hashref
+  - $tarchiveInfo       : tarchive information hashref
+  - $subjectIDsref      : subject's ID information hashref
+  - $acquisitionProtocol: acquisition protocol
+  - $minc               : MINC file to register into the database
+  - $checks             : failed checks to register with the file
+  - $reckless           : boolean, if reckless or not
+  - $tarchive           : tarchive path
+  - $sessionID          : session ID of the MINC file
 
 RETURNS: acquisition protocol ID of the MINC file
 
@@ -1051,12 +1051,12 @@ sub registerScanIntoDB {
 Converts a DICOM study into MINC files.
 
 INPUTS:
-  $study_dir      : DICOM study directory to convert
-  $converter      : converter to be used
-  $get_dicom_info : get DICOM information setting from the Config table
-  $exclude        : which files to exclude from the dcm2mnc command
-  $mail_user      : mail of the user
-  $tarchive_srcloc: tarchive source location
+  - $study_dir      : DICOM study directory to convert
+  - $converter      : converter to be used
+  - $get_dicom_info : get DICOM information setting from the Config table
+  - $exclude        : which files to exclude from the dcm2mnc command
+  - $mail_user      : mail of the user
+  - $tarchive_srcloc: tarchive source location
 
 =cut
 
@@ -1295,11 +1295,11 @@ sub moveAndUpdateTarchive {
 Registers a new candidate in the candidate table.
 
 INPUTS:
-  $subjectIDsref: subject's ID information hashref
-  $gender       : gender of the candidate
-  $tarchiveInfo : tarchive information hashref
-  $User         : user that is running the pipeline
-  $centerID     : center ID
+  - $subjectIDsref: subject's ID information hashref
+  - $gender       : gender of the candidate
+  - $tarchiveInfo : tarchive information hashref
+  - $User         : user that is running the pipeline
+  - $centerID     : center ID
 
 =cut
 
@@ -1777,12 +1777,12 @@ sub getUploadIDUsingTarchiveSrcLoc {
 Calls the Notify->spool function to log all messages.
 
 INPUTS:
-  $message   : message to be logged in the database
-  $error     : if 'Y' it's an error log,
-               'N' otherwise
-  $upload_id : the upload_id
-  $verb      : 'N' for few main messages,
-               'Y' for more messages (developers)
+  - $message   : message to be logged in the database
+  - $error     : if 'Y' it's an error log,
+                 'N' otherwise
+  - $upload_id : the upload_id
+  - $verb      : 'N' for few main messages,
+                 'Y' for more messages (developers)
 
 =cut
 
@@ -1810,6 +1810,8 @@ Document the following functions:
   - concat_mri($minc_files)
   - registerProgs(@toregister)
 
+Remove function get_acqusitions($study_dir, \@acquisitions) that is not used
+
 =head1 BUGS
 
 None reported (or list of bugs)
@@ -1820,6 +1822,7 @@ License: GPLv3
 
 =head1 AUTHORS
 
-LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience
 
 =cut


### PR DESCRIPTION
Using perldoc/perlpod to document `MRIProcessingUtility.pm` so that users can type in the terminal
`perldoc MRIProcessingUtility.pm` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `MRIProcessingUtility.md` file has been created so that we have a web displayed version of the documentation.
`pod2markdown MRIProcessingUtility.pm > MRIProcessingUtility.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage