### PR TITLE
[Documentation] DICOM::Element library perldocification

### DIFF
--- a/dicom-archive/DICOM/Element.pm
+++ b/dicom-archive/DICOM/Element.pm
@@ -60,7 +60,7 @@ BEGIN {
 
 Creates a new instance of this class.
 
-RETURNS: a DICOM::Element object
+RETURNS: a C<DICOM::Element> object
 
 =cut
 
@@ -75,9 +75,12 @@ sub new {
 
 =head3 fill($IN, $dictref, $big_endian_image)
 
-Fills in self from file.
+Fills in C<self> from file.
 
-INPUT: input file, DICOM dictionary, if big endian image
+INPUTS:
+  - $IN              : input file
+  - $dictref         : DICOM dictionary
+  - $big_endian_image: if big endian image
 
 RETURNS: element hash
 
@@ -148,12 +151,12 @@ sub fill {
 
 Reads Int.
 
-INPUT:
-  $IN   : input file stream.
-  $bytes: SHORT (2) or INT (4) bytes.
-  $len  : total number of bytes in the field.
+INPUTS:
+  - $IN   : input file stream.
+  - $bytes: SHORT (2) or INT (4) bytes.
+  - $len  : total number of bytes in the field.
 
-If fieldlength > bytelength, multiple values are read in and stored as a
+If C<fieldlength> > C<bytelength>, multiple values are read in and stored as a
 string representation of an array.
 
 RETURNS: string representation of an array
@@ -188,7 +191,9 @@ sub readInt {
 
 Writes Int into the output file C<$OUT>.
 
-INPUT: output file, number of bytes in the field
+INPUTS:
+  - $OUT  : output file
+  - $bytes: number of bytes in the field
 
 =cut
 
@@ -213,8 +218,10 @@ sub writeInt {
 
 Reads Float.
 
-INPUT: input file stream, format of the variable, total number of bytes in
-the field.
+INPUTS:
+  - $IN    : input file stream
+  - $format: format of the variable
+  - $len   : total number of bytes in the field
 
 RETURNS: string
 
@@ -239,14 +246,15 @@ Reads Sequence.
 
 Three different cases:
     - implicit Value Representation (VR), explicit length
-    - explicit VR, undefined length, items of defined length
-       (w/end delimiter)
+    - explicit VR, undefined length, items of defined length (w/end delimiter)
     - implicit VR, undefined length, items of undefined length
 
 
-INPUT: input file stream, total number of bytes in the field
+INPUTS:
+  - $IN : input file stream
+  - $len: total number of bytes in the field
 
-RETURNS: ??????
+RETURNS: 'skipped' string
 
 =cut
 
@@ -403,7 +411,7 @@ sub values {
 
 =head3 print()
 
-Prints formatted representation of element to stdout.
+Prints formatted representation of element to C<STDOUT>.
 
 =cut
 
@@ -422,7 +430,7 @@ sub print {
 Returns a string representation of the value field.
 
 RETURNS: string representation of the value field, or null if value field is
-binary
+          binary
 
 =cut
 
@@ -521,9 +529,9 @@ sub setValue {
 
 =head3 byteswap($valref)
 
-?????
+Swaps byte.
 
-INPUT: value reference???
+INPUT: value reference
 
 =cut
 

--- a/dicom-archive/DICOM/Element.pm
+++ b/dicom-archive/DICOM/Element.pm
@@ -14,7 +14,7 @@ use DICOM::Element;
 
 =head1 DESCRIPTION
 
-Element routines for DICOM::DICOM module to read DICOM headers.
+Element routines for DICOM::DICOM module to read binary DICOM headers.
 
 Each element is a hash with the following keys:
   group	    Group (hex).
@@ -77,7 +77,7 @@ sub new {
 
 Fills in self from file.
 
-INPUT: input file, DICOM dictionary, big endian image
+INPUT: input file, DICOM dictionary, if big endian image
 
 RETURNS: element hash
 
@@ -146,7 +146,7 @@ sub fill {
 
 =head3 readInt($IN, $bytes, $len).
 
-Reads int variables. ??????????????????????????
+Reads Int.
 
 INPUT:
   $IN   : input file stream.
@@ -156,7 +156,7 @@ INPUT:
 If fieldlength > bytelength, multiple values are read in and stored as a
 string representation of an array.
 
-RETURNS: string representation of an array???
+RETURNS: string representation of an array
 
 =cut
 
@@ -186,7 +186,7 @@ sub readInt {
 
 =head3 writeInt($OUT, $bytes)
 
-Writes Int variable into the output file C<$OUT>. ?????
+Writes Int into the output file C<$OUT>.
 
 INPUT: output file, number of bytes in the field
 
@@ -211,12 +211,12 @@ sub writeInt {
 
 =head3 readFloat($IN, $format, $len)
 
-Reads float variables ????
+Reads Float.
 
 INPUT: input file stream, format of the variable, total number of bytes in
 the field.
 
-RETURNS: string ?????
+RETURNS: string
 
 =cut
 
@@ -235,10 +235,10 @@ sub readFloat {
 
 =head3 readSequence($IN, $len)
 
-Reads sequence. ??????
+Reads Sequence.
 
 Three different cases:
-    - implicit VR, explicit length
+    - implicit Value Representation (VR), explicit length
     - explicit VR, undefined length, items of defined length (w/end delimiter)
     - implicit VR, undefined length, items of undefined length
 
@@ -301,8 +301,8 @@ sub readSequence {
 
 =head3 readLength($IN)
 
-Reads length. ????????????????????????
-  - Implicit VR: Length is 4 byte int.
+Reads length.
+  - Implicit Value Representation (VR): Length is 4 byte int.
   - Explicit VR: 2 bytes hold VR, then 2 byte length.
 
 INPUT: input file stream

--- a/dicom-archive/DICOM/Element.pm
+++ b/dicom-archive/DICOM/Element.pm
@@ -8,7 +8,7 @@ DICOM::Element -- Element routines for DICOM::DICOM module
 
 =head1 SYNOPSIS
 
-use DICOM::Element;
+  use DICOM::Element;
 
 
 

--- a/dicom-archive/DICOM/Element.pm
+++ b/dicom-archive/DICOM/Element.pm
@@ -17,14 +17,14 @@ use DICOM::Element;
 Element routines for DICOM::DICOM module to read binary DICOM headers.
 
 Each element is a hash with the following keys:
-  group	    Group (hex).
-  element	Element within group (hex).
-  offset	Offset from file start (dec).
-  code	    Field code eg 'US', 'UI'.
-  length	Field value length (dec).
-  name	    Field descriptive name.
-  value	    Value.
-  header	All bytes up to value, for easy writing.
+  - group  : group (hex)
+  - element: element within group (hex)
+  - offset : offset from file start (dec)
+  - code   : field code eg 'US', 'UI'
+  - length : field value length (dec)
+  - name   : field descriptive name
+  - value  : value
+  - header : all bytes up to value, for easy writing
 
 =head2 Methods
 
@@ -239,7 +239,8 @@ Reads Sequence.
 
 Three different cases:
     - implicit Value Representation (VR), explicit length
-    - explicit VR, undefined length, items of defined length (w/end delimiter)
+    - explicit VR, undefined length, items of defined length
+       (w/end delimiter)
     - implicit VR, undefined length, items of undefined length
 
 
@@ -449,6 +450,8 @@ sub valueString {
 
 
 =pod
+
+=head3 write($OUTFILE)
 
 Writes this data element to disk. All fields up to value are stored in
 immutable field 'header' - write this to disk then value field.

--- a/dicom-archive/DICOM/Element.pm
+++ b/dicom-archive/DICOM/Element.pm
@@ -1,19 +1,34 @@
-# Element.pm ver 0.3
-# Andrew Crabb (ahc@jhu.edu), May 2002.
-# Element routines for DICOM.pm: a Perl module to read DICOM headers.
-# $Id: Element.pm 4 2007-12-11 20:21:51Z jharlap $
-
-# Each element is a hash with the following keys:
-#   group	Group (hex).
-#   element	Element within group (hex).
-#   offset	Offset from file start (dec).
-#   code	Field code eg 'US', 'UI'.
-#   length	Field value length (dec).
-#   name	Field descriptive name.
-#   value	Value.
-#   header	All bytes up to value, for easy writing.
-
 package DICOM::Element;
+
+=pod
+
+=head1 NAME
+
+DICOM::Element -- Element routines for DICOM::DICOM module
+
+=head1 SYNOPSIS
+
+use DICOM::Element;
+
+
+
+=head1 DESCRIPTION
+
+Element routines for DICOM::DICOM module to read DICOM headers.
+
+Each element is a hash with the following keys:
+  group	    Group (hex).
+  element	Element within group (hex).
+  offset	Offset from file start (dec).
+  code	    Field code eg 'US', 'UI'.
+  length	Field value length (dec).
+  name	    Field descriptive name.
+  value	    Value.
+  header	All bytes up to value, for easy writing.
+
+=head2 Methods
+
+=cut
 
 use strict;
 use DICOM::VRfields;
@@ -38,13 +53,35 @@ BEGIN {
   }
 }
 
+
+=pod
+
+=head3 new() (constructor)
+
+Creates a new instance of this class.
+
+RETURNS: a DICOM::Element object
+
+=cut
+
 sub new {
   my $type = shift;
   my $self = {};
   return bless $self, $type;
 }
 
-# Fill in self from file.
+
+=pod
+
+=head3 fill($IN, $dictref, $big_endian_image)
+
+Fills in self from file.
+
+INPUT: input file, DICOM dictionary, big endian image
+
+RETURNS: element hash
+
+=cut
 
 sub fill {
   my $this = shift;
@@ -104,12 +141,24 @@ sub fill {
   return $this;
 }
 
-# readInt(instream, bytelength, fieldlength).
-#   instream:	Input file stream.
-#   bytelength: SHORT (2) or INT (4) bytes.
-#   fieldlength:Total number of bytes in the field.
-# If fieldlength > bytelength, multiple values are read in and
-# stored as a string representation of an array.
+
+=pod
+
+=head3 readInt($IN, $bytes, $len).
+
+Reads int variables. ??????????????????????????
+
+INPUT:
+  $IN   : input file stream.
+  $bytes: SHORT (2) or INT (4) bytes.
+  $len  : total number of bytes in the field.
+
+If fieldlength > bytelength, multiple values are read in and stored as a
+string representation of an array.
+
+RETURNS: string representation of an array???
+
+=cut
 
 sub readInt {
   my ($IN, $bytes, $len) = @_;
@@ -132,6 +181,17 @@ sub readInt {
   return $val;
 }
 
+
+=pod
+
+=head3 writeInt($OUT, $bytes)
+
+Writes Int variable into the output file C<$OUT>. ?????
+
+INPUT: output file, number of bytes in the field
+
+=cut
+
 sub writeInt {
   my ($this, $OUT, $bytes) = @_;
   my $val = $this->{value};
@@ -146,6 +206,20 @@ sub writeInt {
   }
 }
 
+
+=pod
+
+=head3 readFloat($IN, $format, $len)
+
+Reads float variables ????
+
+INPUT: input file stream, format of the variable, total number of bytes in
+the field.
+
+RETURNS: string ?????
+
+=cut
+
 sub readFloat {
     my ($IN, $format, $len) = @_;
     my ($buff, $val);
@@ -155,6 +229,25 @@ sub readFloat {
     $val = unpack($format, $buff);
     return sprintf("%e", $val);
 }
+
+
+=pod
+
+=head3 readSequence($IN, $len)
+
+Reads sequence. ??????
+
+Three different cases:
+    - implicit VR, explicit length
+    - explicit VR, undefined length, items of defined length (w/end delimiter)
+    - implicit VR, undefined length, items of undefined length
+
+
+INPUT: input file stream, total number of bytes in the field
+
+RETURNS: ??????
+
+=cut
 
 sub readSequence {
     my ($IN, $len) = @_;
@@ -204,9 +297,19 @@ sub readSequence {
 }
 
 
-# Return the Value Field length, and length before Value Field.
-# Implicit VR: Length is 4 byte int.
-# Explicit VR: 2 bytes hold VR, then 2 byte length.
+=pod
+
+=head3 readLength($IN)
+
+Reads length. ????????????????????????
+  - Implicit VR: Length is 4 byte int.
+  - Explicit VR: 2 bytes hold VR, then 2 byte length.
+
+INPUT: input file stream
+
+RETURNS: the value field length, and length before value field
+
+=cut
 
 sub readLength {
   my ($IN) = @_;
@@ -272,7 +375,16 @@ sub readLength {
   return ($vrstr, $length);
 }
 
-# Return the values of each field.
+
+=pod
+
+=head3 values()
+
+Returns the values of each field of the object.
+
+RETURNS: values of each field
+
+=cut
 
 sub values {
   my $this = shift;
@@ -285,7 +397,14 @@ sub values {
   return @vals;
 }
 
-# Print formatted representation of element to stdout.
+
+=pod
+
+=head3 print()
+
+Prints formatted representation of element to stdout.
+
+=cut
 
 sub print {
   my $this = shift;
@@ -294,7 +413,17 @@ sub print {
   printf "(%04X, %04X) %s %6d: %-33s = %s\n", hex($gp), hex($el), $code, $len, $name, $val;
 }
 
-# Return a string representation of the value field (null if binary).
+
+=pod
+
+=head3 valueString()
+
+Returns a string representation of the value field.
+
+RETURNS: string representation of the value field, or null if value field is
+binary
+
+=cut
 
 sub valueString {
   my $this = shift;
@@ -318,8 +447,15 @@ sub valueString {
   return $value;
 }
 
-# Write this data element to disk.  All fields up to value are stored in 
-# immutable field 'header' - write this to disk then value field.
+
+=pod
+
+Writes this data element to disk. All fields up to value are stored in
+immutable field 'header' - write this to disk then value field.
+
+INPUT: output file
+
+=cut
 
 sub write {
   my ($this, $OUTFILE) = @_;
@@ -341,13 +477,33 @@ sub write {
   }
 }
 
+
+=pod
+
+=head3 value()
+
+Returns the value of the field.
+
+RETURNS: value field
+
+=cut
+
 sub value {
   my $this = shift;
 
   return $this->{'value'};
 }
 
-# Set the value field of this element.  Truncates to max length.
+
+=pod
+
+=head3 setValue($value)
+
+Sets the value field of this element. Truncates to max length.
+
+INPUT: value field
+
+=cut
 
 sub setValue {
   my $this = shift;
@@ -356,6 +512,17 @@ sub setValue {
 
   $this->{'value'} = $value;
 }
+
+
+=pod
+
+=head3 byteswap($valref)
+
+?????
+
+INPUT: value reference???
+
+=cut
 
 sub byteswap {
     my ($valref) = @_;
@@ -373,3 +540,29 @@ sub byteswap {
 1;
 __END__
 
+=pod
+
+=head1 TO DO
+
+Better documentation of the following functions:
+  - readInt()
+  - readFloat()
+  - readSequence($IN, $len)
+  - readLength($IN)
+  - writeInt($OUT, $bytes)
+  - byteswap($valref)
+
+=head1 BUGS
+
+None reported (or list of bugs)
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+Andrew Crabb (ahc@jhu.edu),
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut

--- a/dicom-archive/DICOM/Element.pm
+++ b/dicom-archive/DICOM/Element.pm
@@ -324,7 +324,8 @@ Reads the length of a VR from a file, as an integer encoded on 16 or 32 bits.
 
 INPUT: input file stream
 
-RETURNS: the value field length, and length before value field
+RETURNS: the VR code (string of length 2) and the length of the associated
+          VR value
 
 =cut
 
@@ -397,9 +398,11 @@ sub readLength {
 
 =head3 values()
 
-Returns the values of each field of the object.
+Returns the properties of a VR: group, element, offset, code, length, name and
+value.
 
-RETURNS: values of each field
+RETURNS: the properties of a VR: group, element, offset, code, length, name and
+          value
 
 =cut
 

--- a/docs/scripts_md/Element.md
+++ b/docs/scripts_md/Element.md
@@ -1,0 +1,152 @@
+# NAME
+
+DICOM::Element -- Element routines for DICOM::DICOM module
+
+# SYNOPSIS
+
+use DICOM::Element;
+
+# DESCRIPTION
+
+Element routines for DICOM::DICOM module to read DICOM headers.
+
+Each element is a hash with the following keys:
+  group	    Group (hex).
+  element	Element within group (hex).
+  offset	Offset from file start (dec).
+  code	    Field code eg 'US', 'UI'.
+  length	Field value length (dec).
+  name	    Field descriptive name.
+  value	    Value.
+  header	All bytes up to value, for easy writing.
+
+## Methods
+
+### new() (constructor)
+
+Creates a new instance of this class.
+
+RETURNS: a DICOM::Element object
+
+### fill($IN, $dictref, $big\_endian\_image)
+
+Fills in self from file.
+
+INPUT: input file, DICOM dictionary, big endian image
+
+RETURNS: element hash
+
+### readInt($IN, $bytes, $len).
+
+Reads int variables. ??????????????????????????
+
+INPUT:
+  $IN   : input file stream.
+  $bytes: SHORT (2) or INT (4) bytes.
+  $len  : total number of bytes in the field.
+
+If fieldlength > bytelength, multiple values are read in and stored as a
+string representation of an array.
+
+RETURNS: string representation of an array???
+
+### writeInt($OUT, $bytes)
+
+Writes Int variable into the output file `$OUT`. ?????
+
+INPUT: output file, number of bytes in the field
+
+### readFloat($IN, $format, $len)
+
+Reads float variables ????
+
+INPUT: input file stream, format of the variable, total number of bytes in
+the field.
+
+RETURNS: string ?????
+
+### readSequence($IN, $len)
+
+Reads sequence. ??????
+
+Three different cases:
+    - implicit VR, explicit length
+    - explicit VR, undefined length, items of defined length (w/end delimiter)
+    - implicit VR, undefined length, items of undefined length
+
+INPUT: input file stream, total number of bytes in the field
+
+RETURNS: ??????
+
+### readLength($IN)
+
+Reads length. ????????????????????????
+  - Implicit VR: Length is 4 byte int.
+  - Explicit VR: 2 bytes hold VR, then 2 byte length.
+
+INPUT: input file stream
+
+RETURNS: the value field length, and length before value field
+
+### values()
+
+Returns the values of each field of the object.
+
+RETURNS: values of each field
+
+### print()
+
+Prints formatted representation of element to stdout.
+
+### valueString()
+
+Returns a string representation of the value field.
+
+RETURNS: string representation of the value field, or null if value field is
+binary
+
+Writes this data element to disk. All fields up to value are stored in
+immutable field 'header' - write this to disk then value field.
+
+INPUT: output file
+
+### value()
+
+Returns the value of the field.
+
+RETURNS: value field
+
+### setValue($value)
+
+Sets the value field of this element. Truncates to max length.
+
+INPUT: value field
+
+### byteswap($valref)
+
+?????
+
+INPUT: value reference???
+
+# TO DO
+
+Better documentation of the following functions:
+  - readInt()
+  - readFloat()
+  - readSequence($IN, $len)
+  - readLength($IN)
+  - writeInt($OUT, $bytes)
+  - byteswap($valref)
+
+# BUGS
+
+None reported (or list of bugs)
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+Andrew Crabb (ahc@jhu.edu),
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/Element.md
+++ b/docs/scripts_md/Element.md
@@ -8,7 +8,7 @@ use DICOM::Element;
 
 # DESCRIPTION
 
-Element routines for DICOM::DICOM module to read DICOM headers.
+Element routines for DICOM::DICOM module to read binary DICOM headers.
 
 Each element is a hash with the following keys:
   group	    Group (hex).
@@ -32,13 +32,13 @@ RETURNS: a DICOM::Element object
 
 Fills in self from file.
 
-INPUT: input file, DICOM dictionary, big endian image
+INPUT: input file, DICOM dictionary, if big endian image
 
 RETURNS: element hash
 
 ### readInt($IN, $bytes, $len).
 
-Reads int variables. ??????????????????????????
+Reads Int.
 
 INPUT:
   $IN   : input file stream.
@@ -48,29 +48,29 @@ INPUT:
 If fieldlength > bytelength, multiple values are read in and stored as a
 string representation of an array.
 
-RETURNS: string representation of an array???
+RETURNS: string representation of an array
 
 ### writeInt($OUT, $bytes)
 
-Writes Int variable into the output file `$OUT`. ?????
+Writes Int into the output file `$OUT`.
 
 INPUT: output file, number of bytes in the field
 
 ### readFloat($IN, $format, $len)
 
-Reads float variables ????
+Reads Float.
 
 INPUT: input file stream, format of the variable, total number of bytes in
 the field.
 
-RETURNS: string ?????
+RETURNS: string
 
 ### readSequence($IN, $len)
 
-Reads sequence. ??????
+Reads Sequence.
 
 Three different cases:
-    - implicit VR, explicit length
+    - implicit Value Representation (VR), explicit length
     - explicit VR, undefined length, items of defined length (w/end delimiter)
     - implicit VR, undefined length, items of undefined length
 
@@ -80,8 +80,8 @@ RETURNS: ??????
 
 ### readLength($IN)
 
-Reads length. ????????????????????????
-  - Implicit VR: Length is 4 byte int.
+Reads length.
+  - Implicit Value Representation (VR): Length is 4 byte int.
   - Explicit VR: 2 bytes hold VR, then 2 byte length.
 
 INPUT: input file stream

--- a/docs/scripts_md/Element.md
+++ b/docs/scripts_md/Element.md
@@ -35,13 +35,13 @@ Fills in `self` from file.
 INPUTS:
   - $IN              : input file
   - $dictref         : DICOM dictionary
-  - $big\_endian\_image: if big endian image
 
 RETURNS: element hash
 
 ### readInt($IN, $bytes, $len).
 
-Reads Int.
+Decodes one or more integers that were encoded as a string of bytes
+(2 or 4 bytes per number) in the file whose handle is passed as argument.
 
 INPUTS:
   - $IN   : input file stream.
@@ -51,30 +51,37 @@ INPUTS:
 If `fieldlength` > `bytelength`, multiple values are read in and stored as a
 string representation of an array.
 
-RETURNS: string representation of an array
+RETURNS: string representation of the array of decoded integers
+          (e.g. '\[34, 65, 900\]')
 
 ### writeInt($OUT, $bytes)
 
-Writes Int into the output file `$OUT`.
+Encodes each integer stored in string `$this-`{'value'}> as a 2 or 4 byte
+string and writes them in a file
 
 INPUTS:
   - $OUT  : output file
-  - $bytes: number of bytes in the field
+  - $bytes: number of bytes (2 for shorts 4 for ints) in the field
 
 ### readFloat($IN, $format, $len)
 
-Reads Float.
+Decodes a floating point number that was encoded as a string of bytes in the
+file whose handle is passed as argument.
 
 INPUTS:
   - $IN    : input file stream
-  - $format: format of the variable
+  - $format: format used when decoding (with Perl's `unpack`) the number:
+              `f` for floats and `d` for doubles
   - $len   : total number of bytes in the field
 
 RETURNS: string
 
 ### readSequence($IN, $len)
 
-Reads Sequence.
+Skips over either a fixed number of bytes or over multiple sets of byte
+sequences delimited with specific byte values. When doing the latter,
+byte `0x00000000` is used to signal the end of the set of sequences.
+The sequence of bytes read is always discarded.
 
 Three different cases:
     - implicit Value Representation (VR), explicit length
@@ -83,13 +90,14 @@ Three different cases:
 
 INPUTS:
   - $IN : input file stream
-  - $len: total number of bytes in the field
+  - $len: total number of bytes to skip, or 0 if all sequences should be
+           skipped until the delimiter `0x00000000` is found
 
 RETURNS: 'skipped' string
 
 ### readLength($IN)
 
-Reads length.
+Reads the length of a VR from a file, as an integer encoded on 16 or 32 bits.
   - Implicit Value Representation (VR): Length is 4 byte int.
   - Explicit VR: 2 bytes hold VR, then 2 byte length.
 

--- a/docs/scripts_md/Element.md
+++ b/docs/scripts_md/Element.md
@@ -26,13 +26,16 @@ Each element is a hash with the following keys:
 
 Creates a new instance of this class.
 
-RETURNS: a DICOM::Element object
+RETURNS: a `DICOM::Element` object
 
 ### fill($IN, $dictref, $big\_endian\_image)
 
-Fills in self from file.
+Fills in `self` from file.
 
-INPUT: input file, DICOM dictionary, if big endian image
+INPUTS:
+  - $IN              : input file
+  - $dictref         : DICOM dictionary
+  - $big\_endian\_image: if big endian image
 
 RETURNS: element hash
 
@@ -40,12 +43,12 @@ RETURNS: element hash
 
 Reads Int.
 
-INPUT:
-  $IN   : input file stream.
-  $bytes: SHORT (2) or INT (4) bytes.
-  $len  : total number of bytes in the field.
+INPUTS:
+  - $IN   : input file stream.
+  - $bytes: SHORT (2) or INT (4) bytes.
+  - $len  : total number of bytes in the field.
 
-If fieldlength > bytelength, multiple values are read in and stored as a
+If `fieldlength` > `bytelength`, multiple values are read in and stored as a
 string representation of an array.
 
 RETURNS: string representation of an array
@@ -54,14 +57,18 @@ RETURNS: string representation of an array
 
 Writes Int into the output file `$OUT`.
 
-INPUT: output file, number of bytes in the field
+INPUTS:
+  - $OUT  : output file
+  - $bytes: number of bytes in the field
 
 ### readFloat($IN, $format, $len)
 
 Reads Float.
 
-INPUT: input file stream, format of the variable, total number of bytes in
-the field.
+INPUTS:
+  - $IN    : input file stream
+  - $format: format of the variable
+  - $len   : total number of bytes in the field
 
 RETURNS: string
 
@@ -71,13 +78,14 @@ Reads Sequence.
 
 Three different cases:
     - implicit Value Representation (VR), explicit length
-    - explicit VR, undefined length, items of defined length
-       (w/end delimiter)
+    - explicit VR, undefined length, items of defined length (w/end delimiter)
     - implicit VR, undefined length, items of undefined length
 
-INPUT: input file stream, total number of bytes in the field
+INPUTS:
+  - $IN : input file stream
+  - $len: total number of bytes in the field
 
-RETURNS: ??????
+RETURNS: 'skipped' string
 
 ### readLength($IN)
 
@@ -97,14 +105,14 @@ RETURNS: values of each field
 
 ### print()
 
-Prints formatted representation of element to stdout.
+Prints formatted representation of element to `STDOUT`.
 
 ### valueString()
 
 Returns a string representation of the value field.
 
 RETURNS: string representation of the value field, or null if value field is
-binary
+          binary
 
 ### write($OUTFILE)
 
@@ -127,9 +135,9 @@ INPUT: value field
 
 ### byteswap($valref)
 
-?????
+Swaps byte.
 
-INPUT: value reference???
+INPUT: value reference
 
 # TO DO
 

--- a/docs/scripts_md/Element.md
+++ b/docs/scripts_md/Element.md
@@ -4,7 +4,7 @@ DICOM::Element -- Element routines for DICOM::DICOM module
 
 # SYNOPSIS
 
-use DICOM::Element;
+    use DICOM::Element;
 
 # DESCRIPTION
 

--- a/docs/scripts_md/Element.md
+++ b/docs/scripts_md/Element.md
@@ -11,14 +11,14 @@ use DICOM::Element;
 Element routines for DICOM::DICOM module to read binary DICOM headers.
 
 Each element is a hash with the following keys:
-  group	    Group (hex).
-  element	Element within group (hex).
-  offset	Offset from file start (dec).
-  code	    Field code eg 'US', 'UI'.
-  length	Field value length (dec).
-  name	    Field descriptive name.
-  value	    Value.
-  header	All bytes up to value, for easy writing.
+  - group  : group (hex)
+  - element: element within group (hex)
+  - offset : offset from file start (dec)
+  - code   : field code eg 'US', 'UI'
+  - length : field value length (dec)
+  - name   : field descriptive name
+  - value  : value
+  - header : all bytes up to value, for easy writing
 
 ## Methods
 
@@ -71,7 +71,8 @@ Reads Sequence.
 
 Three different cases:
     - implicit Value Representation (VR), explicit length
-    - explicit VR, undefined length, items of defined length (w/end delimiter)
+    - explicit VR, undefined length, items of defined length
+       (w/end delimiter)
     - implicit VR, undefined length, items of undefined length
 
 INPUT: input file stream, total number of bytes in the field
@@ -104,6 +105,8 @@ Returns a string representation of the value field.
 
 RETURNS: string representation of the value field, or null if value field is
 binary
+
+### write($OUTFILE)
 
 Writes this data element to disk. All fields up to value are stored in
 immutable field 'header' - write this to disk then value field.

--- a/docs/scripts_md/Element.md
+++ b/docs/scripts_md/Element.md
@@ -103,13 +103,16 @@ Reads the length of a VR from a file, as an integer encoded on 16 or 32 bits.
 
 INPUT: input file stream
 
-RETURNS: the value field length, and length before value field
+RETURNS: the VR code (string of length 2) and the length of the associated
+          VR value
 
 ### values()
 
-Returns the values of each field of the object.
+Returns the properties of a VR: group, element, offset, code, length, name and
+value.
 
-RETURNS: values of each field
+RETURNS: the properties of a VR: group, element, offset, code, length, name and
+          value
 
 ### print()
 


### PR DESCRIPTION
Using perldoc/perlpod to document `Element.pm` so that users can type in the terminal
`perldoc Element.pm` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `Element.md` file has been created so that we have a web displayed version of the documentation.
`pod2markdown Element.pm > Element.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage