### PR TITLE
[Documentation] DICOM::VRfields library perldocification

### DIFF
--- a/dicom-archive/DICOM/VRfields.pm
+++ b/dicom-archive/DICOM/VRfields.pm
@@ -8,15 +8,15 @@ DICOM::VRfields -- Value Representations (DICOM Standard PS 3.5 Sect 6.2)
 
 =head1 SYNOPSIS
 
-# Initialize VR hash.
-# Fill in VR definitions from DICOM_fields.
-BEGIN {
-  foreach my $line (@VR) {
-    next if ($line =~ /^\#/);
-    my ($vr, $name, $len, $fix, $numeric, $byteswap) = split(/\t+/, $line);
-    $VR{$vr} = [($name, $len, $fix, $numeric, $byteswap)];
+  # Initialize VR hash.
+  # Fill in VR definitions from DICOM_fields.
+  BEGIN {
+    foreach my $line (@VR) {
+      next if ($line =~ /^\#/);
+      my ($vr, $name, $len, $fix, $numeric, $byteswap) = split(/\t+/, $line);
+      $VR{$vr} = [($name, $len, $fix, $numeric, $byteswap)];
+    }
   }
-}
 
 =head1 DESCRIPTION
 

--- a/dicom-archive/DICOM/VRfields.pm
+++ b/dicom-archive/DICOM/VRfields.pm
@@ -26,33 +26,33 @@ Value Representations (DICOM Standard PS 3.5 Sect 6.2)
 
 Simply creating an array of DICOM Value Representations:
 
-  Code  Name                     Bytes  Fixed  Numeric  ByteSwap.
+  Code  Name                     Bytes  Fixed  Numeric  ByteSwap
   AE    'Application Entity'     16     0      0        0
   AS    'Age String'             4      1      0        0
-  AT	  'Attribute Tag'          4      1      0        1
-  CS    'Code String'            16     0	     0        0
-  DA    'Date'                   8      1	     0        0
-  DS    'Decimal String'         16     0	     1        0
-  DT    'Date Time'              26     0	     0        0
-  FL    'Floating Point Single'  4      1	     1        1
-  FD    'Floating Point Double'  8      1	     1        1
-  IS    'Integer String'         12     0	     1        0
-  LO    'Long Strong'            64     0	     0        0
-  LT    'Long Text'              10240  0	     0        0
-  OB    'Other Byte String'  	   0      0	     0        0
-  OW    'Other Word String' 	   0      0	     0        1
-  PN    'Person Name'	           64     0	     0        0
-  SH    'Short String'           16     0	     0        0
-  SL    'Signed Long'	           4      1	     1        1
-  SQ    'Sequence of Items'      0      0	     0        0
-  SS    'Signed Short'           2      1	     1        1
-  ST    'Short Text'             1024   0	     0        0
-  TM    'Time'                   16     0	     0        0
-  UI    'Unique Identifier UID'  64     0	     0        0
-  UL    'Unsigned Long'          4      1	     1        1
-  UN    'Unknown'	               0      0	     0        0
-  US    'Unsigned Short'         2      1	     1        1
-  UT    'Unlimited Text'         0      0	     0        0
+  AT	'Attribute Tag'          4      1      0        1
+  CS    'Code String'            16     0      0        0
+  DA    'Date'                   8      1      0        0
+  DS    'Decimal String'         16     0      1        0
+  DT    'Date Time'              26     0      0        0
+  FL    'Floating Point Single'  4      1      1        1
+  FD    'Floating Point Double'  8      1      1        1
+  IS    'Integer String'         12     0      1        0
+  LO    'Long Strong'            64     0      0        0
+  LT    'Long Text'              10240  0      0        0
+  OB    'Other Byte String'  	 0      0      0        0
+  OW    'Other Word String' 	 0      0      0        1
+  PN    'Person Name'	         64     0      0        0
+  SH    'Short String'           16     0      0        0
+  SL    'Signed Long'	         4      1      1        1
+  SQ    'Sequence of Items'      0      0      0        0
+  SS    'Signed Short'           2      1      1        1
+  ST    'Short Text'             1024   0      0        0
+  TM    'Time'                   16     0      0        0
+  UI    'Unique Identifier UID'  64     0      0        0
+  UL    'Unsigned Long'          4      1      1        1
+  UN    'Unknown'                0      0      0        0
+  US    'Unsigned Short'         2      1      1        1
+  UT    'Unlimited Text'         0      0      0        0
 
 =cut
 

--- a/dicom-archive/DICOM/VRfields.pm
+++ b/dicom-archive/DICOM/VRfields.pm
@@ -8,6 +8,10 @@ DICOM::VRfields -- Value Representations (DICOM Standard PS 3.5 Sect 6.2)
 
 =head1 SYNOPSIS
 
+  use DICOM::Element;
+  use DICOM::Fields;	# Standard header definitions.
+  use DICOM::Private;	# Private or custom definitions.
+
   # Initialize VR hash.
   # Fill in VR definitions from DICOM_fields.
   BEGIN {

--- a/dicom-archive/DICOM/VRfields.pm
+++ b/dicom-archive/DICOM/VRfields.pm
@@ -24,34 +24,35 @@ Value Representations (DICOM Standard PS 3.5 Sect 6.2)
   - Bytes=0 => Undefined length.
   - Fixed=1 => Exact field length, otherwise max length.
 
-Simply creating an array of:
-Code  Name                     Bytes  Fixed  Numeric  ByteSwap.
-AE    'Application Entity'     16     0      0        0
-AS    'Age String'             4      1      0        0
-AT	  'Attribute Tag'          4      1      0        1
-CS    'Code String'            16     0	     0        0
-DA    'Date'                   8      1	     0        0
-DS    'Decimal String'         16     0	     1        0
-DT    'Date Time'              26     0	     0        0
-FL    'Floating Point Single'  4      1	     1        1
-FD    'Floating Point Double'  8      1	     1        1
-IS    'Integer String'         12     0	     1        0
-LO    'Long Strong'            64     0	     0        0
-LT    'Long Text'              10240  0	     0        0
-OB    'Other Byte String'  	   0      0	     0        0
-OW    'Other Word String' 	   0      0	     0        1
-PN    'Person Name'	           64     0	     0        0
-SH    'Short String'           16     0	     0        0
-SL    'Signed Long'	           4      1	     1        1
-SQ    'Sequence of Items'      0      0	     0        0
-SS    'Signed Short'           2      1	     1        1
-ST    'Short Text'             1024   0	     0        0
-TM    'Time'                   16     0	     0        0
-UI    'Unique Identifier UID'  64     0	     0        0
-UL    'Unsigned Long'          4      1	     1        1
-UN    'Unknown'	               0      0	     0        0
-US    'Unsigned Short'         2      1	     1        1
-UT    'Unlimited Text'         0      0	     0        0
+Simply creating an array of DICOM Value Representations:
+
+  Code  Name                     Bytes  Fixed  Numeric  ByteSwap.
+  AE    'Application Entity'     16     0      0        0
+  AS    'Age String'             4      1      0        0
+  AT	  'Attribute Tag'          4      1      0        1
+  CS    'Code String'            16     0	     0        0
+  DA    'Date'                   8      1	     0        0
+  DS    'Decimal String'         16     0	     1        0
+  DT    'Date Time'              26     0	     0        0
+  FL    'Floating Point Single'  4      1	     1        1
+  FD    'Floating Point Double'  8      1	     1        1
+  IS    'Integer String'         12     0	     1        0
+  LO    'Long Strong'            64     0	     0        0
+  LT    'Long Text'              10240  0	     0        0
+  OB    'Other Byte String'  	   0      0	     0        0
+  OW    'Other Word String' 	   0      0	     0        1
+  PN    'Person Name'	           64     0	     0        0
+  SH    'Short String'           16     0	     0        0
+  SL    'Signed Long'	           4      1	     1        1
+  SQ    'Sequence of Items'      0      0	     0        0
+  SS    'Signed Short'           2      1	     1        1
+  ST    'Short Text'             1024   0	     0        0
+  TM    'Time'                   16     0	     0        0
+  UI    'Unique Identifier UID'  64     0	     0        0
+  UL    'Unsigned Long'          4      1	     1        1
+  UN    'Unknown'	               0      0	     0        0
+  US    'Unsigned Short'         2      1	     1        1
+  UT    'Unlimited Text'         0      0	     0        0
 
 =cut
 

--- a/docs/scripts_md/VRfields.md
+++ b/docs/scripts_md/VRfields.md
@@ -1,24 +1,20 @@
-package DICOM::VRfields;
-
-=pod
-
-=head1 NAME
+# NAME
 
 DICOM::VRfields -- Value Representations (DICOM Standard PS 3.5 Sect 6.2)
 
-=head1 SYNOPSIS
+# SYNOPSIS
 
-# Initialize VR hash.
-# Fill in VR definitions from DICOM_fields.
+\# Initialize VR hash.
+\# Fill in VR definitions from DICOM\_fields.
 BEGIN {
   foreach my $line (@VR) {
-    next if ($line =~ /^\#/);
-    my ($vr, $name, $len, $fix, $numeric, $byteswap) = split(/\t+/, $line);
-    $VR{$vr} = [($name, $len, $fix, $numeric, $byteswap)];
+    next if ($line =~ /^\\#/);
+    my ($vr, $name, $len, $fix, $numeric, $byteswap) = split(/\\t+/, $line);
+    $VR{$vr} = \[($name, $len, $fix, $numeric, $byteswap)\];
   }
 }
 
-=head1 DESCRIPTION
+# DESCRIPTION
 
 Value Representations (DICOM Standard PS 3.5 Sect 6.2)
   - Bytes=0 => Undefined length.
@@ -53,71 +49,19 @@ UN    'Unknown'	               0      0	     0        0
 US    'Unsigned Short'         2      1	     1        1
 UT    'Unlimited Text'         0      0	     0        0
 
-=cut
-
-
-use strict;
-use vars qw(@ISA @EXPORT $VERSION @VR);
-
-require Exporter;
-
-@ISA = qw(Exporter);
-@EXPORT = qw(@VR);
-$VERSION = sprintf "%d", q$Revision: 4 $ =~ /: (\d+)/;
-
-# Value Representations (DICOM Standard PS 3.5 Sect 6.2)
-# Bytes=0 => Undefined length.
-# Fixed=1 => Exact field length, otherwise max length.
-# Code  Name                    Bytes   Fixed   Numeric ByteSwap
-
-@VR = (<<END_VR =~ m/^\s*(.+)/gm);
-AE	'Application Entity'	16	0	0	0
-AS	'Age String'		4	1	0	0
-AT	'Attribute Tag'		4	1	0	1
-CS	'Code String'		16	0	0	0
-DA	'Date'			8	1	0	0
-DS	'Decimal String'	16	0	1	0
-DT	'Date Time'		26	0	0	0
-FL	'Floating Point Single'	4	1	1	1
-FD	'Floating Point Double'	8	1	1	1
-IS	'Integer String'	12	0	1	0
-LO	'Long Strong'		64	0	0	0
-LT	'Long Text'		10240	0	0	0
-OB	'Other Byte String'	0	0	0	0
-OW	'Other Word String'	0	0	0	1
-PN	'Person Name'		64	0	0	0
-SH	'Short String'		16	0	0	0
-SL	'Signed Long'		4	1	1	1
-SQ	'Sequence of Items'	0	0	0	0
-SS	'Signed Short'		2	1	1	1
-ST	'Short Text'		1024	0	0	0
-TM	'Time'			16	0	0	0
-UI	'Unique Identifier UID'	64	0	0	0
-UL	'Unsigned Long'		4	1	1	1
-UN	'Unknown'		0	0	0	0
-US	'Unsigned Short'	2	1	1	1
-UT	'Unlimited Text'	0	0	0	0
-END_VR
-
-
-=pod
-
-=head1 TO DO
+# TO DO
 
 Nothing planned.
 
-=head1 BUGS
+# BUGS
 
 None reported.
 
-=head1 LICENSING
+# LICENSING
 
 License: GPLv3
 
-=head1 AUTHORS
+# AUTHORS
 
 Andrew Crabb (ahc@jhu.edu),
 LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
-
-=cut
-

--- a/docs/scripts_md/VRfields.md
+++ b/docs/scripts_md/VRfields.md
@@ -4,6 +4,10 @@ DICOM::VRfields -- Value Representations (DICOM Standard PS 3.5 Sect 6.2)
 
 # SYNOPSIS
 
+    use DICOM::Element;
+    use DICOM::Fields;    # Standard header definitions.
+    use DICOM::Private;   # Private or custom definitions.
+
     # Initialize VR hash.
     # Fill in VR definitions from DICOM_fields.
     BEGIN {

--- a/docs/scripts_md/VRfields.md
+++ b/docs/scripts_md/VRfields.md
@@ -20,34 +20,35 @@ Value Representations (DICOM Standard PS 3.5 Sect 6.2)
   - Bytes=0 => Undefined length.
   - Fixed=1 => Exact field length, otherwise max length.
 
-Simply creating an array of:
-Code  Name                     Bytes  Fixed  Numeric  ByteSwap.
-AE    'Application Entity'     16     0      0        0
-AS    'Age String'             4      1      0        0
-AT	  'Attribute Tag'          4      1      0        1
-CS    'Code String'            16     0	     0        0
-DA    'Date'                   8      1	     0        0
-DS    'Decimal String'         16     0	     1        0
-DT    'Date Time'              26     0	     0        0
-FL    'Floating Point Single'  4      1	     1        1
-FD    'Floating Point Double'  8      1	     1        1
-IS    'Integer String'         12     0	     1        0
-LO    'Long Strong'            64     0	     0        0
-LT    'Long Text'              10240  0	     0        0
-OB    'Other Byte String'  	   0      0	     0        0
-OW    'Other Word String' 	   0      0	     0        1
-PN    'Person Name'	           64     0	     0        0
-SH    'Short String'           16     0	     0        0
-SL    'Signed Long'	           4      1	     1        1
-SQ    'Sequence of Items'      0      0	     0        0
-SS    'Signed Short'           2      1	     1        1
-ST    'Short Text'             1024   0	     0        0
-TM    'Time'                   16     0	     0        0
-UI    'Unique Identifier UID'  64     0	     0        0
-UL    'Unsigned Long'          4      1	     1        1
-UN    'Unknown'	               0      0	     0        0
-US    'Unsigned Short'         2      1	     1        1
-UT    'Unlimited Text'         0      0	     0        0
+Simply creating an array of DICOM Value Representations:
+
+    Code  Name                     Bytes  Fixed  Numeric  ByteSwap.
+    AE    'Application Entity'     16     0      0        0
+    AS    'Age String'             4      1      0        0
+    AT      'Attribute Tag'          4      1      0        1
+    CS    'Code String'            16     0            0        0
+    DA    'Date'                   8      1            0        0
+    DS    'Decimal String'         16     0            1        0
+    DT    'Date Time'              26     0            0        0
+    FL    'Floating Point Single'  4      1            1        1
+    FD    'Floating Point Double'  8      1            1        1
+    IS    'Integer String'         12     0            1        0
+    LO    'Long Strong'            64     0            0        0
+    LT    'Long Text'              10240  0            0        0
+    OB    'Other Byte String'        0      0          0        0
+    OW    'Other Word String'        0      0          0        1
+    PN    'Person Name'              64     0          0        0
+    SH    'Short String'           16     0            0        0
+    SL    'Signed Long'              4      1          1        1
+    SQ    'Sequence of Items'      0      0            0        0
+    SS    'Signed Short'           2      1            1        1
+    ST    'Short Text'             1024   0            0        0
+    TM    'Time'                   16     0            0        0
+    UI    'Unique Identifier UID'  64     0            0        0
+    UL    'Unsigned Long'          4      1            1        1
+    UN    'Unknown'                      0      0      0        0
+    US    'Unsigned Short'         2      1            1        1
+    UT    'Unlimited Text'         0      0            0        0
 
 # TO DO
 

--- a/docs/scripts_md/VRfields.md
+++ b/docs/scripts_md/VRfields.md
@@ -22,33 +22,33 @@ Value Representations (DICOM Standard PS 3.5 Sect 6.2)
 
 Simply creating an array of DICOM Value Representations:
 
-    Code  Name                     Bytes  Fixed  Numeric  ByteSwap.
+    Code  Name                     Bytes  Fixed  Numeric  ByteSwap
     AE    'Application Entity'     16     0      0        0
     AS    'Age String'             4      1      0        0
-    AT      'Attribute Tag'          4      1      0        1
-    CS    'Code String'            16     0            0        0
-    DA    'Date'                   8      1            0        0
-    DS    'Decimal String'         16     0            1        0
-    DT    'Date Time'              26     0            0        0
-    FL    'Floating Point Single'  4      1            1        1
-    FD    'Floating Point Double'  8      1            1        1
-    IS    'Integer String'         12     0            1        0
-    LO    'Long Strong'            64     0            0        0
-    LT    'Long Text'              10240  0            0        0
-    OB    'Other Byte String'        0      0          0        0
-    OW    'Other Word String'        0      0          0        1
-    PN    'Person Name'              64     0          0        0
-    SH    'Short String'           16     0            0        0
-    SL    'Signed Long'              4      1          1        1
-    SQ    'Sequence of Items'      0      0            0        0
-    SS    'Signed Short'           2      1            1        1
-    ST    'Short Text'             1024   0            0        0
-    TM    'Time'                   16     0            0        0
-    UI    'Unique Identifier UID'  64     0            0        0
-    UL    'Unsigned Long'          4      1            1        1
-    UN    'Unknown'                      0      0      0        0
-    US    'Unsigned Short'         2      1            1        1
-    UT    'Unlimited Text'         0      0            0        0
+    AT    'Attribute Tag'          4      1      0        1
+    CS    'Code String'            16     0      0        0
+    DA    'Date'                   8      1      0        0
+    DS    'Decimal String'         16     0      1        0
+    DT    'Date Time'              26     0      0        0
+    FL    'Floating Point Single'  4      1      1        1
+    FD    'Floating Point Double'  8      1      1        1
+    IS    'Integer String'         12     0      1        0
+    LO    'Long Strong'            64     0      0        0
+    LT    'Long Text'              10240  0      0        0
+    OB    'Other Byte String'      0      0      0        0
+    OW    'Other Word String'      0      0      0        1
+    PN    'Person Name'            64     0      0        0
+    SH    'Short String'           16     0      0        0
+    SL    'Signed Long'            4      1      1        1
+    SQ    'Sequence of Items'      0      0      0        0
+    SS    'Signed Short'           2      1      1        1
+    ST    'Short Text'             1024   0      0        0
+    TM    'Time'                   16     0      0        0
+    UI    'Unique Identifier UID'  64     0      0        0
+    UL    'Unsigned Long'          4      1      1        1
+    UN    'Unknown'                0      0      0        0
+    US    'Unsigned Short'         2      1      1        1
+    UT    'Unlimited Text'         0      0      0        0
 
 # TO DO
 

--- a/docs/scripts_md/VRfields.md
+++ b/docs/scripts_md/VRfields.md
@@ -4,15 +4,15 @@ DICOM::VRfields -- Value Representations (DICOM Standard PS 3.5 Sect 6.2)
 
 # SYNOPSIS
 
-\# Initialize VR hash.
-\# Fill in VR definitions from DICOM\_fields.
-BEGIN {
-  foreach my $line (@VR) {
-    next if ($line =~ /^\\#/);
-    my ($vr, $name, $len, $fix, $numeric, $byteswap) = split(/\\t+/, $line);
-    $VR{$vr} = \[($name, $len, $fix, $numeric, $byteswap)\];
-  }
-}
+    # Initialize VR hash.
+    # Fill in VR definitions from DICOM_fields.
+    BEGIN {
+      foreach my $line (@VR) {
+        next if ($line =~ /^\#/);
+        my ($vr, $name, $len, $fix, $numeric, $byteswap) = split(/\t+/, $line);
+        $VR{$vr} = [($name, $len, $fix, $numeric, $byteswap)];
+      }
+    }
 
 # DESCRIPTION
 


### PR DESCRIPTION
Using perldoc/perlpod to document `VRfields.pm` so that users can type in the terminal
`perldoc VRfields.pm` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `VRfields.md` file has been created so that we have a web displayed version of the documentation.
`pod2markdown VRfields.pm > VRfields.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage