### PR TITLE
[Documentation] DICOM::Fields library perldocification

### DIFF
--- a/dicom-archive/DICOM/Fields.pm
+++ b/dicom-archive/DICOM/Fields.pm
@@ -27,8 +27,8 @@ DICOM::Fields -- Definitions of fields of DICOM headers.
 
 =head1 DESCRIPTION
 
-Definitions of fields of DICOM headers. Not for medical use. This file is
-provided purely for experimental use.
+Definitions of fields of DICOM headers. This file is provided purely for
+experimental use.
 
 Simply creating an array of:
 

--- a/dicom-archive/DICOM/Fields.pm
+++ b/dicom-archive/DICOM/Fields.pm
@@ -4,6 +4,25 @@
 
 package DICOM::Fields;
 
+=pod
+
+=head1 NAME
+
+DICOM::Fields
+
+=head1 SYNOPSIS
+
+A few lines of code on how to use the package or script
+
+=head1 DESCRIPTION
+
+Overall description of the package or script
+
+=head2 Methods
+
+=cut
+
+
 use strict;
 
 require Exporter;

--- a/dicom-archive/DICOM/Fields.pm
+++ b/dicom-archive/DICOM/Fields.pm
@@ -8,7 +8,7 @@ package DICOM::Fields;
 
 =head1 NAME
 
-DICOM::Fields
+DICOM::Fields -- Definitions of fields of DICOM headers.
 
 =head1 SYNOPSIS
 
@@ -16,9 +16,20 @@ A few lines of code on how to use the package or script
 
 =head1 DESCRIPTION
 
-Overall description of the package or script
+Definitions of fields of DICOM headers. Not for medical use. This file is
+provided purely for experimental use.
 
-=head2 Methods
+Simply creating an array of:
+  0000   0000   UL   1      GroupLength
+  0000   0001   UL   1      CommandLengthToEnd
+  0000   0002   UI   1      AffectedSOPClassUID
+  0000   0003   UI   1      RequestedSOPClassUID
+  0000   0010   CS   1      CommandRecognitionCode
+  0000   0100   US   1      CommandField
+  0000   0110   US   1      MessageID
+  0000   0120   US   1      MessageIDBeingRespondedTo
+  0000   0200   AE   1      Initiator
+  ...
 
 =cut
 

--- a/dicom-archive/DICOM/Fields.pm
+++ b/dicom-archive/DICOM/Fields.pm
@@ -1,7 +1,3 @@
-# Definitions of fields of DICOM headers.
-# Andrew Crabb (ahc@jhu.edu), May 2002.
-# $Id: Fields.pm 4 2007-12-11 20:21:51Z jharlap $
-
 package DICOM::Fields;
 
 =pod
@@ -12,7 +8,22 @@ DICOM::Fields -- Definitions of fields of DICOM headers.
 
 =head1 SYNOPSIS
 
-A few lines of code on how to use the package or script
+  use DICOM::Element;
+  use DICOM::Fields;	# Standard header definitions.
+  use DICOM::Private;	# Private or custom definitions.
+
+  # Initialize dictionary.
+  # Read the contents of the DICOM dictionary into a hash by group and element.
+  # dicom_private is read after dicom_fields, so overrides common fields.
+  BEGIN {
+    foreach my $line (@dicom_fields, @dicom_private) {
+      next if ($line =~ /^\#/);
+      my ($group, $elem, $code, $numa, $name) = split(/\s+/, $line);
+      my @lst = ($code, $name);
+      $dict{$group}{$elem} = [@lst];
+    }
+  }
+
 
 =head1 DESCRIPTION
 
@@ -20,6 +31,7 @@ Definitions of fields of DICOM headers. Not for medical use. This file is
 provided purely for experimental use.
 
 Simply creating an array of:
+
   0000   0000   UL   1      GroupLength
   0000   0001   UL   1      CommandLengthToEnd
   0000   0002   UI   1      AffectedSOPClassUID
@@ -29,6 +41,17 @@ Simply creating an array of:
   0000   0110   US   1      MessageID
   0000   0120   US   1      MessageIDBeingRespondedTo
   0000   0200   AE   1      Initiator
+  0000   0300   AE   1      Receiver
+  0000   0400   AE   1      FindLocation
+  0000   0600   AE   1      MoveDestination
+  0000   0700   US   1      Priority
+  0000   0800   US   1      DataSetType
+  0000   0850   US   1      NumberOfMatches
+  0000   0860   US   1      ResponseSequenceNumber
+  0000   0900   US   1      Status
+  0000   0901   AT   1-n    OffendingElement
+  0000   0902   LO   1      ErrorComment
+  0000   0903   US   1      ErrorID
   ...
 
 =cut
@@ -1951,3 +1974,26 @@ END_DICOM_FIELDS
 #  7Fxx   0020   OW   1-n    VariableCoefficientsSDVN
 #  7Fxx   0030   OW   1-n    VariableCoefficientsSDHN
 #  7Fxx   0040   OW   1-n    VariableCoefficientsSDDN
+
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+Andrew Crabb (ahc@jhu.edu),
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut
+

--- a/docs/scripts_md/Fields.md
+++ b/docs/scripts_md/Fields.md
@@ -22,8 +22,8 @@ DICOM::Fields -- Definitions of fields of DICOM headers.
 
 # DESCRIPTION
 
-Definitions of fields of DICOM headers. Not for medical use. This file is
-provided purely for experimental use.
+Definitions of fields of DICOM headers. This file is provided purely for
+experimental use.
 
 Simply creating an array of:
 

--- a/docs/scripts_md/Fields.md
+++ b/docs/scripts_md/Fields.md
@@ -1,0 +1,67 @@
+# NAME
+
+DICOM::Fields -- Definitions of fields of DICOM headers.
+
+# SYNOPSIS
+
+    use DICOM::Element;
+    use DICOM::Fields;    # Standard header definitions.
+    use DICOM::Private;   # Private or custom definitions.
+
+    # Initialize dictionary.
+    # Read the contents of the DICOM dictionary into a hash by group and element.
+    # dicom_private is read after dicom_fields, so overrides common fields.
+    BEGIN {
+      foreach my $line (@dicom_fields, @dicom_private) {
+        next if ($line =~ /^\#/);
+        my ($group, $elem, $code, $numa, $name) = split(/\s+/, $line);
+        my @lst = ($code, $name);
+        $dict{$group}{$elem} = [@lst];
+      }
+    }
+
+# DESCRIPTION
+
+Definitions of fields of DICOM headers. Not for medical use. This file is
+provided purely for experimental use.
+
+Simply creating an array of:
+
+    0000   0000   UL   1      GroupLength
+    0000   0001   UL   1      CommandLengthToEnd
+    0000   0002   UI   1      AffectedSOPClassUID
+    0000   0003   UI   1      RequestedSOPClassUID
+    0000   0010   CS   1      CommandRecognitionCode
+    0000   0100   US   1      CommandField
+    0000   0110   US   1      MessageID
+    0000   0120   US   1      MessageIDBeingRespondedTo
+    0000   0200   AE   1      Initiator
+    0000   0300   AE   1      Receiver
+    0000   0400   AE   1      FindLocation
+    0000   0600   AE   1      MoveDestination
+    0000   0700   US   1      Priority
+    0000   0800   US   1      DataSetType
+    0000   0850   US   1      NumberOfMatches
+    0000   0860   US   1      ResponseSequenceNumber
+    0000   0900   US   1      Status
+    0000   0901   AT   1-n    OffendingElement
+    0000   0902   LO   1      ErrorComment
+    0000   0903   US   1      ErrorID
+    ...
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+Andrew Crabb (ahc@jhu.edu),
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience


### PR DESCRIPTION
Using perldoc/perlpod to document `Fields.pm` so that users can type in the terminal
`perldoc Fields.pm` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `Fields.md` file has been created so that we have a web displayed version of the documentation.
`pod2markdown Fields.pm > Fields.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage