### PR TITLE
[Documentation] DICOM::Private library perldocification

### DIFF
--- a/dicom-archive/DICOM/Private.pm
+++ b/dicom-archive/DICOM/Private.pm
@@ -1,7 +1,41 @@
-# Definitions of (optional) private fields of DICOM headers.
-# $Id: Private.pm 4 2007-12-11 20:21:51Z jharlap $
-
 package DICOM::Private;
+
+=pod
+
+=head1 NAME
+
+DICOM::Private -- Definitions of (optional) private fields of DICOM headers.
+
+=head1 SYNOPSIS
+
+  use DICOM::Element;
+  use DICOM::Fields;	# Standard header definitions.
+  use DICOM::Private;	# Private or custom definitions.
+
+  # Initialize dictionary.
+  # Read the contents of the DICOM dictionary into a hash by group and element.
+  # dicom_private is read after dicom_fields, so overrides common fields.
+  BEGIN {
+    foreach my $line (@dicom_fields, @dicom_private) {
+      next if ($line =~ /^\#/);
+      my ($group, $elem, $code, $numa, $name) = split(/\s+/, $line);
+      my @lst = ($code, $name);
+      $dict{$group}{$elem} = [@lst];
+    }
+  }
+
+=head1 DESCRIPTION
+
+Definitions of (optional) private fields of DICOM headers. By default, none
+are defined in the LORIS-MRI code base but users could define them here.
+
+Example format:
+
+  0000   0000   UL   1      GroupLength
+  ...
+
+=cut
+
 
 use strict;
 use vars qw(@ISA @EXPORT $VERSION @dicom_private);
@@ -19,3 +53,24 @@ $VERSION = sprintf "%d", q$Revision: 4 $ =~ /: (\d+)/;
 # Example format:
 # 0000   0000   UL   1      GroupLength
 END_DICOM_PRIVATE
+
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut

--- a/docs/scripts_md/Private.md
+++ b/docs/scripts_md/Private.md
@@ -1,0 +1,47 @@
+# NAME
+
+DICOM::Private -- Definitions of (optional) private fields of DICOM headers.
+
+# SYNOPSIS
+
+    use DICOM::Element;
+    use DICOM::Fields;    # Standard header definitions.
+    use DICOM::Private;   # Private or custom definitions.
+
+    # Initialize dictionary.
+    # Read the contents of the DICOM dictionary into a hash by group and element.
+    # dicom_private is read after dicom_fields, so overrides common fields.
+    BEGIN {
+      foreach my $line (@dicom_fields, @dicom_private) {
+        next if ($line =~ /^\#/);
+        my ($group, $elem, $code, $numa, $name) = split(/\s+/, $line);
+        my @lst = ($code, $name);
+        $dict{$group}{$elem} = [@lst];
+      }
+    }
+
+# DESCRIPTION
+
+Definitions of (optional) private fields of DICOM headers. By default, none
+are defined in the LORIS-MRI code base but users could define them here.
+
+Example format:
+
+    0000   0000   UL   1      GroupLength
+    ...
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience


### PR DESCRIPTION
Using perldoc/perlpod to document `Private.pm` so that users can type in the terminal
`perldoc Private.pm` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `Private.md` file has been created so that we have a web displayed version of the documentation.
`pod2markdown Private.pm > Private.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage