### PR TITLE
[Documentation] DTI::DTI library perldocification

### DIFF
--- a/DTIPrep/DTI/DTI.pm
+++ b/DTIPrep/DTI/DTI.pm
@@ -82,9 +82,10 @@ INPUT:
   - $subjID    : candidate ID stored in dataset's basename
   - $visit     : visit label stored in dataset's basename
   - $protocol  : DTIPrep XML protocol to use (or used) to run DTIPrep
-  - $runDTIPrep: boolean:
-                  if 1, DTIPrep will be run and create the output folders
-                  if undef, DTIPrep already run and folder already exists
+  - $runDTIPrep: if set, will run DTIPrep and create the output dir.
+
+Note: If $runDTIPrep is not set, then DTIPrep was already run and the
+output folder already exists.
 
 RETURNS: candidate/visit/protocol folder that will store DTIPrep outputs.
 
@@ -301,11 +302,11 @@ INPUT:
   - $anat           : anat file to be used for processing
   - $QCoutdir       : processed output directory
   - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
-  - $protXMLrefs    : hash containing all information about DTIPrep's protocol
-  - $QCed2_step     : optionaly, step name at which DTIPrep will produce a
-                       secondary QCed file
+  - $protXMLrefs    : hash containing info about DTIPrep's protocol
+  - $QCed2_step     : optionally, step name at which DTIPrep will
+                       produce a secondary QCed file
 
-RETURNS: - $DTIrefs: hash containing outputs naming convension
+RETURNS: hash containing outputs naming convension
 
 =cut
 
@@ -342,7 +343,7 @@ INPUT:
   - $QCoutdir       : directory that will contain output files
   - $dti_file       : raw DWI file to be processed
   - $DTIPrepProtocol: DTIPrepProtocol to copy into output directory
-  - $protXMLrefs    : hash containing information stored in DTIPrep XML protocol
+  - $protXMLrefs    : hash containing info from DTIPrep XML protocol
                        (including suffix for the different outputs)
 
 RETURNS: $DTIrefs{$dti_file}{'Preproc'}{'Output'} fields for DTIPrep processing
@@ -393,8 +394,8 @@ or mincdiffusion postprocessing) and append them to $DTIrefs.
 INPUT:
   - $QCoutdir   : directory that will contain output files
   - $dti_file   : raw DWI file to be processed
-  - $anat       : anatomic T1 image to be used for mincdiffusion postprocessing
-  - $protXMLrefs: hash containing information stored in DTIPrep XML protocol
+  - $anat       : T1 image to be used for mincdiffusion postprocessing
+  - $protXMLrefs: hash containing info from DTIPrep XML protocol
                    (including suffix for the different outputs)
 
 RETURNS:
@@ -429,14 +430,14 @@ sub determinePostprocOutputs {
 
 =pod
 
-=head3 determineDTIPrepPostprocOutputs($QCoutdir, $dti_file, $QCed_suffix, ...)
+=head3 determineDTIPrepPostprocOutputs($QCoutdir, $dti_file, ...)
 
 Function that will determine DTIPrep's postprocessing output names (based on the XML protocol) and append them to $DTIrefs
 
 INPUT:
   - $QCoutdir   : directory that will contain output files
   - $dti_file   : raw DWI file to be processed
-  - $protXMLrefs: hash containing information stored in DTIPrep XML protocol
+  - $protXMLrefs: hash containing info from DTIPrep XML protocol
 
 RETURNS: $DTIrefs{$dti_file}{'Postproc'}{'Output'} fields for DTIPrep
 postprocessing
@@ -514,7 +515,7 @@ Function that will determine mincdiffusion postprocessing output names and appen
 INPUT:
   - $QCoutdir   : directory that will contain output files
   - $dti_file   : raw DWI file to be processed
-  - $QCed_suffix: QCed suffix for QCed nrrd & determine postprocessing filenames
+  - $QCed_suffix: QCed suffix for QCed NRRD & postprocessing file names
   - $anat       : anatomic T1 file to use for DWI-anat registration
 
 RETURNS: $DTIrefs{$dti_file}{'Postproc'} for mincdiffusion postprocessing
@@ -623,7 +624,7 @@ sub runDTIPrep {
 
 =pod
 
-=head3 insertMincHeader($raw_file, $data_dir, $processed_minc, $QC_report, ...)
+=head3 insertMincHeader($raw_file, $data_dir, $processed_minc, ...)
 
 Insert in the MINC header all the acquisition arguments except:
   - acquisition:bvalues
@@ -637,7 +638,7 @@ the QCed MINC file based on the raw MINC file's argument.
 
 If one of the value to insert is not defined, return undef, otherwise return 1.
 
-Inputs:
+INPUT:
   - $raw_file      : raw DTI MINC file to grep header information
   - $data_dir      : data dir as defined in the profile file
   - $processed_minc: processed MINC file in which to insert header information
@@ -674,7 +675,7 @@ sub insertMincHeader {
 
 =pod
 
-=head3 insertProcessInfo($raw_dti, $data_dir, $processed_minc, $QC_report, ...)
+=head3 insertProcessInfo($raw_dti, $data_dir, $processed_minc, ...)
 
 This will insert in the header of the processed file processing information. If
 one of the value to insert is not defined, return undef, otherwise return 1.
@@ -682,7 +683,7 @@ one of the value to insert is not defined, return undef, otherwise return 1.
 INPUT:
   - $raw_dti       : raw DTI MINC file to grep header information
   - $data_dir      : data dir as defined in the profile file
-  - $processed_minc: processed MINC file in which to insert header information
+  - $processed_minc: processed MINC file in which to insert header info
   - $QC_report     : DTIPrep QC report text file
   - $DTIPrepVersion: DTIPrep version used to obtain processed file
 
@@ -737,7 +738,7 @@ undef, otherwise return 1.
 
 INPUT:
   - $raw_dti       : raw DTI MINC file to grep header information
-  - $processed_minc: processed MINC file in which to insert header information
+  - $processed_minc: processed MINC file in which to insert header info
 
 RETURNS: 1 on success, undef on failure
 
@@ -776,7 +777,7 @@ otherwise return 1.
 
 INPUT:
   - $raw_dti       : raw DTI MINC file to grep header information
-  - $processed_minc: processed MINC file in which to insert header information
+  - $processed_minc: processed MINC file in which to insert header info
   - $minc_field    : MINC field to be inserted in processed MINC file
 
 RETURNS: 1 on success, undef on failure
@@ -828,7 +829,7 @@ INPUT:
   - $argument: argument to be inserted in MINC header
   - $value   : value of the argument to be inserted in MINC header
   - $minc    : MINC file
-  - $awk     : awk information to check if argument inserted in MINC header
+  - $awk     : awk info to check if argument inserted in MINC header
 
 RETURNS: 1 if argument was inserted in the MINC header, undef otherwise
 
@@ -863,8 +864,8 @@ Function that fetch header information in MINC file.
 INPUT:
   - $field: field to look for in MINC header
   - $minc : MINC file
-  - $awk  : awk information to check if argument inserted in MINC header
-  - $keep_semicolon: if defined, keep semicolon at the end of extracted value
+  - $awk  : awk info to check if argument inserted in MINC header
+  - $keep_semicolon: if set, keep ";" at the end of extracted value
 
 RETURNS: value of the field found in the MINC header
 
@@ -895,8 +896,8 @@ Get the list of arguments and values to insert into the MINC header
 (C<acquisition:*>, C<patient:*> and C<study:*>).
 
 INPUT:
-  - $splitter: splitter used to separate list of fields stored in C<$fields>
-  - $fields  : list header arguments and values to insert in the MINC header
+  - $splitter: splitter used to split list of fields stored in C<$fields>
+  - $fields  : list header arguments/values to insert in the MINC header
 
 Outputs: - $list: array of header arguments and values' list
          - $list_size: size of the array $list
@@ -929,7 +930,7 @@ Function that runs diff_preprocess.pl script from the mincdiffusion tools on
 the QCed MINC and raw anat dataset.
 
 INPUT:
-  - $dti_file: hash key to use to fetch file names (a.k.a. Raw DTI file)
+  - $dti_file: hash key to use to fetch file names (e.g. raw DWI file)
   - $DTIrefs : hash storing file names to be used
   - $QCoutdir: directory used to create outputs from QC pipeline
 
@@ -972,7 +973,7 @@ Function that runs minctensor.pl script from the mincdiffusion tools on the
 mincdiff preprocessed MINC and anatomical mask images.
 
 INPUT:
-  - $dti_file: hash key to use to fetch file names (a.k.a. Raw DTI file)
+  - $dti_file: hash key to use to fetch file names (e.g. raw DWI file)
   - $DTIrefs : hash storing file names to be used
   - $QCoutdir: directory used to create outputs from QC pipeline
 
@@ -1018,7 +1019,7 @@ sub mincdiff_minctensor {
 Function that runs mincpik on the RGB map.
 
 INPUT:
-  - $dti_file: hash key to use to fetch file names (a.k.a. Raw DTI file)
+  - $dti_file: hash key to use to fetch file names (e.g. raw DWI file)
   - $DTIrefs : hash storing file names to be used
 
 RETURNS: 1 on success, undef on failure
@@ -1057,12 +1058,14 @@ INPUT:
   - $dti_file      : raw DTI dataset that was processed through DTIPrep
   - $DTIrefs       : hash containing information about output names
   - $data_dir      : directory containing raw DTI dataset
-  - $DTIPrepVersion: DTIPrep version used to post process the DTI dataset
+  - $DTIPrepVersion: DTIPrep version used to process the DWI dataset
 
 RETURNS:
   - $nrrds_found  : 1 if all NRRD outputs found, undef otherwise
-  - $mincs_created: 1 if all NRRD files converted to MINC files, undef otherwise
-  - $hdrs_inserted: 1 if all header info inserted in MINC files, undef otherwise
+  - $mincs_created: 1 if all NRRD files converted to MINC files,
+                      undef otherwise
+  - $hdrs_inserted: 1 if all header info inserted in MINC files,
+                      undef otherwise
 
 =cut
 

--- a/DTIPrep/DTI/DTI.pm
+++ b/DTIPrep/DTI/DTI.pm
@@ -3,7 +3,7 @@
 =head1 NAME
 
 DTI::DTI --- A set of utility functions for performing common tasks relating to
-DTI data (particularly with regards to perform DTI QC)
+DTI data (particularly with regards to performing DTI QC)
 
 =head1 SYNOPSIS
 
@@ -46,7 +46,7 @@ DTI data (particularly with regards to perform DTI QC)
 
 =head1 DESCRIPTION
 
-Really a mismatch of utility functions, primarily used by DTIPrep_pipeline.pl
+Really a mishmash of utility functions, primarily used by DTIPrep_pipeline.pl
 and DTIPrepRegister.pl.
 
 =head2 Methods
@@ -77,7 +77,7 @@ use MNI::FileUtilities  qw(check_output_dirs);
 Creates DTIPrep pipeline output folders. It will return the created output
 folder only if the output folder was created.
 
-INPUT:
+INPUTS:
   - $outdir    : base output folder
   - $subjID    : candidate ID stored in dataset's basename
   - $visit     : visit label stored in dataset's basename
@@ -111,10 +111,11 @@ sub createOutputFolders{
 =head3 getFilesList($dir, $match)
 
 Subroutine that will read the content of a directory and return a list
-of files matching the string given in argument with C<$match>.
+of files whose names match the string given in argument with C<$match>.
 
-INPUT: directory with DTI files to be fetch, string used to look for DTI files
-to be returned
+INPUTS:
+  - $dir  : directory with DTI files to be fetch
+  - $match: string used to look for DTI files to be returned
 
 RETURNS: list of DTI files found in C<$dir> matching C<$match>
 
@@ -145,12 +146,16 @@ sub getFilesList {
 
 =head3 getAnatFile($nativedir, $t1_scan_type)
 
-Function that parses files in native MRI directory and grab
+Function that parses files in the native MRI directory and grabs
 the T1 acquisition based on $t1_scan_type.
 
-INPUT: native directory, scan type string used for t1 acquisitions
+INPUTS:
+  - $nativedir   : native directory
+  - $t1_scan_type: scan type string used for t1 acquisitions
 
-RETURNS: undef if no anat found, first anat found if multiple anats were found.
+RETURNS:
+  - undef if no anat found
+  - $anat: anatomical file (first anat found if multiple anats were found).
 
 =cut
 
@@ -174,11 +179,13 @@ sub getAnatFile {
 
 =head3 getRawDTIFiles($nativedir, $DTI_volumes)
 
-Function that parses files in native MRI directories and fetch DTI files.
+Function that parses files in the native MRI directories and fetches DTI files.
 This function will also concatenate together multipleDTI files if DTI 
 acquisition performed accross several DTI scans.
 
-INPUT: native directory, DTI's number of volumes
+INPUTS:
+  - $nativedir  : native directory
+  - $DTI_volumes: DTI's number of volumes
 
 RETURNS: list of matching DTIs found in native directory
 
@@ -212,9 +219,12 @@ sub getRawDTIFiles{
 
 =head3 copyDTIPrepProtocol($DTIPrepProtocol, $QCProt)
 
-Function that will copy the DTIPrep protocol used to the output directory of DTIPrep.
+Function that will copy the DTIPrep protocol to the output directory of
+DTIPrep.
 
-INPUT: DTIPrep protocol to be copied, future path of copied DTIPrep protocol
+INPUTS:
+  - $DTIPrepProtocol: DTIPrep protocol to be copied
+  - $QCProt         : future path of copied DTIPrep protocol
 
 RETURNS: 1 on success, undef on failure
 
@@ -242,7 +252,7 @@ Read DTIPrep XML protocol and return information into a hash.
 
 INPUT: XML protocol used (or that has been used) to run DTIPrep
 
-RETURNS: dereferenced hash containing DTIPrep protocol as follows:
+RETURNS: reference to a hash containing DTIPrep protocol as follows:
 
   entry   => 'QC_QCOutputDirectory'     => {}
           => 'QC_QCedDWIFileNameSuffix' => {
@@ -297,7 +307,7 @@ return a hash of DTIref:
        dti_file_2  -> Raw_nrrd     => outputname
         ...
 
-INPUT:
+INPUTS:
   - $DTIs_list      : list of native DTI files to be processed
   - $anat           : anat file to be used for processing
   - $QCoutdir       : processed output directory
@@ -306,7 +316,7 @@ INPUT:
   - $QCed2_step     : optionally, step name at which DTIPrep will
                        produce a secondary QCed file
 
-RETURNS: hash containing outputs naming convension
+RETURNS: hash containing outputs naming convention
 
 =cut
 
@@ -336,10 +346,10 @@ sub createDTIhashref {
 
 =head3 determinePreprocOutputs($QCoutdir, $dti_file, $DTIPrepProtocol, ...)
 
-Function that will determine post processing output names (for either DTIPrep
+Function that will determine pre processing output names (for either DTIPrep
 or mincdiffusion postprocessing) and append them to C<$DTIrefs>.
 
-INPUT:
+INPUTS:
   - $QCoutdir       : directory that will contain output files
   - $dti_file       : raw DWI file to be processed
   - $DTIPrepProtocol: DTIPrepProtocol to copy into output directory
@@ -389,9 +399,9 @@ sub determinePreprocOutputs {
 =head3 determinePostprocOutputs($QCoutdir, $dti_file, $anat, $protXMLrefs)
 
 Function that will determine post processing output names (for either DTIPrep
-or mincdiffusion postprocessing) and append them to $DTIrefs.
+or mincdiffusion postprocessing) and append them to C<$DTIrefs>.
 
-INPUT:
+INPUTS:
   - $QCoutdir   : directory that will contain output files
   - $dti_file   : raw DWI file to be processed
   - $anat       : T1 image to be used for mincdiffusion postprocessing
@@ -434,7 +444,7 @@ sub determinePostprocOutputs {
 
 Function that will determine DTIPrep's postprocessing output names (based on the XML protocol) and append them to $DTIrefs
 
-INPUT:
+INPUTS:
   - $QCoutdir   : directory that will contain output files
   - $dti_file   : raw DWI file to be processed
   - $protXMLrefs: hash containing info from DTIPrep XML protocol
@@ -512,7 +522,7 @@ sub determineDTIPrepPostprocOutputs {
 
 Function that will determine mincdiffusion postprocessing output names and append them to $DTIrefs
 
-INPUT:
+INPUTS:
   - $QCoutdir   : directory that will contain output files
   - $dti_file   : raw DWI file to be processed
   - $QCed_suffix: QCed suffix for QCed NRRD & postprocessing file names
@@ -559,11 +569,13 @@ sub determineMincdiffusionPostprocOutputs {
 
 =head3 convert_DTI($file_in, $file_out, $options)
 
-Function that convert MINC file to NRRD or NRRD file to MINC.
+Function that converts MINC file to NRRD or NRRD file to MINC.
 (depending on $options)
 
-INPUT: file to be converted, converted file, conversion options (mnc2nrrd or
-nrrd2mnc)
+INPUTS:
+  - $file_in : file to be converted
+  - $file_out: converted file
+  - $options : conversion options (mnc2nrrd or nrrd2mnc)
 
 RETURNS: 1 on success, undef on failure
 
@@ -593,9 +605,9 @@ sub convert_DTI {
 
 =head3 runDTIPrep($raw_nrrd, $protocol, $QCed_nrrd, $QCed2_nrrd)
 
-Function that run DTIPrep on nrrd file.
+Function that runs DTIPrep on nrrd file.
 
-INPUT:
+INPUTS:
   - $raw_nrrd  : raw DTI nrrd file to be processed through DTIPrep
   - $protocol  : DTIPrep protocol used
   - $QCed_nrrd : QCed file produced by DTIPrep
@@ -626,19 +638,19 @@ sub runDTIPrep {
 
 =head3 insertMincHeader($raw_file, $data_dir, $processed_minc, ...)
 
-Insert in the MINC header all the acquisition arguments except:
+Inserts in the MINC header all the acquisition arguments except:
   - acquisition:bvalues
   - acquisition:direction_x
   - acquisition:direction_y
   - acquisition:direction_z
   - acquisition:b_matrix
 
-Takes the raw DTI file and the QCed MINC file as input and modify
+Takes the raw DTI file and the QCed MINC file as input and modifies
 the QCed MINC file based on the raw MINC file's argument.
 
 If one of the value to insert is not defined, return undef, otherwise return 1.
 
-INPUT:
+INPUTS:
   - $raw_file      : raw DTI MINC file to grep header information
   - $data_dir      : data dir as defined in the profile file
   - $processed_minc: processed MINC file in which to insert header information
@@ -680,8 +692,8 @@ sub insertMincHeader {
 This will insert in the header of the processed file processing information. If
 one of the value to insert is not defined, return undef, otherwise return 1.
 
-INPUT:
-  - $raw_dti       : raw DTI MINC file to grep header information
+INPUTS:
+  - $raw_dti       : raw DTI MINC file to grep header information from
   - $data_dir      : data dir as defined in the profile file
   - $processed_minc: processed MINC file in which to insert header info
   - $QC_report     : DTIPrep QC report text file
@@ -732,11 +744,11 @@ sub insertProcessInfo {
 
 =head3 insertAcqInfo($raw_dti, $processed_minc)
 
-Insert acquisition information extracted from raw DTI dataset and insert it in
+Inserts acquisition information extracted from raw DTI dataset and insert it in
 the processed file. If one of the value to insert is not defined, return
 undef, otherwise return 1.
 
-INPUT:
+INPUTS:
   - $raw_dti       : raw DTI MINC file to grep header information
   - $processed_minc: processed MINC file in which to insert header info
 
@@ -771,12 +783,12 @@ sub insertAcqInfo {
 
 =head3 insertFieldList($raw_dti, $processed_minc, $minc_field)
 
-Insert information extracted from raw DTI dataset and insert it in the
+Inserts information extracted from raw DTI dataset and insert it in the
 processed file. If one of the value to insert is not defined, return undef,
 otherwise return 1.
 
-INPUT:
-  - $raw_dti       : raw DTI MINC file to grep header information
+INPUTS:
+  - $raw_dti       : raw DTI MINC file to grep header information from
   - $processed_minc: processed MINC file in which to insert header info
   - $minc_field    : MINC field to be inserted in processed MINC file
 
@@ -822,14 +834,14 @@ sub insertFieldList {
 
 =head3 modify_header($argument, $value, $minc, $awk)
 
-Function that runs C<minc_modify_header> and insert MINC header information if
+Function that runs C<minc_modify_header> and inserts MINC header information if
 not already inserted.
 
-INPUT:
+INPUTS:
   - $argument: argument to be inserted in MINC header
   - $value   : value of the argument to be inserted in MINC header
   - $minc    : MINC file
-  - $awk     : awk info to check if argument inserted in MINC header
+  - $awk     : awk info to check if the argument was inserted in MINC header
 
 RETURNS: 1 if argument was inserted in the MINC header, undef otherwise
 
@@ -859,9 +871,9 @@ sub modify_header {
 
 =head3 fetch_header_info($field, $minc, $awk, $keep_semicolon)
 
-Function that fetch header information in MINC file.
+Function that fetches header information in MINC file.
 
-INPUT:
+INPUTS:
   - $field: field to look for in MINC header
   - $minc : MINC file
   - $awk  : awk info to check if argument inserted in MINC header
@@ -892,14 +904,14 @@ sub fetch_header_info {
 
 =head3 get_header_list($splitter, $fields)
 
-Get the list of arguments and values to insert into the MINC header
+Gets the list of arguments and values to insert into the MINC header
 (C<acquisition:*>, C<patient:*> and C<study:*>).
 
-INPUT:
-  - $splitter: splitter used to split list of fields stored in C<$fields>
+INPUTS:
+  - $splitter: delimiter used to split list of fields stored in C<$fields>
   - $fields  : list header arguments/values to insert in the MINC header
 
-Outputs: - $list: array of header arguments and values' list
+RETURNS: - $list: array of header arguments and values' list
          - $list_size: size of the array $list
 
 =cut
@@ -929,7 +941,7 @@ sub get_header_list {
 Function that runs diff_preprocess.pl script from the mincdiffusion tools on
 the QCed MINC and raw anat dataset.
 
-INPUT:
+INPUTS:
   - $dti_file: hash key to use to fetch file names (e.g. raw DWI file)
   - $DTIrefs : hash storing file names to be used
   - $QCoutdir: directory used to create outputs from QC pipeline
@@ -972,7 +984,7 @@ sub mincdiff_preprocess {
 Function that runs minctensor.pl script from the mincdiffusion tools on the
 mincdiff preprocessed MINC and anatomical mask images.
 
-INPUT:
+INPUTS:
   - $dti_file: hash key to use to fetch file names (e.g. raw DWI file)
   - $DTIrefs : hash storing file names to be used
   - $QCoutdir: directory used to create outputs from QC pipeline
@@ -1018,7 +1030,7 @@ sub mincdiff_minctensor {
 
 Function that runs mincpik on the RGB map.
 
-INPUT:
+INPUTS:
   - $dti_file: hash key to use to fetch file names (e.g. raw DWI file)
   - $DTIrefs : hash storing file names to be used
 
@@ -1054,7 +1066,7 @@ sub RGBpik_creation {
 This function will check if all DTIPrep nrrd files were created and convert
 them into MINC files with relevant header information inserted.
 
-INPUT:
+INPUTS:
   - $dti_file      : raw DTI dataset that was processed through DTIPrep
   - $DTIrefs       : hash containing information about output names
   - $data_dir      : directory containing raw DTI dataset
@@ -1130,11 +1142,11 @@ sub convert_DTIPrep_postproc_outputs {
 Summarize which directions were rejected by DTIPrep for slice-wise correlations,
 inter-lace artifacts, inter-gradient artifacts.
 
-INPUT:
+INPUTS:
   - $data_dir: data_dir defined in the config file
   - $QCReport: DTIPrep's QC txt report to extract rejected directions
 
-RETURNS: numbers for
+RETURNS: 
   - number of directions rejected due to slice wise correlations
   - number of directions rejected due to interlace artifacts
   - number of directions rejected due to inter-gradient artifacts

--- a/DTIPrep/DTI/DTI.pm
+++ b/DTIPrep/DTI/DTI.pm
@@ -2,17 +2,54 @@
 
 =head1 NAME
 
-DTI --- A set of utility functions for performing common tasks relating to DTI data (particularly with regards to perform DTI QC)
+DTI::DTI --- A set of utility functions for performing common tasks relating to
+DTI data (particularly with regards to perform DTI QC)
 
 =head1 SYNOPSIS
 
-use DTI;
+  use DTI::DTI;
+
+  my ($protXMLrefs) = &DTI::readDTIPrepXMLprot( $DTIPrepProtocol );
+
+  my ($QCoutdir) = &DTI::createOutputFolders( $outdir,     $subjID,
+                                              $visit,      $DTIPrepProtocol,
+                                              $runDTIPrep
+                                            );
+
+  my ($DTIs_list)  = &DTI::getRawDTIFiles( $nativedir, $DTI_volumes );
+  my ($anat)       = &DTI::getAnatFile( $nativedir, $t1_scan_type );
+  my ($DTIrefs)    = &DTI::createDTIhashref( $DTIs_list,   $anat,
+                                             $QCoutdir,    $DTIPrepProtocol,
+                                             $protXMLrefs, $QCed2_step
+                                           );
+
+  my ($convert_status) = &DTI::convert_DTI( $dti_file,
+                                            $raw_nrrd,
+                                            '--short --minc-to-nrrd --dwi'
+                                          );
+
+  my ($copyProt_status) = &DTI::copyDTIPrepProtocol($DTIPrepProtocol, $QCProt);
+  my ($DTIPrep_status)  = &DTI::runDTIPrep( $raw_nrrd,  $DTIPrepProtocol,
+                                            $QCed_nrrd, $QCed2_nrrd
+                                          );
+
+
+  ($convert_status) = &DTI::convert_DTI( $QCed_nrrd,
+                                         $QCed_minc,
+                                         '--nrrd-to-minc --dwi'
+                                       );
+  ($insert_header)  = &DTI::insertMincHeader( $dti_file,      $data_dir,
+                                              $QCed_minc,     $QCTxtReport,
+                                              $DTIPrepVersion
+                                            );
+
 
 =head1 DESCRIPTION
 
-Really a mismatch of utility functions, primarily used by DTIPrep_pipeline.pl and DTIPrepRegister.pl
+Really a mismatch of utility functions, primarily used by DTIPrep_pipeline.pl
+and DTIPrepRegister.pl.
 
-=head1 METHODS
+=head2 Methods
 
 =cut
 
@@ -33,21 +70,26 @@ use MNI::FileUtilities  qw(check_output_dirs);
 @EXPORT_OK  = qw(createOutputFolders getFiles sortParam insertMincHeader create_processed_maps);
 
 
-
-
-
-
-
-
 =pod
-Create DTIPrep pipeline output folders.
-- Inputs:   - $outdir       = base output folder (folder where all candidate's DTIPrep outputs will be saved)
-            - $subjID       = candidate ID stored in dataset's basename
-            - $visit        = visit label stored in dataset's basename
-            - $protocol     = DTIPrep XML protocol that will be used (or has been used) to run DTIPrep
-            - $runDTIPrep   = boolean variable. If set to 1, DTIPrep will be run and need to create output folders. If set to undef, DTIPrep has already been run and folder already exists
-- Outputs:  - $QC_out       = candidate/visit/protocol folder that was created and that will store DTIPrep outputs. This will be return only if $QC_out exists in the file system.
+
+=head3 createOutputFolders($outdir, $subjID, $visit, $protocol, $runDTIPrep)
+
+Creates DTIPrep pipeline output folders. It will return the created output
+folder only if the output folder was created.
+
+INPUT:
+  - $outdir    : base output folder
+  - $subjID    : candidate ID stored in dataset's basename
+  - $visit     : visit label stored in dataset's basename
+  - $protocol  : DTIPrep XML protocol to use (or used) to run DTIPrep
+  - $runDTIPrep: boolean:
+                  if 1, DTIPrep will be run and create the output folders
+                  if undef, DTIPrep already run and folder already exists
+
+RETURNS: candidate/visit/protocol folder that will store DTIPrep outputs.
+
 =cut
+
 sub createOutputFolders{
     my  ($outdir, $subjID, $visit, $protocol, $runDTIPrep) = @_;   
     
@@ -63,22 +105,20 @@ sub createOutputFolders{
 }
 
 
-
-
-
-
-
-
-
-
-
 =pod
-Subroutine that will read the content of a directory and return a list 
-of files matching the string given in argument with $match.
-Inputs:  - $dir:    directory containing files to be fetch
-         - $match:  string used to look for files to be returned
-Outputs: - @files_list: list of files found in $dir matching $match
+
+=head3 getFilesList($dir, $match)
+
+Subroutine that will read the content of a directory and return a list
+of files matching the string given in argument with C<$match>.
+
+INPUT: directory with DTI files to be fetch, string used to look for DTI files
+to be returned
+
+RETURNS: list of DTI files found in C<$dir> matching C<$match>
+
 =cut
+
 sub getFilesList {
     my ($dir, $match)   = @_;
     my (@files_list)    = ();
@@ -101,13 +141,18 @@ sub getFilesList {
 
 
 =pod
-Function that parses files in native MRI directory and grab 
+
+=head3 getAnatFile($nativedir, $t1_scan_type)
+
+Function that parses files in native MRI directory and grab
 the T1 acquisition based on $t1_scan_type.
-Inputs:  - $nativedir: directory containing native imaging files
-         - $t1_scan_type: scan type string used for t1 acquisitions
-Outputs: - If no anat was found, will return undef.
-         - If multiple anat were found, will return the first anat of the list.
+
+INPUT: native directory, scan type string used for t1 acquisitions
+
+RETURNS: undef if no anat found, first anat found if multiple anats were found.
+
 =cut
+
 sub getAnatFile {
     my ($nativedir, $t1_scan_type)  = @_;
 
@@ -124,17 +169,20 @@ sub getAnatFile {
 }
 
 
-
-
-
 =pod
-Function that parses files in native MRI directories and fetch DTI files. 
+
+=head3 getRawDTIFiles($nativedir, $DTI_volumes)
+
+Function that parses files in native MRI directories and fetch DTI files.
 This function will also concatenate together multipleDTI files if DTI 
 acquisition performed accross several DTI scans.
-Inputs:  - $nativedir: directory containing native files
-         - $DTIvolumes: DTI's number of volumes
-Outputs: - @DTIs_list: list of matching DTIs found in native directory
+
+INPUT: native directory, DTI's number of volumes
+
+RETURNS: list of matching DTIs found in native directory
+
 =cut
+
 sub getRawDTIFiles{
     my ($nativedir, $DTI_volumes)   = @_;
     
@@ -159,17 +207,18 @@ sub getRawDTIFiles{
 }
 
 
-
-
-
-
 =pod
-Function that will copy the DTIPrep protocol used to the output directory of DTIPrep. 
-Inputs:  - $DTIPrepProtocol: DTIPrep protocol to be copied
-         - $QCProt: path of copied DTIPrep protocol
-Outputs: - 1 if copy was successful
-         - undef if copy failed
+
+=head3 copyDTIPrepProtocol($DTIPrepProtocol, $QCProt)
+
+Function that will copy the DTIPrep protocol used to the output directory of DTIPrep.
+
+INPUT: DTIPrep protocol to be copied, future path of copied DTIPrep protocol
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub copyDTIPrepProtocol {
     my ($DTIPrepProtocol, $QCProt)    =   @_;
 
@@ -184,35 +233,40 @@ sub copyDTIPrepProtocol {
 }
 
 
-
-
-
 =pod
+
+=head3 readDTIPrepXMLprot($DTIPrepProtocol)
+
 Read DTIPrep XML protocol and return information into a hash.
-- Inputs: - $DTIPrepProtocol    = XML protocol used (or that has been used) to run DTIPrep
-- Output: - $protXMLrefs        = dereferenced hash containing DTIPrep protocol as follows:
-        entry   => 'QC_QCOutputDirectory'     => {}
-                => 'QC_QCedDWIFileNameSuffix' => { 
-                                                  'value'   => '_QCed.nrrd'
-                                                 },
-                => 'IMAGE_bCheck'             => {
-                         'entry' => {
-                                    'IMAGE_size' => {
-                                                    'value' => [
-                                                               '96',
-                                                               '96',
-                                                               '65'
-                                                               ]
-                                                    },
-                                    'IMAGE_reportFileMode'  => {
-                                                               'value' => '1'
-                                                               }, 
-                                    ...                
-                                    'value' => 'Yes'
-                                    },
-                => 'QC_badGradientPercentageTolerance' => {
-                            etc...
+
+INPUT: XML protocol used (or that has been used) to run DTIPrep
+
+RETURNS: dereferenced hash containing DTIPrep protocol as follows:
+
+  entry   => 'QC_QCOutputDirectory'     => {}
+          => 'QC_QCedDWIFileNameSuffix' => {
+                                            'value'   => '_QCed.nrrd'
+                                           },
+          => 'IMAGE_bCheck'             => {
+                   'entry' => {
+                              'IMAGE_size' => {
+                                               'value' => [
+                                                           '96',
+                                                           '96',
+                                                           '65'
+                                                          ]
+                                              },
+                              'IMAGE_reportFileMode'  => {
+                                                          'value' => '1'
+                                                         },
+                              ...
+                              'value' => 'Yes'
+                              },
+          => 'QC_badGradientPercentageTolerance' => {
+            ...
+
 =cut
+
 sub readDTIPrepXMLprot {
     my ($DTIPrepProtocol)   = @_;
 
@@ -226,27 +280,35 @@ sub readDTIPrepXMLprot {
 }
 
 
-
-
-
-
 =pod
-Function that will determine output names based on each DTI file dataset and return a hash of DTIref:
+
+=head3 createDTIhashref($DTIs_list, $anat, $QCoutdir, $DTIPrepProtocol, ...)
+
+Function that will determine output names based on each DTI file dataset and
+return a hash of DTIref:
+
        dti_file_1  -> Raw_nrrd     => outputname
                    -> QCed_nrrd    => outputname
                    -> QCTxtReport  => outputname
                    -> QCXmlReport  => outputname
                    -> QCed_minc    => outputname
                    -> QCProt       => outputname
-       dti_file_2  -> Raw_nrrd     => outputname etc...
-Inputs:  - $DTIs_list: list of native DTI files to be processed
-         - $anat: anat file to be used for processing
-         - $QCoutdir: output directory that will be used to stored processed data
-         - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
-         - $protXMLrefs: hash containing all information about DTIPrep protocol to be used
-         - $QCed2_step: optionaly, step name at which DTIPrep will produce a secondary QCed file
-Outputs: - $DTIrefs: hash containing outputs naming convension
+       dti_file_2  -> Raw_nrrd     => outputname
+        ...
+
+INPUT:
+  - $DTIs_list      : list of native DTI files to be processed
+  - $anat           : anat file to be used for processing
+  - $QCoutdir       : processed output directory
+  - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
+  - $protXMLrefs    : hash containing all information about DTIPrep's protocol
+  - $QCed2_step     : optionaly, step name at which DTIPrep will produce a
+                       secondary QCed file
+
+RETURNS: - $DTIrefs: hash containing outputs naming convension
+
 =cut
+
 sub createDTIhashref {
     my ($DTIs_list, $anat, $QCoutdir, $DTIPrepProtocol, $protXMLrefs, $QCed2_step)    =   @_;
     my %DTIrefs;
@@ -269,19 +331,24 @@ sub createDTIhashref {
 }
 
 
-
-
-
-
-
 =pod
-Function that will determine post processing output names (for either DTIPrep or mincdiffusion postprocessing) and append them to $DTIrefs.
-- Inputs:   - $QCoutdir         = directory that will contain output files
-            - $dti_file         = raw DWI file to be processed
-            - $DTIPrepProtocol  = DTIPrepProtocol to copy into output directory
-            - $protXMLrefs      = hash containing informations stored in DTIPrep XML protocol (with suffix for the different outputs, among other things) 
-- Outputs:  - $DTIrefs{$dti_file}{'Preproc'}{'Output'} fields for DTIPrep preprocessing
+
+=head3 determinePreprocOutputs($QCoutdir, $dti_file, $DTIPrepProtocol, ...)
+
+Function that will determine post processing output names (for either DTIPrep
+or mincdiffusion postprocessing) and append them to C<$DTIrefs>.
+
+INPUT:
+  - $QCoutdir       : directory that will contain output files
+  - $dti_file       : raw DWI file to be processed
+  - $DTIPrepProtocol: DTIPrepProtocol to copy into output directory
+  - $protXMLrefs    : hash containing information stored in DTIPrep XML protocol
+                       (including suffix for the different outputs)
+
+RETURNS: $DTIrefs{$dti_file}{'Preproc'}{'Output'} fields for DTIPrep processing
+
 =cut
+
 sub determinePreprocOutputs {
     my ($QCoutdir, $dti_file, $DTIPrepProtocol, $protXMLrefs, $QCed2_step)   = @_;
 
@@ -317,14 +384,25 @@ sub determinePreprocOutputs {
 
 
 =pod
-Function that will determine post processing output names (for either DTIPrep or mincdiffusion postprocessing) and append them to $DTIrefs.
-- Inputs:   - $QCoutdir     = directory that will contain output files
-            - $dti_file     = raw DWI file to be processed
-            - $anat         = anatomic T1 image to be used for mincdiffusion postprocessing
-            - $protXMLrefs  = hash containing informations stored in DTIPrep XML protocol (with suffix for the different outputs, among other things) 
-- Outputs:  - $DTIrefs{$dti_file}{'Postproc'}{'Tool'} field storing which postprocessing pipeline was used
-            - $DTIrefs{$dti_file}{'Postproc'}{'Output'} fields for DTIPrep postprocessing
+
+=head3 determinePostprocOutputs($QCoutdir, $dti_file, $anat, $protXMLrefs)
+
+Function that will determine post processing output names (for either DTIPrep
+or mincdiffusion postprocessing) and append them to $DTIrefs.
+
+INPUT:
+  - $QCoutdir   : directory that will contain output files
+  - $dti_file   : raw DWI file to be processed
+  - $anat       : anatomic T1 image to be used for mincdiffusion postprocessing
+  - $protXMLrefs: hash containing information stored in DTIPrep XML protocol
+                   (including suffix for the different outputs)
+
+RETURNS:
+  - $DTIrefs{$dti_file}{'Postproc'}{'Tool'} with postprocessing used
+  - $DTIrefs{$dti_file}{'Postproc'}{'Output'} fields for DTIPrep postprocessing
+
 =cut
+
 sub determinePostprocOutputs {
     my ($QCoutdir, $dti_file, $anat, $protXMLrefs) = @_;
 
@@ -348,13 +426,23 @@ sub determinePostprocOutputs {
     }
 }
 
+
 =pod
+
+=head3 determineDTIPrepPostprocOutputs($QCoutdir, $dti_file, $QCed_suffix, ...)
+
 Function that will determine DTIPrep's postprocessing output names (based on the XML protocol) and append them to $DTIrefs
-- Inputs:   - $QCoutdir     = directory that will contain output files
-            - $dti_file     = raw DWI file to be processed
-            - $protXMLrefs  = hash containing informations stored in DTIPrep XML protocol (with suffix for the different outputs, among other things) 
-- Outputs:  - $DTIrefs{$dti_file}{'Postproc'}{'Output'} fields for DTIPrep postprocessing
+
+INPUT:
+  - $QCoutdir   : directory that will contain output files
+  - $dti_file   : raw DWI file to be processed
+  - $protXMLrefs: hash containing information stored in DTIPrep XML protocol
+
+RETURNS: $DTIrefs{$dti_file}{'Postproc'}{'Output'} fields for DTIPrep
+postprocessing
+
 =cut
+
 sub determineDTIPrepPostprocOutputs {
     my ($QCoutdir, $dti_file, $QCed_suffix, $protXMLrefs) = @_;
     
@@ -416,14 +504,23 @@ sub determineDTIPrepPostprocOutputs {
     }
 }    
 
+
 =pod
+
+=head3 determineMincdiffusionPostprocOutputs($QCoutdir, $dti_file, ...)
+
 Function that will determine mincdiffusion postprocessing output names and append them to $DTIrefs
-- Inputs:   - $QCoutdir     = directory that will contain output files
-            - $dti_file     = raw DWI file to be processed
-            - $QCed_suffix  = QCed suffix used to create QCed nrrd and determine postprocessing file names
-            - $anat         = anatomic T1 file to use for DWI-anat registration
-- Outputs:  - $DTIrefs{$dti_file}{'Postproc'} for mincdiffusion postprocessing
+
+INPUT:
+  - $QCoutdir   : directory that will contain output files
+  - $dti_file   : raw DWI file to be processed
+  - $QCed_suffix: QCed suffix for QCed nrrd & determine postprocessing filenames
+  - $anat       : anatomic T1 file to use for DWI-anat registration
+
+RETURNS: $DTIrefs{$dti_file}{'Postproc'} for mincdiffusion postprocessing
+
 =cut
+
 sub determineMincdiffusionPostprocOutputs {
     my ($QCoutdir, $dti_file, $QCed_suffix, $anat) = @_;
     
@@ -458,14 +555,19 @@ sub determineMincdiffusionPostprocOutputs {
 }    
 
 =pod
-Function that convert minc file to nrrd or nrrd file to minc. 
+
+=head3 convert_DTI($file_in, $file_out, $options)
+
+Function that convert MINC file to NRRD or NRRD file to MINC.
 (depending on $options)
-Inputs:  - $file_in: file to be converted 
-         - $file_out: converted file
-         - $options: conversion options: mnc2nrrd or nrrd2mnc
-Outputs: - 1 if conversion was successful
-         - undef if conversion failed
+
+INPUT: file to be converted, converted file, conversion options (mnc2nrrd or
+nrrd2mnc)
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub convert_DTI {
     my  ($file_in, $file_out, $options)    =   @_;
 
@@ -486,19 +588,22 @@ sub convert_DTI {
 }
 
 
-
-
-
-
 =pod
-Function that run DTIPrep on nrrd file. 
-Inputs:  - $raw_nrrd: raw DTI nrrd file to be processed through DTIPrep
-         - $protocol: DTIPrep protocol used
-         - $QCed_nrrd:  QCed file produced by DTIPrep
-         - $QCed2_nrrd: optionaly, secondary QCed file
-Outputs: - 1 if QCed file found and secondary QCed file (if defined) is found
-         - undef if DTIPrep outputs not found
+
+=head3 runDTIPrep($raw_nrrd, $protocol, $QCed_nrrd, $QCed2_nrrd)
+
+Function that run DTIPrep on nrrd file.
+
+INPUT:
+  - $raw_nrrd  : raw DTI nrrd file to be processed through DTIPrep
+  - $protocol  : DTIPrep protocol used
+  - $QCed_nrrd : QCed file produced by DTIPrep
+  - $QCed2_nrrd: optionaly, secondary QCed file
+
+RETURNS: 1 on success, under on failure
+
 =cut
+
 sub runDTIPrep {
     my  ($raw_nrrd, $protocol, $QCed_nrrd, $QCed2_nrrd)  =   @_;    
 
@@ -516,30 +621,34 @@ sub runDTIPrep {
 }
 
 
-
-
-
-
 =pod
-Insert in the minc header all the acquisition arguments except:
-    - acquisition:bvalues
-    - acquisition:direction_x
-    - acquisition:direction_y
-    - acquisition:direction_z
-    - acquisition:b_matrix
 
-Takes the raw DTI file and the QCed minc file as input and modify 
-the QCed minc file based on the raw minc file's argument.
+=head3 insertMincHeader($raw_file, $data_dir, $processed_minc, $QC_report, ...)
 
-Inputs:  - $raw_file: raw DTI minc file to grep header information
-         - $data_dir: data dir as defined in the profile file
-         - $processed_minc: processed minc file in which header information will be inserted
-         - $QC_report: DTIPrep QC report text file
-         - $DTIPrepVersion: DTIPrep version used to obtain processed file
-         - $is_anat: if defined (=if file is anat based), will only insert processing, patient and study information 
-Outputs: - 1 if if all mincheader information was inserted
-         - undef otherwise
+Insert in the MINC header all the acquisition arguments except:
+  - acquisition:bvalues
+  - acquisition:direction_x
+  - acquisition:direction_y
+  - acquisition:direction_z
+  - acquisition:b_matrix
+
+Takes the raw DTI file and the QCed MINC file as input and modify
+the QCed MINC file based on the raw MINC file's argument.
+
+If one of the value to insert is not defined, return undef, otherwise return 1.
+
+Inputs:
+  - $raw_file      : raw DTI MINC file to grep header information
+  - $data_dir      : data dir as defined in the profile file
+  - $processed_minc: processed MINC file in which to insert header information
+  - $QC_report     : DTIPrep QC report text file
+  - $DTIPrepVersion: DTIPrep version used to obtain processed file
+  - $is_anat       : if set, will only insert processing, patient & study info
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub insertMincHeader {
     my  ($raw_file, $data_dir, $processed_minc, $QC_report, $DTIPrepVersion, $is_anat)    =   @_;
 
@@ -562,16 +671,25 @@ sub insertMincHeader {
     }
 }
 
+
 =pod
-This will insert in the header of the processed file processing information.
-Inputs:  - $raw_dti: raw DTI minc file to grep header information
-         - $data_dir: data dir as defined in the profile file
-         - $processed_minc: processed minc file in which header information will be inserted
-         - $QC_report: DTIPrep QC report text file
-         - $DTIPrepVersion: DTIPrep version used to obtain processed file
-Outputs: - 1 if all processed info were inserted in the processed minc header
-         - undef otherwise
+
+=head3 insertProcessInfo($raw_dti, $data_dir, $processed_minc, $QC_report, ...)
+
+This will insert in the header of the processed file processing information. If
+one of the value to insert is not defined, return undef, otherwise return 1.
+
+INPUT:
+  - $raw_dti       : raw DTI MINC file to grep header information
+  - $data_dir      : data dir as defined in the profile file
+  - $processed_minc: processed MINC file in which to insert header information
+  - $QC_report     : DTIPrep QC report text file
+  - $DTIPrepVersion: DTIPrep version used to obtain processed file
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub insertProcessInfo {
     my ($raw_dti, $data_dir, $processed_minc, $QC_report, $DTIPrepVersion) = @_;
 
@@ -609,18 +727,22 @@ sub insertProcessInfo {
 }
 
 
-
-
-
-
 =pod
-Insert acquisition information extracted from raw DTI dataset and insert it in the processed file. 
-If one of the value to insert is not defined, return undef, otherwise return 1.
-Inputs:  - $raw_dti: raw DTI minc file to grep header information
-         - $processed_minc: processed minc file in which header information will be inserted
-Outputs: - 1 if acquisition information were inserted in processed DTIPrep mincs
-         - undef otherwise
+
+=head3 insertAcqInfo($raw_dti, $processed_minc)
+
+Insert acquisition information extracted from raw DTI dataset and insert it in
+the processed file. If one of the value to insert is not defined, return
+undef, otherwise return 1.
+
+INPUT:
+  - $raw_dti       : raw DTI MINC file to grep header information
+  - $processed_minc: processed MINC file in which to insert header information
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub insertAcqInfo {
     my  ($raw_dti, $processed_minc) = @_;
 
@@ -644,18 +766,23 @@ sub insertAcqInfo {
 }
 
 
-
-
-
 =pod
-Insert information extracted from raw DTI dataset and insert it in the processed file. 
-If one of the value to insert is not defined, return undef, otherwise return 1.
-Inputs:  - $raw_dti: raw DTI minc file to grep header information
-         - $processed_minc: processed minc file in which header information will be inserted
-         - $minc_field: minc field to be inserted in processed minc file
-Outputs: - 1 if information were inserted in processed DTIPrep mincs
-         - undef otherwise
+
+=head3 insertFieldList($raw_dti, $processed_minc, $minc_field)
+
+Insert information extracted from raw DTI dataset and insert it in the
+processed file. If one of the value to insert is not defined, return undef,
+otherwise return 1.
+
+INPUT:
+  - $raw_dti       : raw DTI MINC file to grep header information
+  - $processed_minc: processed MINC file in which to insert header information
+  - $minc_field    : MINC field to be inserted in processed MINC file
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub insertFieldList {
     my  ($raw_dti, $processed_minc, $minc_field) = @_;
 
@@ -689,16 +816,24 @@ sub insertFieldList {
     }
 }    
 
+
 =pod
-Function that runs minc_modify_header and insert 
-minc header information if not already inserted.
-Inputs:  - $argument: argument to be inserted in minc header
-         - $value: value of the argument to be inserted in minc header
-         - $minc: minc file
-         - $awk: awk information to check if argument not already inserted in minc header
-Outputs: - 1 if argument was indeed inserted into the minc file
-         - undef otherwise
+
+=head3 modify_header($argument, $value, $minc, $awk)
+
+Function that runs C<minc_modify_header> and insert MINC header information if
+not already inserted.
+
+INPUT:
+  - $argument: argument to be inserted in MINC header
+  - $value   : value of the argument to be inserted in MINC header
+  - $minc    : MINC file
+  - $awk     : awk information to check if argument inserted in MINC header
+
+RETURNS: 1 if argument was inserted in the MINC header, undef otherwise
+
 =cut
+
 sub modify_header {
     my  ($argument, $value, $minc, $awk) =   @_;
     
@@ -719,16 +854,22 @@ sub modify_header {
 }
 
 
-
-
 =pod
-Function that fetch header information in minc file 
-Inputs:  - $field: field to look for in minc header
-         - $minc: minc file
-         - $awk: awk information to check if argument not already inserted in minc header
-         - $keep_semicolon: if defined, keep semicolon at the end of the value extracted
-Outputs: - $value: value of the field found in the minc header
+
+=head3 fetch_header_info($field, $minc, $awk, $keep_semicolon)
+
+Function that fetch header information in MINC file.
+
+INPUT:
+  - $field: field to look for in MINC header
+  - $minc : MINC file
+  - $awk  : awk information to check if argument inserted in MINC header
+  - $keep_semicolon: if defined, keep semicolon at the end of extracted value
+
+RETURNS: value of the field found in the MINC header
+
 =cut
+
 sub fetch_header_info {
     my  ($field, $minc, $awk, $keep_semicolon)  =   @_;
 
@@ -746,18 +887,22 @@ sub fetch_header_info {
 }
 
 
-
-
-
-
-
 =pod
-Get the list of arguments and values to insert into the mincheader (acquisition:*, patient:* and study:*).
-Inputs:  - $splitter: splitter used to separate list of fields stored in $fields
-         - $fields: list header arguments and values to insert in the minc header
+
+=head3 get_header_list($splitter, $fields)
+
+Get the list of arguments and values to insert into the MINC header
+(C<acquisition:*>, C<patient:*> and C<study:*>).
+
+INPUT:
+  - $splitter: splitter used to separate list of fields stored in C<$fields>
+  - $fields  : list header arguments and values to insert in the MINC header
+
 Outputs: - $list: array of header arguments and values' list
          - $list_size: size of the array $list
+
 =cut
+
 sub get_header_list {
     my  ($splitter, $fields) =   @_;
     
@@ -776,21 +921,22 @@ sub get_header_list {
 }
 
 
-
-
-
-
-
-
-
 =pod
-Function that runs diff_preprocess.pl script from the mincdiffusion tools on the QCed minc and raw anat dataset.
-- Arguments:- $dti_file: hash key to use to fetch file names (a.k.a. Raw DTI file) 
-            - $DTIrefs: hash storing file names to be used
-            - $QCoutdir: directory used to create outputs from QC pipeline
-- Returns:  - 1 if all outputs were created
-            - undef if outputs were not created
+
+=head3 mincdiff_preprocess($dti_file, $DTIrefs, $QCoutdir)
+
+Function that runs diff_preprocess.pl script from the mincdiffusion tools on
+the QCed MINC and raw anat dataset.
+
+INPUT:
+  - $dti_file: hash key to use to fetch file names (a.k.a. Raw DTI file)
+  - $DTIrefs : hash storing file names to be used
+  - $QCoutdir: directory used to create outputs from QC pipeline
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub mincdiff_preprocess {
     my ($dti_file, $DTIrefs, $QCoutdir) = @_;    
     
@@ -818,21 +964,22 @@ sub mincdiff_preprocess {
 }
 
 
-
-
-
-
-
-
-
 =pod
-Function that runs minctensor.pl script from the mincdiffusion tools on the mincdiff preprocessed minc and anatomical mask images.
-- Arguments:- $dti_file: hash key to use to fetch file names (a.k.a. Raw DTI file) 
-            - $DTIrefs: hash storing file names to be used
-            - $QCoutdir: directory used to create outputs from QC pipeline
-- Returns:  - 1 if all outputs were created
-            - undef if outputs were not created
+
+=head3 mincdiff_minctensor($dti_file, $DTIrefs, $QCoutdir, $niak_path)
+
+Function that runs minctensor.pl script from the mincdiffusion tools on the
+mincdiff preprocessed MINC and anatomical mask images.
+
+INPUT:
+  - $dti_file: hash key to use to fetch file names (a.k.a. Raw DTI file)
+  - $DTIrefs : hash storing file names to be used
+  - $QCoutdir: directory used to create outputs from QC pipeline
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub mincdiff_minctensor {
     my ($dti_file, $DTIrefs, $QCoutdir, $niak_path) = @_;
 
@@ -864,20 +1011,20 @@ sub mincdiff_minctensor {
 }
 
 
-
-
-
-
-
-
-
 =pod
+
+=head3 RGBpik_creation($dti_file, $DTIrefs)
+
 Function that runs mincpik on the RGB map.
-- Arguments:- $dti_file: hash key to use to fetch file names (a.k.a. Raw DTI file) 
-            - $DTIrefs: hash storing file names to be used
-- Returns:  - 1 if rgb_pic was created
-            - undef if rgb_pic was not created
+
+INPUT:
+  - $dti_file: hash key to use to fetch file names (a.k.a. Raw DTI file)
+  - $DTIrefs : hash storing file names to be used
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub RGBpik_creation {
     my ($dti_file, $DTIrefs) = @_;
 
@@ -899,34 +1046,26 @@ sub RGBpik_creation {
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 =pod
-This function will check if all DTIPrep nrrd files were created and convert them into minc files with relevant header information inserted.
-- Inputs:   - $dti_file         = raw DTI dataset that was processed through DTIPrep
-            - $DTIrefs          = hash containing information about output names for all DWI datasets
-            - $data_dir         = directory containing raw DTI dataset
-            - $DTIPrepVersion   = DTIPrep version that was used to post process the DTI dataset
-- Outputs:  - $nrrds_found set to 1 if all nrrd outputs were found. If not, $nrrds_found is not defined
-            - $mincs_created set to 1 if all nrrd files were successfully converted to minc files. If not, $mincs_
-created is not defined.
-            - $hdrs_inserted set to 1 if all relevant header information were successfully inserted into the minc files. If not, $hdrs_inserted is not defined.
+
+=head3 convert_DTIPrep_postproc_outputs($dti_file, $DTIrefs, $data_dir, ...)
+
+This function will check if all DTIPrep nrrd files were created and convert
+them into MINC files with relevant header information inserted.
+
+INPUT:
+  - $dti_file      : raw DTI dataset that was processed through DTIPrep
+  - $DTIrefs       : hash containing information about output names
+  - $data_dir      : directory containing raw DTI dataset
+  - $DTIPrepVersion: DTIPrep version used to post process the DTI dataset
+
+RETURNS:
+  - $nrrds_found  : 1 if all NRRD outputs found, undef otherwise
+  - $mincs_created: 1 if all NRRD files converted to MINC files, undef otherwise
+  - $hdrs_inserted: 1 if all header info inserted in MINC files, undef otherwise
+
 =cut
+
 sub convert_DTIPrep_postproc_outputs {
     my ($dti_file, $DTIrefs, $data_dir, $QCTxtReport, $DTIPrepVersion) = @_;
 
@@ -980,15 +1119,25 @@ sub convert_DTIPrep_postproc_outputs {
     return ($nrrds_found, $mincs_created, $hdrs_inserted);
 
 }
+
 =pod
-Summarize which directions were rejected by DTIPrep for slice-wise correlations, 
+
+=head3 getRejectedDirections($data_dir, $XMLReport)
+
+Summarize which directions were rejected by DTIPrep for slice-wise correlations,
 inter-lace artifacts, inter-gradient artifacts.
-Inputs:  - $data_dir = data_dir defined in the config file
-         - $QCReport = DTIPrep's QC txt report to extract rejected directions
-Outputs: - $rm_slicewise        = directions rejected due to slice wise correlations (number)
-         - $rm_interlace        = directions rejected due to interlace artifacts (number)
-         - $rm_intergradient    = directions rejected due to inter-gradient artifacts (number)
+
+INPUT:
+  - $data_dir: data_dir defined in the config file
+  - $QCReport: DTIPrep's QC txt report to extract rejected directions
+
+RETURNS: numbers for
+  - number of directions rejected due to slice wise correlations
+  - number of directions rejected due to interlace artifacts
+  - number of directions rejected due to inter-gradient artifacts
+
 =cut
+
 sub getRejectedDirections   {
     my ($data_dir, $XMLReport)  =   @_;
 
@@ -1055,3 +1204,30 @@ sub getRejectedDirections   {
 
     return (\%summary);
 }
+
+1;
+
+__END__
+
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut
+
+

--- a/docs/scripts_md/DTI.md
+++ b/docs/scripts_md/DTI.md
@@ -58,9 +58,10 @@ INPUT:
   - $subjID    : candidate ID stored in dataset's basename
   - $visit     : visit label stored in dataset's basename
   - $protocol  : DTIPrep XML protocol to use (or used) to run DTIPrep
-  - $runDTIPrep: boolean:
-                  if 1, DTIPrep will be run and create the output folders
-                  if undef, DTIPrep already run and folder already exists
+  - $runDTIPrep: if set, will run DTIPrep and create the output dir.
+
+Note: If $runDTIPrep is not set, then DTIPrep was already run and the
+output folder already exists.
 
 RETURNS: candidate/visit/protocol folder that will store DTIPrep outputs.
 
@@ -150,11 +151,11 @@ INPUT:
   - $anat           : anat file to be used for processing
   - $QCoutdir       : processed output directory
   - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
-  - $protXMLrefs    : hash containing all information about DTIPrep's protocol
-  - $QCed2\_step     : optionaly, step name at which DTIPrep will produce a
-                       secondary QCed file
+  - $protXMLrefs    : hash containing info about DTIPrep's protocol
+  - $QCed2\_step     : optionally, step name at which DTIPrep will
+                       produce a secondary QCed file
 
-RETURNS: - $DTIrefs: hash containing outputs naming convension
+RETURNS: hash containing outputs naming convension
 
 ### determinePreprocOutputs($QCoutdir, $dti\_file, $DTIPrepProtocol, ...)
 
@@ -165,7 +166,7 @@ INPUT:
   - $QCoutdir       : directory that will contain output files
   - $dti\_file       : raw DWI file to be processed
   - $DTIPrepProtocol: DTIPrepProtocol to copy into output directory
-  - $protXMLrefs    : hash containing information stored in DTIPrep XML protocol
+  - $protXMLrefs    : hash containing info from DTIPrep XML protocol
                        (including suffix for the different outputs)
 
 RETURNS: $DTIrefs{$dti\_file}{'Preproc'}{'Output'} fields for DTIPrep processing
@@ -178,22 +179,22 @@ or mincdiffusion postprocessing) and append them to $DTIrefs.
 INPUT:
   - $QCoutdir   : directory that will contain output files
   - $dti\_file   : raw DWI file to be processed
-  - $anat       : anatomic T1 image to be used for mincdiffusion postprocessing
-  - $protXMLrefs: hash containing information stored in DTIPrep XML protocol
+  - $anat       : T1 image to be used for mincdiffusion postprocessing
+  - $protXMLrefs: hash containing info from DTIPrep XML protocol
                    (including suffix for the different outputs)
 
 RETURNS:
   - $DTIrefs{$dti\_file}{'Postproc'}{'Tool'} with postprocessing used
   - $DTIrefs{$dti\_file}{'Postproc'}{'Output'} fields for DTIPrep postprocessing
 
-### determineDTIPrepPostprocOutputs($QCoutdir, $dti\_file, $QCed\_suffix, ...)
+### determineDTIPrepPostprocOutputs($QCoutdir, $dti\_file, ...)
 
 Function that will determine DTIPrep's postprocessing output names (based on the XML protocol) and append them to $DTIrefs
 
 INPUT:
   - $QCoutdir   : directory that will contain output files
   - $dti\_file   : raw DWI file to be processed
-  - $protXMLrefs: hash containing information stored in DTIPrep XML protocol
+  - $protXMLrefs: hash containing info from DTIPrep XML protocol
 
 RETURNS: $DTIrefs{$dti\_file}{'Postproc'}{'Output'} fields for DTIPrep
 postprocessing
@@ -205,7 +206,7 @@ Function that will determine mincdiffusion postprocessing output names and appen
 INPUT:
   - $QCoutdir   : directory that will contain output files
   - $dti\_file   : raw DWI file to be processed
-  - $QCed\_suffix: QCed suffix for QCed nrrd & determine postprocessing filenames
+  - $QCed\_suffix: QCed suffix for QCed NRRD & postprocessing file names
   - $anat       : anatomic T1 file to use for DWI-anat registration
 
 RETURNS: $DTIrefs{$dti\_file}{'Postproc'} for mincdiffusion postprocessing
@@ -232,7 +233,7 @@ INPUT:
 
 RETURNS: 1 on success, under on failure
 
-### insertMincHeader($raw\_file, $data\_dir, $processed\_minc, $QC\_report, ...)
+### insertMincHeader($raw\_file, $data\_dir, $processed\_minc, ...)
 
 Insert in the MINC header all the acquisition arguments except:
   - acquisition:bvalues
@@ -246,7 +247,7 @@ the QCed MINC file based on the raw MINC file's argument.
 
 If one of the value to insert is not defined, return undef, otherwise return 1.
 
-Inputs:
+INPUT:
   - $raw\_file      : raw DTI MINC file to grep header information
   - $data\_dir      : data dir as defined in the profile file
   - $processed\_minc: processed MINC file in which to insert header information
@@ -256,7 +257,7 @@ Inputs:
 
 RETURNS: 1 on success, undef on failure
 
-### insertProcessInfo($raw\_dti, $data\_dir, $processed\_minc, $QC\_report, ...)
+### insertProcessInfo($raw\_dti, $data\_dir, $processed\_minc, ...)
 
 This will insert in the header of the processed file processing information. If
 one of the value to insert is not defined, return undef, otherwise return 1.
@@ -264,7 +265,7 @@ one of the value to insert is not defined, return undef, otherwise return 1.
 INPUT:
   - $raw\_dti       : raw DTI MINC file to grep header information
   - $data\_dir      : data dir as defined in the profile file
-  - $processed\_minc: processed MINC file in which to insert header information
+  - $processed\_minc: processed MINC file in which to insert header info
   - $QC\_report     : DTIPrep QC report text file
   - $DTIPrepVersion: DTIPrep version used to obtain processed file
 
@@ -278,7 +279,7 @@ undef, otherwise return 1.
 
 INPUT:
   - $raw\_dti       : raw DTI MINC file to grep header information
-  - $processed\_minc: processed MINC file in which to insert header information
+  - $processed\_minc: processed MINC file in which to insert header info
 
 RETURNS: 1 on success, undef on failure
 
@@ -290,7 +291,7 @@ otherwise return 1.
 
 INPUT:
   - $raw\_dti       : raw DTI MINC file to grep header information
-  - $processed\_minc: processed MINC file in which to insert header information
+  - $processed\_minc: processed MINC file in which to insert header info
   - $minc\_field    : MINC field to be inserted in processed MINC file
 
 RETURNS: 1 on success, undef on failure
@@ -304,7 +305,7 @@ INPUT:
   - $argument: argument to be inserted in MINC header
   - $value   : value of the argument to be inserted in MINC header
   - $minc    : MINC file
-  - $awk     : awk information to check if argument inserted in MINC header
+  - $awk     : awk info to check if argument inserted in MINC header
 
 RETURNS: 1 if argument was inserted in the MINC header, undef otherwise
 
@@ -315,8 +316,8 @@ Function that fetch header information in MINC file.
 INPUT:
   - $field: field to look for in MINC header
   - $minc : MINC file
-  - $awk  : awk information to check if argument inserted in MINC header
-  - $keep\_semicolon: if defined, keep semicolon at the end of extracted value
+  - $awk  : awk info to check if argument inserted in MINC header
+  - $keep\_semicolon: if set, keep ";" at the end of extracted value
 
 RETURNS: value of the field found in the MINC header
 
@@ -326,8 +327,8 @@ Get the list of arguments and values to insert into the MINC header
 (`acquisition:*`, `patient:*` and `study:*`).
 
 INPUT:
-  - $splitter: splitter used to separate list of fields stored in `$fields`
-  - $fields  : list header arguments and values to insert in the MINC header
+  - $splitter: splitter used to split list of fields stored in `$fields`
+  - $fields  : list header arguments/values to insert in the MINC header
 
 Outputs: - $list: array of header arguments and values' list
          - $list\_size: size of the array $list
@@ -338,7 +339,7 @@ Function that runs diff\_preprocess.pl script from the mincdiffusion tools on
 the QCed MINC and raw anat dataset.
 
 INPUT:
-  - $dti\_file: hash key to use to fetch file names (a.k.a. Raw DTI file)
+  - $dti\_file: hash key to use to fetch file names (e.g. raw DWI file)
   - $DTIrefs : hash storing file names to be used
   - $QCoutdir: directory used to create outputs from QC pipeline
 
@@ -350,7 +351,7 @@ Function that runs minctensor.pl script from the mincdiffusion tools on the
 mincdiff preprocessed MINC and anatomical mask images.
 
 INPUT:
-  - $dti\_file: hash key to use to fetch file names (a.k.a. Raw DTI file)
+  - $dti\_file: hash key to use to fetch file names (e.g. raw DWI file)
   - $DTIrefs : hash storing file names to be used
   - $QCoutdir: directory used to create outputs from QC pipeline
 
@@ -361,7 +362,7 @@ RETURNS: 1 on success, undef on failure
 Function that runs mincpik on the RGB map.
 
 INPUT:
-  - $dti\_file: hash key to use to fetch file names (a.k.a. Raw DTI file)
+  - $dti\_file: hash key to use to fetch file names (e.g. raw DWI file)
   - $DTIrefs : hash storing file names to be used
 
 RETURNS: 1 on success, undef on failure
@@ -375,12 +376,14 @@ INPUT:
   - $dti\_file      : raw DTI dataset that was processed through DTIPrep
   - $DTIrefs       : hash containing information about output names
   - $data\_dir      : directory containing raw DTI dataset
-  - $DTIPrepVersion: DTIPrep version used to post process the DTI dataset
+  - $DTIPrepVersion: DTIPrep version used to process the DWI dataset
 
 RETURNS:
   - $nrrds\_found  : 1 if all NRRD outputs found, undef otherwise
-  - $mincs\_created: 1 if all NRRD files converted to MINC files, undef otherwise
-  - $hdrs\_inserted: 1 if all header info inserted in MINC files, undef otherwise
+  - $mincs\_created: 1 if all NRRD files converted to MINC files,
+                      undef otherwise
+  - $hdrs\_inserted: 1 if all header info inserted in MINC files,
+                      undef otherwise
 
 ### getRejectedDirections($data\_dir, $XMLReport)
 

--- a/docs/scripts_md/DTI.md
+++ b/docs/scripts_md/DTI.md
@@ -1,7 +1,7 @@
 # NAME
 
 DTI::DTI --- A set of utility functions for performing common tasks relating to
-DTI data (particularly with regards to perform DTI QC)
+DTI data (particularly with regards to performing DTI QC)
 
 # SYNOPSIS
 
@@ -43,7 +43,7 @@ DTI data (particularly with regards to perform DTI QC)
 
 # DESCRIPTION
 
-Really a mismatch of utility functions, primarily used by DTIPrep\_pipeline.pl
+Really a mishmash of utility functions, primarily used by DTIPrep\_pipeline.pl
 and DTIPrepRegister.pl.
 
 ## Methods
@@ -53,7 +53,7 @@ and DTIPrepRegister.pl.
 Creates DTIPrep pipeline output folders. It will return the created output
 folder only if the output folder was created.
 
-INPUT:
+INPUTS:
   - $outdir    : base output folder
   - $subjID    : candidate ID stored in dataset's basename
   - $visit     : visit label stored in dataset's basename
@@ -68,37 +68,47 @@ RETURNS: candidate/visit/protocol folder that will store DTIPrep outputs.
 ### getFilesList($dir, $match)
 
 Subroutine that will read the content of a directory and return a list
-of files matching the string given in argument with `$match`.
+of files whose names match the string given in argument with `$match`.
 
-INPUT: directory with DTI files to be fetch, string used to look for DTI files
-to be returned
+INPUTS:
+  - $dir  : directory with DTI files to be fetch
+  - $match: string used to look for DTI files to be returned
 
 RETURNS: list of DTI files found in `$dir` matching `$match`
 
 ### getAnatFile($nativedir, $t1\_scan\_type)
 
-Function that parses files in native MRI directory and grab
+Function that parses files in the native MRI directory and grabs
 the T1 acquisition based on $t1\_scan\_type.
 
-INPUT: native directory, scan type string used for t1 acquisitions
+INPUTS:
+  - $nativedir   : native directory
+  - $t1\_scan\_type: scan type string used for t1 acquisitions
 
-RETURNS: undef if no anat found, first anat found if multiple anats were found.
+RETURNS:
+  - undef if no anat found
+  - $anat: anatomical file (first anat found if multiple anats were found).
 
 ### getRawDTIFiles($nativedir, $DTI\_volumes)
 
-Function that parses files in native MRI directories and fetch DTI files.
+Function that parses files in the native MRI directories and fetches DTI files.
 This function will also concatenate together multipleDTI files if DTI 
 acquisition performed accross several DTI scans.
 
-INPUT: native directory, DTI's number of volumes
+INPUTS:
+  - $nativedir  : native directory
+  - $DTI\_volumes: DTI's number of volumes
 
 RETURNS: list of matching DTIs found in native directory
 
 ### copyDTIPrepProtocol($DTIPrepProtocol, $QCProt)
 
-Function that will copy the DTIPrep protocol used to the output directory of DTIPrep.
+Function that will copy the DTIPrep protocol to the output directory of
+DTIPrep.
 
-INPUT: DTIPrep protocol to be copied, future path of copied DTIPrep protocol
+INPUTS:
+  - $DTIPrepProtocol: DTIPrep protocol to be copied
+  - $QCProt         : future path of copied DTIPrep protocol
 
 RETURNS: 1 on success, undef on failure
 
@@ -108,7 +118,7 @@ Read DTIPrep XML protocol and return information into a hash.
 
 INPUT: XML protocol used (or that has been used) to run DTIPrep
 
-RETURNS: dereferenced hash containing DTIPrep protocol as follows:
+RETURNS: reference to a hash containing DTIPrep protocol as follows:
 
     entry   => 'QC_QCOutputDirectory'     => {}
             => 'QC_QCedDWIFileNameSuffix' => {
@@ -146,7 +156,7 @@ return a hash of DTIref:
        dti_file_2  -> Raw_nrrd     => outputname
         ...
 
-INPUT:
+INPUTS:
   - $DTIs\_list      : list of native DTI files to be processed
   - $anat           : anat file to be used for processing
   - $QCoutdir       : processed output directory
@@ -155,14 +165,14 @@ INPUT:
   - $QCed2\_step     : optionally, step name at which DTIPrep will
                        produce a secondary QCed file
 
-RETURNS: hash containing outputs naming convension
+RETURNS: hash containing outputs naming convention
 
 ### determinePreprocOutputs($QCoutdir, $dti\_file, $DTIPrepProtocol, ...)
 
-Function that will determine post processing output names (for either DTIPrep
+Function that will determine pre processing output names (for either DTIPrep
 or mincdiffusion postprocessing) and append them to `$DTIrefs`.
 
-INPUT:
+INPUTS:
   - $QCoutdir       : directory that will contain output files
   - $dti\_file       : raw DWI file to be processed
   - $DTIPrepProtocol: DTIPrepProtocol to copy into output directory
@@ -174,9 +184,9 @@ RETURNS: $DTIrefs{$dti\_file}{'Preproc'}{'Output'} fields for DTIPrep processing
 ### determinePostprocOutputs($QCoutdir, $dti\_file, $anat, $protXMLrefs)
 
 Function that will determine post processing output names (for either DTIPrep
-or mincdiffusion postprocessing) and append them to $DTIrefs.
+or mincdiffusion postprocessing) and append them to `$DTIrefs`.
 
-INPUT:
+INPUTS:
   - $QCoutdir   : directory that will contain output files
   - $dti\_file   : raw DWI file to be processed
   - $anat       : T1 image to be used for mincdiffusion postprocessing
@@ -191,7 +201,7 @@ RETURNS:
 
 Function that will determine DTIPrep's postprocessing output names (based on the XML protocol) and append them to $DTIrefs
 
-INPUT:
+INPUTS:
   - $QCoutdir   : directory that will contain output files
   - $dti\_file   : raw DWI file to be processed
   - $protXMLrefs: hash containing info from DTIPrep XML protocol
@@ -203,7 +213,7 @@ postprocessing
 
 Function that will determine mincdiffusion postprocessing output names and append them to $DTIrefs
 
-INPUT:
+INPUTS:
   - $QCoutdir   : directory that will contain output files
   - $dti\_file   : raw DWI file to be processed
   - $QCed\_suffix: QCed suffix for QCed NRRD & postprocessing file names
@@ -213,19 +223,21 @@ RETURNS: $DTIrefs{$dti\_file}{'Postproc'} for mincdiffusion postprocessing
 
 ### convert\_DTI($file\_in, $file\_out, $options)
 
-Function that convert MINC file to NRRD or NRRD file to MINC.
+Function that converts MINC file to NRRD or NRRD file to MINC.
 (depending on $options)
 
-INPUT: file to be converted, converted file, conversion options (mnc2nrrd or
-nrrd2mnc)
+INPUTS:
+  - $file\_in : file to be converted
+  - $file\_out: converted file
+  - $options : conversion options (mnc2nrrd or nrrd2mnc)
 
 RETURNS: 1 on success, undef on failure
 
 ### runDTIPrep($raw\_nrrd, $protocol, $QCed\_nrrd, $QCed2\_nrrd)
 
-Function that run DTIPrep on nrrd file.
+Function that runs DTIPrep on nrrd file.
 
-INPUT:
+INPUTS:
   - $raw\_nrrd  : raw DTI nrrd file to be processed through DTIPrep
   - $protocol  : DTIPrep protocol used
   - $QCed\_nrrd : QCed file produced by DTIPrep
@@ -235,19 +247,19 @@ RETURNS: 1 on success, under on failure
 
 ### insertMincHeader($raw\_file, $data\_dir, $processed\_minc, ...)
 
-Insert in the MINC header all the acquisition arguments except:
+Inserts in the MINC header all the acquisition arguments except:
   - acquisition:bvalues
   - acquisition:direction\_x
   - acquisition:direction\_y
   - acquisition:direction\_z
   - acquisition:b\_matrix
 
-Takes the raw DTI file and the QCed MINC file as input and modify
+Takes the raw DTI file and the QCed MINC file as input and modifies
 the QCed MINC file based on the raw MINC file's argument.
 
 If one of the value to insert is not defined, return undef, otherwise return 1.
 
-INPUT:
+INPUTS:
   - $raw\_file      : raw DTI MINC file to grep header information
   - $data\_dir      : data dir as defined in the profile file
   - $processed\_minc: processed MINC file in which to insert header information
@@ -262,8 +274,8 @@ RETURNS: 1 on success, undef on failure
 This will insert in the header of the processed file processing information. If
 one of the value to insert is not defined, return undef, otherwise return 1.
 
-INPUT:
-  - $raw\_dti       : raw DTI MINC file to grep header information
+INPUTS:
+  - $raw\_dti       : raw DTI MINC file to grep header information from
   - $data\_dir      : data dir as defined in the profile file
   - $processed\_minc: processed MINC file in which to insert header info
   - $QC\_report     : DTIPrep QC report text file
@@ -273,11 +285,11 @@ RETURNS: 1 on success, undef on failure
 
 ### insertAcqInfo($raw\_dti, $processed\_minc)
 
-Insert acquisition information extracted from raw DTI dataset and insert it in
+Inserts acquisition information extracted from raw DTI dataset and insert it in
 the processed file. If one of the value to insert is not defined, return
 undef, otherwise return 1.
 
-INPUT:
+INPUTS:
   - $raw\_dti       : raw DTI MINC file to grep header information
   - $processed\_minc: processed MINC file in which to insert header info
 
@@ -285,12 +297,12 @@ RETURNS: 1 on success, undef on failure
 
 ### insertFieldList($raw\_dti, $processed\_minc, $minc\_field)
 
-Insert information extracted from raw DTI dataset and insert it in the
+Inserts information extracted from raw DTI dataset and insert it in the
 processed file. If one of the value to insert is not defined, return undef,
 otherwise return 1.
 
-INPUT:
-  - $raw\_dti       : raw DTI MINC file to grep header information
+INPUTS:
+  - $raw\_dti       : raw DTI MINC file to grep header information from
   - $processed\_minc: processed MINC file in which to insert header info
   - $minc\_field    : MINC field to be inserted in processed MINC file
 
@@ -298,22 +310,22 @@ RETURNS: 1 on success, undef on failure
 
 ### modify\_header($argument, $value, $minc, $awk)
 
-Function that runs `minc_modify_header` and insert MINC header information if
+Function that runs `minc_modify_header` and inserts MINC header information if
 not already inserted.
 
-INPUT:
+INPUTS:
   - $argument: argument to be inserted in MINC header
   - $value   : value of the argument to be inserted in MINC header
   - $minc    : MINC file
-  - $awk     : awk info to check if argument inserted in MINC header
+  - $awk     : awk info to check if the argument was inserted in MINC header
 
 RETURNS: 1 if argument was inserted in the MINC header, undef otherwise
 
 ### fetch\_header\_info($field, $minc, $awk, $keep\_semicolon)
 
-Function that fetch header information in MINC file.
+Function that fetches header information in MINC file.
 
-INPUT:
+INPUTS:
   - $field: field to look for in MINC header
   - $minc : MINC file
   - $awk  : awk info to check if argument inserted in MINC header
@@ -323,14 +335,14 @@ RETURNS: value of the field found in the MINC header
 
 ### get\_header\_list($splitter, $fields)
 
-Get the list of arguments and values to insert into the MINC header
+Gets the list of arguments and values to insert into the MINC header
 (`acquisition:*`, `patient:*` and `study:*`).
 
-INPUT:
-  - $splitter: splitter used to split list of fields stored in `$fields`
+INPUTS:
+  - $splitter: delimiter used to split list of fields stored in `$fields`
   - $fields  : list header arguments/values to insert in the MINC header
 
-Outputs: - $list: array of header arguments and values' list
+RETURNS: - $list: array of header arguments and values' list
          - $list\_size: size of the array $list
 
 ### mincdiff\_preprocess($dti\_file, $DTIrefs, $QCoutdir)
@@ -338,7 +350,7 @@ Outputs: - $list: array of header arguments and values' list
 Function that runs diff\_preprocess.pl script from the mincdiffusion tools on
 the QCed MINC and raw anat dataset.
 
-INPUT:
+INPUTS:
   - $dti\_file: hash key to use to fetch file names (e.g. raw DWI file)
   - $DTIrefs : hash storing file names to be used
   - $QCoutdir: directory used to create outputs from QC pipeline
@@ -350,7 +362,7 @@ RETURNS: 1 on success, undef on failure
 Function that runs minctensor.pl script from the mincdiffusion tools on the
 mincdiff preprocessed MINC and anatomical mask images.
 
-INPUT:
+INPUTS:
   - $dti\_file: hash key to use to fetch file names (e.g. raw DWI file)
   - $DTIrefs : hash storing file names to be used
   - $QCoutdir: directory used to create outputs from QC pipeline
@@ -361,7 +373,7 @@ RETURNS: 1 on success, undef on failure
 
 Function that runs mincpik on the RGB map.
 
-INPUT:
+INPUTS:
   - $dti\_file: hash key to use to fetch file names (e.g. raw DWI file)
   - $DTIrefs : hash storing file names to be used
 
@@ -372,7 +384,7 @@ RETURNS: 1 on success, undef on failure
 This function will check if all DTIPrep nrrd files were created and convert
 them into MINC files with relevant header information inserted.
 
-INPUT:
+INPUTS:
   - $dti\_file      : raw DTI dataset that was processed through DTIPrep
   - $DTIrefs       : hash containing information about output names
   - $data\_dir      : directory containing raw DTI dataset
@@ -390,11 +402,11 @@ RETURNS:
 Summarize which directions were rejected by DTIPrep for slice-wise correlations,
 inter-lace artifacts, inter-gradient artifacts.
 
-INPUT:
+INPUTS:
   - $data\_dir: data\_dir defined in the config file
   - $QCReport: DTIPrep's QC txt report to extract rejected directions
 
-RETURNS: numbers for
+RETURNS: 
   - number of directions rejected due to slice wise correlations
   - number of directions rejected due to interlace artifacts
   - number of directions rejected due to inter-gradient artifacts


### PR DESCRIPTION
Using perldoc/perlpod to document `DTI.pm` so that users can type in the terminal
`perldoc DTI.pm` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `DTI.md` file has been created so that we have a web displayed version of the documentation.
`pod2markdown DTI.pm > DTI.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage