### PR TITLE
[Documentation] DTIPrep_pipeline.pl perldocification

### DIFF
--- a/DTIPrep/DTIPrep_pipeline.pl
+++ b/DTIPrep/DTIPrep_pipeline.pl
@@ -9,7 +9,17 @@ database.
 
 =head1 SYNOPSIS
 
+perl DTIPrep_pipeline.pl -profile C<prod> -list
+C</path/to/list/of/native/dir> -DTIPrepVersion C<DTIPrep_version>
+-mincdiffusionVersion C<mincdiffusion_version> -runDTIPrep - DTIPrepProtocol
+C</path/to/DTIPrep/XML/protocol> -registerFilesInDB
 
+Note:
+- C<-DTIPrepVersion> and C<-mincdiffusionVersion> are optional if the
+version of those tools can be found directly from the tools installed on the
+server running C<DTIPrepRegister>.
+- C<-runDTIPrep> and C<registerFilesInDB> are optional depending on whether
+just want to run the DTIPrep pipeline or just want to register the outputs...
 
 =head1 DESCRIPTION
 

--- a/DTIPrep/DTIPrep_pipeline.pl
+++ b/DTIPrep/DTIPrep_pipeline.pl
@@ -1,5 +1,44 @@
 #!/usr/bin/perl -w
 
+=pod
+
+=head1 NAME
+
+DTIPrep_pipeline.pl -- Run DTIPrep and/or insert DTIPrep's outputs in the
+database.
+
+=head1 SYNOPSIS
+
+
+
+=head1 DESCRIPTION
+
+C<DTIPrep_pipeline.pl> can be used to run DTIPrep on native DWI datasets. It
+will also organize, convert and register the outputs of DTIPrep in the database.
+
+If C<-runDTIPrep> option is not set, DTIPrep processing will be skipped
+(DTIPrep outputs being already available, as well as the DTIPrep protocol that
+was used).
+
+This pipeline will:
+  - grep native DWI files from list of given native directories (-list option)
+  - create (or fetch if C<-runDTIPrep> not set) output directories based on the
+     DTIPrep version and protocol that are to be (or were) used for DTIPrep
+     processing.
+  - convert native DWI minc file to NRRD & run DTIPrep if C<-runDTIPrep> is set
+  - fetch DTIPrep preprocessing outputs (QCed.nrrd, QCReport.txt,
+     QCXMLResults.xml and protocol.xml)
+  - convert pre-processed NRRD back to MINC with all the header information
+     (based on the native MINC file)
+  - create post-processing files (FA, RGB maps...) with all header information
+  - call C<DTIPrepRegister.pl> to register the files in the database if
+     C<-registerFilesInDB> is set
+
+=head2 Methods
+
+=cut
+
+
 require 5.001;
 use strict;
 use Getopt::Tabular;
@@ -258,11 +297,19 @@ exit 0;
 ###############
 
 =pod
-Function that determine tool version used for processing.
-- Inputs:   - $tool = tool to search absolute path containing version information
-            - $match= string to match to determine tool version
-- Output:   - Version of the tool found or undef if version could not be determined based on the path
+
+=head3 identify_tool_version($tool, $match)
+
+Function that determines the tool version used for processing.
+
+INPUT: tool to search absolute path containing version information, string to
+match to determine tool version
+
+RETURNS: version of the tool found, or undef if version could not be
+determined based on the path
+
 =cut
+
 sub identify_tool_version {
     my ($tool, $match) = @_;
 
@@ -276,20 +323,20 @@ sub identify_tool_version {
 }
 
 
-
-
-
-
-
-
-
 =pod
-Fetches candID and visit label from the native directory of the dataset to process.
-Input:  - $nativedir: native directory of the dataset to process
-Output: - undef if could not find the site, candID or visit label.
-        - $candID and $visit_label informations if they were found.
-Relevant information will also be printed in the log file.
+
+=head3 getIdentifiers($nativedir)
+
+Fetches CandID and visit label from the native directory of the dataset to
+process. Relevant information will also be printed in the log file.
+
+INPUT: native directory of the dataset to process
+
+RETURNS: $candID & $visit_label information, or undef if could not find the
+site, CandID or visit label.
+
 =cut
+
 sub getIdentifiers {
     my ($nativedir) = @_;    
 
@@ -310,27 +357,30 @@ sub getIdentifiers {
 }
 
 
-
-
-
-
-
-
-
-
 =pod
-Determine pipeline's output directory, based on the root outdir, DTIPrep protocol, candID and visit label: (outdir/ProtocolName/CandID/VisitLabel).
-If $runDTIPrep is defined, the function will create the output folders.
-If $runDTIPrep is not defined, will check that the directory exists.
 
-- Inputs: -$outdir  = output directory where DTIPrep results for all datasets for all subjects will be stored (in /data/project/data/pipelines/DTIPrep/DTIPrep_version)
-          - $subjID = candidate ID of the DTI dataset to be processed
-          - $visit  = visit label of the DTI dataset to be processed
-          - $DTIPrepProtocol= XML file with the DTIPrep protocol to be used for analyses
-          - $runDTIPrep = a boolean which will determine if OutputFolders should be created in the filesystem (before processing data through DTIPrep) if they don't exist
+=head3 getOutputDirectories($outdir, $subjID, $visit, $DTIPrepProtocol, ...)
 
-- Ouput:  - $QCoutdir   = directory where processed files for the candidate, visit label and DTIPrep protocol will be stored. 
+Determine pipeline's output directory, based on the root C<$outdir>, DTIPrep
+protocol, candID and visit label: (outdir/ProtocolName/CandID/VisitLabel).
+  - If $runDTIPrep is defined, the function will create the output folders.
+  - If $runDTIPrep is not defined, will check that the directory exists.
+
+INPUT:
+  - $outdir         : root directory for DTIPrep outputs (in
+                       C</data/project/data/pipelines/DTIPrep/DTIPrep_version>)
+  - $subjID         : candidate ID of the DTI dataset to be processed
+  - $visit          : visit label of the DTI dataset to be processed
+  - $DTIPrepProtocol: XML file with the DTIPrep protocol to be used for analyses
+  - $runDTIPrep     : boolean, if OutputFolders should be created in the
+                       filesystem (before processing data through DTIPrep) if
+                       they don't exist
+
+RETURNS: directory where processed files for the candidate, visit label and
+DTIPrep protocol will be stored.
+
 =cut
+
 sub getOutputDirectories {
     my ($outdir, $subjID, $visit, $DTIPrepProtocol, $runDTIPrep)    = @_;    
 
@@ -351,29 +401,28 @@ sub getOutputDirectories {
 }
 
 
-
-
-
-
-
-
-
-
-
-
 =pod
-Fetch the raw DWI datasets and foreach DWI, determine output names to be used and store them into a hash ($DTIrefs).
 
-- Inputs:   - $nativedir    = native directory to look for native DWI dataset.
-            - $DTI_volumes  = number of volumes expected in the DWI dataset.
-            - $t1_scan_type = the scan type name of the T1 weighted dataset.
-            - $QCoutdir     = directory to save processed files.
-            - $DTIPrepProtocol= XML DTIPrep protocol to be used to process DWI datasets.
+=head3 fetchData($nativedir, $DTI_volumes, $t1_scan_type, $QCoutdir, ...)
 
-- Outputs:  - Will return undef if could not find any raw DWI dataset. 
-            - Will return the list of raw DTIs found and a hash with the preprocessing output names and paths if raw DWI dataset was found.
-            - Will also print relevant information in the log file.
+Fetch the raw DWI datasets and foreach DWI, determine output names to be used
+and store them into a hash ($DTIrefs). Will also print relevant information
+in the log file.
+
+INPUT:
+  - $nativedir      : native directory to look for native DWI dataset
+  - $DTI_volumes    : number of volumes expected in the DWI dataset
+  - $t1_scan_type   : the scan type name of the T1 weighted dataset
+  - $QCoutdir       : directory to save processed files
+  - $DTIPrepProtocol: XML DTIPrep protocol to be used to process DWI datasets
+
+RETURNS:
+  - list of raw DTIs found, a hash with the preprocessing output names
+     and paths if raw DWI dataset was found.
+  - undef if could not find any raw DWI dataset.
+
 =cut
+
 sub fetchData {
     my ($nativedir, $DTI_volumes, $t1_scan_type, $QCoutdir, $DTIPrepProtocol, $protXMLrefs, $QCed2_step)  = @_;
 
@@ -399,21 +448,25 @@ sub fetchData {
 }
 
 
-
-
-
-
 =pod
-Function that creates the output folders, get the raw DTI files, convert them to nrrd and run DTIPrep using a bcheck protocol and a nobcheck protocol.
 
-Inputs: - $DTIs_list    = list of DWI datasets to preprocess through DTIPrep for a given candidate and visit.
-        - $DTIrefs      = hash where all output file names and paths for the different DWI are stored.
-        - $QCoutdir     = output directory to use to save preprocessed files.
-        - $DTIPrepProtocol= XML DTIPrep protocol to be used to preprocess the DWI dataset.
+=head3 preprocessingPipeline($DTIs_list, $DTIrefs, $QCoutdir, $DTIPrepProtocol)
 
-Outputs: - Will return undef if preprocessing was not successful on a least one raw DWI dataset
-         - Will return 1 if at least one raw DWI dataset was successfully preprocessed
+Function that creates the output folders, get the raw DTI files, convert them
+to NRRD and run DTIPrep using a C<bcheck> protocol and a C<nobcheck> protocol.
+
+INPUT:
+  - $DTIs_list      : list of DWI files to process for a given candidate/visit
+  - $DTIrefs        : hash with output file names & paths for the different DWI
+  - $QCoutdir       : output directory to use to save preprocessed files.
+  - $DTIPrepProtocol: XML DTIPrep protocol to use to pre-process the DWI data
+
+RETURNS:
+  - 1 if at least one raw DWI dataset was successfully preprocessed
+  - undef if pre-processing was not successful on a least one raw DWI dataset
+
 =cut
+
 sub preprocessingPipeline {
     my ($DTIs_list, $DTIrefs, $QCoutdir, $DTIPrepProtocol)  = @_;
 
@@ -460,18 +513,18 @@ sub preprocessingPipeline {
 }                                                  
 
 
-
-
-
-
-
 =pod
-Function that convert minc raw DWI file to nrrd and log the conversion status.
-Inputs: - $raw_nrrd = Raw nrrd file to create
-        - $dti_file = Raw DWI file to convert to nrrd
-Output: - Will return undef if conversion failed, 
-        - Will return 1 if conversion is a success.
+
+=head3 preproc_mnc2nrrd($raw_nrrd, $dti_file)
+
+Function that convert MINC raw DWI file to NRRD and log the conversion status.
+
+INPUT: raw NRRD file to create, raw DWI file to convert to NRRD
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub preproc_mnc2nrrd {
     my ($raw_nrrd, $dti_file) = @_;
     
@@ -488,18 +541,21 @@ sub preproc_mnc2nrrd {
 }
 
 
-
-
-
-
 =pod
-This function will call DTI::runDTIPrep to run DTIPrep on the raw nrrd file.
-Inputs: - $QCed_nrrd        = QCed DWI nrrd file to be created by DTIPrep
-        - $raw_nrrd         = Raw DWI nrrd file to process through DTIPrep
-        - $DTIPrepProtocol  = DTIPrep XML Protocol to use to run DTIPrep
-Output: - Will return 1 if QCed nrrd already exist
-        - Will return $DTIPrep_status if DTIPrep is run. (DTIPrep_status can be equal to 1 if DTIPrep ran successfully, or undef if something went bad while running DTIPrep).
+
+=head3 preproc_DTIPrep($QCed_nrrd, $raw_nrrd, $DTIPrepProtocol, $QCed2_nrrd)
+
+This function will call C<&DTI::runDTIPrep> to run DTIPrep on the raw NRRD file.
+
+INPUT:
+  - $QCed_nrrd      : QCed DWI NRRD file to be created by DTIPrep
+  - $raw_nrrd       : raw DWI NRRD file to process through DTIPrep
+  - $DTIPrepProtocol: DTIPrep XML Protocol to use to run DTIPrep
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub preproc_DTIPrep {
     my ($QCed_nrrd, $raw_nrrd, $DTIPrepProtocol, $QCed2_nrrd) = @_;
 
@@ -515,19 +571,22 @@ sub preproc_DTIPrep {
 }
 
 
-
-
-
-
-
 =pod
-Function that will call DTI::copyDTIPrepProtocol if the XML protocol has not already been copied in DTIPrep QC outdir.
-Inputs: - $QCProt           = Copied QC XML protocol (in QC output folder)
-        - $QCoutdir         = QC output directory
-        - $DTIPrepProtocol  = DTIPrep XML protocol used to run DTIPrep
-Output: - Will return 1 if XML protocol has already been copied 
-        - Or will return $copyProt_status from DTI::copyDTIPrepProtocol (which will be either equal to 1 if copy was successful or undef if copy failed).
+
+=head3 preproc_copyXMLprotocol($QCProt, $QCoutdir, $DTIPrepProtocol)
+
+Function that will call C<&DTI::copyDTIPrepProtocol> if the XML protocol has
+not already been copied in DTIPrep QC outdir.
+
+INPUT:
+  - $QCProt         : copied QC XML protocol (in QC output folder)
+  - $QCoutdir       : QC output directory
+  - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub preproc_copyXMLprotocol {
     my ($QCProt, $QCoutdir, $DTIPrepProtocol) = @_;
 
@@ -543,22 +602,27 @@ sub preproc_copyXMLprotocol {
 }        
 
 
-
-
-
-
-
 =pod
-This function will check preprocessing outputs and call convertPreproc2mnc, which will convert and reinsert headers into minc file.
-Inputs: - $DTIs_list        = list of raw DWI that were processed
-        - $DTIrefs          = hash with list of raw DTIs as a key and corresponding output names as values
-        - $data_dir         = directory containing raw DWI dataset
-        - $QCoutdir         = directory containing preprocessed outputs
-        - $DTIPrepProtocol  = DTIPrep XML protocol used to run DTIPrep
-        - $DTIPrepVersion   = DTIPrep version that was run to preprocess images
-Output: - Will return undef if could not find preprocessed files or convert it to minc. 
+
+=head3 check_and_convertPreprocessedFiles($DTIs_list, $DTIrefs, $data_dir, ...)
+
+This function will check pre-processing outputs and call
+C<&convertPreproc2mnc>, which will convert and reinsert headers into MINC file.
+
+INPUT:
+  - $DTIs_list      : list of raw DWI that were pre-processed
+  - $DTIrefs        : hash with list of raw DTIs as a key & corresponding
+                       output names as values
+  - $data_dir       : directory containing raw DWI dataset
+  - $QCoutdir       : directory containing preprocessed outputs
+  - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
+  - $DTIPrepVersion : DTIPrep version that was run to preprocess images
+
+Output: - Will return undef if could not find preprocessed files or convert it to minc.
         - Will return 1 if conversion was a success and all preprocessing files were found in QC outdir.
+
 =cut
+
 sub check_and_convertPreprocessedFiles {
     my ($DTIs_list, $DTIrefs, $data_dir, $QCoutdir, $DTIPrepProtocol, $DTIPrepVersion)  = @_;
 
@@ -595,27 +659,29 @@ sub check_and_convertPreprocessedFiles {
 }
 
 
-
-
-
-
-
-
-
 =pod
-Check if all Preprocessing DTIPrep files are in the output folder.
-They should include: - QCed nrrd file
-                     - DTIPrep QC text report
-                     - DTIPrep QC xml report
-                     - & a copy of the protocol used to run DTIPrep (QCProt)
-Inputs: - $dti_file         = raw DWI file that was processed
-        - $DTIrefs          = hash containing output names
-        - $QCoutdir         = preprocessing output directory
-        - $DTIPrepProtocol  = DTIPrep XML protocol that was used to run DTIPrep
-Output: - Will return 1 if all output files could be found 
-        - Will return undef if at least one output file is missing. 
+
+=head3 checkPreprocessOutputs($dti_file, $DTIrefs, $QCoutdir, $DTIPrepProtocol)
+
+Check if all pre-processing DTIPrep files are in the output folder. They
+should include:
+  - QCed NRRD file
+  - DTIPrep QC text report
+  - DTIPrep QC XML report
+  - a copy of the protocol used to run DTIPrep
 Relevant information will also be printed in the log file.
+
+INPUT:
+  - $dti_file       : raw DWI file that was processed
+  - $DTIrefs        : hash containing output names
+  - $QCoutdir       : preprocessing output directory
+  - $DTIPrepProtocol: DTIPrep XML protocol that was used to run DTIPrep
+
+RETURNS: 1 if all output files were found, undef if at least one output file
+is missing
+
 =cut
+
 sub checkPreprocessOutputs {
     my ($dti_file, $DTIrefs, $QCoutdir, $DTIPrepProtocol)  = @_;
 
@@ -649,20 +715,23 @@ sub checkPreprocessOutputs {
 }    
 
 
-
-
-
-
-
 =pod
-This function will convert to minc DTI QCed nrrd file from DTIPrep and reinsert all mincheader informations.
-Inputs: - $dti_file         = Raw DWI file to be processed
-        - $DTIrefs          = Hash containing output names
-        - $data_dir         = Directory containing the raw dataset
-        - $DTIPrepVersion   = DTIPrep version used to preprocess raw DWI
-Output: - Will return 1 if QCed minc file has been created or already exists
-        - Will return undef if QCed DWI was not successfully converted to minc
+
+=head3 convertPreproc2mnc($dti_file, $DTIrefs, $data_dir, $DTIPrepVersion)
+
+This function will convert to MINC DTI QCed NRRD file from DTIPrep and reinsert
+all mincheader information.
+
+INPUT:
+  - $dti_file      : raw DWI file to be processed
+  - $DTIrefs       : hash containing output names
+  - $data_dir      : directory containing the raw dataset
+  - $DTIPrepVersion: DTIPrep version used to pre-process raw DWI
+
+RETURNS: 1 if QCed MINC file created and exists; undef otherwise
+
 =cut
+
 sub convertPreproc2mnc {
     my ($dti_file, $DTIrefs, $data_dir, $DTIPrepVersion)   = @_;
 
@@ -700,27 +769,26 @@ sub convertPreproc2mnc {
 }
 
 
-
-
-
-
-
-
-
-
 =pod
-Post processing pipeline will:
-    - check if post processing outputs already exists
-    - if no post-processed outputs, it will call &runMincdiffusion to run mincdiffusion tools
-Inputs: - $DTIs_list        = list with raw DWI to post-process
-        - $DTIrefs          = hash containing output names and paths
-        - $data_dir         = directory hosting raw DWI dataset
-        - $QCoutdir         = QC process output directory
-        - $DTIPrepProtocol  = DTIPrep XML protocol used to run DTIPrep
-        - $mincdiffVersion  = mincdiffusion version 
-Output: - Will return undef if post-processing outputs could not be created
-        - Will return 1 if post-processing outputs was sucessfully created or already created
+
+=head3 mincdiffusionPipeline($DTIs_list, $DTIrefs, $data_dir, $QCoutdir, ...)
+
+Running post-processing pipeline that will check if post-processing outputs
+already exist. If they don't exist, it will call C<&runMincdiffusion> to run
+the mincdiffusion tools.
+
+INPUT:
+  - $DTIs_list      : list with raw DWI to post-process
+  - $DTIrefs        : hash containing output names and paths
+  - $data_dir       : directory hosting raw DWI dataset
+  - $QCoutdir       : QC process output directory
+  - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
+  - $mincdiffVersion: mincdiffusion version
+
+RETURNS: 1 if all post-processing outputs found, undef otherwise
+
 =cut
+
 sub mincdiffusionPipeline {
     my ($DTIs_list, $DTIrefs, $data_dir, $QCoutdir, $DTIPrepProtocol, $mincdiffVersion, $niak_path)  = @_;    
 
@@ -771,20 +839,21 @@ sub mincdiffusionPipeline {
 }
 
 
-
-
-
-
-
-
 =pod
+
+=head3 checkMincdiffusionPostProcessedOutputs($dti_file, $DTIrefs, $QCoutdir)
+
 Function that check if all outputs are present in the QC output directory.
-Inputs: - $dti_file = raw DWI dataset to use as a key in $DTIrefs
-        - $DTIrefs  = hash containing output names
-        - $QCoutdir = QC output directory 
-Output: - return 1 if all post processing outputs were found
-        - return undef if could not find all post processing outputs
+
+INPUT:
+  - $dti_file: raw DWI dataset to use as a key in $DTIrefs
+  - $DTIrefs : hash containing output names
+  - $QCoutdir: QC output directory
+
+RETURNS: 1 if all post processing outputs were found, undef otherwise
+
 =cut
+
 sub checkMincdiffusionPostProcessedOutputs {
     my ($dti_file, $DTIrefs, $QCoutdir)  = @_;
 
@@ -820,27 +889,23 @@ sub checkMincdiffusionPostProcessedOutputs {
 }    
 
 
-
-
-
-
-
-
-
-
-
-
-
 =pod
+
+=head3 runMincdiffusionTools($dti_file, $DTIrefs, $data_dir, $QCoutdir, ...)
+
 Will create FA, MD and RGB maps.
-Inputs: - $dti_file         = raw DWI file that is used as a key in $DTIrefs
-        - $DTIrefs          = hash containing output names and paths
-        - $data_dir         = directory containing raw datasets
-        - $QCoutdir         = QC output directory
-        - $mincdiffVersion  = mincdiffusion version used
-Output: - Return 1 if mincdiffusion pipeline was successful
-        - Return undef if at least one step of the mincdiffusion pipeline failed
+
+INPUT:
+  - $dti_file       : raw DWI file that is used as a key in $DTIrefs
+  - $DTIrefs        : hash containing output names and paths
+  - $data_dir       : directory containing raw datasets
+  - $QCoutdir       : QC output directory
+  - $mincdiffVersion: mincdiffusion version used
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub runMincdiffusionTools {
     my ($dti_file, $DTIrefs, $data_dir, $QCoutdir, $mincdiffVersion, $niak_path) = @_;
 
@@ -903,16 +968,26 @@ sub runMincdiffusionTools {
     }
 }
 
+
 =pod
-Function that loop through DTI files acquired for the candID and session to check if DTIPrep post processed nrrd files have been created and convert them to minc files with relevant header information.
-- Inputs:   - $DTIs_list        = list of DTI files for the session and candidate
-            - $DTIrefs          = hash containing all the reference for output naming for all DTIs
-            - $data_dir         = directory containing the raw DTI dataset
-            - $QCoutdir         = directory containing the processed data
-            - $DTIPrepVersion   = Version of DTIPrep used to process the data
-- Outputs:  - Return 1 if nrrd files were found and converted to minc with the relevant minc header information
-            - Return undef otherwise with the error written to the log file
+
+=head3 check_and_convert_DTIPrep_postproc_outputs($DTIs_list, $DTIrefs, ...)
+
+Function that loop through DTI files acquired for the CandID and session to
+check if DTIPrep post processed NRRD files have been created and convert them
+to MINC files with relevant header information.
+
+INPUT:
+  - $DTIs_list     : list of DTI files for the session and candidate
+  - $DTIrefs       : hash containing references for all DTI output naming
+  - $data_dir      : directory containing the raw DTI dataset
+  - $QCoutdir      : directory containing the processed data
+  - $DTIPrepVersion: Version of DTIPrep used to process the data
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub check_and_convert_DTIPrep_postproc_outputs {
     my ($DTIs_list, $DTIrefs, $data_dir, $QCoutdir, $DTIPrepVersion) = @_;
 
@@ -945,20 +1020,23 @@ sub check_and_convert_DTIPrep_postproc_outputs {
 }
 
 
-
-
-
-
-
 =pod
-Calls the script DTIPrepRegister.pl to register processed files into the database.
-Inputs:  - $DTIs_list:  list of native DTI files processed
-         - $DTIrefs:    hash containing the processed filenames
-         - $profile:    config file (a.k.a ./dicom-archive/.loris_mri/prod)
-         - $QCoutdir:   output directory containing the processed files
-         - $DTIPrepVersion:  DTIPrep version used to obtain QCed files
-         - $mincdiffVersion: mincdiffusion tool version used to obtain post-processing files
+
+=head3 register_processed_files_in_DB($DTIs_list, $DTIrefs, $profile, ...)
+
+Calls the script C<DTIPrepRegister.pl> to register processed files into the
+database.
+
+INPUT:
+  - $DTIs_list      : list of native DTI files processed
+  - $DTIrefs        : hash containing the processed filenames
+  - $profile        : config file (a.k.a ./dicom-archive/.loris_mri/prod)
+  - $QCoutdir       : output directory containing the processed files
+  - $DTIPrepVersion : DTIPrep version used to obtain QCed files
+  - $mincdiffVersion: mincdiffusion tool version used
+
 =cut
+
 sub register_processed_files_in_DB {
     my ($DTIs_list, $DTIrefs, $profile, $QCoutdir, $DTIPrepVersion, $mincdiffVersion) = @_;
 
@@ -987,3 +1065,24 @@ sub register_processed_files_in_DB {
 }
 
 
+__END__
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut

--- a/DTIPrep/DTIPrep_pipeline.pl
+++ b/DTIPrep/DTIPrep_pipeline.pl
@@ -75,6 +75,8 @@ Usage: $0 [options]
 
 -help for options
 
+Documentation: perldoc DTIPrep_pipeline.pl.
+
 USAGE
 
 # Set default option values

--- a/DTIPrep/DTIPrep_pipeline.pl
+++ b/DTIPrep/DTIPrep_pipeline.pl
@@ -34,14 +34,14 @@ perl DTIPrep_pipeline.p C<[options]>
 B<Notes:>
 
 - tool version options (C<-DTIPrepVersion> & C<-mincdiffusionVersion>)
-do not need to be set if it can be found directly in the path of the binary
+do not need to be set if they can be found directly in the path of the binary
 tools.
 
-- can run the script without the C<-runDTIPrep> option if don't want to run
-DTIPrep when calling the script.
+- the script can be run without the C<-runDTIPrep> option if execution of
+DTIPrep is not needed.
 
-- can run the script without the C<-registerFilesInDB> option if don't want
-to register DTIPrep outputs in the database.
+- the script cab be run without the C<-registerFilesInDB> option if
+registration of DTIPrep is not needed.
 
 =head1 DESCRIPTION
 
@@ -346,8 +346,9 @@ exit 0;
 
 Function that determines the tool version used for processing.
 
-INPUT: tool to search absolute path containing version information, string to
-match to determine tool version
+INPUTS:
+  - $tool : tool to search absolute path containing version information
+  - $match: string to match to determine tool version
 
 RETURNS: version of the tool found, or undef if version could not be
 determined based on the path
@@ -376,8 +377,8 @@ process. Relevant information will also be printed in the log file.
 
 INPUT: native directory of the dataset to process
 
-RETURNS: $candID & $visit_label information, or undef if could not find the
-site, CandID or visit label.
+RETURNS: $candID & $visit_label information, or undef if the script could not
+determine the site, CandID or visit label.
 
 =cut
 
@@ -411,9 +412,9 @@ C<outdir/ProtocolName/CandID/VisitLabel>
 
 - If $runDTIPrep is set, the function will create the output folders
 
-- If $runDTIPrep is not set, will check that the directory exists
+- If $runDTIPrep is not set, the function will check that the directory exists
 
-INPUT:
+INPUTS:
   - $outdir         : root directory for DTIPrep outputs (in
                        C</data/project/data/pipelines/DTIPrep/DTIPrep_version>)
   - $subjID         : candidate ID of the DTI dataset to be processed
@@ -452,11 +453,11 @@ sub getOutputDirectories {
 
 =head3 fetchData($nativedir, $DTI_volumes, $t1_scan_type, $QCoutdir, ...)
 
-Fetch the raw DWI datasets and foreach DWI, determine output names to be used
-and store them into a hash ($DTIrefs). Will also print relevant information
+Fetches the raw DWI datasets and foreach DWI, determines output names to be used
+and stores them into a hash ($DTIrefs). Will also print relevant information
 in the log file.
 
-INPUT:
+INPUTS:
   - $nativedir      : native directory to look for native DWI dataset
   - $DTI_volumes    : number of volumes expected in the DWI dataset
   - $t1_scan_type   : the scan type name of the T1 weighted dataset
@@ -499,10 +500,10 @@ sub fetchData {
 
 =head3 preprocessingPipeline($DTIs_list, $DTIrefs, $QCoutdir, ...)
 
-Function that creates the output folders, get the raw DTI files, convert them
-to NRRD and run DTIPrep using a C<bcheck> protocol and a C<nobcheck> protocol.
+Function that creates the output folders, gets the raw DTI files, converts them
+to NRRD and runs DTIPrep using a C<bcheck> protocol and a C<nobcheck> protocol.
 
-INPUT:
+INPUTS:
   - $DTIs_list      : list of DWI files to process for a given
                        CandID/Visit
   - $DTIrefs        : hash with output file names & paths for the
@@ -567,9 +568,9 @@ sub preprocessingPipeline {
 
 =head3 preproc_mnc2nrrd($raw_nrrd, $dti_file)
 
-Function that converts MINC raw DWI file to NRRD and log the conversion status.
+Function that converts MINC raw DWI file to NRRD and logs the conversion status.
 
-INPUT: raw NRRD file to create, raw DWI file to convert to NRRD
+INPUTS: raw NRRD file to create, raw DWI file to convert to NRRD
 
 RETURNS: 1 on success, undef on failure
 
@@ -597,7 +598,7 @@ sub preproc_mnc2nrrd {
 
 This function will call C<&DTI::runDTIPrep> to run DTIPrep on the raw NRRD file.
 
-INPUT:
+INPUTS:
   - $QCed_nrrd      : QCed DWI NRRD file to be created by DTIPrep
   - $raw_nrrd       : raw DWI NRRD file to process through DTIPrep
   - $DTIPrepProtocol: DTIPrep XML Protocol to use to run DTIPrep
@@ -628,7 +629,7 @@ sub preproc_DTIPrep {
 Function that will call C<&DTI::copyDTIPrepProtocol> if the XML protocol has
 not already been copied in DTIPrep QC outdir.
 
-INPUT:
+INPUTS:
   - $QCProt         : copied QC XML protocol (in QC output folder)
   - $QCoutdir       : QC output directory
   - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
@@ -659,7 +660,7 @@ sub preproc_copyXMLprotocol {
 This function will check pre-processing outputs and call
 C<&convertPreproc2mnc>, which will convert and reinsert headers into MINC file.
 
-INPUT:
+INPUTS:
   - $DTIs_list      : list of raw DWI that were pre-processed
   - $DTIrefs        : hash with list of raw DTIs as a key &
                        corresponding output names as values
@@ -668,10 +669,11 @@ INPUT:
   - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
   - $DTIPrepVersion : DTIPrep version that was run to pre-process images
 
-Output: - Will return undef if could not find preprocessed files
-           or convert it to MINC
-        - Will return 1 if conversion was a success and all
-           preprocessing files were found in QC output directory
+RETURNS:
+  - Will return undef if the function could not find preprocessed files
+     or convert them to MINC
+  - Will return 1 if conversion was a success and all
+     preprocessing files were found in QC output directory
 
 =cut
 
@@ -715,7 +717,7 @@ sub check_and_convertPreprocessedFiles {
 
 =head3 checkPreprocessOutputs($dti_file, $DTIrefs, $QCoutdir, ...)
 
-Check if all pre-processing DTIPrep files are in the output folder. They
+Checks if all pre-processing DTIPrep files are in the output folder. They
 should include:
   - QCed NRRD file
   - DTIPrep QC text report
@@ -724,7 +726,7 @@ should include:
 
 Relevant information will also be printed in the log file.
 
-INPUT:
+INPUTS:
   - $dti_file       : raw DWI file that was processed
   - $DTIrefs        : hash containing output names
   - $QCoutdir       : preprocessing output directory
@@ -773,9 +775,9 @@ sub checkPreprocessOutputs {
 =head3 convertPreproc2mnc($dti_file, $DTIrefs, $data_dir, $DTIPrepVersion)
 
 This function will convert to MINC DTI QCed NRRD file from DTIPrep and reinsert
-all mincheader information.
+all MINC header information.
 
-INPUT:
+INPUTS:
   - $dti_file      : raw DWI file to be processed
   - $DTIrefs       : hash containing output names
   - $data_dir      : directory containing the raw dataset
@@ -830,7 +832,7 @@ Running post-processing pipeline that will check if post-processing outputs
 already exist. If they don't exist, it will call C<&runMincdiffusion> to run
 the mincdiffusion tools.
 
-INPUT:
+INPUTS:
   - $DTIs_list      : list with raw DWI to post-process
   - $DTIrefs        : hash containing output names and paths
   - $data_dir       : directory hosting raw DWI dataset
@@ -896,9 +898,9 @@ sub mincdiffusionPipeline {
 
 =head3 checkMincdiffusionPostProcessedOutputs($dti_file, $DTIrefs, $QCoutdir)
 
-Function that check if all outputs are present in the QC output directory.
+Function that checks if all outputs are present in the QC output directory.
 
-INPUT:
+INPUTS:
   - $dti_file: raw DWI dataset to use as a key in $DTIrefs
   - $DTIrefs : hash containing output names
   - $QCoutdir: QC output directory
@@ -948,7 +950,7 @@ sub checkMincdiffusionPostProcessedOutputs {
 
 Will create FA, MD and RGB maps.
 
-INPUT:
+INPUTS:
   - $dti_file       : raw DWI file that is used as a key in $DTIrefs
   - $DTIrefs        : hash containing output names and paths
   - $data_dir       : directory containing raw datasets
@@ -1026,11 +1028,11 @@ sub runMincdiffusionTools {
 
 =head3 check_and_convert_DTIPrep_postproc_outputs($DTIs_list, $DTIrefs, ...)
 
-Function that loop through DTI files acquired for the CandID and session to
-check if DTIPrep post processed NRRD files have been created and convert them
+Function that loops through DTI files acquired for the CandID and session to
+check if DTIPrep post processed NRRD files have been created and converts them
 to MINC files with relevant header information.
 
-INPUT:
+INPUTS:
   - $DTIs_list     : list of DTI files for the session and candidate
   - $DTIrefs       : hash containing references for DTI output naming
   - $data_dir      : directory containing the raw DTI dataset

--- a/docs/scripts_md/DTIPrep_pipeline.md
+++ b/docs/scripts_md/DTIPrep_pipeline.md
@@ -1,0 +1,268 @@
+# NAME
+
+DTIPrep\_pipeline.pl -- Run DTIPrep and/or insert DTIPrep's outputs in the
+database.
+
+# SYNOPSIS
+
+# DESCRIPTION
+
+`DTIPrep_pipeline.pl` can be used to run DTIPrep on native DWI datasets. It
+will also organize, convert and register the outputs of DTIPrep in the database.
+
+If `-runDTIPrep` option is not set, DTIPrep processing will be skipped
+(DTIPrep outputs being already available, as well as the DTIPrep protocol that
+was used).
+
+This pipeline will:
+  - grep native DWI files from list of given native directories (-list option)
+  - create (or fetch if `-runDTIPrep` not set) output directories based on the
+     DTIPrep version and protocol that are to be (or were) used for DTIPrep
+     processing.
+  - convert native DWI minc file to NRRD & run DTIPrep if `-runDTIPrep` is set
+  - fetch DTIPrep preprocessing outputs (QCed.nrrd, QCReport.txt,
+     QCXMLResults.xml and protocol.xml)
+  - convert pre-processed NRRD back to MINC with all the header information
+     (based on the native MINC file)
+  - create post-processing files (FA, RGB maps...) with all header information
+  - call `DTIPrepRegister.pl` to register the files in the database if
+     `-registerFilesInDB` is set
+
+## Methods
+
+### identify\_tool\_version($tool, $match)
+
+Function that determines the tool version used for processing.
+
+INPUT: tool to search absolute path containing version information, string to
+match to determine tool version
+
+RETURNS: version of the tool found, or undef if version could not be
+determined based on the path
+
+### getIdentifiers($nativedir)
+
+Fetches CandID and visit label from the native directory of the dataset to
+process. Relevant information will also be printed in the log file.
+
+INPUT: native directory of the dataset to process
+
+RETURNS: $candID & $visit\_label information, or undef if could not find the
+site, CandID or visit label.
+
+### getOutputDirectories($outdir, $subjID, $visit, $DTIPrepProtocol, ...)
+
+Determine pipeline's output directory, based on the root `$outdir`, DTIPrep
+protocol, candID and visit label: (outdir/ProtocolName/CandID/VisitLabel).
+  - If $runDTIPrep is defined, the function will create the output folders.
+  - If $runDTIPrep is not defined, will check that the directory exists.
+
+INPUT:
+  - $outdir         : root directory for DTIPrep outputs (in
+                       `/data/project/data/pipelines/DTIPrep/DTIPrep_version`)
+  - $subjID         : candidate ID of the DTI dataset to be processed
+  - $visit          : visit label of the DTI dataset to be processed
+  - $DTIPrepProtocol: XML file with the DTIPrep protocol to be used for analyses
+  - $runDTIPrep     : boolean, if OutputFolders should be created in the
+                       filesystem (before processing data through DTIPrep) if
+                       they don't exist
+
+RETURNS: directory where processed files for the candidate, visit label and
+DTIPrep protocol will be stored.
+
+### fetchData($nativedir, $DTI\_volumes, $t1\_scan\_type, $QCoutdir, ...)
+
+Fetch the raw DWI datasets and foreach DWI, determine output names to be used
+and store them into a hash ($DTIrefs). Will also print relevant information
+in the log file.
+
+INPUT:
+  - $nativedir      : native directory to look for native DWI dataset
+  - $DTI\_volumes    : number of volumes expected in the DWI dataset
+  - $t1\_scan\_type   : the scan type name of the T1 weighted dataset
+  - $QCoutdir       : directory to save processed files
+  - $DTIPrepProtocol: XML DTIPrep protocol to be used to process DWI datasets
+
+RETURNS:
+  - list of raw DTIs found, a hash with the preprocessing output names
+     and paths if raw DWI dataset was found.
+  - undef if could not find any raw DWI dataset.
+
+### preprocessingPipeline($DTIs\_list, $DTIrefs, $QCoutdir, $DTIPrepProtocol)
+
+Function that creates the output folders, get the raw DTI files, convert them
+to NRRD and run DTIPrep using a `bcheck` protocol and a `nobcheck` protocol.
+
+INPUT:
+  - $DTIs\_list      : list of DWI files to process for a given candidate/visit
+  - $DTIrefs        : hash with output file names & paths for the different DWI
+  - $QCoutdir       : output directory to use to save preprocessed files.
+  - $DTIPrepProtocol: XML DTIPrep protocol to use to pre-process the DWI data
+
+RETURNS:
+  - 1 if at least one raw DWI dataset was successfully preprocessed
+  - undef if pre-processing was not successful on a least one raw DWI dataset
+
+### preproc\_mnc2nrrd($raw\_nrrd, $dti\_file)
+
+Function that convert MINC raw DWI file to NRRD and log the conversion status.
+
+INPUT: raw NRRD file to create, raw DWI file to convert to NRRD
+
+RETURNS: 1 on success, undef on failure
+
+### preproc\_DTIPrep($QCed\_nrrd, $raw\_nrrd, $DTIPrepProtocol, $QCed2\_nrrd)
+
+This function will call `&DTI::runDTIPrep` to run DTIPrep on the raw NRRD file.
+
+INPUT:
+  - $QCed\_nrrd      : QCed DWI NRRD file to be created by DTIPrep
+  - $raw\_nrrd       : raw DWI NRRD file to process through DTIPrep
+  - $DTIPrepProtocol: DTIPrep XML Protocol to use to run DTIPrep
+
+RETURNS: 1 on success, undef on failure
+
+### preproc\_copyXMLprotocol($QCProt, $QCoutdir, $DTIPrepProtocol)
+
+Function that will call `&DTI::copyDTIPrepProtocol` if the XML protocol has
+not already been copied in DTIPrep QC outdir.
+
+INPUT:
+  - $QCProt         : copied QC XML protocol (in QC output folder)
+  - $QCoutdir       : QC output directory
+  - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
+
+RETURNS: 1 on success, undef on failure
+
+### check\_and\_convertPreprocessedFiles($DTIs\_list, $DTIrefs, $data\_dir, ...)
+
+This function will check pre-processing outputs and call
+`&convertPreproc2mnc`, which will convert and reinsert headers into MINC file.
+
+INPUT:
+  - $DTIs\_list      : list of raw DWI that were pre-processed
+  - $DTIrefs        : hash with list of raw DTIs as a key & corresponding
+                       output names as values
+  - $data\_dir       : directory containing raw DWI dataset
+  - $QCoutdir       : directory containing preprocessed outputs
+  - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
+  - $DTIPrepVersion : DTIPrep version that was run to preprocess images
+
+Output: - Will return undef if could not find preprocessed files or convert it to minc.
+        - Will return 1 if conversion was a success and all preprocessing files were found in QC outdir.
+
+### checkPreprocessOutputs($dti\_file, $DTIrefs, $QCoutdir, $DTIPrepProtocol)
+
+Check if all pre-processing DTIPrep files are in the output folder. They
+should include:
+  - QCed NRRD file
+  - DTIPrep QC text report
+  - DTIPrep QC XML report
+  - a copy of the protocol used to run DTIPrep
+Relevant information will also be printed in the log file.
+
+INPUT:
+  - $dti\_file       : raw DWI file that was processed
+  - $DTIrefs        : hash containing output names
+  - $QCoutdir       : preprocessing output directory
+  - $DTIPrepProtocol: DTIPrep XML protocol that was used to run DTIPrep
+
+RETURNS: 1 if all output files were found, undef if at least one output file
+is missing
+
+### convertPreproc2mnc($dti\_file, $DTIrefs, $data\_dir, $DTIPrepVersion)
+
+This function will convert to MINC DTI QCed NRRD file from DTIPrep and reinsert
+all mincheader information.
+
+INPUT:
+  - $dti\_file      : raw DWI file to be processed
+  - $DTIrefs       : hash containing output names
+  - $data\_dir      : directory containing the raw dataset
+  - $DTIPrepVersion: DTIPrep version used to pre-process raw DWI
+
+RETURNS: 1 if QCed MINC file created and exists; undef otherwise
+
+### mincdiffusionPipeline($DTIs\_list, $DTIrefs, $data\_dir, $QCoutdir, ...)
+
+Running post-processing pipeline that will check if post-processing outputs
+already exist. If they don't exist, it will call `&runMincdiffusion` to run
+the mincdiffusion tools.
+
+INPUT:
+  - $DTIs\_list      : list with raw DWI to post-process
+  - $DTIrefs        : hash containing output names and paths
+  - $data\_dir       : directory hosting raw DWI dataset
+  - $QCoutdir       : QC process output directory
+  - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
+  - $mincdiffVersion: mincdiffusion version
+
+RETURNS: 1 if all post-processing outputs found, undef otherwise
+
+### checkMincdiffusionPostProcessedOutputs($dti\_file, $DTIrefs, $QCoutdir)
+
+Function that check if all outputs are present in the QC output directory.
+
+INPUT:
+  - $dti\_file: raw DWI dataset to use as a key in $DTIrefs
+  - $DTIrefs : hash containing output names
+  - $QCoutdir: QC output directory
+
+RETURNS: 1 if all post processing outputs were found, undef otherwise
+
+### runMincdiffusionTools($dti\_file, $DTIrefs, $data\_dir, $QCoutdir, ...)
+
+Will create FA, MD and RGB maps.
+
+INPUT:
+  - $dti\_file       : raw DWI file that is used as a key in $DTIrefs
+  - $DTIrefs        : hash containing output names and paths
+  - $data\_dir       : directory containing raw datasets
+  - $QCoutdir       : QC output directory
+  - $mincdiffVersion: mincdiffusion version used
+
+RETURNS: 1 on success, undef on failure
+
+### check\_and\_convert\_DTIPrep\_postproc\_outputs($DTIs\_list, $DTIrefs, ...)
+
+Function that loop through DTI files acquired for the CandID and session to
+check if DTIPrep post processed NRRD files have been created and convert them
+to MINC files with relevant header information.
+
+INPUT:
+  - $DTIs\_list     : list of DTI files for the session and candidate
+  - $DTIrefs       : hash containing references for all DTI output naming
+  - $data\_dir      : directory containing the raw DTI dataset
+  - $QCoutdir      : directory containing the processed data
+  - $DTIPrepVersion: Version of DTIPrep used to process the data
+
+RETURNS: 1 on success, undef on failure
+
+### register\_processed\_files\_in\_DB($DTIs\_list, $DTIrefs, $profile, ...)
+
+Calls the script `DTIPrepRegister.pl` to register processed files into the
+database.
+
+INPUT:
+  - $DTIs\_list      : list of native DTI files processed
+  - $DTIrefs        : hash containing the processed filenames
+  - $profile        : config file (a.k.a ./dicom-archive/.loris\_mri/prod)
+  - $QCoutdir       : output directory containing the processed files
+  - $DTIPrepVersion : DTIPrep version used to obtain QCed files
+  - $mincdiffVersion: mincdiffusion tool version used
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/DTIPrep_pipeline.md
+++ b/docs/scripts_md/DTIPrep_pipeline.md
@@ -28,14 +28,14 @@ perl DTIPrep\_pipeline.p `[options]`
 **Notes:**
 
 \- tool version options (`-DTIPrepVersion` & `-mincdiffusionVersion`)
-do not need to be set if it can be found directly in the path of the binary
+do not need to be set if they can be found directly in the path of the binary
 tools.
 
-\- can run the script without the `-runDTIPrep` option if don't want to run
-DTIPrep when calling the script.
+\- the script can be run without the `-runDTIPrep` option if execution of
+DTIPrep is not needed.
 
-\- can run the script without the `-registerFilesInDB` option if don't want
-to register DTIPrep outputs in the database.
+\- the script cab be run without the `-registerFilesInDB` option if
+registration of DTIPrep is not needed.
 
 # DESCRIPTION
 
@@ -76,8 +76,9 @@ was used).
 
 Function that determines the tool version used for processing.
 
-INPUT: tool to search absolute path containing version information, string to
-match to determine tool version
+INPUTS:
+  - $tool : tool to search absolute path containing version information
+  - $match: string to match to determine tool version
 
 RETURNS: version of the tool found, or undef if version could not be
 determined based on the path
@@ -89,8 +90,8 @@ process. Relevant information will also be printed in the log file.
 
 INPUT: native directory of the dataset to process
 
-RETURNS: $candID & $visit\_label information, or undef if could not find the
-site, CandID or visit label.
+RETURNS: $candID & $visit\_label information, or undef if the script could not
+determine the site, CandID or visit label.
 
 ### getOutputDirectories($outdir, $subjID, $visit, $DTIPrepProtocol, ...)
 
@@ -100,9 +101,9 @@ protocol name, candidate ID `CandID` and visit label:
 
 \- If $runDTIPrep is set, the function will create the output folders
 
-\- If $runDTIPrep is not set, will check that the directory exists
+\- If $runDTIPrep is not set, the function will check that the directory exists
 
-INPUT:
+INPUTS:
   - $outdir         : root directory for DTIPrep outputs (in
                        `/data/project/data/pipelines/DTIPrep/DTIPrep_version`)
   - $subjID         : candidate ID of the DTI dataset to be processed
@@ -117,11 +118,11 @@ DTIPrep protocol will be stored.
 
 ### fetchData($nativedir, $DTI\_volumes, $t1\_scan\_type, $QCoutdir, ...)
 
-Fetch the raw DWI datasets and foreach DWI, determine output names to be used
-and store them into a hash ($DTIrefs). Will also print relevant information
+Fetches the raw DWI datasets and foreach DWI, determines output names to be used
+and stores them into a hash ($DTIrefs). Will also print relevant information
 in the log file.
 
-INPUT:
+INPUTS:
   - $nativedir      : native directory to look for native DWI dataset
   - $DTI\_volumes    : number of volumes expected in the DWI dataset
   - $t1\_scan\_type   : the scan type name of the T1 weighted dataset
@@ -135,10 +136,10 @@ RETURNS:
 
 ### preprocessingPipeline($DTIs\_list, $DTIrefs, $QCoutdir, ...)
 
-Function that creates the output folders, get the raw DTI files, convert them
-to NRRD and run DTIPrep using a `bcheck` protocol and a `nobcheck` protocol.
+Function that creates the output folders, gets the raw DTI files, converts them
+to NRRD and runs DTIPrep using a `bcheck` protocol and a `nobcheck` protocol.
 
-INPUT:
+INPUTS:
   - $DTIs\_list      : list of DWI files to process for a given
                        CandID/Visit
   - $DTIrefs        : hash with output file names & paths for the
@@ -153,9 +154,9 @@ RETURNS:
 
 ### preproc\_mnc2nrrd($raw\_nrrd, $dti\_file)
 
-Function that converts MINC raw DWI file to NRRD and log the conversion status.
+Function that converts MINC raw DWI file to NRRD and logs the conversion status.
 
-INPUT: raw NRRD file to create, raw DWI file to convert to NRRD
+INPUTS: raw NRRD file to create, raw DWI file to convert to NRRD
 
 RETURNS: 1 on success, undef on failure
 
@@ -163,7 +164,7 @@ RETURNS: 1 on success, undef on failure
 
 This function will call `&DTI::runDTIPrep` to run DTIPrep on the raw NRRD file.
 
-INPUT:
+INPUTS:
   - $QCed\_nrrd      : QCed DWI NRRD file to be created by DTIPrep
   - $raw\_nrrd       : raw DWI NRRD file to process through DTIPrep
   - $DTIPrepProtocol: DTIPrep XML Protocol to use to run DTIPrep
@@ -175,7 +176,7 @@ RETURNS: 1 on success, undef on failure
 Function that will call `&DTI::copyDTIPrepProtocol` if the XML protocol has
 not already been copied in DTIPrep QC outdir.
 
-INPUT:
+INPUTS:
   - $QCProt         : copied QC XML protocol (in QC output folder)
   - $QCoutdir       : QC output directory
   - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
@@ -187,7 +188,7 @@ RETURNS: 1 on success, undef on failure
 This function will check pre-processing outputs and call
 `&convertPreproc2mnc`, which will convert and reinsert headers into MINC file.
 
-INPUT:
+INPUTS:
   - $DTIs\_list      : list of raw DWI that were pre-processed
   - $DTIrefs        : hash with list of raw DTIs as a key &
                        corresponding output names as values
@@ -196,14 +197,15 @@ INPUT:
   - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
   - $DTIPrepVersion : DTIPrep version that was run to pre-process images
 
-Output: - Will return undef if could not find preprocessed files
-           or convert it to MINC
-        - Will return 1 if conversion was a success and all
-           preprocessing files were found in QC output directory
+RETURNS:
+  - Will return undef if the function could not find preprocessed files
+     or convert them to MINC
+  - Will return 1 if conversion was a success and all
+     preprocessing files were found in QC output directory
 
 ### checkPreprocessOutputs($dti\_file, $DTIrefs, $QCoutdir, ...)
 
-Check if all pre-processing DTIPrep files are in the output folder. They
+Checks if all pre-processing DTIPrep files are in the output folder. They
 should include:
   - QCed NRRD file
   - DTIPrep QC text report
@@ -212,7 +214,7 @@ should include:
 
 Relevant information will also be printed in the log file.
 
-INPUT:
+INPUTS:
   - $dti\_file       : raw DWI file that was processed
   - $DTIrefs        : hash containing output names
   - $QCoutdir       : preprocessing output directory
@@ -224,9 +226,9 @@ is missing
 ### convertPreproc2mnc($dti\_file, $DTIrefs, $data\_dir, $DTIPrepVersion)
 
 This function will convert to MINC DTI QCed NRRD file from DTIPrep and reinsert
-all mincheader information.
+all MINC header information.
 
-INPUT:
+INPUTS:
   - $dti\_file      : raw DWI file to be processed
   - $DTIrefs       : hash containing output names
   - $data\_dir      : directory containing the raw dataset
@@ -240,7 +242,7 @@ Running post-processing pipeline that will check if post-processing outputs
 already exist. If they don't exist, it will call `&runMincdiffusion` to run
 the mincdiffusion tools.
 
-INPUT:
+INPUTS:
   - $DTIs\_list      : list with raw DWI to post-process
   - $DTIrefs        : hash containing output names and paths
   - $data\_dir       : directory hosting raw DWI dataset
@@ -252,9 +254,9 @@ RETURNS: 1 if all post-processing outputs found, undef otherwise
 
 ### checkMincdiffusionPostProcessedOutputs($dti\_file, $DTIrefs, $QCoutdir)
 
-Function that check if all outputs are present in the QC output directory.
+Function that checks if all outputs are present in the QC output directory.
 
-INPUT:
+INPUTS:
   - $dti\_file: raw DWI dataset to use as a key in $DTIrefs
   - $DTIrefs : hash containing output names
   - $QCoutdir: QC output directory
@@ -265,7 +267,7 @@ RETURNS: 1 if all post processing outputs were found, undef otherwise
 
 Will create FA, MD and RGB maps.
 
-INPUT:
+INPUTS:
   - $dti\_file       : raw DWI file that is used as a key in $DTIrefs
   - $DTIrefs        : hash containing output names and paths
   - $data\_dir       : directory containing raw datasets
@@ -276,11 +278,11 @@ RETURNS: 1 on success, undef on failure
 
 ### check\_and\_convert\_DTIPrep\_postproc\_outputs($DTIs\_list, $DTIrefs, ...)
 
-Function that loop through DTI files acquired for the CandID and session to
-check if DTIPrep post processed NRRD files have been created and convert them
+Function that loops through DTI files acquired for the CandID and session to
+check if DTIPrep post processed NRRD files have been created and converts them
 to MINC files with relevant header information.
 
-INPUT:
+INPUTS:
   - $DTIs\_list     : list of DTI files for the session and candidate
   - $DTIrefs       : hash containing references for DTI output naming
   - $data\_dir      : directory containing the raw DTI dataset

--- a/docs/scripts_md/DTIPrep_pipeline.md
+++ b/docs/scripts_md/DTIPrep_pipeline.md
@@ -5,6 +5,18 @@ database.
 
 # SYNOPSIS
 
+perl DTIPrep\_pipeline.pl -profile `prod` -list
+`/path/to/list/of/native/dir` -DTIPrepVersion `DTIPrep_version`
+\-mincdiffusionVersion `mincdiffusion_version` -runDTIPrep - DTIPrepProtocol
+`/path/to/DTIPrep/XML/protocol` -registerFilesInDB
+
+Note:
+\- `-DTIPrepVersion` and `-mincdiffusionVersion` are optional if the
+version of those tools can be found directly from the tools installed on the
+server running `DTIPrepRegister`.
+\- `-runDTIPrep` and `registerFilesInDB` are optional depending on whether
+just want to run the DTIPrep pipeline or just want to register the outputs...
+
 # DESCRIPTION
 
 `DTIPrep_pipeline.pl` can be used to run DTIPrep on native DWI datasets. It


### PR DESCRIPTION
Using perldoc/perlpod to document `DTIPrep_pipeline.pl` so that users can type in the terminal
`perldoc DTIPrep_pipeline.pl` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `DTIPrep_pipeline.pl` file has been created so that we have a web displayed version of the documentation.
`pod2markdown DTIPrep_pipeline.pl > DTIPrep_pipeline.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage