### PR TITLE
[Documentation] DTIPrepRegister.pl perldocification

### DIFF
--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -24,10 +24,10 @@ Available options are:
 -anat_file      : native anatomical dataset used to create FA, RGB and
                    other post-processed maps using mincdiffusion tools
 
--DTIPrepVersion : DTIPrep version used if cannot be found in MINC
+-DTIPrepVersion : DTIPrep version used if it cannot be found in MINC
                    files' C<processing:pipeline> header field
 
--mincdiffusionVersion: mincdiffusion release version used if cannot be
+-mincdiffusionVersion: mincdiffusion release version used if it cannot be
                         found in minc files' C<processing:pipeline>
                         header field
 
@@ -372,15 +372,17 @@ exit 0;
 
 =head3 register_XMLProt($XMLProtocol, $data_dir, $tool)
 
-Registers XML protocol file into C<mri_processing_protocol> table. It will first
-check if protocol file was already registered in the database. If the protocol
-file is already registered in the database, it will return the
+Registers XML protocol file into the C<mri_processing_protocol> table. It will
+first check if protocol file was already registered in the database. If the
+protocol file is already registered in the database, it will return the
 ProcessProtocolID from the database. If the protocol file is not registered yet
 in the database, it will register it in the database and return the
 ProcessProtocolID of the registered protocol file.
 
-INPUT: XML protocol file of DTIPrep to be registered, data directory from the
-Config table, tool name of the protocol (a.k.a. "DTIPrep")
+INPUTS:
+  - $XMLProtocol: XML protocol file of DTIPrep to be registered
+  - $data_dir   : data directory from the C<Config> table, tool name of the
+                   protocol (a.k.a. "DTIPrep")
 
 RETURNS: ID of the registered protocol file
 
@@ -411,7 +413,7 @@ sub register_XMLProt {
 Registers protocol file into C<mri_processing_protocol> table and move the
 protocol to the C<$data_dir/protocols/DTIPrep> folder.
 
-INPUT:
+INPUTS:
   - $protocol: protocol file to be registered
   - $md5sum  : md5sum of the protocol file to be registered
   - $tool    : tool of the protocol file (DTIPrep)
@@ -484,11 +486,11 @@ sub fetchProtocolID {
 
 =head3 register_minc($minc, $raw_file, $data_dir, $inputs, ...)
 
-Set the different parameters needed for MINC files' registration
-and call C<&registerFile> to register the MINC file in the database
+Sets the different parameters needed for MINC files' registration
+and calls C<&registerFile> to register the MINC file in the database
 via C<register_processed_data.pl> script.
 
-INPUT:
+INPUTS:
   - $minc                  : MINC file to be registered
   - $raw_file              : source file of the MINC file to register
   - $data_dir              : data_dir directory from the config table
@@ -632,7 +634,7 @@ INPUT:
   - $toolName    : DTIPrep name & version used to process the DWI file
 
 RETURNS: the registered XNL file if it was registered in the database, undef
-otherwise
+          otherwise
 
 =cut
 
@@ -708,11 +710,11 @@ sub register_XMLFile {
 
 =head3 register_QCReport($QCReport, $raw_file, $data_dir, $inputs, ...)
 
-Set parameters needed to register the QCreport of DTIPrep and call
+Sets parameters needed to register the QCreport of DTIPrep and calls
 C<&registerFile> to register the QCreport file via
 C<register_processed_data.pl>.
 
-INPUT:
+INPUTS:
   - $QCReport    : QC report file to be registered
   - $raw_file    : native DWI file used to obtain the DTIPrep outputs
   - $data_dir    : data_dir from the config table
@@ -722,7 +724,7 @@ INPUT:
   - $toolName    : DTIPrep name & version used to process the DWI file
 
 RETURNS: registered QCReport file if it was registered in the database, undef
- otherwise
+          otherwise
 
 =cut
 
@@ -793,12 +795,13 @@ sub register_QCReport {
 =head3 getFiles($dti_file, $DTIrefs)
 
 This function checks that all the processing files exist on the filesystem and
-returns the files to be inserted in the database. When NRRD and MINC files were
+returns the files to be inserted in the database. When NRRD and MINC files are
 found, it will only return the MINC file. (NRRD files will be linked to the
 MINC file when inserting files in the database).
 
-INPUT: raw DTI dataset that is used as a key in C<$DTIrefs> hash; hash
-containing all output paths and tool information
+INPUTS:
+  - $dit_file: raw DTI dataset that is used as a key in C<$DTIrefs> hash
+  - $DTIref  : hash containing all output paths and tool information
 
 RETURNS:
   - $XMLProtocol    : DTIPrep XML protocol found in the file system
@@ -843,8 +846,11 @@ sub getFiles {
 Function that checks if all DTIPrep pre-processing files are present in the
 file system.
 
-INPUT: raw DTI dataset that is used as a key in $DTIrefs hash; hash
-containing all output paths and tool information
+INPUTS:
+  - $dti_file: raw DTI dataset that is used as a key in $DTIrefs hash
+  - DTIrefs  : hash containing all output paths and tool information
+  - mri_files: list of processed outputs to register or that have been
+                registered
 
 RETURNS:
   - $XMLProtocol: DTIPrep XML protocol found in the file system
@@ -903,8 +909,11 @@ sub checkPreprocessFiles {
 Function that checks if all postprocessing files (from DTIPrep or
 mincdiffusion) are present in the file system.
 
-INPUT: raw DTI dataset that is used as a key in $DTIrefs hash; hash
-containing all output paths and tool information
+INPUTS:
+  - $dti_file : raw DTI dataset that is used as a key in $DTIrefs hash
+  - $DTIrefs  : hash containing all output paths and tool information
+  - $mri_files: list of processed outputs to register or that
+                 have been registered
 
 RETURNS:
   - $RGB_minc       : RGB map
@@ -1025,11 +1034,13 @@ sub checkPostprocessFiles {
 Fetches the source FileID from the database based on the src_name file
 identified by getFileName.
 
-INPUT: output filename, source filename (file that has been used to obtain
-the output file $file)
+INPUTS:
+  - $file    : output filename
+  - $src_name: source filename (file that has been used to obtain the output
+                file $file)
 
 RETURNS: source File ID (file ID of the source file that has been used to
-obtain $file)
+          obtain $file)
 
 =cut
 
@@ -1062,13 +1073,15 @@ sub getFileID {
 
 =head3 getToolName($file)
 
-Fetches tool information stored either in the MINC's header or in the QCReport.
+Fetches tool information stored either in the MINC file's header or in the
+QCReport.
 
 INPUT: MINC or QC report to look for tool information
 
-RETURNS: name of the pipeline used to obtain $file (a.k.a. DTIPrepPipeline);
-name and version of the tool used to obtain $file (DTIPrep_v1.1.6,
-mincdiffusion_v...)
+RETURNS:
+  - $src_pipeline: name of the pipeline used to obtain $file (DTIPrepPipeline)
+  - $src_tool    : name and version of the tool used to obtain $file
+                    (DTIPrep_v1.1.6, mincdiffusion_v...)
 
 =cut
 
@@ -1098,13 +1111,15 @@ sub getToolName {
 
 =head3 getPipelineDate($file, $data_dir, $QCReport)
 
-Fetches the date at which DTIPrep pipeline was run either in the processed
-MINC's header or in the QCReport.
+Fetches the date at which the DTIPrep pipeline was run either in the processed
+MINC file's header or in the QCReport.
 
-INPUT: MINC or QC report to look for tool information; data_dir from the
-Config table; QC report created when $file was created
+INPUTS:
+  - MINC or QC report to look for tool information
+  - data_dir from the C<Config> table
+  - QC report created when C<$file> was created
 
-RETURNS: date at which the pipeline has been run to obtain $file
+RETURNS: date at which the pipeline has been run to obtain C<$file>
 
 =cut
 
@@ -1159,11 +1174,13 @@ sub getPipelineDate {
 
 =head3 insertReports($minc, $registeredXMLFile, $registeredQCReportFile)
 
-Inserts in the MINC header the path to DTIPrep's QC text and XML reports and XML
-protocol.
+Inserts the path to DTIPrep's QC text, XML reports and XML protocol in the
+MINC file's header.
 
-INPUT: minc file to modify header; path to the registered DTIPrep's XML
-report; path to the registered DTIPrep's QC text report
+INPUTS:
+  - $minc                  : MINC file for which the header should be modified
+  - $registeredXMLfile     : path to the registered DTIPrep's XML report
+  - $registeredQCReportFile: path to the registered DTIPrep's QC text report
 
 RETURNS:
  - $Txtreport_insert: 1 if on text report path insertion success,
@@ -1202,8 +1219,10 @@ of the directions rejected due to slice wise correlation, the directions
 rejected due to interlace correlation, and the directions rejected due to
 gradient wise correlation.
 
-INPUT: minc file in which the summary will be inserted; data_dir from the
-Config file; DTIPrep's QC report from which the summary will be extracted
+INPUTS:
+  - $minc     : MINC file in which the summary will be inserted
+  - $data_dir : C<data_dir> from the C<Config> table
+  - $XMLReport: DTIPrep's XML QC report from which the summary will be extracted
 
 RETURNS: 1 on success, undef on failure
 
@@ -1270,7 +1289,7 @@ sub insertPipelineSummary   {
 Registers file into the database via register_processed_data.pl with all
 options.
 
-INPUT:
+INPUTS:
   - $file           : file to be registered in the database
   - $src_fileID     : source file's FileID
   - $src_pipeline   : pipeline used to obtain the file
@@ -1339,9 +1358,9 @@ sub registerFile  {
 
 =head3 fetchRegisteredFile($src_fileID, $src_pipeline, $pipelineDate, ...)
 
-Fetches the registered file from the database to link it to the minc files.
+Fetches the registered file from the database to link it to the MINC files.
 
-INPUT:
+INPUTS:
  - $src_fileID     : FileID of the source native file
  - $src_pipeline   : pipeline name used to register the processed file
  - $pipelineDate   : pipeline data used to register the processed file
@@ -1392,11 +1411,24 @@ registered NRRD file (C<&register_minc> function will modify the MINC header to
 include this information) in addition to the links toward QC reports and
 protocol.
 
-INPUT: files to be registered ($minc, $nrrd); registered QC report files
-($registeredXMLReportFile, $registeredQCReportFile); $DTIPrepVersion used to
-produce the files
+INPUTS:
+  - $minc                   : MINC file to be registered
+  - $nrrd                   : NRRD file to be registered
+  - $raw_file               : raw DWI file used to create the MINC file to
+                               register
+  - $data_dir               : C<data_dir> from the C<Config> table
+  - $inputs                 : input files that were used to create the file to
+                               be registered (intermediary files)
+  - $registeredXMLProtocolID: registered XML protocol file
+  - $pipelineName           : name of the pipeline that created the file to be
+                               registered (DTIPrepPipeline)
+  - $DTIPrepVersion         : DTIPrep's version
+  - $registeredXMLReportFile: registered XML report file
+  - $registeredQCReport     : registered QC text file
+  - $scanType               : scan type to use to label/register the MINC file
 
-RETURNS: registered minc files or undef on insertion's failure
+
+RETURNS: registered MINC files or undef on insertion's failure
 
 =cut
 
@@ -1457,11 +1489,11 @@ sub register_DTIPrep_files {
 
 =head3 register_nrrd($nrrd, $raw_file, $data_dir, $QCReport, $inputs, ...)
 
-Set parameters needed to register the NRRD file produced by DTIPrep
-and call registerFile to register the NRRD file via
+Sets parameters needed to register the NRRD file produced by DTIPrep
+and calls registerFile to register the NRRD file via
 C<register_processed_data.pl>.
 
-INPUT:
+INPUTS:
   - $nrrd        : NRRD file to be registered
   - $raw_file    : native DWI file used to obtain the DTIPrep outputs
   - $data_dir    : data_dir from the config table
@@ -1546,11 +1578,11 @@ sub register_nrrd {
 
 =head3 register_Preproc($mri_files, $dti_file, $data_dir, ...)
 
-Gather all DTIPrep preprocessed files to be registered in the database
-and call C<&register_DTIPrep_files> on all of them. Will register first the
+Gathers all DTIPrep preprocessed files to be registered in the database
+and calls C<&register_DTIPrep_files> on all of them. Will register first the
 NRRD file and then the MINC file for each scan type.
 
-INPUT:
+INPUTS:
   - $mri_files   : hash containing all DTI output information
   - $dti_file    : native DWI file (that will be used as a key
                     for $mri_files)
@@ -1604,7 +1636,7 @@ used to obtain them. Will call C<&register_DTIPrep_files> if files to be
 registered are obtained via DTIPrep or C<&register_minc> if files to be
 registered are obtained using mincdiffusion tools.
 
-INPUT:
+INPUTS:
   - $mri_files   : hash with information about the files to be registered
   - $raw_file    : source raw image
   - $data_dir    : data directory from the Config table
@@ -1689,7 +1721,7 @@ sub register_images {
 Function that will return in a string the list of inputs used to process the
 data separated by ';'.
 
-INPUT:
+INPUTS:
   - $mri_files   : list of processed outputs to register or that
                     have been registered
   - $data_dir    : data directory from the Config table
@@ -1742,8 +1774,9 @@ Will check if md5sum has already been registered into the database.
 
 INPUT: md5sum of the file
 
-RETURNS: registered FileID matching md5sum and scan type of the registered
-FileID matching md5sum
+RETURNS:
+  - $registeredFile    : registered FileID matching md5sum
+  - $registeredScanType: scan type of the registered FileID matching md5sum
 
 =cut
 

--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -620,8 +620,8 @@ sub register_minc {
 
 =head3 register_XMLFile($XMLFile, $raw_file, $data_dir, $QCReport, ...)
 
-Set parameters needed to register the XML report/protocol of DTIPrep
-and call registerFile to register the XML file via register_processed_data.pl. 
+Sets parameters needed to register the XML report/protocol of DTIPrep
+and calls registerFile to register the XML file via register_processed_data.pl.
 
 INPUT:
   - $XMLFile     : XML file to be registered

--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -1,5 +1,45 @@
 #!/usr/bin/perl -w
 
+=pod
+
+=head1 NAME
+
+DTIPrepRegister.pl -- registers DTIPrep outputs in the LORIS database
+
+=head1 SYNOPSIS
+
+perl DTIPrepRegister.pl -profile C<prod> -DTIPrep_subdir
+C</path/to/DTIPrep/dir> -DTIPrepProtocol C</Path/to/DTIPrep/XML/protocol>
+-DTI_file C</path/to/DTI/native/file> -anat_file C</path/to/anat/native/file>
+-DTIPrepVersion C<DTIPrep_version> -mincdiffusionVersion
+C<mincdiffusion_version>
+
+Note: C<-DTIPrepVersion> and C<-mincdiffusionVersion> are optional if the
+version of those tools can be found directly from the tools installed on the
+server running C<DTIPrepRegister>.
+
+=head1 DESCRIPTION
+
+Registers DWI QC pipeline's output files of interest into the LORIS database
+via C<register_processed_data.pl>.
+
+The following output files will be inserted:
+  - QCed MINC file produced by DTIPrep pre-processing step (i.e. DWI dataset
+     without the bad directions detected by DTIPrep)
+  - QCReport produced by DTPrep
+  - XMLQCResult produced by DTIPrep
+  - RGB map produced by either DTIPrep or mincdiffusion post-processing
+  - MD map produced by either DTIPrep or mincdiffusion post-processing
+  - FA map produced by either DTIPrep or mincdiffusion post-processing
+  - baseline image produced by DTIPrep or mincdiffusion post-processing
+  - DTI mask produced by mincdiffusion post-processing (only if mincdiffusion
+     was used to post-process the data)
+
+=head2 Methods
+
+=cut
+
+
 use strict;
 use warnings;
 use Getopt::Tabular;
@@ -310,20 +350,23 @@ exit 0;
 #############
 
 =pod
-Register XML protocol file into mri_processing_protocol table.
-1. Check if protocol file was already registered in the database. 
-2. If protocol file already registered in the database, will return 
-the ProcessProtocolID from the database
-   If protocol file not registered yet in the database, will register
-it in the database and return the ProcessProtocolID of the file 
-registered.
-Inputs: $XMLProtocol= XML protocol file of DTIPrep to be registered
-        $data_dir   = data directory in the prod file
-        $tool       = Tool name of the protocol (a.k.a. "DTIPrep")
-Outputs:$ProtocolID = ID of the registered protocol file
-in mri_processing_protocol table that will be used to register output
-files in the files table.
+
+=head3 register_XMLProt($XMLProtocol, $data_dir, $tool)
+
+Registers XML protocol file into C<mri_processing_protocol> table. It will first
+check if protocol file was already registered in the database. If the protocol
+file is already registered in the database, it will return the
+ProcessProtocolID from the database. If the protocol file is not registered yet
+in the database, it will register it in the database and return the
+ProcessProtocolID of the registered protocol file.
+
+INPUT: XML protocol file of DTIPrep to be registered, data directory from the
+Config table, tool name of the protocol (a.k.a. "DTIPrep")
+
+RETURNS: ID of the registered protocol file
+
 =cut
+
 sub register_XMLProt {
     my ($XMLProtocol, $data_dir, $tool) = @_;
     
@@ -342,19 +385,23 @@ sub register_XMLProt {
 }
 
 
-
-
-
-
 =pod
-Register protocol file into mri_processing_protocol table and move the protocol to the $data_dir/protocols/DTIPrep folder
-Inputs: $protocol   = protocol file to be registered
-        $md5sum     = md5sum of the protocol file to be registered
-        $tool       = tool of the protocol file (DTIPrep)
-        $data_dir   = data_dir of the prod file
-Output: $protPath if protocol has been successfully moved to the 
-datadir/protocol/tool folder and registered into the mri_processing_protocol table.
+
+=head3 registerProtocol($protocol, $md5sum, $tool, $data_dir)
+
+Registers protocol file into C<mri_processing_protocol> table and move the
+protocol to the C<$data_dir/protocols/DTIPrep> folder.
+
+INPUT:
+  - $protocol: protocol file to be registered
+  - $md5sum  : md5sum of the protocol file to be registered
+  - $tool    : tool of the protocol file (DTIPrep)
+  - $data_dir: data_dir of the prod file
+
+RETURNS: ID of the registered protocol file
+
 =cut
+
 sub registerProtocol {
     my ($protocol, $md5sum, $tool, $data_dir) = @_; 
 
@@ -381,21 +428,19 @@ sub registerProtocol {
 }
 
 
-
-
-
-
-
-
-
-
 =pod
-Fetches the protocol ID in the mri_processing_protocol table based on
+
+=head3 fetchProtocolID($md5sum)
+
+Fetches the protocol ID in the C<mri_processing_protocol> table based on
 the XML protocol's md5sum.
-Input:  $md5sum     = md5sum of the XML protocol
-Output: $ProtocolID = protocol ID from the mri_proceesing_protocol table
-of the registered XML protocol file if could find a match with md5sum.
+
+INPUT: md5sum of the XML protocol
+
+RETURNS: ID of the registered protocol file
+
 =cut
+
 sub fetchProtocolID {
     my ($md5sum) = @_;
 
@@ -415,23 +460,32 @@ sub fetchProtocolID {
     return ($protocolID);
 }
 
+
 =pod
-Set the different parameters needed for minc files' registration 
-and call registerFile to register the minc file in the database
-via register_processed_data.pl script. 
-Inputs:  - $minc        = minc file to be registered
-         - $raw_file    = native file that was the source of the minc file to register
-         - $data_dir    = data_dir directory set in the config file (/data/project/data)
-         - $inputs      = input files used to obtain minc file to be registered
-         - $pipelineName= name of the pipeline used to obtain the minc file (a.k.a. DTIPrepPipeline)
-         - $toolName    = tool name and version that was used to obtain the minc file
-         - $registeredXMLFile        = registered DTIPrep XML report associated with the minc file
-         - $registeredQCReportFile   = registered DTIPrep Txt report associated with the minc file
-         - $scanType        = type of scan to be used to register the minc file 
-         - $registered_nrrd = optionally, registered nrrd file that was used to create the minc file
-Outputs: - $registeredMincFile if minc file was indeed registered in the database
-         - undef is not all options could be set or file was not registered in the database
+
+=head3 register_minc($minc, $raw_file, $data_dir, $inputs, ...)
+
+Set the different parameters needed for MINC files' registration
+and call C<&registerFile> to register the MINC file in the database
+via C<register_processed_data.pl> script.
+
+INPUT:
+  - $minc                  : MINC file to be registered
+  - $raw_file              : source native file the MINC file to register
+  - $data_dir              : data_dir directory from the config table
+  - $inputs                : input files of the MINC file to be registered
+  - $pipelineName          : name of the pipeline used to obtain the MINC file
+  - $toolName              : tool name & version used
+  - $registeredXMLFile     : registered DTIPrep XML report
+  - $registeredQCReportFile: registered DTIPrep txt report
+  - $scanType              : type of scan to be used to register the minc file
+  - $registered_nrrd       : optional, registered NRRD file used to create
+                              the MINC file
+
+RETURNS: registered MINC file on success, undef otherwise
+
 =cut
+
 sub register_minc {
     my ($minc, $raw_file, $data_dir, $inputs, $registeredXMLprotocolID, $pipelineName, $toolName, $registeredXMLFile, $registeredQCReportFile, $scanType, $registered_nrrd)  =   @_;
 
@@ -539,19 +593,28 @@ sub register_minc {
 
 }   
 
+
 =pod
-Set parameters needed to register the XML report/protocol of DTIPrep 
+
+=head3 register_XMLFile($XMLFile, $raw_file, $data_dir, $QCReport, ...)
+
+Set parameters needed to register the XML report/protocol of DTIPrep
 and call registerFile to register the XML file via register_processed_data.pl. 
-Inputs: - $XMLFile      = XML file to be registered
-        - $raw_file     = Native DTI file that was processed to obtain the DTIPrep outputs
-        - $data_dir     = data_dir as defined in the config file (a.k.a. /data/project/data)
-        - $QCReport     = DTIPrep QCreport 
-        - $inputs       = input files that were used to process data through DTIPrep
-        - $pipelineName = name of the pipeline used to process DTIs (DTIPrepPipeline)
-        - $toolName     = DTIPrep name and version that was used to process DTIs
-Outputs: - $registeredXMLFile if the XML file was indeed registered in the database
-         - undef if could not set all parameters for registration or file could not be registered in the database
+
+INPUT:
+  - $XMLFile     : XML file to be registered
+  - $raw_file    : native DWI file used to obtain the DTIPrep outputs
+  - $data_dir    : data_dir from the config table (a.k.a. /data/project/data)
+  - $QCReport    : DTIPrep QCreport
+  - $inputs      : input files that were used to process data through DTIPrep
+  - $pipelineName: name of the pipeline used to process DTIs (DTIPrepPipeline)
+  - $toolName    : DTIPrep name and version that was used to process DTIs
+
+RETURNS: the registered XNL file if it was registered in the database, undef
+otherwise
+
 =cut
+
 sub register_XMLFile {
     my ($XMLFile, $raw_file, $data_dir, $QCReport, $inputs, $registeredXMLprotocolID, $pipelineName, $toolName) =   @_;
 
@@ -619,18 +682,28 @@ sub register_XMLFile {
     }
 }        
 
+
 =pod
-Set parameters needed to register the QCreport of DTIPrep 
-and call registerFile to register the QCreport file via register_processed_data.pl. 
-Inputs: - $QCReport     = QC report file to be registered
-        - $raw_file     = Native DTI file that was processed to obtain the DTIPrep outputs
-        - $data_dir     = data_dir as defined in the config file (a.k.a. /data/project/data)
-        - $inputs       = input files that were used to process data through DTIPrep
-        - $pipelineName = name of the pipeline used to process DTIs (DTIPrepPipeline)
-        - $toolName     = DTIPrep name and version that was used to process DTIs
-Outputs: - $registeredQCReportFile if the QC report file was indeed registered in the database
-         - undef if could not set all parameters for registration or file could not be registered in the database
+
+=head3 register_QCReport($QCReport, $raw_file, $data_dir, $inputs, ...)
+
+Set parameters needed to register the QCreport of DTIPrep and call
+C<&registerFile> to register the QCreport file via
+C<register_processed_data.pl>.
+
+INPUT:
+  - $QCReport    : QC report file to be registered
+  - $raw_file    : native DWI file used to obtain the DTIPrep outputs
+  - $data_dir    : data_dir from the config table (a.k.a. /data/project/data)
+  - $inputs      : input files that were used to process data through DTIPrep
+  - $pipelineName: name of the pipeline used to process DTIs (DTIPrepPipeline)
+  - $toolName    : DTIPrep name and version that was used to process DTIs
+
+RETURNS: registered QCReport file if it was registered in the database, undef
+ otherwise
+
 =cut
+
 sub register_QCReport {
     my ($QCReport, $raw_file, $data_dir, $inputs, $registeredXMLprotocolID, $pipelineName, $toolName)    =   @_;
 
@@ -691,15 +764,37 @@ sub register_QCReport {
     }
 
 }        
-        
+
+
 =pod
-This function checks that all the processing files exist on the filesystem and returns the files to be inserted in the database. When nrrd and minc files were found, it will only return the minc file. (nrrd files will be linked to the minc file when inserting files in the database).
-- Inputs:   - $dti_file = raw DTI dataset that is used as a key in $DTIrefs hash
-            - $DTIrefs      = hash containing all output paths and tool information
-- Outputs:  - if all files have been found on the file system, will return:
-                - ($XMLProtocol, $QCReport, $XMLReport, $QCed_minc, $RGB_minc, $FA_minc, $MD_minc, $baseline_minc, $brain_mask_minc, $QCed2_minc)
-            - if there are some missing files, it will return undef 
+
+=head3 getFiles($dti_file, $DTIrefs)
+
+This function checks that all the processing files exist on the filesystem and
+returns the files to be inserted in the database. When NRRD and MINC files were
+found, it will only return the MINC file. (NRRD files will be linked to the
+MINC file when inserting files in the database).
+
+INPUT: raw DTI dataset that is used as a key in C<$DTIrefs> hash; hash
+containing all output paths and tool information
+
+RETURNS:
+  - $XMLProtocol    : DTIPrep XML protocol that was found in the file system
+  - $QCReport       : DTIPrep text QCReport that was found in the file system
+  - $XMLReport      : DTIPrep XML QCReport that was found in the file system
+  - $QCed_minc      : QCed MINC file created after conversion of QCed NRRD file
+  - $RGB_minc       : RGB MINC file found in the file system
+  - $FA_minc        : FA MINC file found in the file system
+  - $MD_minc        : MD MINC file found in the file system
+  - $baseline_minc  : baseline MINC file found in the file system
+  - $brain_mask_minc: brain mask MINC file found in the file system
+  - $QCed2_minc     : optional, secondary QCed MINC file created after
+                       conversion of secondary QCed DTIPrep NRRD file
+  - returns undef if there are some missing files (except for QCed2_minc which
+     is optional)
+
 =cut
+
 sub getFiles {
     my ($dti_file, $DTIrefs)   =   @_;
 
@@ -717,17 +812,29 @@ sub getFiles {
     }
 }
 
+
 =pod
-Function that checks if all DTIPrep preprocessing files are present in the file system.
-- Inputs:   - $dti_file     = raw DTI dataset that is used as a key in $DTIrefs hash
-            - $DTIrefs      = hash containing all output paths and tool information
-- Outputs:  - $XMLProtocol  = DTIPrep XML protocol that was found in the file system
-            - $QCReport     = DTIPrep Txt QCReport that was found in the file system
-            - $XMLReport    = DTIPrep XML QCReport that was found in the file system
-            - $QCed_minc    = QCed minc file that was created after conversion of QCed DTIPrep nrrd file
-            - $QCed2_minc   = Optionally, secondary QCed minc file that was created after conversion of secondary QCed DTIPrep nrrd file 
-            - return undef if one of the file listed above is missing (except for QCed2_minc which is optional)
+
+=head3 checkPreprocessFiles($dti_file, $DTIrefs, $mri_files)
+
+Function that checks if all DTIPrep pre-processing files are present in the
+file system.
+
+INPUT: raw DTI dataset that is used as a key in $DTIrefs hash; hash
+containing all output paths and tool information
+
+RETURNS:
+  - $XMLProtocol: DTIPrep XML protocol that was found in the file system
+  - $QCReport   : DTIPrep text QCReport that was found in the file system
+  - $XMLReport  : DTIPrep XML QCReport that was found in the file system
+  - $QCed_minc  : QCed MINC file created after conversion of QCed NRRD file
+  - $QCed2_minc : optional, secondary QCed MINC file created after conversion of
+                   secondary QCed DTIPrep NRRD file
+  - returns undef if one of the file listed above is missing (except for
+     QCed2_minc which is optional)
+
 =cut
+
 sub checkPreprocessFiles {
     my  ($dti_file, $DTIrefs, $mri_files) = @_;
 
@@ -765,27 +872,28 @@ sub checkPreprocessFiles {
 }
 
 
-
-
-
-
 =pod
-Function that checks if all postprocessing files (from DTIPrep or mincdiffusion) are present in the file system.
-- Inputs:   - $dti_file     = raw DTI dataset that is used as a key in $DTIrefs hash
-            - $DTIrefs      = hash containing all output paths and tool information
-- Outputs:  - if mincdiffusion was run and found all outputs on the filesystem, will return:
-                - $RGB_minc         = RGB map
-                - $FA_minc          = FA map
-                - $MD_minc          = MD map
-                - $baseline_minc    = baseline (or frame-0) map
-                - $brain_mask_minc  = brain mask produced by mincdiffusion tools
-            - if DTIPrep was run and found all postprocessed outputs (nrrd & minc) on the filesystem, will return:
-                - $RGB_minc         = RGB map
-                - $FA_minc          = FA map
-                - $MD_minc          = MD map
-                - $baseline_minc    = baseline (or frame-0) map
-            - will return undef and print messages into the LOG file otherwise 
+
+=head3 checkPostprocessFiles($dti_file, $DTIrefs, $mri_files)
+
+Function that checks if all postprocessing files (from DTIPrep or
+mincdiffusion) are present in the file system.
+
+INPUT: raw DTI dataset that is used as a key in $DTIrefs hash; hash
+containing all output paths and tool information
+
+RETURNS:
+  - $RGB_minc       : RGB map
+  - $FA_minc        : FA map
+  - $MD_minc        : MD map
+  - $baseline_minc  : baseline (or frame-0) map
+  - $brain_mask_minc: brain mask produced by mincdiffusion tools (not
+                       available if DTIPrep was run to obtain the
+                       post-processing outputs)
+  - will return undef if one of the file listed above is missing
+
 =cut
+
 sub checkPostprocessFiles {
     my ($dti_file, $DTIrefs, $mri_files) = @_;
 
@@ -886,20 +994,21 @@ sub checkPostprocessFiles {
 }
 
 
-
-
-
-
-
-
-
-
 =pod
-Fetches the source FileID from the database based on the src_name file identified by getFileName.
-Inputs: - $file     = output filename 
-        - $src_name = source filename (file that has been used to obtain $file)
-Outputs: - $fileID  = source File ID (file ID of the source file that has been used to obtain $file)
+
+=head3 getFileID($file, $src_name)
+
+Fetches the source FileID from the database based on the src_name file
+identified by getFileName.
+
+INPUT: output filename, source filename (file that has been used to obtain
+the output file $file)
+
+RETURNS: source File ID (file ID of the source file that has been used to
+obtain $file)
+
 =cut
+
 sub getFileID {
     my  ($file, $src_name) = @_;
 
@@ -925,16 +1034,21 @@ sub getFileID {
 }
 
 
-
-
-
 =pod
-Fetches tool informations stored either in the minc's header or in the QCReport.
-Inputs:  - $file        = minc or QC report to look for tool information
-Outputs: - $src_pipeline= name of the pipeline used to obtain $file (a.k.a. DTIPrepPipeline)
-         - $src_tool    = name and version of the tool used to obtain $file (DTIPrep_v1.1.6, mincdiffusion_v...)
+
+=head3 getToolName($file)
+
+Fetches tool information stored either in the MINC's header or in the QCReport.
+
+INPUT: MINC or QC report to look for tool information
+
+RETURNS: name of the pipeline used to obtain $file (a.k.a. DTIPrepPipeline);
+name and version of the tool used to obtain $file (DTIPrep_v1.1.6,
+mincdiffusion_v...)
+
 =cut
-sub getToolName {    
+
+sub getToolName {
     my  ($file)     =   @_;
 
     my  $src_pipeline   = &DTI::fetch_header_info('processing:pipeline',
@@ -955,13 +1069,21 @@ sub getToolName {
     return  ($src_pipeline, $src_tool);
 }
 
+
 =pod
-Fetches the date at which DTIPrep pipeline was run either in the processed minc's header or in the QCReport.
-Inputs:  - $file            = minc or QC report to look for tool information
-         - $data_dir        = data_dir stored in the config file
-         - $QCReport        = QC report created when $file was created
-Outputs: - $pipeline_date   = date at which the pipeline has been run to obtain $file
+
+=head3 getPipelineDate($file, $data_dir, $QCReport)
+
+Fetches the date at which DTIPrep pipeline was run either in the processed
+MINC's header or in the QCReport.
+
+INPUT: MINC or QC report to look for tool information; data_dir from the
+Config table; QC report created when $file was created
+
+RETURNS: date at which the pipeline has been run to obtain $file
+
 =cut
+
 sub getPipelineDate {
     my  ($file, $data_dir, $QCReport)   =   @_;
     
@@ -1009,21 +1131,22 @@ sub getPipelineDate {
 }
 
 
-
-
-
 =pod
-Insert in mincheader the path to DTIPrep's QC txt and xml reports and xml protocol.
-Inputs:  - $minc                     = minc file to modify header
-         - $registeredXMLFile        = path to the registered DTIPrep's XML report
-         - $registeredQCReportFile   = path to the registered DTIPrep's QC txt report
-Outputs: - $Txtreport_insert    = 1 if text report path insertion was successful
-                                = undef if text report path was not inserted
-         - $XMLreport_insert    = 1 if xml report path insertion was successful
-                                = undef if xml report path was not inserted
-         - $protocol_insert     = 1 if xml protocol path insertion was successful
-                                = undef if xml protocol path was not inserted
+
+=head3 insertReports($minc, $registeredXMLFile, $registeredQCReportFile)
+
+Inserts in the MINC header the path to DTIPrep's QC text and XML reports and XML
+protocol.
+
+INPUT: minc file to modify header; path to the registered DTIPrep's XML
+report; path to the registered DTIPrep's QC text report
+
+RETURNS:
+- $Txtreport_insert: 1 if on text report path insertion success, undef otherwise
+- $XMLreport_insert: 1 if on  xml report path insertion success, undef otherwise
+
 =cut
+
 sub insertReports {
     my ($minc, $registeredXMLFile, $registeredQCReportFile) = @_;
 
@@ -1044,21 +1167,22 @@ sub insertReports {
 }
 
 
-
-
-
-
 =pod
-Insert in mincheader a summary of DTIPrep reports.
-This summary consist of the directions rejected due to slice wise correlation,
-the directions rejected due to interlace correlation,
-and the directions rejected due to gradient wise correlation
-Inputs:  - $minc     = minc file in which the summary will be inserted
-         - $data_dir = data_dir as defined in the config file
-         - $QCReport = DTIPrep's QC report from which the summary will be extractec
-Outputs: - 1 if all information has been successfully inserted
-         - undef if at least one information has not been inserted
+
+=head3 insertPipelineSummary($minc, $data_dir, $XMLReport, $scanType)
+
+Inserts in the MINC header a summary of DTIPrep reports. This summary consists
+of the directions rejected due to slice wise correlation, the directions
+rejected due to interlace correlation, and the directions rejected due to
+gradient wise correlation.
+
+INPUT: minc file in which the summary will be inserted; data_dir from the
+Config file; DTIPrep's QC report from which the summary will be extracted
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub insertPipelineSummary   {
     my ($minc, $data_dir, $XMLReport, $scanType)   =   @_;
 
@@ -1113,23 +1237,30 @@ sub insertPipelineSummary   {
 }
 
 
-
-
-
-
 =pod
-Register file into the database via register_processed_data.pl with all options.
-Inputs:  - $file            = file to be registered in the database
-         - $src_fileID      = FileID of the source file used to obtain the file to be registered
-         - $src_pipeline    = Pipeline used to obtain the file (DTIPrepPipeline)
-         - $src_tool        = Name and version of the tool used to obtain the file (DTIPrep or mincdiffusion)
-         - $pipelineDate    = file's creation date (= pipeline date)
-         - $coordinateSpace = file's coordinate space (= native, T1 ...)
-         - $scanType        = file's scan type (= DTIPrepReg, DTIPrepDTIFA, DTIPrepDTIMD, DTIPrepDTIColorFA...)
-         - $outputType      = file's output type (.xml, .txt, .mnc...)
-         - $inputs          = files that were used to create the file to be registered (intermediary files)
-Outputs: - $registeredFile  = file that has been registered in the database
+
+=head3 registerFile($file, $src_fileID, $src_pipeline, $src_tool, ...)
+
+Registers file into the database via register_processed_data.pl with all
+options.
+
+INPUT:
+  - $file           : file to be registered in the database
+  - $src_fileID     : source file's FileID
+  - $src_pipeline   : pipeline used to obtain the file (DTIPrepPipeline)
+  - $src_tool       : name and version of the tool (DTIPrep or mincdiffusion)
+  - $pipelineDate   : file's creation date (= pipeline date)
+  - $coordinateSpace: file's coordinate space (= native, T1 ...)
+  - $scanType       : file's scan type (= DTIPrepReg, DTIPrepDTIFA,
+                       DTIPrepDTIMD, DTIPrepDTIColorFA...)
+  - $outputType     : file's output type (.xml, .txt, .mnc...)
+  - $inputs         : input files that were used to create the file to be
+                       registered (intermediary files)
+
+RETURNS: registered file
+
 =cut
+
 sub registerFile  {
     my  ($file, $src_fileID, $src_pipeline, $src_tool, $pipelineDate, $coordinateSpace, $scanType, $outputType, $inputs, $registeredXMLprotocolID)    =   @_;
 
@@ -1176,19 +1307,24 @@ sub registerFile  {
 }        
 
 
-
-
-
 =pod
-Fetch the registered file from the database to link it to the minc files.
-Inputs:  - $src_fileID      = FileID of the native file used to register the processed file
-         - $src_pipeline    = Pipeline name used to register the processed file
-         - $pipelineDate    = Pipeline data used to register the processed file
-         - $coordinateSpace = coordinate space used to register the processed file
-         - $scanType        = scan type used to register the processed file
-         - $outputType      = output type used to register the processed file
-Outputs: - $registeredFile  = path to the registered processed file
+
+=head3 fetchRegisteredFile($src_fileID, $src_pipeline, $pipelineDate, ...)
+
+Fetches the registered file from the database to link it to the minc files.
+
+INPUT:
+ - $src_fileID     : FileID of the source native file
+ - $src_pipeline   : Pipeline name used to register the processed file
+ - $pipelineDate   : Pipeline data used to register the processed file
+ - $coordinateSpace: coordinate space used to register the processed file
+ - $scanType       : scan type used to register the processed file
+ - $outputType     : output type used to register the processed file
+
+RETURNS: path to the registered processed file
+
 =cut
+
 sub fetchRegisteredFile {
     my ($src_fileID, $src_pipeline, $pipelineDate, $coordinateSpace, $scanType, $outputType) = @_;
 
@@ -1219,19 +1355,23 @@ sub fetchRegisteredFile {
 }
 
 
-
-
-
-
-
 =pod
-Register DTIPrep nrrd and minc files. The minc file will have a link to the registered nrrd file (register_minc function will modify mincheader to include this information) in addition to the links toward QC reports and protocol.
-- Inputs:   - files to be registered ($minc, $nrrd)
-            - registered QC report files ($registeredXMLReportFile, $registeredQCReportFile)
-            - $DTIPrepVersion used to produce the files
-- Outputs:  - registered minc files if the nrrd and minc files were successfully registered in the database
-            - undef if one argument of the function if missing or if nrrd file could not be registered
+
+=head3 register_DTIPrep_files($minc, $nrrd, $raw_file, $data_dir, ...)
+
+Registers DTIPrep NRRD and MINC files. The MINC file will have a link to the
+registered NRRD file (C<&register_minc> function will modify the MINC header to
+include this information) in addition to the links toward QC reports and
+protocol.
+
+INPUT: files to be registered ($minc, $nrrd); registered QC report files
+($registeredXMLReportFile, $registeredQCReportFile); $DTIPrepVersion used to
+produce the files
+
+RETURNS: registered minc files or undef on insertion's failure
+
 =cut
+
 sub register_DTIPrep_files {
     my  ($minc, $nrrd, $raw_file, $data_dir, $inputs, $registeredXMLprotocolID, $pipelineName, $DTIPrepVersion, $registeredXMLReportFile, $registeredQCReportFile, $scanType) = @_;
 
@@ -1285,24 +1425,28 @@ sub register_DTIPrep_files {
 }
 
 
-
-
-
-
 =pod
-Set parameters needed to register the nrrd file produced by DTIPrep 
-and call registerFile to register the nrrd file via register_processed_data.pl. 
-Inputs: - $nrrd         = nrrd file to be registered
-        - $raw_file     = Native DTI file that was processed to obtain the DTIPrep outputs
-        - $data_dir     = data_dir as defined in the config file (a.k.a. /data/project/data)
-        - $QCReport     = DTIPrep QCreport 
-        - $inputs       = input files that were used to process data through DTIPrep
-        - $pipelineName = name of the pipeline used to process DTIs (DTIPrepPipeline)
-        - $toolName     = DTIPrep name and version that was used to process DTIs
-        - $scanType     = nrrd file's scan type
-Outputs: - $registeredNrrdFile if the nrrd file was indeed registered in the database
-         - undef if could not set all parameters for registration or file could not be registered in the database
+
+=head3 register_nrrd($nrrd, $raw_file, $data_dir, $QCReport, $inputs, ...)
+
+Set parameters needed to register the NRRD file produced by DTIPrep
+and call registerFile to register the NRRD file via
+C<register_processed_data.pl>.
+
+INPUT:
+  - $nrrd        : NRRD file to be registered
+  - $raw_file    : native DWI file used to obtain the DTIPrep outputs
+  - $data_dir    : data_dir from the config table (a.k.a. /data/project/data)
+  - $QCReport    : DTIPrep QCreport
+  - $inputs      : input files that were used to process data through DTIPrep
+  - $pipelineName: name of the pipeline used to process DTIs (DTIPrepPipeline)
+  - $toolName    : DTIPrep name and version that was used to process DTIs
+  - $scanType    : nrrd file's scan type
+
+RETURNS: registered NRRD file or undef on insertion's failure
+
 =cut
+
 sub register_nrrd {
     my ($nrrd, $raw_file, $data_dir, $QCReport, $inputs, $registeredXMLprotocolID, $pipelineName, $toolName, $scanType) =   @_;
 
@@ -1368,22 +1512,27 @@ sub register_nrrd {
 }   
 
 
-
-
-
 =pod
+
+=head3 register_Preproc($mri_files, $dti_file, $data_dir, ...)
+
 Gather all DTIPrep preprocessed files to be registered in the database
-and call register_DTIPrep_files on all of them. Will register first the 
-nrrd file and then the minc file for each scan type.
-Inputs:  - $mri_files       = hash containing all DTI output information
-         - $dti_file        = native DTI file that was processed (that will be used as a key for $mri_files)
-         - $data_dir        = data_dir defined in the config file
-         - $pipelineName    = name of the pipeline used to preprocess data (DTIPrepPipeline)
-         - $toolName        = name and version of the tool used to preprocess data
-         - $process_step    = processing step ('Preproc' or 'Postproc') depending on the processed file
-         - $proc_file       = key to the processed file to be registered ('QCed', 'QCed2'...)
-Outputs: - $registered_minc = path to the minc file that was registered
+and call C<&register_DTIPrep_files> on all of them. Will register first the
+NRRD file and then the MINC file for each scan type.
+
+INPUT:
+  - $mri_files   : hash containing all DTI output information
+  - $dti_file    : native DWI file (that will be used as a key for $mri_files)
+  - $data_dir    : data_dir defined in the config file
+  - $pipelineName: pipeline name (DTIPrepPipeline)
+  - $toolName    : tool's name and version
+  - $process_step: processing step ('Preproc' or 'Postproc')
+  - $proc_file   : processed file key ('QCed', 'QCed2'...)
+
+RETURNS: path to the MINC file that was registered
+
 =cut
+
 sub register_Preproc {
     my ($mri_files, $dti_file, $data_dir, $registeredXMLprotocolID, $pipelineName, $toolName, $process_step, $proc_file) = @_;
 
@@ -1415,23 +1564,29 @@ sub register_Preproc {
 }
 
 
-
-
-
-
 =pod
-Function to register processed images in the database depending on the tool used to obtain them. 
-Will call register_DTIPrep_files if files to be registered are obtained via DTIPrep
-or register_minc if files to be registered are obtained using mincdiffusion tools.
-Inputs:  - $mri_files: hash containing information about the files to be registered
-         - $raw_file: source raw image used to obtain processed files to be registered
-         - $data_dir: data directory where all images are stored (set in the prod file)
-         - $pipelineName: name of the pipeline used (a.k.a DTIPrep)
-         - $toolName: version and name of the tool used to produce the images to be registered
-         - $process_step: processing step (preprocessing, post-processing)
-Outputs: - @registered: list of registered files
-         - @failed_to_register: list of files that failed to be registered in the database
+
+=head3 register_images($mri_files, $raw_file, $data_dir, $pipelineName, ...)
+
+Function to register processed images in the database depending on the tool
+used to obtain them. Will call C<&register_DTIPrep_files> if files to be
+registered are obtained via DTIPrep or C<&register_minc> if files to be
+registered are obtained using mincdiffusion tools.
+
+INPUT:
+  - $mri_files   : hash with information about the files to be registered
+  - $raw_file    : source raw image
+  - $data_dir    : data directory from the Config table
+  - $pipelineName: name of the pipeline used (a.k.a DTIPrep)
+  - $toolName    : tool's version and name
+  - $process_step: processing step (preprocessing, post-processing)
+
+RETURNS:
+  - @registered: list of registered files
+  - @failed_to_register: list of files that failed to be registered in the DB
+
 =cut
+
 sub register_images {
     my ($mri_files, $raw_file, $data_dir, $pipelineName, $toolName, $process_step) = @_;
 
@@ -1495,14 +1650,25 @@ sub register_images {
 }
 
 
-
 =pod
-Function that will return in a string the list of inputs used to process the data separated by ';'.
-Inputs: - $mri_files    = list of processed outputs to registered or that have been registered
-        - $process_step = processing step used for the processed output to determine inputs
-        - $proc_file    = processing file to determine inputs used 
-Outputs:- $inputs_list  = string with each inputs used separated by ';'
+
+=head3 getInputList($mri_files, $data_dir, $process_step, $proc_file)
+
+Function that will return in a string the list of inputs used to process the
+data separated by ';'.
+
+INPUT:
+  - $mri_files   : list of processed outputs to register or that have been
+                    registered
+  - $data_dir    : data directory from the Config table
+  - $process_step: processing step used for the processed output to determine
+                    inputs
+  - $proc_file   : processing file to determine inputs used
+
+RETURNS: string with each inputs used separated by ';'
+
 =cut
+
 sub getInputList {
     my ($mri_files, $data_dir, $process_step, $proc_file) = @_;
 
@@ -1536,17 +1702,19 @@ sub getInputList {
 }    
 
 
-
-
-
-
-
 =pod
+
+=head3 fetchRegisteredMD5($md5sum)
+
 Will check if md5sum has already been registered into the database.
-Input:  - $md5sum: md5sum of the file
-Output: - $registeredFileID: registered FileID matching md5sum
-        - $registeredScanType: scan type of the registered FileID matching md5sum
+
+INPUT: md5sum of the file
+
+RETURNS: registered FileID matching md5sum and scan type of the registered
+FileID matching md5sum
+
 =cut
+
 sub fetchRegisteredMD5 {
     my ($md5sum) = @_;
 
@@ -1567,3 +1735,25 @@ sub fetchRegisteredMD5 {
 
     return ($registeredFile, $registeredScanType);
 }
+
+__END__
+
+=pod
+
+=head1 TO DO
+
+Nothing planned (or things that are left to do)
+
+=head1 BUGS
+
+None reported (or list of bugs)
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut

--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -8,15 +8,32 @@ DTIPrepRegister.pl -- registers DTIPrep outputs in the LORIS database
 
 =head1 SYNOPSIS
 
-perl DTIPrepRegister.pl -profile C<prod> -DTIPrep_subdir
-C</path/to/DTIPrep/dir> -DTIPrepProtocol C</Path/to/DTIPrep/XML/protocol>
--DTI_file C</path/to/DTI/native/file> -anat_file C</path/to/anat/native/file>
--DTIPrepVersion C<DTIPrep_version> -mincdiffusionVersion
-C<mincdiffusion_version>
+perl DTIPrepRegister.pl C<[options]>
+
+Available options are:
+
+-profile        : name of the config file in ../dicom-archive/.loris-mri
+
+-DTIPrep_subdir : DTIPrep subdirectory storing the processed files to
+                   be registered
+
+-DTIPrepProtocol: DTIPrep protocol used to obtain the output files
+
+-DTI_file       : native DWI file used to obtain the output files
+
+-anat_file      : native anatomical dataset used to create FA, RGB and
+                   other post-processed maps using mincdiffusion tools
+
+-DTIPrepVersion : DTIPrep version used if cannot be found in MINC
+                   files' C<processing:pipeline> header field
+
+-mincdiffusionVersion: mincdiffusion release version used if cannot be
+                        found in minc files' C<processing:pipeline>
+                        header field
 
 Note: C<-DTIPrepVersion> and C<-mincdiffusionVersion> are optional if the
-version of those tools can be found directly from the tools installed on the
-server running C<DTIPrepRegister>.
+version of those tools can be found directly in the MINC header of the
+processed files.
 
 =head1 DESCRIPTION
 
@@ -24,16 +41,16 @@ Registers DWI QC pipeline's output files of interest into the LORIS database
 via C<register_processed_data.pl>.
 
 The following output files will be inserted:
-  - QCed MINC file produced by DTIPrep pre-processing step (i.e. DWI dataset
-     without the bad directions detected by DTIPrep)
+  - QCed MINC file produced by DTIPrep pre-processing step (i.e. DWI
+     dataset without the bad directions detected by DTIPrep)
   - QCReport produced by DTPrep
   - XMLQCResult produced by DTIPrep
   - RGB map produced by either DTIPrep or mincdiffusion post-processing
   - MD map produced by either DTIPrep or mincdiffusion post-processing
   - FA map produced by either DTIPrep or mincdiffusion post-processing
   - baseline image produced by DTIPrep or mincdiffusion post-processing
-  - DTI mask produced by mincdiffusion post-processing (only if mincdiffusion
-     was used to post-process the data)
+  - DTI mask produced by mincdiffusion post-processing (only if
+     mincdiffusion was used to post-process the data)
 
 =head2 Methods
 
@@ -473,16 +490,17 @@ via C<register_processed_data.pl> script.
 
 INPUT:
   - $minc                  : MINC file to be registered
-  - $raw_file              : source native file the MINC file to register
+  - $raw_file              : source file of the MINC file to register
   - $data_dir              : data_dir directory from the config table
-  - $inputs                : input files of the MINC file to be registered
-  - $pipelineName          : name of the pipeline used to obtain the MINC file
+  - $inputs                : input files of the file to be registered
+  - $pipelineName          : name of the pipeline used to obtain the
+                              MINC file
   - $toolName              : tool name & version used
   - $registeredXMLFile     : registered DTIPrep XML report
   - $registeredQCReportFile: registered DTIPrep txt report
-  - $scanType              : type of scan to be used to register the minc file
-  - $registered_nrrd       : optional, registered NRRD file used to create
-                              the MINC file
+  - $scanType              : scan type of the MINC file to register
+  - $registered_nrrd       : optional, registered NRRD file used to
+                              create the MINC file
 
 RETURNS: registered MINC file on success, undef otherwise
 
@@ -606,11 +624,12 @@ and call registerFile to register the XML file via register_processed_data.pl.
 INPUT:
   - $XMLFile     : XML file to be registered
   - $raw_file    : native DWI file used to obtain the DTIPrep outputs
-  - $data_dir    : data_dir from the config table (a.k.a. /data/project/data)
+  - $data_dir    : data_dir from the config table
+                    (e.g. /data/project/data)
   - $QCReport    : DTIPrep QCreport
-  - $inputs      : input files that were used to process data through DTIPrep
-  - $pipelineName: name of the pipeline used to process DTIs (DTIPrepPipeline)
-  - $toolName    : DTIPrep name and version that was used to process DTIs
+  - $inputs      : input files used to process data through DTIPrep
+  - $pipelineName: pipeline name used to process DWIs (DTIPrepPipeline)
+  - $toolName    : DTIPrep name & version used to process the DWI file
 
 RETURNS: the registered XNL file if it was registered in the database, undef
 otherwise
@@ -696,10 +715,11 @@ C<register_processed_data.pl>.
 INPUT:
   - $QCReport    : QC report file to be registered
   - $raw_file    : native DWI file used to obtain the DTIPrep outputs
-  - $data_dir    : data_dir from the config table (a.k.a. /data/project/data)
-  - $inputs      : input files that were used to process data through DTIPrep
-  - $pipelineName: name of the pipeline used to process DTIs (DTIPrepPipeline)
-  - $toolName    : DTIPrep name and version that was used to process DTIs
+  - $data_dir    : data_dir from the config table
+                    (e.g. /data/project/data)
+  - $inputs      : input files used to process data through DTIPrep
+  - $pipelineName: pipeline name used to process DTIs (DTIPrepPipeline)
+  - $toolName    : DTIPrep name & version used to process the DWI file
 
 RETURNS: registered QCReport file if it was registered in the database, undef
  otherwise
@@ -781,10 +801,11 @@ INPUT: raw DTI dataset that is used as a key in C<$DTIrefs> hash; hash
 containing all output paths and tool information
 
 RETURNS:
-  - $XMLProtocol    : DTIPrep XML protocol that was found in the file system
-  - $QCReport       : DTIPrep text QCReport that was found in the file system
-  - $XMLReport      : DTIPrep XML QCReport that was found in the file system
-  - $QCed_minc      : QCed MINC file created after conversion of QCed NRRD file
+  - $XMLProtocol    : DTIPrep XML protocol found in the file system
+  - $QCReport       : DTIPrep text QCReport found in the file system
+  - $XMLReport      : DTIPrep XML QCReport found in the file system
+  - $QCed_minc      : QCed MINC file created after conversion of
+                       QCed NRRD file
   - $RGB_minc       : RGB MINC file found in the file system
   - $FA_minc        : FA MINC file found in the file system
   - $MD_minc        : MD MINC file found in the file system
@@ -792,8 +813,8 @@ RETURNS:
   - $brain_mask_minc: brain mask MINC file found in the file system
   - $QCed2_minc     : optional, secondary QCed MINC file created after
                        conversion of secondary QCed DTIPrep NRRD file
-  - returns undef if there are some missing files (except for QCed2_minc which
-     is optional)
+  - returns undef if there are some missing files (except for
+     QCed2_minc which is optional)
 
 =cut
 
@@ -826,14 +847,15 @@ INPUT: raw DTI dataset that is used as a key in $DTIrefs hash; hash
 containing all output paths and tool information
 
 RETURNS:
-  - $XMLProtocol: DTIPrep XML protocol that was found in the file system
-  - $QCReport   : DTIPrep text QCReport that was found in the file system
-  - $XMLReport  : DTIPrep XML QCReport that was found in the file system
-  - $QCed_minc  : QCed MINC file created after conversion of QCed NRRD file
-  - $QCed2_minc : optional, secondary QCed MINC file created after conversion of
-                   secondary QCed DTIPrep NRRD file
-  - returns undef if one of the file listed above is missing (except for
-     QCed2_minc which is optional)
+  - $XMLProtocol: DTIPrep XML protocol found in the file system
+  - $QCReport   : DTIPrep text QCReport found in the file system
+  - $XMLReport  : DTIPrep XML QCReport found in the file system
+  - $QCed_minc  : QCed MINC file created after conversion of
+                   QCed NRRD file
+  - $QCed2_minc : optional, secondary QCed MINC file created after
+                   conversion of secondary QCed DTIPrep NRRD file
+  - returns undef if one of the file listed above is missing (except
+     for QCed2_minc which is optional)
 
 =cut
 
@@ -1144,8 +1166,10 @@ INPUT: minc file to modify header; path to the registered DTIPrep's XML
 report; path to the registered DTIPrep's QC text report
 
 RETURNS:
-- $Txtreport_insert: 1 if on text report path insertion success, undef otherwise
-- $XMLreport_insert: 1 if on  xml report path insertion success, undef otherwise
+ - $Txtreport_insert: 1 if on text report path insertion success,
+                       undef otherwise
+ - $XMLreport_insert: 1 if on  xml report path insertion success,
+                       undef otherwise
 
 =cut
 
@@ -1249,15 +1273,17 @@ options.
 INPUT:
   - $file           : file to be registered in the database
   - $src_fileID     : source file's FileID
-  - $src_pipeline   : pipeline used to obtain the file (DTIPrepPipeline)
-  - $src_tool       : name and version of the tool (DTIPrep or mincdiffusion)
+  - $src_pipeline   : pipeline used to obtain the file
+                       (DTIPrepPipeline)
+  - $src_tool       : name and version of the tool
+                       (DTIPrep or mincdiffusion)
   - $pipelineDate   : file's creation date (= pipeline date)
   - $coordinateSpace: file's coordinate space (= native, T1 ...)
   - $scanType       : file's scan type (= DTIPrepReg, DTIPrepDTIFA,
                        DTIPrepDTIMD, DTIPrepDTIColorFA...)
   - $outputType     : file's output type (.xml, .txt, .mnc...)
-  - $inputs         : input files that were used to create the file to be
-                       registered (intermediary files)
+  - $inputs         : input files that were used to create the file to
+                       be registered (intermediary files)
 
 RETURNS: registered file
 
@@ -1317,9 +1343,9 @@ Fetches the registered file from the database to link it to the minc files.
 
 INPUT:
  - $src_fileID     : FileID of the source native file
- - $src_pipeline   : Pipeline name used to register the processed file
- - $pipelineDate   : Pipeline data used to register the processed file
- - $coordinateSpace: coordinate space used to register the processed file
+ - $src_pipeline   : pipeline name used to register the processed file
+ - $pipelineDate   : pipeline data used to register the processed file
+ - $coordinateSpace: processed file's coordinate space
  - $scanType       : scan type used to register the processed file
  - $outputType     : output type used to register the processed file
 
@@ -1438,12 +1464,14 @@ C<register_processed_data.pl>.
 INPUT:
   - $nrrd        : NRRD file to be registered
   - $raw_file    : native DWI file used to obtain the DTIPrep outputs
-  - $data_dir    : data_dir from the config table (a.k.a. /data/project/data)
+  - $data_dir    : data_dir from the config table
+                    (a.k.a. /data/project/data)
   - $QCReport    : DTIPrep QCreport
-  - $inputs      : input files that were used to process data through DTIPrep
-  - $pipelineName: name of the pipeline used to process DTIs (DTIPrepPipeline)
-  - $toolName    : DTIPrep name and version that was used to process DTIs
-  - $scanType    : nrrd file's scan type
+  - $inputs      : input files used to process data through DTIPrep
+  - $pipelineName: pipeline name used to process DTIs
+                    (DTIPrepPipeline)
+  - $toolName    : DTIPrep name & version used to process the DWI file
+  - $scanType    : NRRD file's scan type
 
 RETURNS: registered NRRD file or undef on insertion's failure
 
@@ -1524,7 +1552,8 @@ NRRD file and then the MINC file for each scan type.
 
 INPUT:
   - $mri_files   : hash containing all DTI output information
-  - $dti_file    : native DWI file (that will be used as a key for $mri_files)
+  - $dti_file    : native DWI file (that will be used as a key
+                    for $mri_files)
   - $data_dir    : data_dir defined in the config file
   - $pipelineName: pipeline name (DTIPrepPipeline)
   - $toolName    : tool's name and version
@@ -1584,8 +1613,9 @@ INPUT:
   - $process_step: processing step (preprocessing, post-processing)
 
 RETURNS:
-  - @registered: list of registered files
-  - @failed_to_register: list of files that failed to be registered in the DB
+  - @registered        : list of registered files
+  - @failed_to_register: list of files that failed to be registered
+                          in the DB
 
 =cut
 
@@ -1660,11 +1690,11 @@ Function that will return in a string the list of inputs used to process the
 data separated by ';'.
 
 INPUT:
-  - $mri_files   : list of processed outputs to register or that have been
-                    registered
+  - $mri_files   : list of processed outputs to register or that
+                    have been registered
   - $data_dir    : data directory from the Config table
-  - $process_step: processing step used for the processed output to determine
-                    inputs
+  - $process_step: processing step used for the processed output
+                    to determine inputs
   - $proc_file   : processing file to determine inputs used
 
 RETURNS: string with each inputs used separated by ';'

--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -82,6 +82,8 @@ Usage: $0 [options]
 
 -help for options
 
+Documentation: perldoc DTIPrepRegister.pl
+
 USAGE
 
 # Define the table describing the command-line options

--- a/docs/scripts_md/DTIPrepRegister.md
+++ b/docs/scripts_md/DTIPrepRegister.md
@@ -1,0 +1,382 @@
+# NAME
+
+DTIPrepRegister.pl -- registers DTIPrep outputs in the LORIS database
+
+# SYNOPSIS
+
+perl DTIPrepRegister.pl -profile `prod` -DTIPrep\_subdir
+`/path/to/DTIPrep/dir` -DTIPrepProtocol `/Path/to/DTIPrep/XML/protocol`
+\-DTI\_file `/path/to/DTI/native/file` -anat\_file `/path/to/anat/native/file`
+\-DTIPrepVersion `DTIPrep_version` -mincdiffusionVersion
+`mincdiffusion_version`
+
+Note: `-DTIPrepVersion` and `-mincdiffusionVersion` are optional if the
+version of those tools can be found directly from the tools installed on the
+server running `DTIPrepRegister`.
+
+# DESCRIPTION
+
+Registers DWI QC pipeline's output files of interest into the LORIS database
+via `register_processed_data.pl`.
+
+The following output files will be inserted:
+  - QCed MINC file produced by DTIPrep pre-processing step (i.e. DWI dataset
+     without the bad directions detected by DTIPrep)
+  - QCReport produced by DTPrep
+  - XMLQCResult produced by DTIPrep
+  - RGB map produced by either DTIPrep or mincdiffusion post-processing
+  - MD map produced by either DTIPrep or mincdiffusion post-processing
+  - FA map produced by either DTIPrep or mincdiffusion post-processing
+  - baseline image produced by DTIPrep or mincdiffusion post-processing
+  - DTI mask produced by mincdiffusion post-processing (only if mincdiffusion
+     was used to post-process the data)
+
+## Methods
+
+### register\_XMLProt($XMLProtocol, $data\_dir, $tool)
+
+Registers XML protocol file into `mri_processing_protocol` table. It will first
+check if protocol file was already registered in the database. If the protocol
+file is already registered in the database, it will return the
+ProcessProtocolID from the database. If the protocol file is not registered yet
+in the database, it will register it in the database and return the
+ProcessProtocolID of the registered protocol file.
+
+INPUT: XML protocol file of DTIPrep to be registered, data directory from the
+Config table, tool name of the protocol (a.k.a. "DTIPrep")
+
+RETURNS: ID of the registered protocol file
+
+### registerProtocol($protocol, $md5sum, $tool, $data\_dir)
+
+Registers protocol file into `mri_processing_protocol` table and move the
+protocol to the `$data_dir/protocols/DTIPrep` folder.
+
+INPUT:
+  - $protocol: protocol file to be registered
+  - $md5sum  : md5sum of the protocol file to be registered
+  - $tool    : tool of the protocol file (DTIPrep)
+  - $data\_dir: data\_dir of the prod file
+
+RETURNS: ID of the registered protocol file
+
+### fetchProtocolID($md5sum)
+
+Fetches the protocol ID in the `mri_processing_protocol` table based on
+the XML protocol's md5sum.
+
+INPUT: md5sum of the XML protocol
+
+RETURNS: ID of the registered protocol file
+
+### register\_minc($minc, $raw\_file, $data\_dir, $inputs, ...)
+
+Set the different parameters needed for MINC files' registration
+and call `&registerFile` to register the MINC file in the database
+via `register_processed_data.pl` script.
+
+INPUT:
+  - $minc                  : MINC file to be registered
+  - $raw\_file              : source native file the MINC file to register
+  - $data\_dir              : data\_dir directory from the config table
+  - $inputs                : input files of the MINC file to be registered
+  - $pipelineName          : name of the pipeline used to obtain the MINC file
+  - $toolName              : tool name & version used
+  - $registeredXMLFile     : registered DTIPrep XML report
+  - $registeredQCReportFile: registered DTIPrep txt report
+  - $scanType              : type of scan to be used to register the minc file
+  - $registered\_nrrd       : optional, registered NRRD file used to create
+                              the MINC file
+
+RETURNS: registered MINC file on success, undef otherwise
+
+### register\_XMLFile($XMLFile, $raw\_file, $data\_dir, $QCReport, ...)
+
+Set parameters needed to register the XML report/protocol of DTIPrep
+and call registerFile to register the XML file via register\_processed\_data.pl. 
+
+INPUT:
+  - $XMLFile     : XML file to be registered
+  - $raw\_file    : native DWI file used to obtain the DTIPrep outputs
+  - $data\_dir    : data\_dir from the config table (a.k.a. /data/project/data)
+  - $QCReport    : DTIPrep QCreport
+  - $inputs      : input files that were used to process data through DTIPrep
+  - $pipelineName: name of the pipeline used to process DTIs (DTIPrepPipeline)
+  - $toolName    : DTIPrep name and version that was used to process DTIs
+
+RETURNS: the registered XNL file if it was registered in the database, undef
+otherwise
+
+### register\_QCReport($QCReport, $raw\_file, $data\_dir, $inputs, ...)
+
+Set parameters needed to register the QCreport of DTIPrep and call
+`&registerFile` to register the QCreport file via
+`register_processed_data.pl`.
+
+INPUT:
+  - $QCReport    : QC report file to be registered
+  - $raw\_file    : native DWI file used to obtain the DTIPrep outputs
+  - $data\_dir    : data\_dir from the config table (a.k.a. /data/project/data)
+  - $inputs      : input files that were used to process data through DTIPrep
+  - $pipelineName: name of the pipeline used to process DTIs (DTIPrepPipeline)
+  - $toolName    : DTIPrep name and version that was used to process DTIs
+
+RETURNS: registered QCReport file if it was registered in the database, undef
+ otherwise
+
+### getFiles($dti\_file, $DTIrefs)
+
+This function checks that all the processing files exist on the filesystem and
+returns the files to be inserted in the database. When NRRD and MINC files were
+found, it will only return the MINC file. (NRRD files will be linked to the
+MINC file when inserting files in the database).
+
+INPUT: raw DTI dataset that is used as a key in `$DTIrefs` hash; hash
+containing all output paths and tool information
+
+RETURNS:
+  - $XMLProtocol    : DTIPrep XML protocol that was found in the file system
+  - $QCReport       : DTIPrep text QCReport that was found in the file system
+  - $XMLReport      : DTIPrep XML QCReport that was found in the file system
+  - $QCed\_minc      : QCed MINC file created after conversion of QCed NRRD file
+  - $RGB\_minc       : RGB MINC file found in the file system
+  - $FA\_minc        : FA MINC file found in the file system
+  - $MD\_minc        : MD MINC file found in the file system
+  - $baseline\_minc  : baseline MINC file found in the file system
+  - $brain\_mask\_minc: brain mask MINC file found in the file system
+  - $QCed2\_minc     : optional, secondary QCed MINC file created after
+                       conversion of secondary QCed DTIPrep NRRD file
+  - returns undef if there are some missing files (except for QCed2\_minc which
+     is optional)
+
+### checkPreprocessFiles($dti\_file, $DTIrefs, $mri\_files)
+
+Function that checks if all DTIPrep pre-processing files are present in the
+file system.
+
+INPUT: raw DTI dataset that is used as a key in $DTIrefs hash; hash
+containing all output paths and tool information
+
+RETURNS:
+  - $XMLProtocol: DTIPrep XML protocol that was found in the file system
+  - $QCReport   : DTIPrep text QCReport that was found in the file system
+  - $XMLReport  : DTIPrep XML QCReport that was found in the file system
+  - $QCed\_minc  : QCed MINC file created after conversion of QCed NRRD file
+  - $QCed2\_minc : optional, secondary QCed MINC file created after conversion of
+                   secondary QCed DTIPrep NRRD file
+  - returns undef if one of the file listed above is missing (except for
+     QCed2\_minc which is optional)
+
+### checkPostprocessFiles($dti\_file, $DTIrefs, $mri\_files)
+
+Function that checks if all postprocessing files (from DTIPrep or
+mincdiffusion) are present in the file system.
+
+INPUT: raw DTI dataset that is used as a key in $DTIrefs hash; hash
+containing all output paths and tool information
+
+RETURNS:
+  - $RGB\_minc       : RGB map
+  - $FA\_minc        : FA map
+  - $MD\_minc        : MD map
+  - $baseline\_minc  : baseline (or frame-0) map
+  - $brain\_mask\_minc: brain mask produced by mincdiffusion tools (not
+                       available if DTIPrep was run to obtain the
+                       post-processing outputs)
+  - will return undef if one of the file listed above is missing
+
+### getFileID($file, $src\_name)
+
+Fetches the source FileID from the database based on the src\_name file
+identified by getFileName.
+
+INPUT: output filename, source filename (file that has been used to obtain
+the output file $file)
+
+RETURNS: source File ID (file ID of the source file that has been used to
+obtain $file)
+
+### getToolName($file)
+
+Fetches tool information stored either in the MINC's header or in the QCReport.
+
+INPUT: MINC or QC report to look for tool information
+
+RETURNS: name of the pipeline used to obtain $file (a.k.a. DTIPrepPipeline);
+name and version of the tool used to obtain $file (DTIPrep\_v1.1.6,
+mincdiffusion\_v...)
+
+### getPipelineDate($file, $data\_dir, $QCReport)
+
+Fetches the date at which DTIPrep pipeline was run either in the processed
+MINC's header or in the QCReport.
+
+INPUT: MINC or QC report to look for tool information; data\_dir from the
+Config table; QC report created when $file was created
+
+RETURNS: date at which the pipeline has been run to obtain $file
+
+### insertReports($minc, $registeredXMLFile, $registeredQCReportFile)
+
+Inserts in the MINC header the path to DTIPrep's QC text and XML reports and XML
+protocol.
+
+INPUT: minc file to modify header; path to the registered DTIPrep's XML
+report; path to the registered DTIPrep's QC text report
+
+RETURNS:
+\- $Txtreport\_insert: 1 if on text report path insertion success, undef otherwise
+\- $XMLreport\_insert: 1 if on  xml report path insertion success, undef otherwise
+
+### insertPipelineSummary($minc, $data\_dir, $XMLReport, $scanType)
+
+Inserts in the MINC header a summary of DTIPrep reports. This summary consists
+of the directions rejected due to slice wise correlation, the directions
+rejected due to interlace correlation, and the directions rejected due to
+gradient wise correlation.
+
+INPUT: minc file in which the summary will be inserted; data\_dir from the
+Config file; DTIPrep's QC report from which the summary will be extracted
+
+RETURNS: 1 on success, undef on failure
+
+### registerFile($file, $src\_fileID, $src\_pipeline, $src\_tool, ...)
+
+Registers file into the database via register\_processed\_data.pl with all
+options.
+
+INPUT:
+  - $file           : file to be registered in the database
+  - $src\_fileID     : source file's FileID
+  - $src\_pipeline   : pipeline used to obtain the file (DTIPrepPipeline)
+  - $src\_tool       : name and version of the tool (DTIPrep or mincdiffusion)
+  - $pipelineDate   : file's creation date (= pipeline date)
+  - $coordinateSpace: file's coordinate space (= native, T1 ...)
+  - $scanType       : file's scan type (= DTIPrepReg, DTIPrepDTIFA,
+                       DTIPrepDTIMD, DTIPrepDTIColorFA...)
+  - $outputType     : file's output type (.xml, .txt, .mnc...)
+  - $inputs         : input files that were used to create the file to be
+                       registered (intermediary files)
+
+RETURNS: registered file
+
+### fetchRegisteredFile($src\_fileID, $src\_pipeline, $pipelineDate, ...)
+
+Fetches the registered file from the database to link it to the minc files.
+
+INPUT:
+ - $src\_fileID     : FileID of the source native file
+ - $src\_pipeline   : Pipeline name used to register the processed file
+ - $pipelineDate   : Pipeline data used to register the processed file
+ - $coordinateSpace: coordinate space used to register the processed file
+ - $scanType       : scan type used to register the processed file
+ - $outputType     : output type used to register the processed file
+
+RETURNS: path to the registered processed file
+
+### register\_DTIPrep\_files($minc, $nrrd, $raw\_file, $data\_dir, ...)
+
+Registers DTIPrep NRRD and MINC files. The MINC file will have a link to the
+registered NRRD file (`&register_minc` function will modify the MINC header to
+include this information) in addition to the links toward QC reports and
+protocol.
+
+INPUT: files to be registered ($minc, $nrrd); registered QC report files
+($registeredXMLReportFile, $registeredQCReportFile); $DTIPrepVersion used to
+produce the files
+
+RETURNS: registered minc files or undef on insertion's failure
+
+### register\_nrrd($nrrd, $raw\_file, $data\_dir, $QCReport, $inputs, ...)
+
+Set parameters needed to register the NRRD file produced by DTIPrep
+and call registerFile to register the NRRD file via
+`register_processed_data.pl`.
+
+INPUT:
+  - $nrrd        : NRRD file to be registered
+  - $raw\_file    : native DWI file used to obtain the DTIPrep outputs
+  - $data\_dir    : data\_dir from the config table (a.k.a. /data/project/data)
+  - $QCReport    : DTIPrep QCreport
+  - $inputs      : input files that were used to process data through DTIPrep
+  - $pipelineName: name of the pipeline used to process DTIs (DTIPrepPipeline)
+  - $toolName    : DTIPrep name and version that was used to process DTIs
+  - $scanType    : nrrd file's scan type
+
+RETURNS: registered NRRD file or undef on insertion's failure
+
+### register\_Preproc($mri\_files, $dti\_file, $data\_dir, ...)
+
+Gather all DTIPrep preprocessed files to be registered in the database
+and call `&register_DTIPrep_files` on all of them. Will register first the
+NRRD file and then the MINC file for each scan type.
+
+INPUT:
+  - $mri\_files   : hash containing all DTI output information
+  - $dti\_file    : native DWI file (that will be used as a key for $mri\_files)
+  - $data\_dir    : data\_dir defined in the config file
+  - $pipelineName: pipeline name (DTIPrepPipeline)
+  - $toolName    : tool's name and version
+  - $process\_step: processing step ('Preproc' or 'Postproc')
+  - $proc\_file   : processed file key ('QCed', 'QCed2'...)
+
+RETURNS: path to the MINC file that was registered
+
+### register\_images($mri\_files, $raw\_file, $data\_dir, $pipelineName, ...)
+
+Function to register processed images in the database depending on the tool
+used to obtain them. Will call `&register_DTIPrep_files` if files to be
+registered are obtained via DTIPrep or `&register_minc` if files to be
+registered are obtained using mincdiffusion tools.
+
+INPUT:
+  - $mri\_files   : hash with information about the files to be registered
+  - $raw\_file    : source raw image
+  - $data\_dir    : data directory from the Config table
+  - $pipelineName: name of the pipeline used (a.k.a DTIPrep)
+  - $toolName    : tool's version and name
+  - $process\_step: processing step (preprocessing, post-processing)
+
+RETURNS:
+  - @registered: list of registered files
+  - @failed\_to\_register: list of files that failed to be registered in the DB
+
+### getInputList($mri\_files, $data\_dir, $process\_step, $proc\_file)
+
+Function that will return in a string the list of inputs used to process the
+data separated by ';'.
+
+INPUT:
+  - $mri\_files   : list of processed outputs to register or that have been
+                    registered
+  - $data\_dir    : data directory from the Config table
+  - $process\_step: processing step used for the processed output to determine
+                    inputs
+  - $proc\_file   : processing file to determine inputs used
+
+RETURNS: string with each inputs used separated by ';'
+
+### fetchRegisteredMD5($md5sum)
+
+Will check if md5sum has already been registered into the database.
+
+INPUT: md5sum of the file
+
+RETURNS: registered FileID matching md5sum and scan type of the registered
+FileID matching md5sum
+
+# TO DO
+
+Nothing planned (or things that are left to do)
+
+# BUGS
+
+None reported (or list of bugs)
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/DTIPrepRegister.md
+++ b/docs/scripts_md/DTIPrepRegister.md
@@ -112,8 +112,8 @@ RETURNS: registered MINC file on success, undef otherwise
 
 ### register\_XMLFile($XMLFile, $raw\_file, $data\_dir, $QCReport, ...)
 
-Set parameters needed to register the XML report/protocol of DTIPrep
-and call registerFile to register the XML file via register\_processed\_data.pl. 
+Sets parameters needed to register the XML report/protocol of DTIPrep
+and calls registerFile to register the XML file via register\_processed\_data.pl.
 
 INPUT:
   - $XMLFile     : XML file to be registered

--- a/docs/scripts_md/DTIPrepRegister.md
+++ b/docs/scripts_md/DTIPrepRegister.md
@@ -20,10 +20,10 @@ Available options are:
 \-anat\_file      : native anatomical dataset used to create FA, RGB and
                    other post-processed maps using mincdiffusion tools
 
-\-DTIPrepVersion : DTIPrep version used if cannot be found in MINC
+\-DTIPrepVersion : DTIPrep version used if it cannot be found in MINC
                    files' `processing:pipeline` header field
 
-\-mincdiffusionVersion: mincdiffusion release version used if cannot be
+\-mincdiffusionVersion: mincdiffusion release version used if it cannot be
                         found in minc files' `processing:pipeline`
                         header field
 
@@ -52,15 +52,17 @@ The following output files will be inserted:
 
 ### register\_XMLProt($XMLProtocol, $data\_dir, $tool)
 
-Registers XML protocol file into `mri_processing_protocol` table. It will first
-check if protocol file was already registered in the database. If the protocol
-file is already registered in the database, it will return the
+Registers XML protocol file into the `mri_processing_protocol` table. It will
+first check if protocol file was already registered in the database. If the
+protocol file is already registered in the database, it will return the
 ProcessProtocolID from the database. If the protocol file is not registered yet
 in the database, it will register it in the database and return the
 ProcessProtocolID of the registered protocol file.
 
-INPUT: XML protocol file of DTIPrep to be registered, data directory from the
-Config table, tool name of the protocol (a.k.a. "DTIPrep")
+INPUTS:
+  - $XMLProtocol: XML protocol file of DTIPrep to be registered
+  - $data\_dir   : data directory from the `Config` table, tool name of the
+                   protocol (a.k.a. "DTIPrep")
 
 RETURNS: ID of the registered protocol file
 
@@ -69,7 +71,7 @@ RETURNS: ID of the registered protocol file
 Registers protocol file into `mri_processing_protocol` table and move the
 protocol to the `$data_dir/protocols/DTIPrep` folder.
 
-INPUT:
+INPUTS:
   - $protocol: protocol file to be registered
   - $md5sum  : md5sum of the protocol file to be registered
   - $tool    : tool of the protocol file (DTIPrep)
@@ -88,11 +90,11 @@ RETURNS: ID of the registered protocol file
 
 ### register\_minc($minc, $raw\_file, $data\_dir, $inputs, ...)
 
-Set the different parameters needed for MINC files' registration
-and call `&registerFile` to register the MINC file in the database
+Sets the different parameters needed for MINC files' registration
+and calls `&registerFile` to register the MINC file in the database
 via `register_processed_data.pl` script.
 
-INPUT:
+INPUTS:
   - $minc                  : MINC file to be registered
   - $raw\_file              : source file of the MINC file to register
   - $data\_dir              : data\_dir directory from the config table
@@ -124,15 +126,15 @@ INPUT:
   - $toolName    : DTIPrep name & version used to process the DWI file
 
 RETURNS: the registered XNL file if it was registered in the database, undef
-otherwise
+          otherwise
 
 ### register\_QCReport($QCReport, $raw\_file, $data\_dir, $inputs, ...)
 
-Set parameters needed to register the QCreport of DTIPrep and call
+Sets parameters needed to register the QCreport of DTIPrep and calls
 `&registerFile` to register the QCreport file via
 `register_processed_data.pl`.
 
-INPUT:
+INPUTS:
   - $QCReport    : QC report file to be registered
   - $raw\_file    : native DWI file used to obtain the DTIPrep outputs
   - $data\_dir    : data\_dir from the config table
@@ -142,17 +144,18 @@ INPUT:
   - $toolName    : DTIPrep name & version used to process the DWI file
 
 RETURNS: registered QCReport file if it was registered in the database, undef
- otherwise
+          otherwise
 
 ### getFiles($dti\_file, $DTIrefs)
 
 This function checks that all the processing files exist on the filesystem and
-returns the files to be inserted in the database. When NRRD and MINC files were
+returns the files to be inserted in the database. When NRRD and MINC files are
 found, it will only return the MINC file. (NRRD files will be linked to the
 MINC file when inserting files in the database).
 
-INPUT: raw DTI dataset that is used as a key in `$DTIrefs` hash; hash
-containing all output paths and tool information
+INPUTS:
+  - $dit\_file: raw DTI dataset that is used as a key in `$DTIrefs` hash
+  - $DTIref  : hash containing all output paths and tool information
 
 RETURNS:
   - $XMLProtocol    : DTIPrep XML protocol found in the file system
@@ -175,8 +178,11 @@ RETURNS:
 Function that checks if all DTIPrep pre-processing files are present in the
 file system.
 
-INPUT: raw DTI dataset that is used as a key in $DTIrefs hash; hash
-containing all output paths and tool information
+INPUTS:
+  - $dti\_file: raw DTI dataset that is used as a key in $DTIrefs hash
+  - DTIrefs  : hash containing all output paths and tool information
+  - mri\_files: list of processed outputs to register or that have been
+                registered
 
 RETURNS:
   - $XMLProtocol: DTIPrep XML protocol found in the file system
@@ -194,8 +200,11 @@ RETURNS:
 Function that checks if all postprocessing files (from DTIPrep or
 mincdiffusion) are present in the file system.
 
-INPUT: raw DTI dataset that is used as a key in $DTIrefs hash; hash
-containing all output paths and tool information
+INPUTS:
+  - $dti\_file : raw DTI dataset that is used as a key in $DTIrefs hash
+  - $DTIrefs  : hash containing all output paths and tool information
+  - $mri\_files: list of processed outputs to register or that
+                 have been registered
 
 RETURNS:
   - $RGB\_minc       : RGB map
@@ -212,39 +221,47 @@ RETURNS:
 Fetches the source FileID from the database based on the src\_name file
 identified by getFileName.
 
-INPUT: output filename, source filename (file that has been used to obtain
-the output file $file)
+INPUTS:
+  - $file    : output filename
+  - $src\_name: source filename (file that has been used to obtain the output
+                file $file)
 
 RETURNS: source File ID (file ID of the source file that has been used to
-obtain $file)
+          obtain $file)
 
 ### getToolName($file)
 
-Fetches tool information stored either in the MINC's header or in the QCReport.
+Fetches tool information stored either in the MINC file's header or in the
+QCReport.
 
 INPUT: MINC or QC report to look for tool information
 
-RETURNS: name of the pipeline used to obtain $file (a.k.a. DTIPrepPipeline);
-name and version of the tool used to obtain $file (DTIPrep\_v1.1.6,
-mincdiffusion\_v...)
+RETURNS:
+  - $src\_pipeline: name of the pipeline used to obtain $file (DTIPrepPipeline)
+  - $src\_tool    : name and version of the tool used to obtain $file
+                    (DTIPrep\_v1.1.6, mincdiffusion\_v...)
 
 ### getPipelineDate($file, $data\_dir, $QCReport)
 
-Fetches the date at which DTIPrep pipeline was run either in the processed
-MINC's header or in the QCReport.
+Fetches the date at which the DTIPrep pipeline was run either in the processed
+MINC file's header or in the QCReport.
 
-INPUT: MINC or QC report to look for tool information; data\_dir from the
-Config table; QC report created when $file was created
+INPUTS:
+  - MINC or QC report to look for tool information
+  - data\_dir from the `Config` table
+  - QC report created when `$file` was created
 
-RETURNS: date at which the pipeline has been run to obtain $file
+RETURNS: date at which the pipeline has been run to obtain `$file`
 
 ### insertReports($minc, $registeredXMLFile, $registeredQCReportFile)
 
-Inserts in the MINC header the path to DTIPrep's QC text and XML reports and XML
-protocol.
+Inserts the path to DTIPrep's QC text, XML reports and XML protocol in the
+MINC file's header.
 
-INPUT: minc file to modify header; path to the registered DTIPrep's XML
-report; path to the registered DTIPrep's QC text report
+INPUTS:
+  - $minc                  : MINC file for which the header should be modified
+  - $registeredXMLfile     : path to the registered DTIPrep's XML report
+  - $registeredQCReportFile: path to the registered DTIPrep's QC text report
 
 RETURNS:
  - $Txtreport\_insert: 1 if on text report path insertion success,
@@ -259,8 +276,10 @@ of the directions rejected due to slice wise correlation, the directions
 rejected due to interlace correlation, and the directions rejected due to
 gradient wise correlation.
 
-INPUT: minc file in which the summary will be inserted; data\_dir from the
-Config file; DTIPrep's QC report from which the summary will be extracted
+INPUTS:
+  - $minc     : MINC file in which the summary will be inserted
+  - $data\_dir : `data_dir` from the `Config` table
+  - $XMLReport: DTIPrep's XML QC report from which the summary will be extracted
 
 RETURNS: 1 on success, undef on failure
 
@@ -269,7 +288,7 @@ RETURNS: 1 on success, undef on failure
 Registers file into the database via register\_processed\_data.pl with all
 options.
 
-INPUT:
+INPUTS:
   - $file           : file to be registered in the database
   - $src\_fileID     : source file's FileID
   - $src\_pipeline   : pipeline used to obtain the file
@@ -288,9 +307,9 @@ RETURNS: registered file
 
 ### fetchRegisteredFile($src\_fileID, $src\_pipeline, $pipelineDate, ...)
 
-Fetches the registered file from the database to link it to the minc files.
+Fetches the registered file from the database to link it to the MINC files.
 
-INPUT:
+INPUTS:
  - $src\_fileID     : FileID of the source native file
  - $src\_pipeline   : pipeline name used to register the processed file
  - $pipelineDate   : pipeline data used to register the processed file
@@ -307,19 +326,31 @@ registered NRRD file (`&register_minc` function will modify the MINC header to
 include this information) in addition to the links toward QC reports and
 protocol.
 
-INPUT: files to be registered ($minc, $nrrd); registered QC report files
-($registeredXMLReportFile, $registeredQCReportFile); $DTIPrepVersion used to
-produce the files
+INPUTS:
+  - $minc                   : MINC file to be registered
+  - $nrrd                   : NRRD file to be registered
+  - $raw\_file               : raw DWI file used to create the MINC file to
+                               register
+  - $data\_dir               : `data_dir` from the `Config` table
+  - $inputs                 : input files that were used to create the file to
+                               be registered (intermediary files)
+  - $registeredXMLProtocolID: registered XML protocol file
+  - $pipelineName           : name of the pipeline that created the file to be
+                               registered (DTIPrepPipeline)
+  - $DTIPrepVersion         : DTIPrep's version
+  - $registeredXMLReportFile: registered XML report file
+  - $registeredQCReport     : registered QC text file
+  - $scanType               : scan type to use to label/register the MINC file
 
-RETURNS: registered minc files or undef on insertion's failure
+RETURNS: registered MINC files or undef on insertion's failure
 
 ### register\_nrrd($nrrd, $raw\_file, $data\_dir, $QCReport, $inputs, ...)
 
-Set parameters needed to register the NRRD file produced by DTIPrep
-and call registerFile to register the NRRD file via
+Sets parameters needed to register the NRRD file produced by DTIPrep
+and calls registerFile to register the NRRD file via
 `register_processed_data.pl`.
 
-INPUT:
+INPUTS:
   - $nrrd        : NRRD file to be registered
   - $raw\_file    : native DWI file used to obtain the DTIPrep outputs
   - $data\_dir    : data\_dir from the config table
@@ -335,11 +366,11 @@ RETURNS: registered NRRD file or undef on insertion's failure
 
 ### register\_Preproc($mri\_files, $dti\_file, $data\_dir, ...)
 
-Gather all DTIPrep preprocessed files to be registered in the database
-and call `&register_DTIPrep_files` on all of them. Will register first the
+Gathers all DTIPrep preprocessed files to be registered in the database
+and calls `&register_DTIPrep_files` on all of them. Will register first the
 NRRD file and then the MINC file for each scan type.
 
-INPUT:
+INPUTS:
   - $mri\_files   : hash containing all DTI output information
   - $dti\_file    : native DWI file (that will be used as a key
                     for $mri\_files)
@@ -358,7 +389,7 @@ used to obtain them. Will call `&register_DTIPrep_files` if files to be
 registered are obtained via DTIPrep or `&register_minc` if files to be
 registered are obtained using mincdiffusion tools.
 
-INPUT:
+INPUTS:
   - $mri\_files   : hash with information about the files to be registered
   - $raw\_file    : source raw image
   - $data\_dir    : data directory from the Config table
@@ -376,7 +407,7 @@ RETURNS:
 Function that will return in a string the list of inputs used to process the
 data separated by ';'.
 
-INPUT:
+INPUTS:
   - $mri\_files   : list of processed outputs to register or that
                     have been registered
   - $data\_dir    : data directory from the Config table
@@ -392,8 +423,9 @@ Will check if md5sum has already been registered into the database.
 
 INPUT: md5sum of the file
 
-RETURNS: registered FileID matching md5sum and scan type of the registered
-FileID matching md5sum
+RETURNS:
+  - $registeredFile    : registered FileID matching md5sum
+  - $registeredScanType: scan type of the registered FileID matching md5sum
 
 # TO DO
 

--- a/docs/scripts_md/DTIPrepRegister.md
+++ b/docs/scripts_md/DTIPrepRegister.md
@@ -4,15 +4,32 @@ DTIPrepRegister.pl -- registers DTIPrep outputs in the LORIS database
 
 # SYNOPSIS
 
-perl DTIPrepRegister.pl -profile `prod` -DTIPrep\_subdir
-`/path/to/DTIPrep/dir` -DTIPrepProtocol `/Path/to/DTIPrep/XML/protocol`
-\-DTI\_file `/path/to/DTI/native/file` -anat\_file `/path/to/anat/native/file`
-\-DTIPrepVersion `DTIPrep_version` -mincdiffusionVersion
-`mincdiffusion_version`
+perl DTIPrepRegister.pl `[options]`
+
+Available options are:
+
+\-profile        : name of the config file in ../dicom-archive/.loris-mri
+
+\-DTIPrep\_subdir : DTIPrep subdirectory storing the processed files to
+                   be registered
+
+\-DTIPrepProtocol: DTIPrep protocol used to obtain the output files
+
+\-DTI\_file       : native DWI file used to obtain the output files
+
+\-anat\_file      : native anatomical dataset used to create FA, RGB and
+                   other post-processed maps using mincdiffusion tools
+
+\-DTIPrepVersion : DTIPrep version used if cannot be found in MINC
+                   files' `processing:pipeline` header field
+
+\-mincdiffusionVersion: mincdiffusion release version used if cannot be
+                        found in minc files' `processing:pipeline`
+                        header field
 
 Note: `-DTIPrepVersion` and `-mincdiffusionVersion` are optional if the
-version of those tools can be found directly from the tools installed on the
-server running `DTIPrepRegister`.
+version of those tools can be found directly in the MINC header of the
+processed files.
 
 # DESCRIPTION
 
@@ -20,16 +37,16 @@ Registers DWI QC pipeline's output files of interest into the LORIS database
 via `register_processed_data.pl`.
 
 The following output files will be inserted:
-  - QCed MINC file produced by DTIPrep pre-processing step (i.e. DWI dataset
-     without the bad directions detected by DTIPrep)
+  - QCed MINC file produced by DTIPrep pre-processing step (i.e. DWI
+     dataset without the bad directions detected by DTIPrep)
   - QCReport produced by DTPrep
   - XMLQCResult produced by DTIPrep
   - RGB map produced by either DTIPrep or mincdiffusion post-processing
   - MD map produced by either DTIPrep or mincdiffusion post-processing
   - FA map produced by either DTIPrep or mincdiffusion post-processing
   - baseline image produced by DTIPrep or mincdiffusion post-processing
-  - DTI mask produced by mincdiffusion post-processing (only if mincdiffusion
-     was used to post-process the data)
+  - DTI mask produced by mincdiffusion post-processing (only if
+     mincdiffusion was used to post-process the data)
 
 ## Methods
 
@@ -77,16 +94,17 @@ via `register_processed_data.pl` script.
 
 INPUT:
   - $minc                  : MINC file to be registered
-  - $raw\_file              : source native file the MINC file to register
+  - $raw\_file              : source file of the MINC file to register
   - $data\_dir              : data\_dir directory from the config table
-  - $inputs                : input files of the MINC file to be registered
-  - $pipelineName          : name of the pipeline used to obtain the MINC file
+  - $inputs                : input files of the file to be registered
+  - $pipelineName          : name of the pipeline used to obtain the
+                              MINC file
   - $toolName              : tool name & version used
   - $registeredXMLFile     : registered DTIPrep XML report
   - $registeredQCReportFile: registered DTIPrep txt report
-  - $scanType              : type of scan to be used to register the minc file
-  - $registered\_nrrd       : optional, registered NRRD file used to create
-                              the MINC file
+  - $scanType              : scan type of the MINC file to register
+  - $registered\_nrrd       : optional, registered NRRD file used to
+                              create the MINC file
 
 RETURNS: registered MINC file on success, undef otherwise
 
@@ -98,11 +116,12 @@ and call registerFile to register the XML file via register\_processed\_data.pl.
 INPUT:
   - $XMLFile     : XML file to be registered
   - $raw\_file    : native DWI file used to obtain the DTIPrep outputs
-  - $data\_dir    : data\_dir from the config table (a.k.a. /data/project/data)
+  - $data\_dir    : data\_dir from the config table
+                    (e.g. /data/project/data)
   - $QCReport    : DTIPrep QCreport
-  - $inputs      : input files that were used to process data through DTIPrep
-  - $pipelineName: name of the pipeline used to process DTIs (DTIPrepPipeline)
-  - $toolName    : DTIPrep name and version that was used to process DTIs
+  - $inputs      : input files used to process data through DTIPrep
+  - $pipelineName: pipeline name used to process DWIs (DTIPrepPipeline)
+  - $toolName    : DTIPrep name & version used to process the DWI file
 
 RETURNS: the registered XNL file if it was registered in the database, undef
 otherwise
@@ -116,10 +135,11 @@ Set parameters needed to register the QCreport of DTIPrep and call
 INPUT:
   - $QCReport    : QC report file to be registered
   - $raw\_file    : native DWI file used to obtain the DTIPrep outputs
-  - $data\_dir    : data\_dir from the config table (a.k.a. /data/project/data)
-  - $inputs      : input files that were used to process data through DTIPrep
-  - $pipelineName: name of the pipeline used to process DTIs (DTIPrepPipeline)
-  - $toolName    : DTIPrep name and version that was used to process DTIs
+  - $data\_dir    : data\_dir from the config table
+                    (e.g. /data/project/data)
+  - $inputs      : input files used to process data through DTIPrep
+  - $pipelineName: pipeline name used to process DTIs (DTIPrepPipeline)
+  - $toolName    : DTIPrep name & version used to process the DWI file
 
 RETURNS: registered QCReport file if it was registered in the database, undef
  otherwise
@@ -135,10 +155,11 @@ INPUT: raw DTI dataset that is used as a key in `$DTIrefs` hash; hash
 containing all output paths and tool information
 
 RETURNS:
-  - $XMLProtocol    : DTIPrep XML protocol that was found in the file system
-  - $QCReport       : DTIPrep text QCReport that was found in the file system
-  - $XMLReport      : DTIPrep XML QCReport that was found in the file system
-  - $QCed\_minc      : QCed MINC file created after conversion of QCed NRRD file
+  - $XMLProtocol    : DTIPrep XML protocol found in the file system
+  - $QCReport       : DTIPrep text QCReport found in the file system
+  - $XMLReport      : DTIPrep XML QCReport found in the file system
+  - $QCed\_minc      : QCed MINC file created after conversion of
+                       QCed NRRD file
   - $RGB\_minc       : RGB MINC file found in the file system
   - $FA\_minc        : FA MINC file found in the file system
   - $MD\_minc        : MD MINC file found in the file system
@@ -146,8 +167,8 @@ RETURNS:
   - $brain\_mask\_minc: brain mask MINC file found in the file system
   - $QCed2\_minc     : optional, secondary QCed MINC file created after
                        conversion of secondary QCed DTIPrep NRRD file
-  - returns undef if there are some missing files (except for QCed2\_minc which
-     is optional)
+  - returns undef if there are some missing files (except for
+     QCed2\_minc which is optional)
 
 ### checkPreprocessFiles($dti\_file, $DTIrefs, $mri\_files)
 
@@ -158,14 +179,15 @@ INPUT: raw DTI dataset that is used as a key in $DTIrefs hash; hash
 containing all output paths and tool information
 
 RETURNS:
-  - $XMLProtocol: DTIPrep XML protocol that was found in the file system
-  - $QCReport   : DTIPrep text QCReport that was found in the file system
-  - $XMLReport  : DTIPrep XML QCReport that was found in the file system
-  - $QCed\_minc  : QCed MINC file created after conversion of QCed NRRD file
-  - $QCed2\_minc : optional, secondary QCed MINC file created after conversion of
-                   secondary QCed DTIPrep NRRD file
-  - returns undef if one of the file listed above is missing (except for
-     QCed2\_minc which is optional)
+  - $XMLProtocol: DTIPrep XML protocol found in the file system
+  - $QCReport   : DTIPrep text QCReport found in the file system
+  - $XMLReport  : DTIPrep XML QCReport found in the file system
+  - $QCed\_minc  : QCed MINC file created after conversion of
+                   QCed NRRD file
+  - $QCed2\_minc : optional, secondary QCed MINC file created after
+                   conversion of secondary QCed DTIPrep NRRD file
+  - returns undef if one of the file listed above is missing (except
+     for QCed2\_minc which is optional)
 
 ### checkPostprocessFiles($dti\_file, $DTIrefs, $mri\_files)
 
@@ -225,8 +247,10 @@ INPUT: minc file to modify header; path to the registered DTIPrep's XML
 report; path to the registered DTIPrep's QC text report
 
 RETURNS:
-\- $Txtreport\_insert: 1 if on text report path insertion success, undef otherwise
-\- $XMLreport\_insert: 1 if on  xml report path insertion success, undef otherwise
+ - $Txtreport\_insert: 1 if on text report path insertion success,
+                       undef otherwise
+ - $XMLreport\_insert: 1 if on  xml report path insertion success,
+                       undef otherwise
 
 ### insertPipelineSummary($minc, $data\_dir, $XMLReport, $scanType)
 
@@ -248,15 +272,17 @@ options.
 INPUT:
   - $file           : file to be registered in the database
   - $src\_fileID     : source file's FileID
-  - $src\_pipeline   : pipeline used to obtain the file (DTIPrepPipeline)
-  - $src\_tool       : name and version of the tool (DTIPrep or mincdiffusion)
+  - $src\_pipeline   : pipeline used to obtain the file
+                       (DTIPrepPipeline)
+  - $src\_tool       : name and version of the tool
+                       (DTIPrep or mincdiffusion)
   - $pipelineDate   : file's creation date (= pipeline date)
   - $coordinateSpace: file's coordinate space (= native, T1 ...)
   - $scanType       : file's scan type (= DTIPrepReg, DTIPrepDTIFA,
                        DTIPrepDTIMD, DTIPrepDTIColorFA...)
   - $outputType     : file's output type (.xml, .txt, .mnc...)
-  - $inputs         : input files that were used to create the file to be
-                       registered (intermediary files)
+  - $inputs         : input files that were used to create the file to
+                       be registered (intermediary files)
 
 RETURNS: registered file
 
@@ -266,9 +292,9 @@ Fetches the registered file from the database to link it to the minc files.
 
 INPUT:
  - $src\_fileID     : FileID of the source native file
- - $src\_pipeline   : Pipeline name used to register the processed file
- - $pipelineDate   : Pipeline data used to register the processed file
- - $coordinateSpace: coordinate space used to register the processed file
+ - $src\_pipeline   : pipeline name used to register the processed file
+ - $pipelineDate   : pipeline data used to register the processed file
+ - $coordinateSpace: processed file's coordinate space
  - $scanType       : scan type used to register the processed file
  - $outputType     : output type used to register the processed file
 
@@ -296,12 +322,14 @@ and call registerFile to register the NRRD file via
 INPUT:
   - $nrrd        : NRRD file to be registered
   - $raw\_file    : native DWI file used to obtain the DTIPrep outputs
-  - $data\_dir    : data\_dir from the config table (a.k.a. /data/project/data)
+  - $data\_dir    : data\_dir from the config table
+                    (a.k.a. /data/project/data)
   - $QCReport    : DTIPrep QCreport
-  - $inputs      : input files that were used to process data through DTIPrep
-  - $pipelineName: name of the pipeline used to process DTIs (DTIPrepPipeline)
-  - $toolName    : DTIPrep name and version that was used to process DTIs
-  - $scanType    : nrrd file's scan type
+  - $inputs      : input files used to process data through DTIPrep
+  - $pipelineName: pipeline name used to process DTIs
+                    (DTIPrepPipeline)
+  - $toolName    : DTIPrep name & version used to process the DWI file
+  - $scanType    : NRRD file's scan type
 
 RETURNS: registered NRRD file or undef on insertion's failure
 
@@ -313,7 +341,8 @@ NRRD file and then the MINC file for each scan type.
 
 INPUT:
   - $mri\_files   : hash containing all DTI output information
-  - $dti\_file    : native DWI file (that will be used as a key for $mri\_files)
+  - $dti\_file    : native DWI file (that will be used as a key
+                    for $mri\_files)
   - $data\_dir    : data\_dir defined in the config file
   - $pipelineName: pipeline name (DTIPrepPipeline)
   - $toolName    : tool's name and version
@@ -338,8 +367,9 @@ INPUT:
   - $process\_step: processing step (preprocessing, post-processing)
 
 RETURNS:
-  - @registered: list of registered files
-  - @failed\_to\_register: list of files that failed to be registered in the DB
+  - @registered        : list of registered files
+  - @failed\_to\_register: list of files that failed to be registered
+                          in the DB
 
 ### getInputList($mri\_files, $data\_dir, $process\_step, $proc\_file)
 
@@ -347,11 +377,11 @@ Function that will return in a string the list of inputs used to process the
 data separated by ';'.
 
 INPUT:
-  - $mri\_files   : list of processed outputs to register or that have been
-                    registered
+  - $mri\_files   : list of processed outputs to register or that
+                    have been registered
   - $data\_dir    : data directory from the Config table
-  - $process\_step: processing step used for the processed output to determine
-                    inputs
+  - $process\_step: processing step used for the processed output
+                    to determine inputs
   - $proc\_file   : processing file to determine inputs used
 
 RETURNS: string with each inputs used separated by ';'


### PR DESCRIPTION
Using perldoc/perlpod to document `DTIPrepRegister.pl` so that users can type in the terminal
`perldoc DTIPrepRegister.pl` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `DTIPrepRegister.pl` file has been created so that we have a web displayed version of the documentation.
`pod2markdown DTIPrepRegister.pl > DTIPrepRegister.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage