### PR TITLE
[Documentation] register_processed_data.pl perldocification

### DIFF
--- a/docs/scripts_md/register_processed_data.md
+++ b/docs/scripts_md/register_processed_data.md
@@ -1,16 +1,43 @@
 # NAME
 
-register\_processed\_data.pl -- Insert processed data and link it to the source
- data
+register\_processed\_data.pl -- Inserts processed data and link it to the source
+data
 
 # SYNOPSIS
 
-perl register\_processed\_data.pl -profile `name_of_the_profile` -file
-`/path/to/file/to/register` -sourceFileID `source_FileID` -sourcePipeline
-`pipeline_name_used` -tool `tool_used` -pipelineDate `pipeline_date`
-\-coordinateSpace `coordinate_space` -scanType `scan_type` -outputType
-`output_type` -inputFileIDs `list_of_input_FileIDs_separated_by_semi-colon`
-\-protocolID `protocol_ID`
+perl register\_processed\_data.pl `[options]`
+
+Available options are:
+
+\-profile        : name of config file in ../dicom-archive/.loris\_mri
+
+\-file           : file that will be registered in the database
+                   (full path from the root directory is required)
+
+\-sourceFileID   : FileID of the raw input dataset that was processed
+                   to obtain the file to be registered in the database
+
+\-sourcePipeline : pipeline name that was used to obtain the file to be
+                   registered (example: DTIPrep\_pipeline)
+
+\-tool           : tool name and version that was used to obtain the
+                   file to be registered (example: DTIPrep\_v1.1.6)
+
+\-pipelineDate   : date at which the processing pipeline was run
+
+\-coordinateSpace: space coordinate of the file
+                   (i.e. linear, nonlinear or native)
+
+\-scanType       : file scan type stored in the `mri_scan_type` table
+                   (i.e. QCedDTI, RGBqc, TxtQCReport, XMLQCReport...)
+
+\-outputType     : output type to be registered in the database
+                   (i.e. QCed, processed, QCReport)
+
+\-inputFileIDs   : list of input fileIDs used to obtain the file to
+                   be registered (each fileID separated by ';')
+
+\-protocolID     : ID of the registered protocol used to process data
 
 Note: All options are required as they will be necessary to insert a file in
 the database.
@@ -85,8 +112,8 @@ intermediary outputs that were used to obtain the processed file.
 
 INPUT:
   - $fileID      : fileID of the registered processed file
-  - $inputFileIDs: array containing the list of input files that were used to
-                    obtain the processed file
+  - $inputFileIDs: array containing the list of input files that were
+                    used to obtain the processed file
   - $tool        : tool that was used to obtain the processed file
 
 RETURNS: 1 on success, undef on failure

--- a/docs/scripts_md/register_processed_data.md
+++ b/docs/scripts_md/register_processed_data.md
@@ -81,7 +81,7 @@ RETURNS: acquisition protocol ID
 
 ### fetchMincHeader($file, $field)
 
-This function parses the MINC header and looks for specific field's value.
+This function parses the MINC header and looks for a specific field value.
 
 INPUTS:
   - $file : MINC file

--- a/docs/scripts_md/register_processed_data.md
+++ b/docs/scripts_md/register_processed_data.md
@@ -1,0 +1,108 @@
+# NAME
+
+register\_processed\_data.pl -- Insert processed data and link it to the source
+ data
+
+# SYNOPSIS
+
+perl register\_processed\_data.pl -profile `name_of_the_profile` -file
+`/path/to/file/to/register` -sourceFileID `source_FileID` -sourcePipeline
+`pipeline_name_used` -tool `tool_used` -pipelineDate `pipeline_date`
+\-coordinateSpace `coordinate_space` -scanType `scan_type` -outputType
+`output_type` -inputFileIDs `list_of_input_FileIDs_separated_by_semi-colon`
+\-protocolID `protocol_ID`
+
+Note: All options are required as they will be necessary to insert a file in
+the database.
+
+# DESCRIPTION
+
+This script inserts processed data in the files and parameter\_file tables.
+
+## Methods
+
+### getSessionID($sourceFileID, $dbh)
+
+This function returns the sessionID based on the provided sourceFileID.
+
+INPUT: source FileID, database handle
+
+RETURNS: session ID
+
+### getScannerID($sourceFileID, $dbh)
+
+This function gets ScannerID from the `files` table using sourceFileID
+
+INPUT: source FileID, database handle
+
+RETURNS: scanner ID
+
+### getAcqProtID($scanType, $dbh)
+
+This function returns the AcquisitionProtocolID of the file to register in the
+database based on scanType in the `mri_scan_type` table.
+
+INPUT: scan type, database handle
+
+RETURNS: acquisition protocol ID
+
+### fetchMincHeader($file, $field)
+
+This function parses the MINC header and look for specific field's value.
+
+INPUT: MINC file, MINC header field
+
+RETURNS: MINC header value
+
+### copy\_file($filename, $subjectIDsref, $scan\_type, $fileref)
+
+Move files to assembly folder.
+
+INPUT: file to copy, subject ID hashref, scan type, file hash ref
+
+RETURNS: file name of the copied file
+
+### getSourceFilename($sourceFileID)
+
+Grep source file name from the database using SourceFileID.
+
+INPUT: ID of the source file
+
+RETURNS: name of the source file
+
+### which\_directory($subjectIDsref)
+
+Determines where the MINC files will go.
+
+INPUT: subject ID hashref
+
+RETURNS: directory where the MINC files will go
+
+### insert\_intermedFiles($fileID, $inputFileIDs, $tool)
+
+Function that will insert into the `files_intermediary` table of the database,
+intermediary outputs that were used to obtain the processed file.
+
+INPUT:
+  - $fileID      : fileID of the registered processed file
+  - $inputFileIDs: array containing the list of input files that were used to
+                    obtain the processed file
+  - $tool        : tool that was used to obtain the processed file
+
+RETURNS: 1 on success, undef on failure
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/register_processed_data.md
+++ b/docs/scripts_md/register_processed_data.md
@@ -1,6 +1,6 @@
 # NAME
 
-register\_processed\_data.pl -- Inserts processed data and link it to the source
+register\_processed\_data.pl -- Inserts processed data and links it to the source
 data
 
 # SYNOPSIS
@@ -52,15 +52,19 @@ This script inserts processed data in the files and parameter\_file tables.
 
 This function returns the sessionID based on the provided sourceFileID.
 
-INPUT: source FileID, database handle
+INPUTS:
+  - $sourceFileID: source FileID
+  - $dbh         : database handle
 
 RETURNS: session ID
 
 ### getScannerID($sourceFileID, $dbh)
 
-This function gets ScannerID from the `files` table using sourceFileID
+This function gets the ScannerID from the `files` table using sourceFileID
 
-INPUT: source FileID, database handle
+INPUTS:
+  - $sourceFileID: source FileID
+  - $dbh         : database handle
 
 RETURNS: scanner ID
 
@@ -69,29 +73,37 @@ RETURNS: scanner ID
 This function returns the AcquisitionProtocolID of the file to register in the
 database based on scanType in the `mri_scan_type` table.
 
-INPUT: scan type, database handle
+INPUTS:
+  - $scanType: scan type
+  - $dbh     : database handle
 
 RETURNS: acquisition protocol ID
 
 ### fetchMincHeader($file, $field)
 
-This function parses the MINC header and look for specific field's value.
+This function parses the MINC header and looks for specific field's value.
 
-INPUT: MINC file, MINC header field
+INPUTS:
+  - $file : MINC file
+  - $field: MINC header field values
 
 RETURNS: MINC header value
 
 ### copy\_file($filename, $subjectIDsref, $scan\_type, $fileref)
 
-Move files to assembly folder.
+Moves files to `assembly` folder.
 
-INPUT: file to copy, subject ID hashref, scan type, file hash ref
+INPUTS:
+  - $filename     : file to copy
+  - $subjectIDsref: subject ID hashref
+  - $scan\_type    : scan type
+  - $fileref      : file hash ref
 
 RETURNS: file name of the copied file
 
 ### getSourceFilename($sourceFileID)
 
-Grep source file name from the database using SourceFileID.
+Greps source file name from the database using SourceFileID.
 
 INPUT: ID of the source file
 
@@ -107,10 +119,10 @@ RETURNS: directory where the MINC files will go
 
 ### insert\_intermedFiles($fileID, $inputFileIDs, $tool)
 
-Function that will insert into the `files_intermediary` table of the database,
-intermediary outputs that were used to obtain the processed file.
+Function that will insert the intermediary outputs that were used to obtain the
+processed file into the `files_intermediary` table of the database.
 
-INPUT:
+INPUTS:
   - $fileID      : fileID of the registered processed file
   - $inputFileIDs: array containing the list of input files that were
                     used to obtain the processed file

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -452,7 +452,7 @@ sub getAcqProtID    {
 
 =head3 fetchMincHeader($file, $field)
 
-This function parses the MINC header and looks for specific field's value.
+This function parses the MINC header and looks for a specific field value.
 
 INPUTS:
   - $file : MINC file

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -1,5 +1,33 @@
 #!/usr/bin/perl -w
 
+=pod
+
+=head1 NAME
+
+register_processed_data.pl -- Insert processed data and link it to the source
+ data
+
+=head1 SYNOPSIS
+
+perl register_processed_data.pl -profile C<name_of_the_profile> -file
+C</path/to/file/to/register> -sourceFileID C<source_FileID> -sourcePipeline
+C<pipeline_name_used> -tool C<tool_used> -pipelineDate C<pipeline_date>
+-coordinateSpace C<coordinate_space> -scanType C<scan_type> -outputType
+C<output_type> -inputFileIDs C<list_of_input_FileIDs_separated_by_semi-colon>
+-protocolID C<protocol_ID>
+
+Note: All options are required as they will be necessary to insert a file in
+the database.
+
+=head1 DESCRIPTION
+
+This script inserts processed data in the files and parameter_file tables.
+
+=head2 Methods
+
+=cut
+
+
 use strict;
 use warnings;
 use Getopt::Tabular;
@@ -276,9 +304,19 @@ exit 0;
 ###################################
 ##           Functions           ##
 ###################################
+
 =pod
-This function returns the sessionID based on sourceFileID.
+
+=head3 getSessionID($sourceFileID, $dbh)
+
+This function returns the sessionID based on the provided sourceFileID.
+
+INPUT: source FileID, database handle
+
+RETURNS: session ID
+
 =cut
+
 sub getSessionID    {
     my  ($sourceFileID,$dbh)    =   @_;
     
@@ -311,8 +349,17 @@ sub getSessionID    {
 
 
 =pod
-This function gets ScannerID from files using sourceFileID
+
+=head3 getScannerID($sourceFileID, $dbh)
+
+This function gets ScannerID from the C<files> table using sourceFileID
+
+INPUT: source FileID, database handle
+
+RETURNS: scanner ID
+
 =cut
+
 sub getScannerID    {
     my  ($sourceFileID,$dbh)    =   @_;    
 
@@ -332,9 +379,20 @@ sub getScannerID    {
     return  ($scannerID);
 }
 
+
 =pod
-This function returns the AcquisitionProtocolID of the file to register in DB based on scanType in mri_scan_type.
+
+=head3 getAcqProtID($scanType, $dbh)
+
+This function returns the AcquisitionProtocolID of the file to register in the
+database based on scanType in the C<mri_scan_type> table.
+
+INPUT: scan type, database handle
+
+RETURNS: acquisition protocol ID
+
 =cut
+
 sub getAcqProtID    {
     my  ($scanType,$dbh)    =   @_;
 
@@ -354,9 +412,19 @@ sub getAcqProtID    {
     return  ($acqProtID);
 }
 
+
 =pod
-This function parses the mincheader and look for specific field's value.
+
+=head3 fetchMincHeader($file, $field)
+
+This function parses the MINC header and look for specific field's value.
+
+INPUT: MINC file, MINC header field
+
+RETURNS: MINC header value
+
 =cut
+
 sub fetchMincHeader {
     my  ($file,$field)  =   @_;
 
@@ -370,9 +438,19 @@ sub fetchMincHeader {
     return  $value;
 }    
 
+
 =pod
+
+=head3 copy_file($filename, $subjectIDsref, $scan_type, $fileref)
+
 Move files to assembly folder.
+
+INPUT: file to copy, subject ID hashref, scan type, file hash ref
+
+RETURNS: file name of the copied file
+
 =cut
+
 sub copy_file {
     my ($filename, $subjectIDsref, $scan_type, $fileref)    =   @_;
 
@@ -417,12 +495,18 @@ sub copy_file {
 }
 
 
-
 =pod
+
+=head3 getSourceFilename($sourceFileID)
+
 Grep source file name from the database using SourceFileID.
-Input:  $sourceFileID
-Output: $filename
+
+INPUT: ID of the source file
+
+RETURNS: name of the source file
+
 =cut
+
 sub getSourceFilename {
     my ($sourceFileID) = @_;
 
@@ -447,10 +531,18 @@ sub getSourceFilename {
 }
 
 
-
 =pod
-Determines where the mincs will go...
+
+=head3 which_directory($subjectIDsref)
+
+Determines where the MINC files will go.
+
+INPUT: subject ID hashref
+
+RETURNS: directory where the MINC files will go
+
 =cut
+
 sub which_directory {
     my ($subjectIDsref) =   @_;
     
@@ -465,13 +557,22 @@ sub which_directory {
 
 
 =pod
-Function that will insert into the files_intermediary table of the database, intermediary outputs that were used to obtain the processed file.
-- Input:  - fileID : fileID of the registered processed file
-          - inputFileIDs : array containing the list of input files that were used to obtain the processed file
-          - tool : tool that was used to obtain the processed file
-- Output: - return undef if insertion did not succeed
-          - return 1 if insertion into the intermediary table succeeded. 
+
+=head3 insert_intermedFiles($fileID, $inputFileIDs, $tool)
+
+Function that will insert into the C<files_intermediary> table of the database,
+intermediary outputs that were used to obtain the processed file.
+
+INPUT:
+  - $fileID      : fileID of the registered processed file
+  - $inputFileIDs: array containing the list of input files that were used to
+                    obtain the processed file
+  - $tool        : tool that was used to obtain the processed file
+
+RETURNS: 1 on success, undef on failure
+
 =cut
+
 sub insert_intermedFiles {
     my ($fileID, $inputFileIDs, $tool) = @_;
 
@@ -491,3 +592,26 @@ sub insert_intermedFiles {
 
     return 1;
 }
+
+
+__END__
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -4,7 +4,7 @@
 
 =head1 NAME
 
-register_processed_data.pl -- Inserts processed data and link it to the source
+register_processed_data.pl -- Inserts processed data and links it to the source
 data
 
 =head1 SYNOPSIS
@@ -340,7 +340,9 @@ exit 0;
 
 This function returns the sessionID based on the provided sourceFileID.
 
-INPUT: source FileID, database handle
+INPUTS:
+  - $sourceFileID: source FileID
+  - $dbh         : database handle
 
 RETURNS: session ID
 
@@ -381,9 +383,11 @@ sub getSessionID    {
 
 =head3 getScannerID($sourceFileID, $dbh)
 
-This function gets ScannerID from the C<files> table using sourceFileID
+This function gets the ScannerID from the C<files> table using sourceFileID
 
-INPUT: source FileID, database handle
+INPUTS:
+  - $sourceFileID: source FileID
+  - $dbh         : database handle
 
 RETURNS: scanner ID
 
@@ -416,7 +420,9 @@ sub getScannerID    {
 This function returns the AcquisitionProtocolID of the file to register in the
 database based on scanType in the C<mri_scan_type> table.
 
-INPUT: scan type, database handle
+INPUTS:
+  - $scanType: scan type
+  - $dbh     : database handle
 
 RETURNS: acquisition protocol ID
 
@@ -446,9 +452,11 @@ sub getAcqProtID    {
 
 =head3 fetchMincHeader($file, $field)
 
-This function parses the MINC header and look for specific field's value.
+This function parses the MINC header and looks for specific field's value.
 
-INPUT: MINC file, MINC header field
+INPUTS:
+  - $file : MINC file
+  - $field: MINC header field values
 
 RETURNS: MINC header value
 
@@ -472,9 +480,13 @@ sub fetchMincHeader {
 
 =head3 copy_file($filename, $subjectIDsref, $scan_type, $fileref)
 
-Move files to assembly folder.
+Moves files to C<assembly> folder.
 
-INPUT: file to copy, subject ID hashref, scan type, file hash ref
+INPUTS:
+  - $filename     : file to copy
+  - $subjectIDsref: subject ID hashref
+  - $scan_type    : scan type
+  - $fileref      : file hash ref
 
 RETURNS: file name of the copied file
 
@@ -528,7 +540,7 @@ sub copy_file {
 
 =head3 getSourceFilename($sourceFileID)
 
-Grep source file name from the database using SourceFileID.
+Greps source file name from the database using SourceFileID.
 
 INPUT: ID of the source file
 
@@ -589,10 +601,10 @@ sub which_directory {
 
 =head3 insert_intermedFiles($fileID, $inputFileIDs, $tool)
 
-Function that will insert into the C<files_intermediary> table of the database,
-intermediary outputs that were used to obtain the processed file.
+Function that will insert the intermediary outputs that were used to obtain the
+processed file into the C<files_intermediary> table of the database.
 
-INPUT:
+INPUTS:
   - $fileID      : fileID of the registered processed file
   - $inputFileIDs: array containing the list of input files that were
                     used to obtain the processed file

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -61,6 +61,8 @@ Usage: perl register_processed_data.pl [options]
 
 -help for options
 
+Documentation: perldoc register_processed_data.pl
+
 USAGE
 
 my  @args_table = (

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -4,17 +4,44 @@
 
 =head1 NAME
 
-register_processed_data.pl -- Insert processed data and link it to the source
- data
+register_processed_data.pl -- Inserts processed data and link it to the source
+data
 
 =head1 SYNOPSIS
 
-perl register_processed_data.pl -profile C<name_of_the_profile> -file
-C</path/to/file/to/register> -sourceFileID C<source_FileID> -sourcePipeline
-C<pipeline_name_used> -tool C<tool_used> -pipelineDate C<pipeline_date>
--coordinateSpace C<coordinate_space> -scanType C<scan_type> -outputType
-C<output_type> -inputFileIDs C<list_of_input_FileIDs_separated_by_semi-colon>
--protocolID C<protocol_ID>
+perl register_processed_data.pl C<[options]>
+
+Available options are:
+
+-profile        : name of config file in ../dicom-archive/.loris_mri
+
+-file           : file that will be registered in the database
+                   (full path from the root directory is required)
+
+-sourceFileID   : FileID of the raw input dataset that was processed
+                   to obtain the file to be registered in the database
+
+-sourcePipeline : pipeline name that was used to obtain the file to be
+                   registered (example: DTIPrep_pipeline)
+
+-tool           : tool name and version that was used to obtain the
+                   file to be registered (example: DTIPrep_v1.1.6)
+
+-pipelineDate   : date at which the processing pipeline was run
+
+-coordinateSpace: space coordinate of the file
+                   (i.e. linear, nonlinear or native)
+
+-scanType       : file scan type stored in the C<mri_scan_type> table
+                   (i.e. QCedDTI, RGBqc, TxtQCReport, XMLQCReport...)
+
+-outputType     : output type to be registered in the database
+                   (i.e. QCed, processed, QCReport)
+
+-inputFileIDs   : list of input fileIDs used to obtain the file to
+                   be registered (each fileID separated by ';')
+
+-protocolID     : ID of the registered protocol used to process data
 
 Note: All options are required as they will be necessary to insert a file in
 the database.
@@ -567,8 +594,8 @@ intermediary outputs that were used to obtain the processed file.
 
 INPUT:
   - $fileID      : fileID of the registered processed file
-  - $inputFileIDs: array containing the list of input files that were used to
-                    obtain the processed file
+  - $inputFileIDs: array containing the list of input files that were
+                    used to obtain the processed file
   - $tool        : tool that was used to obtain the processed file
 
 RETURNS: 1 on success, undef on failure


### PR DESCRIPTION
Using perldoc/perlpod to document `register_processed_data.pl` so that users can type in the terminal
`perldoc register_processed_data.pl` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `register_processed_data.pl` file has been created so that we have a web displayed version of the documentation.
`pod2markdown register_processed_data.pl > register_processed_data.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage