### PR TITLE
[Documentation] minc_insertion.pl

### DIFF
--- a/docs/scripts_md/minc_insertion.md
+++ b/docs/scripts_md/minc_insertion.md
@@ -9,10 +9,10 @@ perl minc\_insertion.pl `[options]`
 Available options are:
 
 \-profile     : name of the config file in
-                `../dicom-archive/.loris_mri`
+               `../dicom-archive/.loris_mri`
 
 \-reckless    : uploads data to database even if study protocol
-                is not defined or violated
+               is not defined or violated
 
 \-force       : forces the script to run even if validation failed
 
@@ -23,8 +23,8 @@ Available options are:
 \-tarchivePath: the absolute path to the tarchive file
 
 \-globLocation: loosens the validity check of the tarchive allowing
-                 for the possibility that the tarchive was moved
-                 to a different directory
+               for the possibility that the tarchive was moved
+               to a different directory
 
 \-newScanner  : if set \[default\], new scanner will be registered
 

--- a/docs/scripts_md/minc_insertion.md
+++ b/docs/scripts_md/minc_insertion.md
@@ -4,7 +4,39 @@ minc\_insertion.pl -- Insert MINC files into the LORIS database system
 
 # SYNOPSIS
 
-perl minc\_insertion.pl
+perl minc\_insertion.pl `[options]`
+
+Available options are:
+
+\-profile     : name of the config file in
+                `../dicom-archive/.loris_mri`
+
+\-reckless    : uploads data to database even if study protocol
+                is not defined or violated
+
+\-force       : forces the script to run even if validation failed
+
+\-noJIV       : prevents the JIVs from being created
+
+\-mincPath    : the absolute path to the MINC file
+
+\-tarchivePath: the absolute path to the tarchive file
+
+\-globLocation: loosens the validity check of the tarchive allowing
+                 for the possibility that the tarchive was moved
+                 to a different directory
+
+\-newScanner  : if set \[default\], new scanner will be registered
+
+\-xlog        : opens an xterm with a tail on the current log file
+
+\-verbose     : if set, be verbose
+
+\-acquisition\_protocol    : suggests the acquisition protocol to use
+
+\-create\_minc\_pics        : creates the MINC pics
+
+\-bypass\_extra\_file\_checks: bypasses extra file checks
 
 # DESCRIPTION
 

--- a/docs/scripts_md/minc_insertion.md
+++ b/docs/scripts_md/minc_insertion.md
@@ -1,0 +1,51 @@
+# NAME
+
+minc\_insertion.pl -- Insert MINC files into the LORIS database system
+
+# SYNOPSIS
+
+perl minc\_insertion.pl
+
+# DESCRIPTION
+
+The program inserts MINC files into the LORIS database system. It performs the
+four following actions:
+
+\- Loads the created MINC file and then sets the appropriate parameter for
+the loaded object:
+
+    (
+     ScannerID,  SessionID,      SeriesUID,
+     EchoTime,   PendingStaging, CoordinateSpace,
+     OutputType, FileType,       TarchiveSource,
+     Caveat
+    )
+
+\- Extracts the correct acquisition protocol
+
+\- Registers the scan into the LORIS database by changing the path to the MINC
+and setting extra parameters
+
+\- Finally sets the series notification
+
+## Methods
+
+### logHeader()
+
+Creates and prints the LOG header.
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -170,6 +170,8 @@ The program does the following:
   parameters
 - Finally sets the series notification
 
+Documentation: perldoc minc_insertion.pl
+
 HELP
 my $Usage = <<USAGE;
 usage: $0 </path/to/DICOM-tarchive> [options]

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -13,10 +13,10 @@ perl minc_insertion.pl C<[options]>
 Available options are:
 
 -profile     : name of the config file in
-                C<../dicom-archive/.loris_mri>
+               C<../dicom-archive/.loris_mri>
 
 -reckless    : uploads data to database even if study protocol
-                is not defined or violated
+               is not defined or violated
 
 -force       : forces the script to run even if validation failed
 
@@ -27,8 +27,8 @@ Available options are:
 -tarchivePath: the absolute path to the tarchive file
 
 -globLocation: loosens the validity check of the tarchive allowing
-                 for the possibility that the tarchive was moved
-                 to a different directory
+               for the possibility that the tarchive was moved
+               to a different directory
 
 -newScanner  : if set [default], new scanner will be registered
 

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -1,4 +1,41 @@
 #! /usr/bin/perl
+
+=pod
+
+=head1 NAME
+
+minc_insertion.pl -- Insert MINC files into the LORIS database system
+
+=head1 SYNOPSIS
+
+perl minc_insertion.pl
+
+=head1 DESCRIPTION
+
+The program inserts MINC files into the LORIS database system. It performs the
+four following actions:
+
+- Loads the created MINC file and then sets the appropriate parameter for
+the loaded object:
+
+   (
+    ScannerID,  SessionID,      SeriesUID,
+    EchoTime,   PendingStaging, CoordinateSpace,
+    OutputType, FileType,       TarchiveSource,
+    Caveat
+   )
+
+- Extracts the correct acquisition protocol
+
+- Registers the scan into the LORIS database by changing the path to the MINC
+and setting extra parameters
+
+- Finally sets the series notification
+
+=head2 Methods
+
+=cut
+
 use strict;
 use warnings;
 use Carp;
@@ -502,6 +539,15 @@ if ($create_minc_pics) {
 ################################################################
 exit 0;
 
+
+=pod
+
+=head3 logHeader()
+
+Creates and prints the LOG header.
+
+=cut
+
 sub logHeader () {
     print LOG "
 ----------------------------------------------------------------
@@ -512,3 +558,26 @@ sub logHeader () {
 *** tmp dir location           : $TmpDir
 ";
 }
+
+
+__END__
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -8,7 +8,40 @@ minc_insertion.pl -- Insert MINC files into the LORIS database system
 
 =head1 SYNOPSIS
 
-perl minc_insertion.pl
+perl minc_insertion.pl C<[options]>
+
+Available options are:
+
+-profile     : name of the config file in
+                C<../dicom-archive/.loris_mri>
+
+-reckless    : uploads data to database even if study protocol
+                is not defined or violated
+
+-force       : forces the script to run even if validation failed
+
+-noJIV       : prevents the JIVs from being created
+
+-mincPath    : the absolute path to the MINC file
+
+-tarchivePath: the absolute path to the tarchive file
+
+-globLocation: loosens the validity check of the tarchive allowing
+                 for the possibility that the tarchive was moved
+                 to a different directory
+
+-newScanner  : if set [default], new scanner will be registered
+
+-xlog        : opens an xterm with a tail on the current log file
+
+-verbose     : if set, be verbose
+
+-acquisition_protocol    : suggests the acquisition protocol to use
+
+-create_minc_pics        : creates the MINC pics
+
+-bypass_extra_file_checks: bypasses extra file checks
+
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Using perldoc/perlpod to document `minc_insertion.pl` so that users can type in the terminal
`perldoc minc_insertion.pl` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `minc_insertion.pl` file has been created so that we have a web displayed version of the documentation.
`pod2markdown minc_insertion.pl > minc_insertion.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage