### PR TITLE
[Documentation] tarchive_validation.pl perldocification

### DIFF
--- a/docs/scripts_md/tarchive_validation.md
+++ b/docs/scripts_md/tarchive_validation.md
@@ -12,11 +12,11 @@ Available options are:
 \-profile     : name of the config file in ../dicom-archive/.loris-mri
 
 \-reckless    : upload data to the database even if the study protocol
-                is not defined or if it is violated
+               is not defined or if it is violated
 
 \-globLocation: loosen the validity check of the tarchive allowing for
-                the possibility that the tarchive was moved to a
-                different directory
+               the possibility that the tarchive was moved to a
+               different directory
 
 \-newScanner  : boolean, if set, register new scanners into the database
 
@@ -27,29 +27,29 @@ Available options are:
 The program does the following validations:
 
 \- Verification of the DICOM study archive given as an argument to the script
-using the checksum from the one inserted in the database
+against the one inserted in the database using checksum
 
 \- Verification of the PSC information using whatever field containing the site
 string (typically, the patient name or patient ID)
 
-\- Verification/determination of the ScannerID of the DICOM study archive
-(optionally creates a new scanner entry in the database if necessary)
+\- Verification of the ScannerID of the DICOM study archive (optionally
+creates a new scanner entry in the database if necessary)
 
 \- Optionally, creation of candidates as needed and standardization of gender
 information when creating the candidates (DICOM uses M/F, LORIS database uses
 Male/Female)
 
 \- Check of the CandID/PSCID match. It's possible that the CandID exists, but
-that CandID and PSCID does not correspond to the same candidate. This would
+that CandID and PSCID do not correspond to the same candidate. This would
 fail further down silently, so we explicitly check that this information is
 correct here.
 
-\- Validation/Obtention of the SessionID
+\- Validation of the SessionID
 
 \- Optionally, completion of extra filtering on the DICOM dataset, if needed
 
 \- Finally, the `isTarchiveValidated` field in the `mri_upload` table is set
-to `TRUE`
+to `TRUE` if the above validations were successful
 
 ## Methods
 

--- a/docs/scripts_md/tarchive_validation.md
+++ b/docs/scripts_md/tarchive_validation.md
@@ -1,0 +1,74 @@
+# NAME
+
+tarchive\_validation.pl -- Validates the tarchive against the one inserted in
+the LORIS database.
+
+# SYNOPSIS
+
+perl tarchive\_validation.pl `[options]`
+
+Available options are:
+
+\-profile     : name of the config file in ../dicom-archive/.loris-mri
+
+\-reckless    : upload data to the database even if the study protocol
+                is not defined or if it is violated
+
+\-globLocation: loosen the validity check of the tarchive allowing for
+                the possibility that the tarchive was moved to a
+                different directory
+
+\-newScanner  : boolean, if set, register new scanners into the database
+
+\-verbose     : boolean, if set, run the script in verbose mode
+
+# DESCRIPTION
+
+The program does the following validations:
+
+\- Verification of the DICOM study archive given as an argument to the script
+using the checksum from the one inserted in the database
+
+\- Verification of the PSC information using whatever field containing the site
+string (typically, the patient name or patient ID)
+
+\- Verification/determination of the ScannerID of the DICOM study archive
+(optionally creates a new scanner entry in the database if necessary)
+
+\- Optionally, creation of candidates as needed and standardization of gender
+information when creating the candidates (DICOM uses M/F, LORIS database uses
+Male/Female)
+
+\- Check of the CandID/PSCID match. It's possible that the CandID exists, but
+that CandID and PSCID does not correspond to the same candidate. This would
+fail further down silently, so we explicitly check that this information is
+correct here.
+
+\- Validation/Obtention of the SessionID
+
+\- Optionally, completion of extra filtering on the DICOM dataset, if needed
+
+\- Finally, the `isTarchiveValidated` field in the `mri_upload` table is set
+to `TRUE`
+
+## Methods
+
+### logHeader()
+
+Creates and prints the LOG header.
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -1,4 +1,66 @@
 #! /usr/bin/perl
+
+=pod
+
+=head1 NAME
+
+tarchive_validation.pl -- Validates the tarchive against the one inserted in
+the LORIS database.
+
+=head1 SYNOPSIS
+
+perl tarchive_validation.pl C<[options]>
+
+Available options are:
+
+-profile     : name of the config file in ../dicom-archive/.loris-mri
+
+-reckless    : upload data to the database even if the study protocol
+                is not defined or if it is violated
+
+-globLocation: loosen the validity check of the tarchive allowing for
+                the possibility that the tarchive was moved to a
+                different directory
+
+-newScanner  : boolean, if set, register new scanners into the database
+
+-verbose     : boolean, if set, run the script in verbose mode
+
+=head1 DESCRIPTION
+
+The program does the following validations:
+
+- Verification of the DICOM study archive given as an argument to the script
+using the checksum from the one inserted in the database
+
+- Verification of the PSC information using whatever field containing the site
+string (typically, the patient name or patient ID)
+
+- Verification/determination of the ScannerID of the DICOM study archive
+(optionally creates a new scanner entry in the database if necessary)
+
+- Optionally, creation of candidates as needed and standardization of gender
+information when creating the candidates (DICOM uses M/F, LORIS database uses
+Male/Female)
+
+- Check of the CandID/PSCID match. It's possible that the CandID exists, but
+that CandID and PSCID does not correspond to the same candidate. This would
+fail further down silently, so we explicitly check that this information is
+correct here.
+
+- Validation/Obtention of the SessionID
+
+- Optionally, completion of extra filtering on the DICOM dataset, if needed
+
+- Finally, the C<isTarchiveValidated> field in the C<mri_upload> table is set
+to C<TRUE>
+
+=head2 Methods
+
+
+=cut
+
+
 use strict;
 use warnings;
 use Carp;
@@ -320,6 +382,14 @@ $mri_upload_update->execute($tarchiveInfo{TarchiveID});
 
 exit 0;
 
+=pod
+
+=head3 logHeader()
+
+Creates and prints the LOG header.
+
+=cut
+
 sub logHeader () {
     print LOG "
 ----------------------------------------------------------------
@@ -330,3 +400,27 @@ sub logHeader () {
 *** tmp dir location           : $TmpDir
 ";
 }
+
+__END__
+
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut
+

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -16,11 +16,11 @@ Available options are:
 -profile     : name of the config file in ../dicom-archive/.loris-mri
 
 -reckless    : upload data to the database even if the study protocol
-                is not defined or if it is violated
+               is not defined or if it is violated
 
 -globLocation: loosen the validity check of the tarchive allowing for
-                the possibility that the tarchive was moved to a
-                different directory
+               the possibility that the tarchive was moved to a
+               different directory
 
 -newScanner  : boolean, if set, register new scanners into the database
 
@@ -31,29 +31,29 @@ Available options are:
 The program does the following validations:
 
 - Verification of the DICOM study archive given as an argument to the script
-using the checksum from the one inserted in the database
+against the one inserted in the database using checksum
 
 - Verification of the PSC information using whatever field containing the site
 string (typically, the patient name or patient ID)
 
-- Verification/determination of the ScannerID of the DICOM study archive
-(optionally creates a new scanner entry in the database if necessary)
+- Verification of the ScannerID of the DICOM study archive (optionally
+creates a new scanner entry in the database if necessary)
 
 - Optionally, creation of candidates as needed and standardization of gender
 information when creating the candidates (DICOM uses M/F, LORIS database uses
 Male/Female)
 
 - Check of the CandID/PSCID match. It's possible that the CandID exists, but
-that CandID and PSCID does not correspond to the same candidate. This would
+that CandID and PSCID do not correspond to the same candidate. This would
 fail further down silently, so we explicitly check that this information is
 correct here.
 
-- Validation/Obtention of the SessionID
+- Validation of the SessionID
 
 - Optionally, completion of extra filtering on the DICOM dataset, if needed
 
 - Finally, the C<isTarchiveValidated> field in the C<mri_upload> table is set
-to C<TRUE>
+to C<TRUE> if the above validations were successful
 
 =head2 Methods
 

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -160,6 +160,8 @@ The program does the following validation
 
 - Finally the isTarchiveValidated is set true in the MRI_Upload table
 
+Documentation: perldoc tarchive_validation.pl
+
 HELP
 my $Usage = <<USAGE;
 usage: $0 </path/to/DICOM-tarchive> [options]


### PR DESCRIPTION
Using perldoc/perlpod to document `tarchive_validation.pl` so that users can type in the terminal
`perldoc tarchive_validation.pl` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `tarchive_validation.pl` file has been created so that we have a web displayed version of the documentation.
`pod2markdown tarchive_validation.pl > tarchive_validation.md`

Dependencies added: perldoc, Pod::Markdown