### PR TITLE
[Documentation] mass_pic.pl perldocification

### DIFF
--- a/docs/scripts_md/mass_pic.md
+++ b/docs/scripts_md/mass_pic.md
@@ -1,0 +1,39 @@
+# NAME
+
+mass\_pic.pl -- Generates check pic for the LORIS database system
+
+# SYNOPSIS
+
+perl mass\_pic.pl `[options]`
+
+Available options are:
+
+\-profile   : name of the config file in ../dicom-archive/.loris\_mri
+
+\-mincFileID: integer, minimum FileID to operate on
+
+\-maxFileID : integer, maximum FileID to operate on
+
+\-verbose   : be verbose
+
+# DESCRIPTION
+
+This scripts will generate check pics for every registered MINC file that
+have a `FileID` from the `files` table between the specified `minFileID`
+and `maxFileID`.
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/mass_pic.md
+++ b/docs/scripts_md/mass_pic.md
@@ -10,16 +10,16 @@ Available options are:
 
 \-profile   : name of the config file in ../dicom-archive/.loris\_mri
 
-\-mincFileID: integer, minimum FileID to operate on
+\-mincFileID: integer, minimum `FileID` to operate on
 
-\-maxFileID : integer, maximum FileID to operate on
+\-maxFileID : integer, maximum `FileID` to operate on
 
 \-verbose   : be verbose
 
 # DESCRIPTION
 
-This scripts will generate check pics for every registered MINC file that
-have a `FileID` from the `files` table between the specified `minFileID`
+This scripts will generate pics for every registered MINC file that have
+a `FileID` from the `files` table between the specified `minFileID`
 and `maxFileID`.
 
 # TO DO

--- a/uploadNeuroDB/mass_pic.pl
+++ b/uploadNeuroDB/mass_pic.pl
@@ -15,17 +15,17 @@ Available options are:
 
 -profile   : name of the config file in ../dicom-archive/.loris_mri
 
--mincFileID: integer, minimum FileID to operate on
+-mincFileID: integer, minimum C<FileID> to operate on
 
--maxFileID : integer, maximum FileID to operate on
+-maxFileID : integer, maximum C<FileID> to operate on
 
 -verbose   : be verbose
 
 
 =head1 DESCRIPTION
 
-This scripts will generate check pics for every registered MINC file that
-have a C<FileID> from the C<files> table between the specified C<minFileID>
+This scripts will generate pics for every registered MINC file that have
+a C<FileID> from the C<files> table between the specified C<minFileID>
 and C<maxFileID>.
 
 =cut
@@ -47,7 +47,7 @@ my $minFileID  = undef;
 my $maxFileID  = undef;
 my $query;
 my $debug       = 0;
-my $Usage = "mass_pic.pl generates check pic images for NeuroDB for those ".
+my $Usage = "mass_pic.pl generates pic images for NeuroDB for those ".
             "files that are missing pics. ".
             " \n\n See $0 -help for more info\n\n".
             "Documentation: perldoc mass_pic.pl\n\n";
@@ -164,7 +164,6 @@ $dbh->disconnect();
 print "\nFinished mass_pic.pl execution\n" if $verbose;
 exit 0;
 
-1;
 
 __END__
 

--- a/uploadNeuroDB/mass_pic.pl
+++ b/uploadNeuroDB/mass_pic.pl
@@ -1,5 +1,36 @@
 #!/usr/bin/perl
 
+=pod
+
+=head1 NAME
+
+mass_pic.pl -- Generates check pic for the LORIS database system
+
+
+=head1 SYNOPSIS
+
+perl mass_pic.pl C<[options]>
+
+Available options are:
+
+-profile   : name of the config file in ../dicom-archive/.loris_mri
+
+-mincFileID: integer, minimum FileID to operate on
+
+-maxFileID : integer, maximum FileID to operate on
+
+-verbose   : be verbose
+
+
+=head1 DESCRIPTION
+
+This scripts will generate check pics for every registered MINC file that
+have a C<FileID> from the C<files> table between the specified C<minFileID>
+and C<maxFileID>.
+
+=cut
+
+
 use strict;
 use FindBin;
 use lib "$FindBin::Bin";
@@ -131,3 +162,27 @@ $dbh->disconnect();
 
 print "\nFinished mass_pic.pl execution\n" if $verbose;
 exit 0;
+
+1;
+
+__END__
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut

--- a/uploadNeuroDB/mass_pic.pl
+++ b/uploadNeuroDB/mass_pic.pl
@@ -49,7 +49,8 @@ my $query;
 my $debug       = 0;
 my $Usage = "mass_pic.pl generates check pic images for NeuroDB for those ".
             "files that are missing pics. ".
-            " \n\n See $0 -help for more info\n\n";
+            " \n\n See $0 -help for more info\n\n".
+            "Documentation: perldoc mass_pic.pl\n\n";
 
 my @arg_table =
     (


### PR DESCRIPTION
Using perldoc/perlpod to document `mass_pic.pl` so that users can type in the terminal
`perldoc mass_pic.pl` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `mass_pic.pl` file has been created so that we have a web displayed version of the documentation.
`pod2markdown mass_pic.pl > mass_pic.md`

Dependencies added: perldoc, Pod::Markdown, Pod::Usage