### PR TITLE
[Documentation] imaging_upload_file_cronjob.pl

### DIFF
--- a/docs/scripts_md/imaging_upload_file_cronjob.md
+++ b/docs/scripts_md/imaging_upload_file_cronjob.md
@@ -1,0 +1,40 @@
+# NAME
+
+imaging\_upload\_file\_cronjob.pl -- a wrapper script that calls the single step
+script \`imaging\_upload\_file.pl\` for uploaded scans on which the insertion
+pipeline has not been launched.
+
+# SYNOPSIS
+
+perl imaging\_upload\_file\_cronjob.pl \`\[options\]\`
+
+Available options are:
+
+\-profile      : name of the config file in
+                `../dicom-archive/.loris_mri`
+
+\-verbose      : if set, be verbose
+
+# DESCRIPTION
+
+The program gets a series of rows from \`mri\_upload\` on which the insertion
+pipeline has not been run yet, and launches it.
+
+## Methods
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience

--- a/docs/scripts_md/imaging_upload_file_cronjob.md
+++ b/docs/scripts_md/imaging_upload_file_cronjob.md
@@ -10,17 +10,15 @@ perl imaging\_upload\_file\_cronjob.pl \`\[options\]\`
 
 Available options are:
 
-\-profile      : name of the config file in
+\-profile      : Name of the config file in
                 `../dicom-archive/.loris_mri`
 
-\-verbose      : if set, be verbose
+\-verbose      : If set, be verbose
 
 # DESCRIPTION
 
 The program gets a series of rows from \`mri\_upload\` on which the insertion
 pipeline has not been run yet, and launches it.
-
-## Methods
 
 # TO DO
 

--- a/uploadNeuroDB/imaging_upload_file_cronjob.pl
+++ b/uploadNeuroDB/imaging_upload_file_cronjob.pl
@@ -1,4 +1,35 @@
 #! /usr/bin/perl
+
+=pod
+
+=head1 NAME
+
+imaging_upload_file_cronjob.pl -- a wrapper script that calls the single step
+script `imaging_upload_file.pl` for uploaded scans on which the insertion
+pipeline has not been launched.
+
+=head1 SYNOPSIS
+
+perl imaging_upload_file_cronjob.pl `[options]`
+
+Available options are:
+
+-profile      : name of the config file in
+                C<../dicom-archive/.loris_mri>
+
+-verbose      : if set, be verbose
+
+
+=head1 DESCRIPTION
+
+The program gets a series of rows from `mri_upload` on which the insertion
+pipeline has not been run yet, and launches it.
+
+
+=head2 Methods
+
+=cut
+
 use strict;
 use warnings;
 use Carp;
@@ -57,6 +88,9 @@ have insertion completed
 HELP
 my $Usage = <<USAGE;
        $0 -help to list options
+
+Documentation: perldoc imaging_upload_file_cronjob.pl
+
 USAGE
 &Getopt::Tabular::SetHelp( $Help, $Usage );
 &Getopt::Tabular::GetOptions( \@opt_table, \@ARGV ) || exit 1;
@@ -85,7 +119,8 @@ $sth->execute();
 while(@row = $sth->fetchrow_array()) { 
 
     if ( -e $row[1] ) {
-	my $command = "imaging_upload_file.pl -upload_id $row[0] -profile prod $row[1]";
+	my $command =
+        "imaging_upload_file.pl -upload_id $row[0] -profile prod $row[1]";
 	if ($verbose){
 	    $command .= " -verbose";
             print "\n" . $command . "\n";
@@ -99,3 +134,28 @@ while(@row = $sth->fetchrow_array()) {
     }
 }
 exit 0;
+
+
+
+__END__
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience
+
+=cut

--- a/uploadNeuroDB/imaging_upload_file_cronjob.pl
+++ b/uploadNeuroDB/imaging_upload_file_cronjob.pl
@@ -14,19 +14,16 @@ perl imaging_upload_file_cronjob.pl `[options]`
 
 Available options are:
 
--profile      : name of the config file in
+-profile      : Name of the config file in
                 C<../dicom-archive/.loris_mri>
 
--verbose      : if set, be verbose
+-verbose      : If set, be verbose
 
 
 =head1 DESCRIPTION
 
 The program gets a series of rows from `mri_upload` on which the insertion
 pipeline has not been run yet, and launches it.
-
-
-=head2 Methods
 
 =cut
 


### PR DESCRIPTION
Generated using:
pod2markdown uploadNeuroDB/imaging_upload_file_cronjob.pl > docs/scripts_md/imaging_upload_file_cronjob.md

User can type:
perldoc uploadNeuroDB/imaging_upload_file_cronjob.pl
to get the documentation at the terminal