### PR TITLE
[Documentation] mass_nii.pl perldocification

### DIFF
--- a/docs/scripts_md/mass_nii.md
+++ b/docs/scripts_md/mass_nii.md
@@ -1,0 +1,39 @@
+# NAME
+
+mass\_nii.pl -- Generates NIfTI files based on the inserted MINC files and
+insert them into the LORIS database.
+
+# SYNOPSIS
+
+perl mass\_nii.pl `[options]`
+
+Available options are:
+
+\-profile  : name of the config file in `../dicom-archive/.loris_mri`
+
+\-minFileID: specifies the minimum FileID to operate on
+
+\-maxFileID: specifies the maximum FileID to operate on
+
+\-verbose  : be verbose
+
+# DESCRIPTION
+
+This script generates NIfTI images for the inserted MINC files with a FileID
+between `minFileID` and `maxFileID` and that are missing NIfTIs.
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/mass_nii.md
+++ b/docs/scripts_md/mass_nii.md
@@ -1,7 +1,7 @@
 # NAME
 
-mass\_nii.pl -- Generates NIfTI files based on the inserted MINC files and
-insert them into the LORIS database.
+mass\_nii.pl -- Generates NIfTI files based on the MINC files available in the
+LORIS database and inserts them into the parameter\_file table.
 
 # SYNOPSIS
 
@@ -11,9 +11,9 @@ Available options are:
 
 \-profile  : name of the config file in `../dicom-archive/.loris_mri`
 
-\-minFileID: specifies the minimum FileID to operate on
+\-minFileID: specifies the minimum `FileID` to operate on
 
-\-maxFileID: specifies the maximum FileID to operate on
+\-maxFileID: specifies the maximum `FileID` to operate on
 
 \-verbose  : be verbose
 

--- a/docs/scripts_md/mass_nii.md
+++ b/docs/scripts_md/mass_nii.md
@@ -20,7 +20,7 @@ Available options are:
 # DESCRIPTION
 
 This script generates NIfTI images for the inserted MINC files with a FileID
-between `minFileID` and `maxFileID` and that are missing NIfTIs.
+between the specified `minFileID` and `maxFileID`.
 
 # TO DO
 

--- a/docs/scripts_md/mass_nii.md
+++ b/docs/scripts_md/mass_nii.md
@@ -1,7 +1,7 @@
 # NAME
 
 mass\_nii.pl -- Generates NIfTI files based on the MINC files available in the
-LORIS database and inserts them into the parameter\_file table.
+LORIS database and inserts them into the `parameter_file` table.
 
 # SYNOPSIS
 

--- a/uploadNeuroDB/mass_nii.pl
+++ b/uploadNeuroDB/mass_nii.pl
@@ -24,7 +24,7 @@ Available options are:
 =head1 DESCRIPTION
 
 This script generates NIfTI images for the inserted MINC files with a FileID
-between C<minFileID> and C<maxFileID> and that are missing NIfTIs.
+between the specified C<minFileID> and C<maxFileID>.
 
 =cut
 

--- a/uploadNeuroDB/mass_nii.pl
+++ b/uploadNeuroDB/mass_nii.pl
@@ -1,5 +1,33 @@
 #!/usr/bin/perl
 
+=pod
+
+=head1 NAME
+
+mass_nii.pl -- Generates NIfTI files based on the inserted MINC files and
+insert them into the LORIS database.
+
+=head1 SYNOPSIS
+
+perl mass_nii.pl C<[options]>
+
+Available options are:
+
+-profile  : name of the config file in C<../dicom-archive/.loris_mri>
+
+-minFileID: specifies the minimum FileID to operate on
+
+-maxFileID: specifies the maximum FileID to operate on
+
+-verbose  : be verbose
+
+=head1 DESCRIPTION
+
+This script generates NIfTI images for the inserted MINC files with a FileID
+between C<minFileID> and C<maxFileID> and that are missing NIfTIs.
+
+=cut
+
 use strict;
 use FindBin;
 use lib "$FindBin::Bin";
@@ -163,3 +191,27 @@ print "\n Finished mass_nii.pl execution\n" if $verbose;
 
 # Exit script
 exit 0;
+
+1;
+
+__END__
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut

--- a/uploadNeuroDB/mass_nii.pl
+++ b/uploadNeuroDB/mass_nii.pl
@@ -5,7 +5,7 @@
 =head1 NAME
 
 mass_nii.pl -- Generates NIfTI files based on the MINC files available in the
-LORIS database and inserts them into the parameter_file table.
+LORIS database and inserts them into the C<parameter_file> table.
 
 =head1 SYNOPSIS
 

--- a/uploadNeuroDB/mass_nii.pl
+++ b/uploadNeuroDB/mass_nii.pl
@@ -64,6 +64,8 @@ Author  :   Cécile Madjar based on mass_pic.pl.
                         for the inserted MINC images that 
                         are missing NIfTIs.
 
+Documentation: perldoc mass_nii.pl
+
 HELP
 
 my $Usage      = <<USAGE;

--- a/uploadNeuroDB/mass_nii.pl
+++ b/uploadNeuroDB/mass_nii.pl
@@ -4,8 +4,8 @@
 
 =head1 NAME
 
-mass_nii.pl -- Generates NIfTI files based on the inserted MINC files and
-insert them into the LORIS database.
+mass_nii.pl -- Generates NIfTI files based on the MINC files available in the
+LORIS database and inserts them into the parameter_file table.
 
 =head1 SYNOPSIS
 
@@ -15,9 +15,9 @@ Available options are:
 
 -profile  : name of the config file in C<../dicom-archive/.loris_mri>
 
--minFileID: specifies the minimum FileID to operate on
+-minFileID: specifies the minimum C<FileID> to operate on
 
--maxFileID: specifies the maximum FileID to operate on
+-maxFileID: specifies the maximum C<FileID> to operate on
 
 -verbose  : be verbose
 


### PR DESCRIPTION
Using perldoc/perlpod to document `mass_nii.pl` so that users can type in the terminal
`perldoc mass_nii.pl` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `mass_nii.pl` file has been created so that we have a web displayed version of the documentation.
`pod2markdown mass_nii.pl > mass_nii.md`

Dependencies added: perldoc, Pod::Markdown