### PR TITLE
[Documentation] database_files_update.pl perldocification 

### DIFF
--- a/docs/scripts_md/database_files_update.md
+++ b/docs/scripts_md/database_files_update.md
@@ -1,0 +1,72 @@
+# NAME
+
+database\_files\_update.pl -- Updates path stored in `files` and
+`parameter_file` tables so that they are relative to data\_dir
+
+# SYNOPSIS
+
+perl database\_files\_update.pl `[options]`
+
+Available option is:
+
+\-profile: name of the config file in ../dicom-archive/.loris\_mri
+
+# DESCRIPTION
+
+This script updates the path stored in the `files` and `parameter_file`
+tables to remove the <\\$data\_dir> part of the path for security improvements.
+
+## Methods
+
+### get\_minc\_files($data\_dir, $dbh)
+
+Gets the list of MINC files to update the location in the `files` table.
+
+INPUT: data directory from the `Config` tables, database handle
+
+RETURNS: hash of MINC locations, array of FileIDs
+
+### update\_minc\_location($fileID, $new\_minc\_location, $dbh)
+
+Updates the location of MINC files in the `files` table.
+
+INPUT: File ID, new MINC relative location, database handle
+
+RETURNS: Number of rows affected by the update (should always be 1)
+
+### get\_parameter\_files($data\_dir, $parameter\_type, $dbh)
+
+Gets list of JIV files to update location in `parameter_file` (remove root
+directory from path)
+
+INPUT: data directory, parameter type name for the JIV, database handle
+
+RETURNS: hash of JIV file locations, array of FileIDs
+
+### update\_parameter\_file\_location($fileID, $new\_file\_location, ...)
+
+Updates the location of JIV files in the `parameter_file` table.
+
+INPUT:
+  - $fileID           : FileID
+  - $new\_file\_location: new location of the JIV file
+  - $parameter\_type   : parameter type name for the JIV
+  - $dbh              : database handle
+
+RETURNS: number of rows affected by the update (should always be 1)
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/database_files_update.md
+++ b/docs/scripts_md/database_files_update.md
@@ -14,7 +14,7 @@ Available option is:
 # DESCRIPTION
 
 This script updates the path stored in the `files` and `parameter_file`
-tables to remove the `$data_dir` part of the path for security improvements.
+tables to remove the `data_dir` part of the path for security improvements.
 
 ## Methods
 

--- a/docs/scripts_md/database_files_update.md
+++ b/docs/scripts_md/database_files_update.md
@@ -1,7 +1,7 @@
 # NAME
 
 database\_files\_update.pl -- Updates path stored in `files` and
-`parameter_file` tables so that they are relative to data\_dir
+`parameter_file` tables so that they are relative to `data_dir`
 
 # SYNOPSIS
 
@@ -14,7 +14,7 @@ Available option is:
 # DESCRIPTION
 
 This script updates the path stored in the `files` and `parameter_file`
-tables to remove the <\\$data\_dir> part of the path for security improvements.
+tables to remove the `$data_dir` part of the path for security improvements.
 
 ## Methods
 
@@ -22,7 +22,7 @@ tables to remove the <\\$data\_dir> part of the path for security improvements.
 
 Gets the list of MINC files to update the location in the `files` table.
 
-INPUT: data directory from the `Config` tables, database handle
+INPUTS: data directory from the `Config` tables, database handle
 
 RETURNS: hash of MINC locations, array of FileIDs
 
@@ -30,16 +30,16 @@ RETURNS: hash of MINC locations, array of FileIDs
 
 Updates the location of MINC files in the `files` table.
 
-INPUT: File ID, new MINC relative location, database handle
+INPUTS: File ID, new MINC relative location, database handle
 
 RETURNS: Number of rows affected by the update (should always be 1)
 
 ### get\_parameter\_files($data\_dir, $parameter\_type, $dbh)
 
-Gets list of JIV files to update location in `parameter_file` (remove root
-directory from path)
+Gets list of JIV files to update location in the `parameter_file` table by
+removing the root directory from the path.
 
-INPUT: data directory, parameter type name for the JIV, database handle
+INPUTS: data directory, parameter type name for the JIV, database handle
 
 RETURNS: hash of JIV file locations, array of FileIDs
 
@@ -47,7 +47,7 @@ RETURNS: hash of JIV file locations, array of FileIDs
 
 Updates the location of JIV files in the `parameter_file` table.
 
-INPUT:
+INPUTS:
   - $fileID           : FileID
   - $new\_file\_location: new location of the JIV file
   - $parameter\_type   : parameter type name for the JIV

--- a/tools/database_files_update.pl
+++ b/tools/database_files_update.pl
@@ -5,7 +5,7 @@
 =head1 NAME
 
 database_files_update.pl -- Updates path stored in C<files> and
-C<parameter_file> tables so that they are relative to data_dir
+C<parameter_file> tables so that they are relative to C<data_dir>
 
 =head1 SYNOPSIS
 
@@ -18,7 +18,7 @@ Available option is:
 =head1 DESCRIPTION
 
 This script updates the path stored in the C<files> and C<parameter_file>
-tables to remove the <\$data_dir> part of the path for security improvements.
+tables to remove the C<$data_dir> part of the path for security improvements.
 
 =head2 Methods
 
@@ -165,7 +165,7 @@ if  ($tarchive_location_refs) {
 
 Gets the list of MINC files to update the location in the C<files> table.
 
-INPUT: data directory from the C<Config> tables, database handle
+INPUTS: data directory from the C<Config> tables, database handle
 
 RETURNS: hash of MINC locations, array of FileIDs
 
@@ -202,7 +202,7 @@ sub get_minc_files {
 
 Updates the location of MINC files in the C<files> table.
 
-INPUT: File ID, new MINC relative location, database handle
+INPUTS: File ID, new MINC relative location, database handle
 
 RETURNS: Number of rows affected by the update (should always be 1)
 
@@ -225,10 +225,10 @@ sub update_minc_location {
 
 =head3 get_parameter_files($data_dir, $parameter_type, $dbh)
 
-Gets list of JIV files to update location in C<parameter_file> (remove root
-directory from path)
+Gets list of JIV files to update location in the C<parameter_file> table by
+removing the root directory from the path.
 
-INPUT: data directory, parameter type name for the JIV, database handle
+INPUTS: data directory, parameter type name for the JIV, database handle
 
 RETURNS: hash of JIV file locations, array of FileIDs
 
@@ -269,7 +269,7 @@ sub get_parameter_files {
 
 Updates the location of JIV files in the C<parameter_file> table.
 
-INPUT:
+INPUTS:
   - $fileID           : FileID
   - $new_file_location: new location of the JIV file
   - $parameter_type   : parameter type name for the JIV

--- a/tools/database_files_update.pl
+++ b/tools/database_files_update.pl
@@ -18,7 +18,7 @@ Available option is:
 =head1 DESCRIPTION
 
 This script updates the path stored in the C<files> and C<parameter_file>
-tables to remove the C<$data_dir> part of the path for security improvements.
+tables to remove the C<data_dir> part of the path for security improvements.
 
 =head2 Methods
 

--- a/tools/update_to_relative_path/database_files_update.pl
+++ b/tools/update_to_relative_path/database_files_update.pl
@@ -1,5 +1,30 @@
 #! /usr/bin/perl
 
+=pod
+
+=head1 NAME
+
+database_files_update.pl -- Updates path stored in C<files> and
+C<parameter_file> tables so that they are relative to data_dir
+
+=head1 SYNOPSIS
+
+perl database_files_update.pl C<[options]>
+
+Available option is:
+
+-profile: name of the config file in ../dicom-archive/.loris_mri
+
+=head1 DESCRIPTION
+
+This script updates the path stored in the C<files> and C<parameter_file>
+tables to remove the <\$data_dir> part of the path for security improvements.
+
+=head2 Methods
+
+=cut
+
+
 use strict;
 use warnings;
 use Getopt::Tabular;
@@ -10,9 +35,12 @@ my @args;
 
 my $Usage   =   <<USAGE;
 
-This script updates the path stored in the files and parameter_file tables to remove the \$data_dir part of the path for security improvements.
+This script updates the path stored in the files and parameter_file tables to
+remove the \$data_dir part of the path for security improvements.
 
 Usage: perl database_files_update.pl [options]
+
+Documentation: perldoc database_files_update.pl
 
 -help for options
 
@@ -132,8 +160,17 @@ if  ($tarchive_location_refs) {
 ###############
 
 =pod
-Get list of minc files to update location in the files table.
+
+=head3 get_minc_files($data_dir, $dbh)
+
+Gets the list of MINC files to update the location in the C<files> table.
+
+INPUT: data directory from the C<Config> tables, database handle
+
+RETURNS: hash of MINC locations, array of FileIDs
+
 =cut
+
 sub get_minc_files {
     my  ($data_dir, $dbh)   =   @_;
 
@@ -158,11 +195,21 @@ sub get_minc_files {
     return  (\%minc_locations, \@fileIDs);
 }
 
+
 =pod
-Update location of minc files in the files table.
+
+=head3 update_minc_location($fileID, $new_minc_location, $dbh)
+
+Updates the location of MINC files in the C<files> table.
+
+INPUT: File ID, new MINC relative location, database handle
+
+RETURNS: Number of rows affected by the update (should always be 1)
+
 =cut
+
 sub update_minc_location {
-    my  ($fileID, $new_minc_location, $dbh) =   @_;                # update minc location in files table.
+    my  ($fileID, $new_minc_location, $dbh) =   @_;  # update minc location in files table.
 
     my  $query          =   "UPDATE files " .
                             "SET File=? " .
@@ -173,9 +220,20 @@ sub update_minc_location {
     return  ($rows_affected);
 }
 
+
 =pod
-Get list of jivs to update location in parameter_file (remove root directory from path)
+
+=head3 get_parameter_files($data_dir, $parameter_type, $dbh)
+
+Gets list of JIV files to update location in C<parameter_file> (remove root
+directory from path)
+
+INPUT: data directory, parameter type name for the JIV, database handle
+
+RETURNS: hash of JIV file locations, array of FileIDs
+
 =cut
+
 sub get_parameter_files {
     my  ($data_dir, $parameter_type, $dbh)  =   @_;
 
@@ -204,9 +262,23 @@ sub get_parameter_files {
     return  (\%file_locations, \@fileIDs);
 }
 
+
 =pod
-Update location of jiv files in parameter_file
+
+=head3 update_parameter_file_location($fileID, $new_file_location, ...)
+
+Updates the location of JIV files in the C<parameter_file> table.
+
+INPUT:
+  - $fileID           : FileID
+  - $new_file_location: new location of the JIV file
+  - $parameter_type   : parameter type name for the JIV
+  - $dbh              : database handle
+
+RETURNS: number of rows affected by the update (should always be 1)
+
 =cut
+
 sub update_parameter_file_location {
     my  ($fileID, $new_file_location, $parameter_type, $dbh) =   @_; 
 
@@ -232,3 +304,25 @@ sub update_parameter_file_location {
     return  ($rows_affected);   
 }
 
+
+__END__
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut


### PR DESCRIPTION
First, moved this script under the tools directory as it is an (old) tool scripts.

Second, using perldoc/perlpod to document `database_files_update.pl` so that users can type in the terminal
`perldoc database_files_update.pl` and get the documentation.

Using the `pod2markdown` tool from perl `Pod::Markdown` module, the `database_files_update.pl` file has been created so that we have a web displayed version of the documentation.
`pod2markdown database_files_update.pl > database_files_update.md`

Dependencies added: perldoc, Pod::Markdown