### PR TITLE
[Documentation] batch_upload_imageuploader

### DIFF
--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -9,7 +9,7 @@ batch mode
 
 =head1 SYNOPSIS
 
-./batch_uploads_imageuploader -profile prod < list_of_scans.txt >log_batch_imageuploader.txt 2>&1 `[options]`
+./batch_uploads_imageuploader -profile prod < list_of_scans.txt > log_batch_imageuploader.txt 2>&1 `[options]`
 
 Available options are:
 
@@ -22,21 +22,23 @@ Available options are:
 =head1 DESCRIPTION
 
 
-This script runs the Loris-MRI insertion on multiple scans. The list of scans
-are provided through a text file (e.g. list_of_scans.txt) with one scan details
-per line.
+This script runs the Loris-MRI insertion pipeline on multiple scans. The list of
+scans are provided through a text file (e.g. C<list_of_scans.txt>) with one scan
+details per line.
 The scan details includes the path to the scan, identification as to whether the
 scan is for a phantom (Y) or not (N), and the candidate name for non-phantom
 entries.
 
-Like the Loris Imaging Uploader interface, this script also validates the
-candidate name against the (start of the) filename and creates an entry in the
-mri_upload table.
+Like the LORIS Imaging Uploader interface, this script also validates the
+candidate's name against the (start of the) filename and creates an entry in the
+C<mri_upload> table.
 
-An example of what list_of_scans.txt might contain for 3 uploads to be inserted:
-/data/incoming/PSC0001_123457_V1.tar.gz N PSC0000_123456_V1
-/data/incoming/lego_Phantom_MNI_20140101.zip Y
-/data/incoming/PSC0001_123457_V1_RES.tar.gz N PSC0000_123456_V1
+An example of what C<list_of_scans.txt> might contain for 3 uploads to be
+inserted:
+
+ /data/incoming/PSC0001_123457_V1.tar.gz N PSC0000_123456_V1
+ /data/incoming/lego_Phantom_MNI_20140101.zip Y
+ /data/incoming/PSC0001_123457_V1_RES.tar.gz N PSC0000_123456_V1
 
 
 =head2 Methods
@@ -75,24 +77,29 @@ my $Help = <<HELP;
 Run imaging_upload_file.pl in batch mode
 ******************************************************************************
 
-This script runs the Loris-MRI insertion on multiple scans. The list of scans are 
-provided through a text file (e.g. list_of_scans.txt) with one scan details per line.
+This script runs the Loris-MRI insertion pipeline on multiple scans. The list of
+scans are provided through a text file (e.g. C<list_of_scans.txt>) with one scan
+details per line.
 The scan details includes the path to the scan, identification as to whether the
-scan is for a phantom (Y) or not (N), and the candidate name for non-phantom entries.
+scan is for a phantom (Y) or not (N), and the candidate name for non-phantom
+entries.
 
-Like the Loris Imaging Uploader interface, this script also validates the candidate 
-name against the (start of the) filename and creates an entry in the mri_upload table.
+Like the LORIS Imaging Uploader interface, this script also validates the
+candidate's name against the (start of the) filename and creates an entry in the
+mri_upload table.
 
-An example of what list_of_scans.txt might contain for 3 uploads to be inserted:
-/data/incoming/PSC0001_123457_V1.tar.gz N PSC0000_123456_V1
-/data/incoming/Lego_Phantom_MNI_20140101.zip Y
-/data/incoming/PSC0001_123457_V1_RES.tar.gz N PSC0000_123456_V1
+An example of what C<list_of_scans.txt> might contain for 3 uploads to be
+inserted:
+
+ /data/incoming/PSC0001_123457_V1.tar.gz N PSC0000_123456_V1
+ /data/incoming/Lego_Phantom_MNI_20140101.zip Y
+ /data/incoming/PSC0001_123457_V1_RES.tar.gz N PSC0000_123456_V1
 
 Documentation: perldoc batch_uploads_imageuploader
 
 HELP
 my $Usage = <<USAGE;
-usage: ./batch_uploads_imageuploader -profile prod < list_of_scans.txt >log_batch_imageuploader.txt 2>&1 [options]
+usage: ./batch_uploads_imageuploader -profile prod < list_of_scans.txt > log_batch_imageuploader.txt 2>&1 [options]
        $0 -help to list options
 USAGE
 &Getopt::Tabular::SetHelp( $Help, $Usage );
@@ -262,16 +269,14 @@ close MAIL;
 
 =head3 insertIntoMRIUpload($patientname, $phantom, $fullpath)
 
-Function that inserts into the mri_upload table entries for data coming from
+Function that inserts into the C<mri_upload> table entries for data coming from
 the list of scans in the text file provided when calling
 batch_upload_imageuploader
 
-INPUT  :
+INPUTS  :
     - $patientname  : The patient name
-
     - $phantom      : 'Y' if the entry is for a phantom,
-                      'N' othwrwise
-
+                      'N' otherwise
     - $fullpath     : Path to the uploaded file
 
 

--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -1,4 +1,49 @@
 #!/usr/bin/perl -w
+
+=pod
+
+=head1 NAME
+
+batch_uploads_imageuploader -- a script that runs imaging_upload_file.pl in
+batch mode
+
+=head1 SYNOPSIS
+
+./batch_uploads_imageuploader -profile prod < list_of_scans.txt >log_batch_imageuploader.txt 2>&1 `[options]`
+
+Available options are:
+
+-profile      : name of the config file in
+                C<../dicom-archive/.loris_mri>
+
+-verbose      : if set, be verbose
+
+
+=head1 DESCRIPTION
+
+
+This script runs the Loris-MRI insertion on multiple scans. The list of scans
+are provided through a text file (e.g. list_of_scans.txt) with one scan details
+per line.
+The scan details includes the path to the scan, identification as to whether the
+scan is for a phantom (Y) or not (N), and the candidate name for non-phantom
+entries.
+
+Like the Loris Imaging Uploader interface, this script also validates the
+candidate name against the (start of the) filename and creates an entry in the
+mri_upload table.
+
+An example of what list_of_scans.txt might contain for 3 uploads to be inserted:
+/data/incoming/PSC0001_123457_V1.tar.gz N PSC0000_123456_V1
+/data/incoming/lego_Phantom_MNI_20140101.zip Y
+/data/incoming/PSC0001_123457_V1_RES.tar.gz N PSC0000_123456_V1
+
+
+=head2 Methods
+
+=cut
+
+
 use strict;
 use warnings;
 no warnings 'once';
@@ -42,6 +87,8 @@ An example of what list_of_scans.txt might contain for 3 uploads to be inserted:
 /data/incoming/PSC0001_123457_V1.tar.gz N PSC0000_123456_V1
 /data/incoming/Lego_Phantom_MNI_20140101.zip Y
 /data/incoming/PSC0001_123457_V1_RES.tar.gz N PSC0000_123456_V1
+
+Documentation: perldoc batch_uploads_imageuploader
 
 HELP
 my $Usage = <<USAGE;
@@ -210,19 +257,29 @@ close MAIL;
 ################################################################
 ############### insertIntoMRIUpload ############################
 ################################################################
+
 =pod
-insertIntoMRIUpload()
-Description:
-  - Insert into the mri_upload table entries for data coming
-    from batch_upload_imageuploader
 
-Arguments:
-  $patientname: The patient name
-  $phantom : 'Y' if the entry is for a phantom, and 'N' othwrwose
-  $fullpath: Path to the uploaded file
+=head3 insertIntoMRIUpload($patientname, $phantom, $fullpath)
 
-  Returns: $upload_id : The Upload ID
+Function that inserts into the mri_upload table entries for data coming from
+the list of scans in the text file provided when calling
+batch_upload_imageuploader
+
+INPUT  :
+    - $patientname  : The patient name
+
+    - $phantom      : 'Y' if the entry is for a phantom,
+                      'N' othwrwise
+
+    - $fullpath     : Path to the uploaded file
+
+
+
+RETURNS: $upload_id : The upload ID
+
 =cut
+
 
 
 sub insertIntoMRIUpload {
@@ -251,3 +308,25 @@ sub insertIntoMRIUpload {
 ## exit 0 for find to consider this -cmd true (in case we ever run it that way...)
 exit(0);
 
+__END__
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience
+
+=cut

--- a/docs/scripts_md/batch_image_uploader.md
+++ b/docs/scripts_md/batch_image_uploader.md
@@ -5,7 +5,7 @@ batch mode
 
 # SYNOPSIS
 
-./batch\_uploads\_imageuploader -profile prod < list\_of\_scans.txt >log\_batch\_imageuploader.txt 2>&1 \`\[options\]\`
+./batch\_uploads\_imageuploader -profile prod < list\_of\_scans.txt > log\_batch\_imageuploader.txt 2>&1 \`\[options\]\`
 
 Available options are:
 
@@ -16,38 +16,37 @@ Available options are:
 
 # DESCRIPTION
 
-This script runs the Loris-MRI insertion on multiple scans. The list of scans
-are provided through a text file (e.g. list\_of\_scans.txt) with one scan details
-per line.
+This script runs the Loris-MRI insertion pipeline on multiple scans. The list of
+scans are provided through a text file (e.g. `list_of_scans.txt`) with one scan
+details per line.
 The scan details includes the path to the scan, identification as to whether the
 scan is for a phantom (Y) or not (N), and the candidate name for non-phantom
 entries.
 
-Like the Loris Imaging Uploader interface, this script also validates the
-candidate name against the (start of the) filename and creates an entry in the
-mri\_upload table.
+Like the LORIS Imaging Uploader interface, this script also validates the
+candidate's name against the (start of the) filename and creates an entry in the
+`mri_upload` table.
 
-An example of what list\_of\_scans.txt might contain for 3 uploads to be inserted:
-/data/incoming/PSC0001\_123457\_V1.tar.gz N PSC0000\_123456\_V1
-/data/incoming/lego\_Phantom\_MNI\_20140101.zip Y
-/data/incoming/PSC0001\_123457\_V1\_RES.tar.gz N PSC0000\_123456\_V1
+An example of what `list_of_scans.txt` might contain for 3 uploads to be
+inserted:
+
+    /data/incoming/PSC0001_123457_V1.tar.gz N PSC0000_123456_V1
+    /data/incoming/lego_Phantom_MNI_20140101.zip Y
+    /data/incoming/PSC0001_123457_V1_RES.tar.gz N PSC0000_123456_V1
 
 ## Methods
 
 ### insertIntoMRIUpload($patientname, $phantom, $fullpath)
 
-Function that inserts into the mri\_upload table entries for data coming from
+Function that inserts into the `mri_upload` table entries for data coming from
 the list of scans in the text file provided when calling
 batch\_upload\_imageuploader
 
-INPUT  :
+INPUTS  :
     - $patientname  : The patient name
-
     - $phantom      : 'Y' if the entry is for a phantom,
                       'N' otherwise
-
     - $fullpath     : Path to the uploaded file
-    
 
 RETURNS: $upload\_id : The upload ID
 

--- a/docs/scripts_md/batch_image_uploader.md
+++ b/docs/scripts_md/batch_image_uploader.md
@@ -1,0 +1,69 @@
+# NAME
+
+batch\_uploads\_imageuploader -- a script that runs imaging\_upload\_file.pl in
+batch mode
+
+# SYNOPSIS
+
+./batch\_uploads\_imageuploader -profile prod < list\_of\_scans.txt >log\_batch\_imageuploader.txt 2>&1 \`\[options\]\`
+
+Available options are:
+
+\-profile      : name of the config file in
+                `../dicom-archive/.loris_mri`
+
+\-verbose      : if set, be verbose
+
+# DESCRIPTION
+
+This script runs the Loris-MRI insertion on multiple scans. The list of scans
+are provided through a text file (e.g. list\_of\_scans.txt) with one scan details
+per line.
+The scan details includes the path to the scan, identification as to whether the
+scan is for a phantom (Y) or not (N), and the candidate name for non-phantom
+entries.
+
+Like the Loris Imaging Uploader interface, this script also validates the
+candidate name against the (start of the) filename and creates an entry in the
+mri\_upload table.
+
+An example of what list\_of\_scans.txt might contain for 3 uploads to be inserted:
+/data/incoming/PSC0001\_123457\_V1.tar.gz N PSC0000\_123456\_V1
+/data/incoming/lego\_Phantom\_MNI\_20140101.zip Y
+/data/incoming/PSC0001\_123457\_V1\_RES.tar.gz N PSC0000\_123456\_V1
+
+## Methods
+
+### insertIntoMRIUpload($patientname, $phantom, $fullpath)
+
+Function that inserts into the mri\_upload table entries for data coming from
+the list of scans in the text file provided when calling
+batch\_upload\_imageuploader
+
+INPUT  :
+    - $patientname  : The patient name
+
+    - $phantom      : 'Y' if the entry is for a phantom,
+                      'N' otherwise
+
+    - $fullpath     : Path to the uploaded file
+    
+
+RETURNS: $upload\_id : The upload ID
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience


### PR DESCRIPTION
Generated using:
pod2markdown batch_uploads_imageuploader > docs/scripts_md/batch_image_uploader.md

User can type:
perldoc batch_uploads_imageuploader
to get the documentation at the terminal