### PR TITLE
[Documentation] BackPopulateSNRAndAcquisitionOrder.pl

### DIFF
--- a/docs/scripts_md/BackPopulateSNRAndAcquisitionOrder.md
+++ b/docs/scripts_md/BackPopulateSNRAndAcquisitionOrder.md
@@ -1,45 +1,49 @@
-# NAME
+BACKPOPULATESNRANDACQUIUSsIeTrIOCNoOnRtDrEiRb(u1t)ed PerBlACDKoPcOuPmUeLnAtTaEtSiNoRnANDACQUISITIONORDER(1)
 
-BackPopulateSNRAndAcquisitionOrder.pl -- a script that back populates the
-AcqOrderPerModality column of the files table, and the signal-to-noise (SNR)
-values in the parameter\_file table for inserted MINC files. The SNR is computed
-using algorithms built-in the MINC tools.
 
-# SYNOPSIS
 
-perl tools/BackPopulateSNRAndAcquisitionOrder.pl \`\[options\]\`
+NNAAMMEE
+       BackPopulateSNRAndAcquisitionOrder.pl -- a script that back populates
+       the AcqOrderPerModality column of the files table, and the
+       signal-to-noise ratio (SNR) values in the parameter_file table for
+       inserted MINC files. The SNR is computed using MINC tools built-in
+       algorithms.
 
-Available options are:
+SSYYNNOOPPSSIISS
+       perl tools/BackPopulateSNRAndAcquisitionOrder.pl "[options]"
 
-\-profile        : name of the config file in
-                  `../dicom-archive/.loris_mri`
+       Available options are:
 
-\-tarchive\_id    : The tarchive ID of the .tar to be processed from the tarchive
-                  table
+       -profile        : name of the config file in
+                         "../dicom-archive/.loris_mri"
 
-# DESCRIPTION
+       -tarchive_id    : The tarchive ID of the DICOM archive (.tar files) to
+       be
+                         processed from the "tarchive" table
 
-This script will back populate the files table with entries for the
-AcqOrderPerModality column; in reference to:
-https://github.com/aces/Loris-MRI/pull/160
-as well as populate the parameter\_file table with SNR entries in reference to:
-https://github.com/aces/Loris-MRI/pull/142
-It can take in tarchiveID as an argument if only a specific .tar is to be
-processed; otherwise, all .tar in the tarchive table are processed.
+DDEESSCCRRIIPPTTIIOONN
+       This script will back populate the files table with entries for the
+       AcqOrderPerModality column; in reference to:
+       https://github.com/aces/Loris-MRI/pull/160 as well as populate the
+       parameter_file table with SNR entries in reference to:
+       https://github.com/aces/Loris-MRI/pull/142 It can take in tarchiveID as
+       an argument if only a specific DICOM archive (.tar files) is to be
+       processed; otherwise, all DICOM archives (.tar files) in the "tarchive"
+       table are processed.
 
-# TO DO
+TTOO DDOO
+       Nothing planned.
 
-Nothing planned.
+BBUUGGSS
+       None reported.
 
-# BUGS
+LLIICCEENNSSIINNGG
+       License: GPLv3
 
-None reported.
+AAUUTTHHOORRSS
+       LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+       Neuroscience
 
-# LICENSING
 
-License: GPLv3
 
-# AUTHORS
-
-LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
-Neuroscience
+perl v5.18.2                      2018-01-B1A7CKPOPULATESNRANDACQUISITIONORDER(1)

--- a/docs/scripts_md/BackPopulateSNRAndAcquisitionOrder.md
+++ b/docs/scripts_md/BackPopulateSNRAndAcquisitionOrder.md
@@ -19,10 +19,11 @@ Available options are:
 
 # DESCRIPTION
 
-This script will back populate the files table with entries for the
-AcqOrderPerModality column; in reference to:
+This script will back populate the `files` table with entries for the
+`AcqOrderPerModality` column; in reference to:
 https://github.com/aces/Loris-MRI/pull/160
-as well as populate the parameter\_file table with SNR entries in reference to:
+as well as populate the `parameter_file` table with SNR entries in reference
+to:
 https://github.com/aces/Loris-MRI/pull/142
 It can take in tarchiveID as an argument if only a specific DICOM archive
 (.tar files) is to be processed; otherwise, all DICOM archives (.tar files) in

--- a/docs/scripts_md/BackPopulateSNRAndAcquisitionOrder.md
+++ b/docs/scripts_md/BackPopulateSNRAndAcquisitionOrder.md
@@ -1,0 +1,45 @@
+# NAME
+
+BackPopulateSNRAndAcquisitionOrder.pl -- a script that back populates the
+AcqOrderPerModality column of the files table, and the signal-to-noise (SNR)
+values in the parameter\_file table for inserted MINC files. The SNR is computed
+using algorithms built-in the MINC tools.
+
+# SYNOPSIS
+
+perl tools/BackPopulateSNRAndAcquisitionOrder.pl \`\[options\]\`
+
+Available options are:
+
+\-profile        : name of the config file in
+                  `../dicom-archive/.loris_mri`
+
+\-tarchive\_id    : The tarchive ID of the .tar to be processed from the tarchive
+                  table
+
+# DESCRIPTION
+
+This script will back populate the files table with entries for the
+AcqOrderPerModality column; in reference to:
+https://github.com/aces/Loris-MRI/pull/160
+as well as populate the parameter\_file table with SNR entries in reference to:
+https://github.com/aces/Loris-MRI/pull/142
+It can take in tarchiveID as an argument if only a specific .tar is to be
+processed; otherwise, all .tar in the tarchive table are processed.
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience

--- a/docs/scripts_md/BackPopulateSNRAndAcquisitionOrder.md
+++ b/docs/scripts_md/BackPopulateSNRAndAcquisitionOrder.md
@@ -1,49 +1,46 @@
-BACKPOPULATESNRANDACQUIUSsIeTrIOCNoOnRtDrEiRb(u1t)ed PerBlACDKoPcOuPmUeLnAtTaEtSiNoRnANDACQUISITIONORDER(1)
+# NAME
 
+BackPopulateSNRAndAcquisitionOrder.pl -- a script that back populates the
+AcqOrderPerModality column of the files table, and the signal-to-noise ratio
+(SNR) values in the parameter\_file table for inserted MINC files. The SNR is
+computed using MINC tools built-in algorithms.
 
+# SYNOPSIS
 
-NNAAMMEE
-       BackPopulateSNRAndAcquisitionOrder.pl -- a script that back populates
-       the AcqOrderPerModality column of the files table, and the
-       signal-to-noise ratio (SNR) values in the parameter_file table for
-       inserted MINC files. The SNR is computed using MINC tools built-in
-       algorithms.
+perl tools/BackPopulateSNRAndAcquisitionOrder.pl `[options]`
 
-SSYYNNOOPPSSIISS
-       perl tools/BackPopulateSNRAndAcquisitionOrder.pl "[options]"
+Available options are:
 
-       Available options are:
+\-profile        : name of the config file in
+                  `../dicom-archive/.loris_mri`
 
-       -profile        : name of the config file in
-                         "../dicom-archive/.loris_mri"
+\-tarchive\_id    : The tarchive ID of the DICOM archive (.tar files) to be
+                  processed from the `tarchive` table
 
-       -tarchive_id    : The tarchive ID of the DICOM archive (.tar files) to
-       be
-                         processed from the "tarchive" table
+# DESCRIPTION
 
-DDEESSCCRRIIPPTTIIOONN
-       This script will back populate the files table with entries for the
-       AcqOrderPerModality column; in reference to:
-       https://github.com/aces/Loris-MRI/pull/160 as well as populate the
-       parameter_file table with SNR entries in reference to:
-       https://github.com/aces/Loris-MRI/pull/142 It can take in tarchiveID as
-       an argument if only a specific DICOM archive (.tar files) is to be
-       processed; otherwise, all DICOM archives (.tar files) in the "tarchive"
-       table are processed.
+This script will back populate the files table with entries for the
+AcqOrderPerModality column; in reference to:
+https://github.com/aces/Loris-MRI/pull/160
+as well as populate the parameter\_file table with SNR entries in reference to:
+https://github.com/aces/Loris-MRI/pull/142
+It can take in tarchiveID as an argument if only a specific DICOM archive
+(.tar files) is to be processed; otherwise, all DICOM archives (.tar files) in
+the `tarchive` table are processed.
 
-TTOO DDOO
-       Nothing planned.
+# TO DO
 
-BBUUGGSS
-       None reported.
+Nothing planned.
 
-LLIICCEENNSSIINNGG
-       License: GPLv3
+# BUGS
 
-AAUUTTHHOORRSS
-       LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
-       Neuroscience
+None reported.
 
+# LICENSING
 
+License: GPLv3
 
-perl v5.18.2                      2018-01-B1A7CKPOPULATESNRANDACQUISITIONORDER(1)
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience

--- a/docs/scripts_md/BackPopulateSNRAndAcquisitionOrder.md
+++ b/docs/scripts_md/BackPopulateSNRAndAcquisitionOrder.md
@@ -14,7 +14,7 @@ Available options are:
 \-profile        : name of the config file in
                   `../dicom-archive/.loris_mri`
 
-\-tarchive\_id    : The tarchive ID of the DICOM archive (.tar files) to be
+\-tarchive\_id    : The Tarchive ID of the DICOM archive (.tar files) to be
                   processed from the `tarchive` table
 
 # DESCRIPTION
@@ -25,7 +25,7 @@ https://github.com/aces/Loris-MRI/pull/160
 as well as populate the `parameter_file` table with SNR entries in reference
 to:
 https://github.com/aces/Loris-MRI/pull/142
-It can take in tarchiveID as an argument if only a specific DICOM archive
+It can take in TarchiveID as an argument if only a specific DICOM archive
 (.tar files) is to be processed; otherwise, all DICOM archives (.tar files) in
 the `tarchive` table are processed.
 

--- a/tools/BackPopulateSNRAndAcquisitionOrder.pl
+++ b/tools/BackPopulateSNRAndAcquisitionOrder.pl
@@ -26,10 +26,11 @@ Available options are:
 
 =head1 DESCRIPTION
 
-This script will back populate the files table with entries for the
-AcqOrderPerModality column; in reference to:
+This script will back populate the C<files> table with entries for the
+C<AcqOrderPerModality> column; in reference to:
 https://github.com/aces/Loris-MRI/pull/160
-as well as populate the parameter_file table with SNR entries in reference to:
+as well as populate the C<parameter_file> table with SNR entries in reference
+to:
 https://github.com/aces/Loris-MRI/pull/142
 It can take in tarchiveID as an argument if only a specific DICOM archive
 (.tar files) is to be processed; otherwise, all DICOM archives (.tar files) in

--- a/tools/BackPopulateSNRAndAcquisitionOrder.pl
+++ b/tools/BackPopulateSNRAndAcquisitionOrder.pl
@@ -19,7 +19,7 @@ Available options are:
 -profile        : name of the config file in
                   C<../dicom-archive/.loris_mri>
 
--tarchive_id    : The tarchive ID of the DICOM archive (.tar files) to be
+-tarchive_id    : The Tarchive ID of the DICOM archive (.tar files) to be
                   processed from the C<tarchive> table
 
 
@@ -32,7 +32,7 @@ https://github.com/aces/Loris-MRI/pull/160
 as well as populate the C<parameter_file> table with SNR entries in reference
 to:
 https://github.com/aces/Loris-MRI/pull/142
-It can take in tarchiveID as an argument if only a specific DICOM archive
+It can take in TarchiveID as an argument if only a specific DICOM archive
 (.tar files) is to be processed; otherwise, all DICOM archives (.tar files) in
 the C<tarchive> table are processed.
 
@@ -72,9 +72,9 @@ AcqOrderPerModality column; in reference to:
 https://github.com/aces/Loris-MRI/pull/160
 as well as populate the parameter_file table with SNR entries in reference to:
 https://github.com/aces/Loris-MRI/pull/142
-It can take in tarchiveID as an argument if only a specific DICOM archive
+It can take in TarchiveID as an argument if only a specific DICOM archive
 (.tar files) is to be processed; otherwise, all DICOM archives (.tar files) in
-the C<tarchive> table are processed.
+the tarchive table are processed.
 
 
 Documentation: perldoc BackPopulateSNRAndAcquisitionOrder.pl

--- a/tools/BackPopulateSNRAndAcquisitionOrder.pl
+++ b/tools/BackPopulateSNRAndAcquisitionOrder.pl
@@ -5,22 +5,22 @@
 =head1 NAME
 
 BackPopulateSNRAndAcquisitionOrder.pl -- a script that back populates the
-AcqOrderPerModality column of the files table, and the signal-to-noise (SNR)
-values in the parameter_file table for inserted MINC files. The SNR is computed
-using algorithms built-in the MINC tools.
+AcqOrderPerModality column of the files table, and the signal-to-noise ratio
+(SNR) values in the parameter_file table for inserted MINC files. The SNR is
+computed using MINC tools built-in algorithms.
 
 
 =head1 SYNOPSIS
 
-perl tools/BackPopulateSNRAndAcquisitionOrder.pl `[options]`
+perl tools/BackPopulateSNRAndAcquisitionOrder.pl C<[options]>
 
 Available options are:
 
 -profile        : name of the config file in
                   C<../dicom-archive/.loris_mri>
 
--tarchive_id    : The tarchive ID of the .tar to be processed from the tarchive
-                  table
+-tarchive_id    : The tarchive ID of the DICOM archive (.tar files) to be
+                  processed from the C<tarchive> table
 
 
 
@@ -31,8 +31,9 @@ AcqOrderPerModality column; in reference to:
 https://github.com/aces/Loris-MRI/pull/160
 as well as populate the parameter_file table with SNR entries in reference to:
 https://github.com/aces/Loris-MRI/pull/142
-It can take in tarchiveID as an argument if only a specific .tar is to be
-processed; otherwise, all .tar in the tarchive table are processed.
+It can take in tarchiveID as an argument if only a specific DICOM archive
+(.tar files) is to be processed; otherwise, all DICOM archives (.tar files) in
+the C<tarchive> table are processed.
 
 
 =cut
@@ -59,7 +60,7 @@ my @opt_table = (
       "name of config file in ../dicom-archive/.loris_mri"
     ],
     [ "-tarchive_id", "string", 1, \$TarchiveID,
-      "tarchive_id of the .tar to be processed from tarchive table"
+      "tarchive_id of the DICOM archive (.tar files) to be processed from tarchive table"
     ]
 ); 
 
@@ -70,8 +71,9 @@ AcqOrderPerModality column; in reference to:
 https://github.com/aces/Loris-MRI/pull/160
 as well as populate the parameter_file table with SNR entries in reference to:
 https://github.com/aces/Loris-MRI/pull/142
-It can take in tarchiveID as an argument if only a specific .tar is to be 
-processed; otherwise, all .tar in the tarchive table are processed.
+It can take in tarchiveID as an argument if only a specific DICOM archive
+(.tar files) is to be processed; otherwise, all DICOM archives (.tar files) in
+the C<tarchive> table are processed.
 
 
 Documentation: perldoc BackPopulateSNRAndAcquisitionOrder.pl

--- a/tools/BackPopulateSNRAndAcquisitionOrder.pl
+++ b/tools/BackPopulateSNRAndAcquisitionOrder.pl
@@ -1,5 +1,43 @@
 #! /usr/bin/perl
 
+=pod
+
+=head1 NAME
+
+BackPopulateSNRAndAcquisitionOrder.pl -- a script that back populates the
+AcqOrderPerModality column of the files table, and the signal-to-noise (SNR)
+values in the parameter_file table for inserted MINC files. The SNR is computed
+using algorithms built-in the MINC tools.
+
+
+=head1 SYNOPSIS
+
+perl tools/BackPopulateSNRAndAcquisitionOrder.pl `[options]`
+
+Available options are:
+
+-profile        : name of the config file in
+                  C<../dicom-archive/.loris_mri>
+
+-tarchive_id    : The tarchive ID of the .tar to be processed from the tarchive
+                  table
+
+
+
+=head1 DESCRIPTION
+
+This script will back populate the files table with entries for the
+AcqOrderPerModality column; in reference to:
+https://github.com/aces/Loris-MRI/pull/160
+as well as populate the parameter_file table with SNR entries in reference to:
+https://github.com/aces/Loris-MRI/pull/142
+It can take in tarchiveID as an argument if only a specific .tar is to be
+processed; otherwise, all .tar in the tarchive table are processed.
+
+
+=cut
+
+
 use strict;
 use warnings;
 use Getopt::Tabular;
@@ -27,13 +65,17 @@ my @opt_table = (
 
 my $Help = <<HELP;
 
-This script will back populate the files table with entries for 
-the AcqOrderPerModality column; in reference to: 
+This script will back populate the files table with entries for the
+AcqOrderPerModality column; in reference to:
 https://github.com/aces/Loris-MRI/pull/160
-as well as populate the parameter_file table with SNR entries 
-in reference to: https://github.com/aces/Loris-MRI/pull/142
+as well as populate the parameter_file table with SNR entries in reference to:
+https://github.com/aces/Loris-MRI/pull/142
 It can take in tarchiveID as an argument if only a specific .tar is to be 
-processed; otherwise, all .tar in the tarchive tables are processed.
+processed; otherwise, all .tar in the tarchive table are processed.
+
+
+Documentation: perldoc BackPopulateSNRAndAcquisitionOrder.pl
+
 HELP
 
 my $Usage = <<USAGE;
@@ -135,3 +177,27 @@ else {
 
 $dbh->disconnect();
 exit 0;
+
+
+__END__
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience
+
+=cut


### PR DESCRIPTION
Generated using:
pod2markdown tools/BackPopulateSNRAndAcquisitionOrder.pl > docs/scripts_md/BackPopulateSNRAndAcquisitionOrder.md

User can type:
perldoc tools/BackPopulateSNRAndAcquisitionOrder.pl 
to get the documentation at the terminal