### PR TITLE
[Documentation] minc_deletion.pl

### DIFF
--- a/docs/scripts_md/minc_deletion.md
+++ b/docs/scripts_md/minc_deletion.md
@@ -1,0 +1,54 @@
+# NAME
+
+minc\_deletion.pl -- this script deletes files records from the database, and
+archives the actual files. Files to be deleted can be specified either based on
+the series UID or the file ID.
+
+# SYNOPSIS
+
+perl minc\_deletion.pl \`\[options\]\`
+
+Available options are:
+
+\-profile    : name of the config file in
+                `../dicom-archive/.loris_mri`
+
+\-series\_uid : the series UID to be deleted
+
+\-fileid     : the file ID to be deleted
+
+# DESCRIPTION
+
+The program does the following:
+
+Deletes minc files from Loris by:
+  - Moving the existing files (.mnc .nii .jpg .header .raw\_byte.gz) to an
+    archive directory
+  - Deleting all related data from 2 database tables:
+    parameter\_file & files
+  - Deleting data from files\_qcstatus & feedback\_mri\_comments
+    database tables if the -delqcdata is set. In most cases
+    you would want to delete this when the images change
+  - Deleting mri\_acquisition\_dates entry if it is the last file
+    removed from that session.
+
+Users can use the argument "select" to view the record that could be removed
+from the database, or "confirm" to acknowledge that the data in the database
+will be deleted once the script executes.
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+Gregory Luneau and the LORIS community <loris.info@mcin.ca> and McGill Centre
+for Integrative Neuroscience

--- a/docs/scripts_md/minc_deletion.md
+++ b/docs/scripts_md/minc_deletion.md
@@ -27,7 +27,7 @@ This program deletes MINC files from LORIS by:
   - Deleting data from `files_qcstatus` & `feedback_mri_comments`
     database tables if the `-delqcdata` option is set. In most cases
     you would want to delete this when the images change
-  - Deleting mri\_acquisition\_dates entry if it is the last file
+  - Deleting `mri_acquisition_dates` entry if it is the last file
     removed from that session.
 
 Users can use the argument `select` to view the record that could be removed

--- a/docs/scripts_md/minc_deletion.md
+++ b/docs/scripts_md/minc_deletion.md
@@ -50,5 +50,5 @@ License: GPLv3
 
 # AUTHORS
 
-Gregory Luneau and the LORIS community <loris.info@mcin.ca> and McGill Centre
+Gregory Luneau, the LORIS community <loris.info@mcin.ca> and McGill Centre
 for Integrative Neuroscience

--- a/docs/scripts_md/minc_deletion.md
+++ b/docs/scripts_md/minc_deletion.md
@@ -13,9 +13,9 @@ Available options are:
 \-profile    : name of the config file in
                 `../dicom-archive/.loris_mri`
 
-\-series\_uid : the series UID to be deleted
+\-series\_uid : the series UID of the file to be deleted
 
-\-fileid     : the file ID to be deleted
+\-fileid     : the file ID of the file to be deleted
 
 # DESCRIPTION
 

--- a/docs/scripts_md/minc_deletion.md
+++ b/docs/scripts_md/minc_deletion.md
@@ -1,17 +1,18 @@
 # NAME
 
 minc\_deletion.pl -- this script deletes files records from the database, and
-archives the actual files. Files to be deleted can be specified either based on
-the series UID or the file ID.
+deletes and archives the backend files stored in `/data/$PROJECT/data/assembly/`.
+Files to be deleted can be specified either based on the series UID or the file
+ID.
 
 # SYNOPSIS
 
-perl minc\_deletion.pl \`\[options\]\`
+perl minc\_deletion.pl `[options]`
 
 Available options are:
 
 \-profile    : name of the config file in
-                `../dicom-archive/.loris_mri`
+              `../dicom-archive/.loris_mri`
 
 \-series\_uid : the series UID of the file to be deleted
 
@@ -19,21 +20,18 @@ Available options are:
 
 # DESCRIPTION
 
-The program does the following:
-
-Deletes minc files from Loris by:
-  - Moving the existing files (.mnc .nii .jpg .header .raw\_byte.gz) to an
-    archive directory
-  - Deleting all related data from 2 database tables:
-    parameter\_file & files
-  - Deleting data from files\_qcstatus & feedback\_mri\_comments
-    database tables if the -delqcdata is set. In most cases
+This program deletes MINC files from LORIS by:
+  - Moving the existing files (`.mnc`, `.nii`, `.jpg`, `.header`,
+    `.raw_byte.gz`) to the archive directory: `/data/$PROJECT/data/archive/`
+  - Deleting all related data from `parameter_file` & `files` tables
+  - Deleting data from `files_qcstatus` & `feedback_mri_comments`
+    database tables if the `-delqcdata` option is set. In most cases
     you would want to delete this when the images change
   - Deleting mri\_acquisition\_dates entry if it is the last file
     removed from that session.
 
-Users can use the argument "select" to view the record that could be removed
-from the database, or "confirm" to acknowledge that the data in the database
+Users can use the argument `select` to view the record that could be removed
+from the database, or `confirm` to acknowledge that the data in the database
 will be deleted once the script executes.
 
 # TO DO

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -17,9 +17,9 @@ Available options are:
 -profile    : name of the config file in
                 C<../dicom-archive/.loris_mri>
 
--series_uid : the series UID to be deleted
+-series_uid : the series UID of the file to be deleted
 
--fileid     : the file ID to be deleted
+-fileid     : the file ID of the file to be deleted
 
 
 =head1 DESCRIPTION

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -32,7 +32,7 @@ This program deletes MINC files from LORIS by:
   - Deleting data from C<files_qcstatus> & C<feedback_mri_comments>
     database tables if the C<-delqcdata> option is set. In most cases
     you would want to delete this when the images change
-  - Deleting mri_acquisition_dates entry if it is the last file
+  - Deleting C<mri_acquisition_dates> entry if it is the last file
     removed from that session.
 
 Users can use the argument C<select> to view the record that could be removed

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -1,4 +1,50 @@
 #! /usr/bin/perl
+
+=pod
+
+=head1 NAME
+
+minc_deletion.pl -- this script deletes files records from the database, and
+archives the actual files. Files to be deleted can be specified either based on
+the series UID or the file ID.
+
+=head1 SYNOPSIS
+
+perl minc_deletion.pl `[options]`
+
+Available options are:
+
+-profile    : name of the config file in
+                C<../dicom-archive/.loris_mri>
+
+-series_uid : the series UID to be deleted
+
+-fileid     : the file ID to be deleted
+
+
+=head1 DESCRIPTION
+
+The program does the following:
+
+Deletes minc files from Loris by:
+  - Moving the existing files (.mnc .nii .jpg .header .raw_byte.gz) to an
+    archive directory
+  - Deleting all related data from 2 database tables:
+    parameter_file & files
+  - Deleting data from files_qcstatus & feedback_mri_comments
+    database tables if the -delqcdata is set. In most cases
+    you would want to delete this when the images change
+  - Deleting mri_acquisition_dates entry if it is the last file
+    removed from that session.
+
+Users can use the argument "select" to view the record that could be removed
+from the database, or "confirm" to acknowledge that the data in the database
+will be deleted once the script executes.
+
+
+=cut
+
+
 use strict;
 use warnings;
 use Carp;
@@ -60,19 +106,21 @@ Version :   $versionInfo
 The program does the following:
 
 Deletes minc files from Loris by:
-  - Moving the existing files to an archive directory.
-    .mnc .nii .jpg .header .raw_byte.gz
-  - Deleting all related data from 2 database tables.
+  - Moving the existing files (.mnc .nii .jpg .header .raw_byte.gz) to an
+    archive directory
+  - Deleting all related data from 2 database tables:
     parameter_file & files
-  - Deletes data from files_qcstatus & feedback_mri_comments
+  - Deleting data from files_qcstatus & feedback_mri_comments
     database tables if the -delqcdata is set. In most cases
-    you would want to delete this when the images changes.
-  - Deletes mri_acquisition_dates entry if it is the last file
+    you would want to delete this when the images change
+  - Deleting mri_acquisition_dates entry if it is the last file
     removed from that session.
 
-Use the argument "select" to view the record that could be removed
-from the database.  Use "confirm" to acknowledge that the data in 
-the database will be deleted once the script executes.
+Users can use the argument "select" to view the record that could be removed
+from the database, or "confirm" to acknowledge that the data in the database
+will be deleted once the script executes.
+
+Documentation: perldoc minc_deletion.pl
 
 HELP
 my $Usage = <<USAGE;
@@ -375,3 +423,26 @@ if ($selORdel eq "DELETE ") {
     }
 }
 
+
+__END__
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+Gregory Luneau and the LORIS community <loris.info@mcin.ca> and McGill Centre
+for Integrative Neuroscience
+
+=cut

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -5,17 +5,18 @@
 =head1 NAME
 
 minc_deletion.pl -- this script deletes files records from the database, and
-archives the actual files. Files to be deleted can be specified either based on
-the series UID or the file ID.
+deletes and archives the backend files stored in C</data/$PROJECT/data/assembly/>.
+Files to be deleted can be specified either based on the series UID or the file
+ID.
 
 =head1 SYNOPSIS
 
-perl minc_deletion.pl `[options]`
+perl minc_deletion.pl C<[options]>
 
 Available options are:
 
 -profile    : name of the config file in
-                C<../dicom-archive/.loris_mri>
+              C<../dicom-archive/.loris_mri>
 
 -series_uid : the series UID of the file to be deleted
 
@@ -24,21 +25,18 @@ Available options are:
 
 =head1 DESCRIPTION
 
-The program does the following:
-
-Deletes minc files from Loris by:
-  - Moving the existing files (.mnc .nii .jpg .header .raw_byte.gz) to an
-    archive directory
-  - Deleting all related data from 2 database tables:
-    parameter_file & files
-  - Deleting data from files_qcstatus & feedback_mri_comments
-    database tables if the -delqcdata is set. In most cases
+This program deletes MINC files from LORIS by:
+  - Moving the existing files (C<.mnc>, C<.nii>, C<.jpg>, C<.header>,
+    C<.raw_byte.gz>) to the archive directory: C</data/$PROJECT/data/archive/>
+  - Deleting all related data from C<parameter_file> & C<files> tables
+  - Deleting data from C<files_qcstatus> & C<feedback_mri_comments>
+    database tables if the C<-delqcdata> option is set. In most cases
     you would want to delete this when the images change
   - Deleting mri_acquisition_dates entry if it is the last file
     removed from that session.
 
-Users can use the argument "select" to view the record that could be removed
-from the database, or "confirm" to acknowledge that the data in the database
+Users can use the argument C<select> to view the record that could be removed
+from the database, or C<confirm> to acknowledge that the data in the database
 will be deleted once the script executes.
 
 
@@ -105,13 +103,12 @@ Version :   $versionInfo
 
 The program does the following:
 
-Deletes minc files from Loris by:
-  - Moving the existing files (.mnc .nii .jpg .header .raw_byte.gz) to an
-    archive directory
-  - Deleting all related data from 2 database tables:
-    parameter_file & files
+Deletes MINC files from LORIS by:
+  - Moving the existing files (.mnc, .nii, .jpg, .header, .raw_byte.gz) to the
+    archive directory: /data/$PROJECT/data/archive/
+  - Deleting all related data from parameter_file & files tables
   - Deleting data from files_qcstatus & feedback_mri_comments
-    database tables if the -delqcdata is set. In most cases
+    database tables if the -delqcdata option is set. In most cases
     you would want to delete this when the images change
   - Deleting mri_acquisition_dates entry if it is the last file
     removed from that session.

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -442,7 +442,7 @@ License: GPLv3
 
 =head1 AUTHORS
 
-Gregory Luneau and the LORIS community <loris.info@mcin.ca> and McGill Centre
+Gregory Luneau, the LORIS community <loris.info@mcin.ca> and McGill Centre
 for Integrative Neuroscience
 
 =cut


### PR DESCRIPTION
Generated using:
pod2markdown uploadNeuroDB/minc_deletion.pl docs/scripts_md/minc_deletion.md

User can type:
perldoc uploadNeuroDB/minc_deletion.pl
to get the documentation at the terminal