### PR TITLE
Removing hardcoded "prod" from imaging scripts

### DIFF
--- a/dicom-archive/updateMRI_Upload.pl
+++ b/dicom-archive/updateMRI_Upload.pl
@@ -106,7 +106,6 @@ use DateTime;
 
 use NeuroDB::ExitCodes;
 
-
 my $verbose = 0;
 my $profile    = undef;
 my $source_location = '';

--- a/load_tarchive_db.sh
+++ b/load_tarchive_db.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 site=$1
+profile=$2
 
-if [ -z "$site" ]
+if [ ! $# == 2 ]
 then
-echo "Usage: $0 <site>"
+echo "Usage: $0 <site> <profile>"
 exit 1
 fi
 
 
-PREFIX=$(grep '$prefix' $LORIS_CONFIG/.loris_mri/prod | awk '{print $3}' | sed 's/"//g' | sed 's/;//g')
+PREFIX=$(grep '$prefix' $LORIS_CONFIG/.loris_mri/$profile | awk '{print $3}' | sed 's/"//g' | sed 's/;//g')
 
 tempdir=$TMPDIR/load_tarchive_db.$$
 mkdir -p $tempdir

--- a/tools/BackPopulateSNRAndAcquisitionOrder.pl
+++ b/tools/BackPopulateSNRAndAcquisitionOrder.pl
@@ -149,8 +149,7 @@ my $logfile  = "$LogDir/$templog.log";
 ################## Instantiate MRIProcessingUtility ############
 ################################################################
 my $utility = NeuroDB::MRIProcessingUtility->new(
-                  $db, \$dbh,$debug,$TmpDir,$logfile,
-                  $LogDir,$verbose
+                  $db, \$dbh, $debug, $TmpDir, $logfile, $verbose, $profile
               );
 
 ################################################################

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -107,12 +107,13 @@ sub new {
     ############### Create a Notify Object #####################
     ############################################################
 
-    my $Notify 			    = NeuroDB::Notify->new( $dbhr );
-    $self->{'Notify'} 		    = $Notify;
+    my $Notify = NeuroDB::Notify->new( $dbhr );
+    $self->{'Notify'} 		        = $Notify;
     $self->{'uploaded_temp_folder'} = $uploaded_temp_folder;
     $self->{'dbhr'}                 = $dbhr;
     $self->{'pname'}                = $pname;
     $self->{'upload_id'}            = $upload_id;
+    $self->{'profile'}              = $profile;
     $self->{'verbose'}              = $verbose;
     return bless $self, $params;
 }
@@ -133,7 +134,7 @@ RETURNS: 1 on success, 0 on failure
 
 sub IsCandidateInfoValid {
     my $this = shift;
-    my ($message,$query,$where) = '';
+    my ($message, $query, $where) = '';
     ############################################################
     ####Set the Inserting flag to true##########################
     #Which means that the scan is going through the pipeline####
@@ -224,7 +225,7 @@ sub IsCandidateInfoValid {
         my $command =
             $bin_dirPath
             . "/uploadNeuroDB/tarchiveLoader.pl"
-            . " -globLocation -profile prod $archived_file_path";
+            . " -globLocation -profile $this->{'profile'} $archived_file_path";
 
         if ($this->{verbose}){
             $command .= " -verbose";
@@ -332,7 +333,7 @@ sub runDicomTar {
       $bin_dirPath . "/" . "dicom-archive" . "/" . "dicomTar.pl";
     my $command =
         $dicomtar . " " . $this->{'uploaded_temp_folder'} 
-      . " $tarchive_location -clobber -database -profile prod";
+      . " $tarchive_location -clobber -database -profile $this->{'profile'}";
     if ($this->{verbose}) {
         $command .= " -verbose";
     }
@@ -418,7 +419,7 @@ sub runTarchiveLoader {
     my $command =
         $bin_dirPath
       . "/uploadNeuroDB/tarchiveLoader.pl"
-      . " -globLocation -profile prod $archived_file_path";
+      . " -globLocation -profile $this->{'profile'} $archived_file_path";
 
     if ($this->{verbose}){
         $command .= " -verbose";

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -92,7 +92,7 @@ RETURNS: new instance of this class.
 
 sub new {
     my $params = shift;
-    my ($db, $dbhr,$debug,$TmpDir,$logfile,$verbose) = @_;
+    my ($db, $dbhr, $debug, $TmpDir, $logfile, $verbose, $profile) = @_;
     unless(defined $dbhr) {
        croak(
            "Usage: ".$params."->new(\$databaseHandleReference)"
@@ -109,7 +109,6 @@ sub new {
     ############################################################
     ############### Create a settings package ##################
     ############################################################
-    my $profile = "prod";
     {
      package Settings;
      do "$ENV{LORIS_CONFIG}/.loris_mri/$profile";

--- a/uploadNeuroDB/imaging_upload_file_cronjob.pl
+++ b/uploadNeuroDB/imaging_upload_file_cronjob.pl
@@ -121,8 +121,7 @@ $sth->execute();
 while(@row = $sth->fetchrow_array()) { 
 
     if ( -e $row[1] ) {
-	my $command =
-        "imaging_upload_file.pl -upload_id $row[0] -profile prod $row[1]";
+	my $command = "imaging_upload_file.pl -upload_id $row[0] -profile $profile $row[1]";
 	if ($verbose){
 	    $command .= " -verbose";
             print "\n" . $command . "\n";

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -300,8 +300,7 @@ print LOG "\n==> Successfully connected to database \n" if $verbose;
 ################## MRIProcessingUtility object #################
 ################################################################
 my $utility = NeuroDB::MRIProcessingUtility->new(
-                  $db, \$dbh,$debug,$TmpDir,$logfile,
-                  $verbose
+                  $db, \$dbh, $debug, $TmpDir, $logfile, $verbose, $profile
               );
 
 ################################################################

--- a/uploadNeuroDB/tarchiveLoader.pl
+++ b/uploadNeuroDB/tarchiveLoader.pl
@@ -108,17 +108,12 @@ my $debug       = 0;
 my $message     = '';
 my $tarchive_srcloc = '';
 my $upload_id   = undef;
-my $verbose     = 0;           # default, overwritten if the scripts are run
-                               # with -verbose
-my $notify_detailed   = 'Y';   # notification_spool message flag for messages to
-                               # be displayed
-                               # with DETAILED OPTION in the front-end/
-                               # imaging_uploader
-my $notify_notsummary = 'N';   # notification_spool message flag for messages to
-                               # be displayed
-                               # with SUMMARY Option in the front-end/
-                               # imaging_uploader
-my $profile     = 'prod';      # this should never be set unless you are in a
+my $verbose     = 0;           # default, overwritten if the scripts are run with -verbose
+my $notify_detailed   = 'Y';   # notification_spool message flag for messages to be displayed 
+                               # with DETAILED OPTION in the front-end/imaging_uploader 
+my $notify_notsummary = 'N';   # notification_spool message flag for messages to be displayed 
+                               # with SUMMARY Option in the front-end/imaging_uploader 
+my $profile     = undef;       # this should never be set unless you are in a
                                # stable production environment
 my $reckless    = 0;           # this is only for playing and testing. Don't 
                                #set it to 1!!!
@@ -329,8 +324,7 @@ if ($xlog) {
 ################## Instantiate MRIProcessingUtility ############
 ################################################################
 my $utility = NeuroDB::MRIProcessingUtility->new(
-                  $db, \$dbh,$debug,$TmpDir,$logfile,
-                  $LogDir,$verbose
+                  $db, \$dbh, $debug, $TmpDir, $logfile, $verbose, $profile
               );
 
 ################################################################

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -241,8 +241,7 @@ print LOG "\n==> Successfully connected to database \n";
 ################ MRIProcessingUtility object ###################
 ################################################################
 my $utility = NeuroDB::MRIProcessingUtility->new(
-                  $db, \$dbh,$debug,$TmpDir,$logfile,
-                  $verbose
+                  $db, \$dbh, $debug, $TmpDir, $logfile, $verbose, $profile
               );
 
 ################################################################


### PR DESCRIPTION
### The following scripts are affected by the changes:
- tools/seriesuid2fileid
- uploadNeuroDB/tarchiveLoader
- uploadNeuroDB/NeuroDB/ImagingUpload.pm
- uploadNeuroDB/imaging_upload_file_cronjob.pl
- load_tarchive_db.sh
- find_uploads_tarchive
- batch_uploads_tarchive

### **IMPORTANT NOTES FOR EXISTING PROJECT:**
1. **batch_uploads_tarchive**: should be run with the -profile option set:
`batch_uploads_tarchive -profile prod < tarchive_list.txt`
2. **tools/seriesuid2fileid**: should be run with the -profile option set:
`seriesuid2fileid -profile prod < seriesuid_list.txt`

### Additional notes for code review:
- load_tarchive_db.sh appears to be an old and outdated script, only tested that the addition of the option <profile> worked, which it did
- redmine ticket associated with this PR: https://redmine.cbrain.mcgill.ca/issues/5975