### PR TITLE
[Documentation] - batch_uploads_tarchive

### DIFF
--- a/batch_uploads_tarchive
+++ b/batch_uploads_tarchive
@@ -1,4 +1,90 @@
 #!/usr/bin/perl -w
+
+=pod
+
+=head1 NAME
+
+batch_uploads_tarchive - upload a batch of tarchives using script tarchiveLoader
+
+=head1 SYNOPSIS
+
+./batch_uploads_tarchive
+
+=head1 DESCRIPTION
+
+This script uploads a list of tarchive files to the database by calling script 
+C<tarchiveLoader> on each file in succession. The list of files to process is read 
+from STDIN, one file name per line. Each file name is assumed to be a path relative 
+to C<tarchiveLibraryDir> (see below).
+
+The following settings of file F<$ENV{LORIS_CONFIG}/.loris-mri/prod> affect the 
+behvavior of batch_uploads_tarchive (where C<$ENV{LORIS_CONFIG}> is the value of
+the Unix environment variable LORIS_CONFIG):
+
+=over 4
+
+=item *
+B<dataDirBasepath> : controls where the STDOUT and STDERR of each qsub command
+  (see below) will go, namely in 
+  F<< $dataDirBasepath/batch_output/tarstdout.log<index> >> and
+  F<< $dataDirBasepath/batch_output/tarstderr.log<index> >>
+  (where C<< <index> >> is the index of the tarchive file processed, the first file having
+   index 1).
+   
+=item * 
+B<tarchiveLibraryDir>: directory that contains the tarchive files to process. The path
+  of the files listed on STDIN should be relative to this directory.
+  
+=item *
+B<is_qsub>: whether the output (STDOUT) of each tarchiveLoader command should be
+  processed by the qsub Unix command (allows batch execution of jobs on the 
+  Sun Grid Engine, if available). If set, then the qsub command will send its STDOUT
+  and STDERR according to the value of dataDirBasepath (see above). 
+  
+=item *
+B<mail_use>: upon completion of the script, an email will be sent to email address
+  $mail_user cointaining the list of files processed by batch_upload_tarchive
+  
+=back
+
+File prod should also contain the information needed to connect to the database in an
+array C<@db> containing four elements:
+
+=over 4
+
+=item *
+The database name
+
+=item *
+The SQL user name used to connect ot the database
+
+=item *
+The password for the user identified above
+
+=item *
+The database hostname
+
+=back
+
+=head1 TO DO
+
+Code cleanup: remove unused C<-D> and C<-v> program arguments
+
+=head1 BUGS
+
+None reported.
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience
+
+=cut
+
 use strict;
 use warnings;
 no warnings 'once';

--- a/docs/scripts_md/batch_uploads_tarchive.md
+++ b/docs/scripts_md/batch_uploads_tarchive.md
@@ -1,0 +1,58 @@
+# NAME
+
+batch\_uploads\_tarchive - upload a batch of tarchives using script tarchiveLoader
+
+# SYNOPSIS
+
+./batch\_uploads\_tarchive
+
+# DESCRIPTION
+
+This script uploads a list of tarchive files to the database by calling script 
+`tarchiveLoader` on each file in succession. The list of files to process is read 
+from STDIN, one file name per line. Each file name is assumed to be a path relative 
+to `tarchiveLibraryDir` (see below).
+
+The following settings of file `$ENV{LORIS_CONFIG}/.loris-mri/prod` affect the 
+behvavior of batch\_uploads\_tarchive (where `$ENV{LORIS_CONFIG}` is the value of
+the Unix environment variable LORIS\_CONFIG):
+
+- **dataDirBasepath** : controls where the STDOUT and STDERR of each qsub command
+  (see below) will go, namely in 
+  `$dataDirBasepath/batch_output/tarstdout.log<index>` and
+  `$dataDirBasepath/batch_output/tarstderr.log<index>`
+  (where `<index>` is the index of the tarchive file processed, the first file having
+   index 1).
+- **tarchiveLibraryDir**: directory that contains the tarchive files to process. The path
+  of the files listed on STDIN should be relative to this directory.
+- **is\_qsub**: whether the output (STDOUT) of each tarchiveLoader command should be
+  processed by the qsub Unix command (allows batch execution of jobs on the 
+  Sun Grid Engine, if available). If set, then the qsub command will send its STDOUT
+  and STDERR according to the value of dataDirBasepath (see above). 
+- **mail\_use**: upon completion of the script, an email will be sent to email address
+  $mail\_user cointaining the list of files processed by batch\_upload\_tarchive
+
+File prod should also contain the information needed to connect to the database in an
+array `@db` containing four elements:
+
+- The database name
+- The SQL user name used to connect ot the database
+- The password for the user identified above
+- The database hostname
+
+# TO DO
+
+Code cleanup: remove unused `-D` and `-v` program arguments
+
+# BUGS
+
+None reported.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience


### PR DESCRIPTION
Added perldoc for script `batch_uploads_tarchive`. Also ran `pod2markdown batch_uploads_tarchive` to generate `batch_uploads_tarchive.md`, the web-based documentation for the script.