### PR TITLE
Grep the different file types from the DB instead of hardcoding it in the code

### DIFF
--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -261,7 +261,7 @@ QUERY
     $sth->execute();
 
     # else, loop through the different values from ImagingFileTypes table
-        # and see if $file matches one of the file types.
+    # and see if $file matches one of the file types.
     while (my $fileTypeRow = $sth->fetchrow_hashref()) {
         if ($file =~ /\.$fileTypeRow->{'type'}(\.gz)?$/) {
             $fileType = $fileTypeRow->{'type'};

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -260,17 +260,11 @@ QUERY
     my $sth = ${$this->{'dbhr'}}->prepare($query);
     $sth->execute();
 
-    # determine file type of $file
-    if($file =~ /\.mnc(\.gz)?$/) {
-        # if file type is .mnc or .mnc.gz, then file type will be 'mnc'
-        $fileType = 'mnc';
-    } else {
-        # else, loop through the different values from ImagingFileTypes table
+    # else, loop through the different values from ImagingFileTypes table
         # and see if $file matches one of the file types.
-        while (my $fileTypeRow = $sth->fetchrow_hashref()) {
-            if ($file =~ /\.$fileTypeRow->{'type'}$/) {
-                $fileType = $fileTypeRow->{'type'};
-            }
+    while (my $fileTypeRow = $sth->fetchrow_hashref()) {
+        if ($file =~ /\.$fileTypeRow->{'type'}(\.gz)?$/) {
+            $fileType = $fileTypeRow->{'type'};
         }
     }
     $this->setFileData('FileType', $fileType) if defined $fileType;

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -251,21 +251,27 @@ sub loadFileFromDisk {
     my ($user) = getpwuid($UID);
     $this->setFileData('InsertedByUserID', $user);
     $this->setFileData('File', $file);
-    
+
+    # grep possible file types from the database
+    (my $query = <<QUERY) =~ s/\n/ /gm;
+    SELECT type
+    FROM   ImagingFileTypes
+QUERY
+    my $sth = ${$this->{'dbhr'}}->prepare($query);
+    $sth->execute();
+
+    # determine file type of $file
     if($file =~ /\.mnc(\.gz)?$/) {
+        # if file type is .mnc or .mnc.gz, then file type will be 'mnc'
         $fileType = 'mnc';
-    } elsif($file =~ /\.obj$/) {
-        $fileType = 'obj';
-    } elsif($file =~ /\.xfm$/) {
-        $fileType = 'xfm';
-    } elsif($file =~ /\.imp$/) {
-        $fileType = 'imp';
-    } elsif($file =~ /\.xml$/) {
-        $fileType = 'xml';
-    } elsif($file =~ /\.txt$/) {
-        $fileType = 'txt';
-    } elsif($file =~ /\.nrrd$/) {
-        $fileType = 'nrrd';
+    } else {
+        # else, loop through the different values from ImagingFileTypes table
+        # and see if $file matches one of the file types.
+        while (my $fileTypeRow = $sth->fetchrow_hashref()) {
+            if ($file =~ /\.$fileTypeRow->{'type'}$/) {
+                $fileType = $fileTypeRow->{'type'};
+            }
+        }
     }
     $this->setFileData('FileType', $fileType) if defined $fileType;
     


### PR DESCRIPTION
In this PR, instead of hardcoding the different file types in the File.pm file, reads this information from the ImagingFileType table.

The only exception left in the if statements are if a file matches '.mnc' or '.mnc.gz', it will determine the file type to be 'mnc'.

Redmine ticket associated with this PR: https://redmine.cbrain.mcgill.ca/issues/13839