### PR TITLE
Installer: Populate the default LORIS config settings for the MRI paths (Redmine 13915)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,20 @@ The following must be recursively owned by the lorisadmin user and by Apache gro
    ```
 #### 7. Verify Configuration module settings for Imaging Pipeline
   
-In the LORIS front-end, under the Admin menu, go to the `Config` module.  Under the section `Imaging Pipeline`, verify/set the following config settings: 
+In the LORIS front-end, under the Admin menu, go to the `Config` module.  Verify/set the following config settings 
+
+under the section `Imaging Pipeline`:
  * `Loris-MRI Data Directory`
  * `Study Name`
  * `User to notify when executing the pipeline`
  * `Full path to get_dicom_info.pl script`
  * `Path to Tarchives`
+
+under the section `Path`:
+ * `Imaging Data`
+ * `LORIS-MRI Code`
+ * `MINC files`
+ * `Images`
 
 Click 'Submit' at the end of the Configuration page to save any changes. 
 

--- a/README.md
+++ b/README.md
@@ -102,20 +102,20 @@ The following must be recursively owned by the lorisadmin user and by Apache gro
    ```
 #### 7. Verify Configuration module settings for Imaging Pipeline
   
-In the LORIS front-end, under the Admin menu, go to the `Config` module.  Verify/set the following config settings 
+In the LORIS front-end, under the Admin menu, go to the `Config` module.  Verify/set the following config settings (examples below illustrated for a project name `demo`):
 
-under the section `Imaging Pipeline`:
- * `Loris-MRI Data Directory`
- * `Study Name`
+Under the section `Imaging Pipeline`:
+ * `Loris-MRI Data Directory` (typically `/data/demo/data/')
+ * `Study Name` (`exampleStudy`; this name will be appended as a prefix to the filenames in LORIS' Imaging Browser)
  * `User to notify when executing the pipeline`
- * `Full path to get_dicom_info.pl script`
- * `Path to Tarchives`
+ * `Full path to get_dicom_info.pl script`(typically `/data/demo/bin/mri/dicom-archive/get_dicom_info.pl')
+ * `Path to Tarchives` (typically `/data/demo/data/tarchive/')
 
-under the section `Path`:
- * `Imaging Data`
- * `LORIS-MRI Code`
- * `MINC files`
- * `Images`
+Under the section `Path`:
+ * `Imaging Data` (typically `/data/demo/data/')
+ * `LORIS-MRI Code`(typically `/data/demo/bin/mri/')
+ * `MINC files` (typically `/data/demo/data/')
+ * `Images` (typically `/data/demo/data/')
 
 Click 'Submit' at the end of the Configuration page to save any changes. 
 

--- a/README.md
+++ b/README.md
@@ -102,20 +102,20 @@ The following must be recursively owned by the lorisadmin user and by Apache gro
    ```
 #### 7. Verify Configuration module settings for Imaging Pipeline
   
-In the LORIS front-end, under the Admin menu, go to the `Config` module.  Verify/set the following config settings (examples below illustrated for a project name `demo`):
+In the LORIS front-end, under the Admin menu, go to the `Config` module.  Verify/set the following config settings (examples below illustrated for a project named `demo`):
 
 Under the section `Imaging Pipeline`:
- * `Loris-MRI Data Directory` (typically `/data/demo/data/')
+ * `Loris-MRI Data Directory` (typically `/data/demo/data/`)
  * `Study Name` (`exampleStudy`; this name will be appended as a prefix to the filenames in LORIS' Imaging Browser)
  * `User to notify when executing the pipeline`
- * `Full path to get_dicom_info.pl script`(typically `/data/demo/bin/mri/dicom-archive/get_dicom_info.pl')
- * `Path to Tarchives` (typically `/data/demo/data/tarchive/')
+ * `Full path to get_dicom_info.pl script`(typically `/data/demo/bin/mri/dicom-archive/get_dicom_info.pl`)
+ * `Path to Tarchives` (typically `/data/demo/data/tarchive/`)
 
 Under the section `Path`:
- * `Imaging Data` (typically `/data/demo/data/')
- * `LORIS-MRI Code`(typically `/data/demo/bin/mri/')
- * `MINC files` (typically `/data/demo/data/')
- * `Images` (typically `/data/demo/data/')
+ * `Imaging Data` (typically `/data/demo/data/`)
+ * `LORIS-MRI Code`(typically `/data/demo/bin/mri/`)
+ * `MINC files` (typically `/data/demo/data/`)
+ * `Images` (typically `/data/demo/data/`)
 
 Click 'Submit' at the end of the Configuration page to save any changes. 
 

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -193,8 +193,8 @@ mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPD
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='$email' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='mail_user')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/bin/mri/dicom-archive/get_dicom_info.pl' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='get_dicom_info')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/tarchive/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='tarchiveLibraryDir')"
-mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='imagePath')"
-mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='data')"
-mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='mincPath')"
-mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/bin/mri/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='MRICodePath')"
+mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='imagePath') AND Value = '/data/%PROJECTNAME%/data/'"
+mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='data') AND Value = '/data/%PROJECTNAME%/data/'"
+mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='mincPath') AND Value = '/data/%PROJECTNAME%/data/'"
+mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/bin/mri/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='MRICodePath') AND Value = '/data/%PROJECTNAME%/bin/mri/'"
 echo

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -187,10 +187,11 @@ fi
 ######################################################################
 ###### Update the Database table, Config, with the user values #######
 ######################################################################
-echo "Populating database configuration entries for the Imaging Pipeline:"
+echo "Populating database configuration entries for the Imaging Pipeline and LORIS-MRI code Path:"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='dataDirBasepath')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='$PROJ' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='prefix')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='$email' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='mail_user')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/bin/mri/dicom-archive/get_dicom_info.pl' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='get_dicom_info')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/tarchive' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='tarchiveLibraryDir')"
+mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/bin/mri/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='MRICodePath')"
 echo

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -187,11 +187,14 @@ fi
 ######################################################################
 ###### Update the Database table, Config, with the user values #######
 ######################################################################
-echo "Populating database configuration entries for the Imaging Pipeline and LORIS-MRI code Path:"
-mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='dataDirBasepath')"
+echo "Populating database configuration entries for the Imaging Pipeline and LORIS-MRI code and images Path:"
+mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='dataDirBasepath')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='$PROJ' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='prefix')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='$email' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='mail_user')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/bin/mri/dicom-archive/get_dicom_info.pl' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='get_dicom_info')"
-mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/tarchive' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='tarchiveLibraryDir')"
+mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/tarchive/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='tarchiveLibraryDir')"
+mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='imagePath')"
+mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='data')"
+mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='mincPath')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/bin/mri/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='MRICodePath')"
 echo


### PR DESCRIPTION
On the MRI side, since the user provides the projectname during the interactive install; it is better to auto-populate/change the default values that LORIS sets.
It is already done for some setting (Imaging Pipeline section), but makes sense to do it also for the Path section in the configuration module.