### PR TITLE
Adding -uploadID option to minc_insertion.pl

### DIFF
--- a/tools/BackPopulateSNRAndAcquisitionOrder.pl
+++ b/tools/BackPopulateSNRAndAcquisitionOrder.pl
@@ -100,13 +100,13 @@ my $utility = NeuroDB::MRIProcessingUtility->new(
 
 # Query to grep all tarchive entries
 if (!defined($TarchiveID)) {
-    $query = "SELECT TarchiveID, ArchiveLocation " .
+    $query = "SELECT TarchiveID, ArchiveLocation, SourceLocation " .
         "FROM tarchive";
 }
 # Selecting tarchiveID is redundant here but it makes the while() loop
 # applicable to both cases; when a TarchiveID is specified or not
 else {
-    $query = "SELECT TarchiveID, ArchiveLocation " .
+    $query = "SELECT TarchiveID, ArchiveLocation, SourceLocation " .
         "FROM tarchive ".
         "WHERE TarchiveID = $TarchiveID ";
 }
@@ -117,13 +117,18 @@ $sth->execute();
 if($sth->rows > 0) {
 	# Create tarchive list hash with old and new location
     while ( my $rowhr = $sth->fetchrow_hashref()) {    
-        my $TarchiveID = $rowhr->{'TarchiveID'};
-        my $ArchLoc    = $rowhr->{'ArchiveLocation'};
+        $TarchiveID        = $rowhr->{'TarchiveID'};
+        my $ArchLoc        = $rowhr->{'ArchiveLocation'};
+        my $SourceLocation = $rowhr->{'SourceLocation'};
+        # grep the upload_id from the tarchive's source location
+        my $upload_id = NeuroDB::MRIProcessingUtility::getUploadIDUsingTarchiveSrcLoc(
+            $SourceLocation
+        );
 		print "Currently updating the SNR for applicable files in parameter_file table ".
             "for tarchiveID $TarchiveID at location $ArchLoc\n";    
-        $utility->computeSNR($TarchiveID, $ArchLoc, $profile);
+        $utility->computeSNR($TarchiveID, $upload_id, $profile);
 		print "Currently updating the Acquisition Order per modality in files table\n";    
-        $utility->orderModalitiesByAcq($TarchiveID, $ArchLoc);
+        $utility->orderModalitiesByAcq($TarchiveID, $upload_id);
 
 		print "Finished updating back-populating SNR and Acquisition Order ".
             "per modality for TarchiveID $TarchiveID \n";

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -267,7 +267,7 @@ sub createTarchiveArray {
                 " DateAcquired, DicomArchiveID, PatientGender,".
                 " ScannerManufacturer, ScannerModel, ScannerSerialNumber,".
                 " ScannerSoftwareVersion, neurodbCenterName, TarchiveID,".
-                " SourceLocation FROM tarchive WHERE $where";
+                " SourceLocation, ArchiveLocation FROM tarchive WHERE $where";
     if ($this->{debug}) {
         print $query . "\n";
     }
@@ -730,7 +730,7 @@ sub registerScanIntoDB {
                                         $minc_file,
                                         $prefix,
                                         $data_dir,
-					$tarchiveInfo->{'SourceLocation'}					
+					$tarchiveInfo->{'ArchiveLocation'}
                                      );
 
         ########################################################
@@ -746,7 +746,7 @@ sub registerScanIntoDB {
         ########################################################
         ### record which tarchive was used to make this file ###
         ########################################################
-        $tarchive_path =  $tarchiveInfo->{SourceLocation};
+        $tarchive_path =  $tarchiveInfo->{ArchiveLocation};
         $tarchive_path =~ s/$data_dir\///i;
         $${minc_file}->setParameter(
             'tarchiveLocation', 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -617,11 +617,10 @@ sub move_minc {
     
     my $this = shift;
     my ($minc,$subjectIDsref, $minc_type, $fileref,
-		$prefix,$data_dir, $tarchive_srcloc) = @_;
+		$prefix,$data_dir, $upload_id) = @_;
     my ($new_name, $version,$cmd,$new_dir,$extension,@exts,$dir);
     my $concat = "";
     my $message = '';
-    my $upload_id = getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc);
 
     ############################################################
     ### figure out where to put the files ######################
@@ -730,7 +729,7 @@ sub registerScanIntoDB {
                                         $minc_file,
                                         $prefix,
                                         $data_dir,
-					$tarchiveInfo->{'ArchiveLocation'}
+                                        $upload_id
                                      );
 
         ########################################################

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -220,9 +220,7 @@ sub extractAndParseTarchive {
 sub determineSubjectID {
 
     my $this = shift;
-    my ($scannerID,$tarchiveInfo,$to_log) = @_;
-    my $tarchive_srcloc = $tarchiveInfo->{'SourceLocation'};
-    my $upload_id = getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc);
+    my ($scannerID,$tarchiveInfo,$to_log, $upload_id) = @_;
     $to_log = 1 unless defined $to_log;
     if (!defined(&Settings::getSubjectIDs)) {
         if ($to_log) {
@@ -299,9 +297,7 @@ sub createTarchiveArray {
 sub determinePSC {
 
     my $this = shift;
-    my ($tarchiveInfo,$to_log) = @_;
-    my $tarchive_srcloc = $tarchiveInfo->{'SourceLocation'};
-    my $upload_id = undef;
+    my ($tarchiveInfo, $to_log, $upload_id) = @_;
     $to_log = 1 unless defined $to_log;
     my $lookupCenterNameUsing = NeuroDB::DBI::getConfigSetting(
                         $this->{dbhr},'lookupCenterNameUsing'
@@ -312,7 +308,6 @@ sub determinePSC {
         $this->{dbhr}
     );
     if ($to_log) {
-	$upload_id = getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc);
         if (!$center_name) {
 
             my $message = "\nERROR: No center found for this candidate \n\n";
@@ -336,9 +331,7 @@ sub determinePSC {
 sub determineScannerID {
 
     my $this = shift;
-    my ($tarchiveInfo,$to_log,$centerID,$NewScanner) = @_;
-    my $tarchive_srcloc = $tarchiveInfo->{'SourceLocation'};
-    my $upload_id = getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc);
+    my ($tarchiveInfo, $to_log, $centerID, $NewScanner, $upload_id) = @_;
     my $message = '';
     $to_log = 1 unless defined $to_log;
     if ($to_log) {
@@ -396,9 +389,8 @@ sub get_acquisitions {
 ################################################################
 sub computeMd5Hash {
     my $this = shift;
-    my ($file, $tarchive_srcloc) = @_;
+    my ($file, $upload_id) = @_;
     my $message = '';
-    my $upload_id = getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc);
     $message = "\n==> computing md5 hash for MINC body.\n";
     $this->{LOG}->print($message);
     $this->spool($message, 'N', $upload_id, $notify_detailed);
@@ -418,9 +410,8 @@ sub computeMd5Hash {
 sub getAcquisitionProtocol {
    
     my $this = shift;
-    my ($file,$subjectIDsref,$tarchiveInfoRef,$center_name,$minc,$acquisitionProtocol,$bypass_extra_file_checks) = @_;
-    my $tarchive_srcloc = $tarchiveInfoRef->{'SourceLocation'};
-    my $upload_id = getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc);
+    my ($file,$subjectIDsref,$tarchiveInfoRef,$center_name,$minc,
+        $acquisitionProtocol,$bypass_extra_file_checks, $upload_id) = @_;
     my $message = '';
 
     ############################################################
@@ -680,7 +671,7 @@ sub registerScanIntoDB {
     my $this = shift;
     my (
         $minc_file, $tarchiveInfo,$subjectIDsref,$acquisitionProtocol, 
-        $minc, $checks,$reckless, $tarchive, $sessionID
+        $minc, $checks,$reckless, $sessionID, $upload_id
     ) = @_;
 
     my $data_dir = NeuroDB::DBI::getConfigSetting(
@@ -695,8 +686,6 @@ sub registerScanIntoDB {
         $Date_taken,$minc_protocol_identified,
         $file_path,$tarchive_path,$fileID
     );
-    my $tarchive_srcloc = $tarchiveInfo->{'SourceLocation'};
-    my $upload_id = getUploadIDUsingTarchiveSrcLoc($tarchive_srcloc);
     my $message = '';
     ############################################################
     # Register scans into the database.  Which protocols to ####
@@ -757,8 +746,8 @@ sub registerScanIntoDB {
         ########################################################
         ### record which tarchive was used to make this file ###
         ########################################################
-        $tarchive_path   =   $tarchive;
-        $tarchive_path      =~  s/$data_dir\///i;
+        $tarchive_path =  $tarchiveInfo->{SourceLocation};
+        $tarchive_path =~ s/$data_dir\///i;
         $${minc_file}->setParameter(
             'tarchiveLocation', 
             $tarchive_path

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -217,10 +217,8 @@ print "\nlog dir is $LogDir and log file is $logfile \n" if $verbose;
 open LOG, ">>", $logfile or die "Error Opening $logfile";
 LOG->autoflush(1);
 # strings needed for the logHeader, if not set, as an argument, use empty string
-my $source_data_for_log = $tarchive;
-$source_data_for_log = "" unless $tarchive;
-my $upload_id_for_log = $upload_id;
-$upload_id_for_log    = "" unless $upload_id;
+my $source_data_for_log = $tarchive // "";
+my $upload_id_for_log = $upload_id // "";
 &logHeader();
 
 print LOG "\n==> Successfully connected to database \n" if $verbose;

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -355,8 +355,7 @@ my $candlogSth = $dbh->prepare($logQuery);
 ################################################################
 #### Loads/Creates File object and maps dicom fields ###########
 ################################################################
-my $file = $utility->loadAndCreateObjectFile($minc,
-			$tarchiveInfo{'SourceLocation'});
+my $file = $utility->loadAndCreateObjectFile($minc, $upload_id);
 
 ################################################################
 ##### Optionally do extra filtering, if needed #################

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -163,7 +163,7 @@ if (!$profile) {
     exit 3; 
 }
 
-if ( ($tarchive && $upload_id) || (!$tarchive && !$upload_id) ) {
+if ( !($tarchive xor $upload_id) ) {
     print "\nERROR: You should either specify an upload ID or a tarchive ".
         "path. Make sure that you set only one of those options. ".
         "Upload will exit now.\n\n\n";

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -84,6 +84,9 @@ my @opt_table = (
                  ["-tarchivePath","string",1, \$tarchive, "The absolute path". 
                   " to tarchive-file"],
 
+                 ["-uploadID", "string", 1, \$upload_id, "The upload ID " .
+                  "from which this MINC was created"],
+
                  ["-globLocation", "boolean", 1, \$globArchiveLocation,
                   "Loosen the validity check of the tarchive allowing for the". 
                   " possibility that the tarchive was moved to a different". 
@@ -124,11 +127,11 @@ Version :   $versionInfo
 
 The program does the following:
 
-- Loads the created minc file and then sets the appropriate parameter for 
+- Loads the created MINC file and then sets the appropriate parameter for
   the loaded object (i.e ScannerID, SessionID,SeriesUID, EchoTime, 
                      PendingStaging, CoordinateSpace , OutputType , FileType
                      ,TarchiveSource and Caveat)
-- Extracts the correct acquitionprotocol
+- Extracts the correct acquition protocol
 - Registers the scan into db by first changing the minc-path and setting extra
   parameters
 - Finally sets the series notification
@@ -160,8 +163,14 @@ if (!$profile) {
     exit 3; 
 }
 
+if ( ($tarchive && $upload_id) || (!$tarchive && !$upload_id) ) {
+    print "\nERROR: You should either specify an upload ID or a tarchive ".
+        "path. Make sure that you set only one of those options. ".
+        "Upload will exit now.\n\n\n";
+    exit; #TODO 1: use exit code from ExitCodes once it is merged
+}
 
-unless (-e $tarchive) {
+if ($tarchive && !(-e $tarchive) ) {
     print "\nERROR: Could not find archive $tarchive. \nPlease, make sure ".
           " the path to the archive is correct. Upload will exit now.\n\n\n";
     exit 4;
@@ -171,6 +180,9 @@ unless (-e $minc) {
           "path to the minc is correct. Upload will exit now.\n\n\n";
     exit 5;
 }
+
+
+
 
 ################################################################
 ############### Establish database connection ##################
@@ -204,6 +216,11 @@ my $logfile  = "$LogDir/$templog.log";
 print "\nlog dir is $LogDir and log file is $logfile \n" if $verbose;
 open LOG, ">>", $logfile or die "Error Opening $logfile";
 LOG->autoflush(1);
+# strings needed for the logHeader, if not set, as an argument, use empty string
+my $source_data_for_log = $tarchive;
+$source_data_for_log = "" unless $tarchive;
+my $upload_id_for_log = $upload_id;
+$upload_id_for_log    = "" unless $upload_id;
 &logHeader();
 
 print LOG "\n==> Successfully connected to database \n" if $verbose;
@@ -226,34 +243,56 @@ my $notifier = NeuroDB::Notify->new(\$dbh);
 ################################################################
 #################### Check is_valid column #####################
 ################################################################
-my $ArchiveLocation = $tarchive;
-$ArchiveLocation    =~ s/$tarchiveLibraryDir\/?//g;
+my ( $is_valid, $ArchiveLocation );
+if ($tarchive) {
+    # if the tarchive path is given as an argument, find the associated UploadID
+    # and check if IsTarchiveValidated is set to 1.
+    $ArchiveLocation = $tarchive;
+    $ArchiveLocation    =~ s/$tarchiveLibraryDir\/?//g;
 
-my $where = "WHERE t.ArchiveLocation='$tarchive'";
-if ($globArchiveLocation) {
-    $where = "WHERE t.ArchiveLocation LIKE '%".basename($tarchive)."'";
-}
-my $query = "SELECT m.IsTarchiveValidated FROM mri_upload m " .
-            "JOIN tarchive t on (t.TarchiveID = m.TarchiveID) $where ";
-print $query . "\n" if $debug;
-my $is_valid = $dbh->selectrow_array($query);
+    my $where = "WHERE t.ArchiveLocation='$tarchive'";
+    if ($globArchiveLocation) {
+        $where = "WHERE t.ArchiveLocation LIKE '%" . basename($tarchive) . "'";
+    }
+    my $query = "SELECT m.IsTarchiveValidated FROM mri_upload m " .
+        "JOIN tarchive t on (t.TarchiveID = m.TarchiveID) $where ";
+    print $query . "\n" if $debug;
+    $is_valid = $dbh->selectrow_array($query);
 
-## Setup  for the notification_spool table ##
-# get the tarchive_srcloc from $tarchive 
-$query = "SELECT SourceLocation".
+    ## Setup  for the notification_spool table ##
+    # get the tarchive_srcloc from $tarchive
+    $query = "SELECT SourceLocation" .
         " FROM tarchive t $where";
-my $sth = $dbh->prepare($query);
-$sth->execute();
-$tarchive_srcloc = $sth->fetchrow_array;
-# get the $upload_id from $tarchive_srcloc 
-$query =
-	"SELECT UploadID FROM mri_upload "
-	. "WHERE DecompressedLocation =?";
-$sth = $dbh->prepare($query);
-$sth->execute($tarchive_srcloc);
-$upload_id = $sth->fetchrow_array;
-## end of setup IDs for notification_spool table
-
+    my $sth = $dbh->prepare($query);
+    $sth->execute();
+    $tarchive_srcloc = $sth->fetchrow_array;
+    # get the $upload_id from $tarchive_srcloc
+    $query =
+        "SELECT UploadID FROM mri_upload "
+            . "WHERE DecompressedLocation =?";
+    $sth = $dbh->prepare($query);
+    $sth->execute($tarchive_srcloc);
+    $upload_id = $sth->fetchrow_array;
+    ## end of setup IDs for notification_spool table
+} elsif ($upload_id) {
+    # if the uploadID is passed as an argument, verify that the tarchive was
+    # validated
+    (my $query = <<QUERY) =~ s/\n/ /gm;
+    SELECT
+      m.IsTarchiveValidated,
+      t.ArchiveLocation
+    FROM
+      mri_upload m JOIN tarchive t ON (t.TarchiveID = m.TarchiveID)
+    WHERE
+      m.UploadID = ?
+QUERY
+    print $query . "\n" if $debug;
+    my $sth = $dbh->prepare($query);
+    $sth->execute($upload_id);
+    my @array        = $sth->fetchrow_array;
+    $is_valid        = $array[0];
+    $ArchiveLocation = $array[1];
+}
 
 if (($is_valid == 0) && ($force==0)) {
     $message = "\n ERROR: The validation has failed. ".
@@ -278,21 +317,22 @@ if (($is_valid == 0) && ($force==0)) {
 ################################################################
 ############ Get the $center_name, $centerID ##############
 ################################################################
-my ($center_name, $centerID) = $utility->determinePSC(\%tarchiveInfo,0);
+my ($center_name, $centerID) = $utility->determinePSC(
+                    \%tarchiveInfo, 0, $upload_id
+                );
 
 ################################################################
 #### Determine the ScannerID ###################################
 ################################################################
 my $scannerID = $utility->determineScannerID(
-                    \%tarchiveInfo,0,$centerID,
-                    $NewScanner
+                    \%tarchiveInfo, 0, $centerID, $NewScanner, $upload_id
                 );
 
 ################################################################
 ###### Construct the $subjectIDsref array ######################
 ################################################################
 my $subjectIDsref = $utility->determineSubjectID(
-                        $scannerID,\%tarchiveInfo,0
+                        $scannerID, \%tarchiveInfo, 0, $upload_id
                     );
 
 ################################################################
@@ -370,8 +410,7 @@ my ($sessionID, $requiresStaging) =
 ################################################################
 ############ Compute the md5 hash ##############################
 ################################################################
-my $unique = $utility->computeMd5Hash($file, 
-				$tarchiveInfo{'SourceLocation'});
+my $unique = $utility->computeMd5Hash( $file, $upload_id );
 if (!$unique) { 
     $message = "\n--> WARNING: This file has already been uploaded!\n";  
     print $message if $verbose;
@@ -408,10 +447,12 @@ if (defined($acquisitionProtocol)) {
   = $utility->getAcquisitionProtocol(
       $file,
       $subjectIDsref,
-      \%tarchiveInfo,$center_name,
+      \%tarchiveInfo,
+      $center_name,
       $minc,
       $acquisitionProtocol,
-      $bypass_extra_file_checks
+      $bypass_extra_file_checks,
+      $upload_id
     );
 
 
@@ -432,9 +473,9 @@ if($acquisitionProtocol =~ /unknown/) {
 ################################################################
 
 my $acquisitionProtocolIDFromProd = $utility->registerScanIntoDB(
-    \$file, \%tarchiveInfo,$subjectIDsref, 
-    $acquisitionProtocol, $minc, \@checks, 
-    $reckless, $tarchive, $sessionID
+    \$file,               \%tarchiveInfo, $subjectIDsref,
+    $acquisitionProtocol, $minc,          \@checks,
+    $reckless,            $sessionID,     $upload_id
 );
 
 if ((!defined$acquisitionProtocolIDFromProd)
@@ -508,7 +549,8 @@ sub logHeader () {
             AUTOMATED DICOM DATA UPLOAD
 ----------------------------------------------------------------
 *** Date and time of upload    : $date
-*** Location of source data    : $tarchive
+*** Location of source data    : $source_data_for_log
 *** tmp dir location           : $TmpDir
+*** Upload ID of source data   : $upload_id_for_log
 ";
 }

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -380,23 +380,23 @@ my ($sessionID, $requiresStaging) =
 ################################################################
 my ($ExtractSuffix,$study_dir,$header) = 
     $utility->extractAndParseTarchive(
-        $tarchive, $tarchiveInfo{'SourceLocation'}, $seriesuid);
+        $tarchive, $tarchiveInfo{'SourceLocation'}, $upload_id, $seriesuid
+    );
 
 
 ################################################################
 ##################### convert the dicom data to minc ###########
 ################################################################
 $utility->dicom_to_minc(
-    $study_dir,$converter,$get_dicom_info,
-    $exclude,$mail_user, $tarchiveInfo{'SourceLocation'});
+    $study_dir, $converter, $get_dicom_info, $exclude, $mail_user, $upload_id
+);
 
 
 ################################################################
 ############### get a list of mincs ############################
 ################################################################
 my @minc_files = ();
-$utility->get_mincs(\@minc_files,
-		     	 $tarchiveInfo{'SourceLocation'});
+$utility->get_mincs(\@minc_files, $upload_id);
 my $mcount = $#minc_files + 1;
 $message = "\nNumber of MINC files that will be considered for inserting ".
       "into the database: $mcount\n";
@@ -439,8 +439,9 @@ foreach my $minc (@minc_files) {
     }
     elsif (!$valid_study) {
         $newTarchiveLocation = 
-            $utility->moveAndUpdateTarchive($tarchive,
-					\%tarchiveInfo);
+            $utility->moveAndUpdateTarchive(
+                $tarchive, \%tarchiveInfo, $upload_id
+            );
     }
     $tarchive = $newTarchiveLocation;
 
@@ -502,15 +503,12 @@ foreach my $minc (@minc_files) {
 ################################################################
 ############### Compute SNR on 3D modalities ###################
 ################################################################
-$utility->computeSNR($tarchiveInfo{TarchiveID},
-                         $tarchiveInfo{'SourceLocation'},
-			 $profile);
+$utility->computeSNR($tarchiveInfo{TarchiveID}, $upload_id, $profile);
 ################################################################
 ####### Add order of acquisition for similar modalities ########
 ####### within the same session based on series number #########
 ################################################################
-$utility->orderModalitiesByAcq($tarchiveInfo{TarchiveID},
-                         $tarchiveInfo{'SourceLocation'});
+$utility->orderModalitiesByAcq($tarchiveInfo{TarchiveID}, $upload_id);
 
 
 if ($valid_study) {

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -342,24 +342,21 @@ if (($output != 0)  && ($force==0)) {
 ########## Get the $center_name, $centerID ################
 ################################################################
 my ($center_name, $centerID) =
-     $utility->determinePSC(\%tarchiveInfo,0);
+     $utility->determinePSC(\%tarchiveInfo, 0, $upload_id);
 
 ################################################################
 ######### Determine the ScannerID ##############################
 ################################################################
 my $scannerID = $utility->determineScannerID(
-                    \%tarchiveInfo,0,
-                    $centerID,
-                    $NewScanner
-                );
+        \%tarchiveInfo, 0, $centerID, $NewScanner, $upload_id
+);
 
 ################################################################
 ###### Construct the $subjectIDsref array ######################
 ################################################################
 my $subjectIDsref = $utility->determineSubjectID(
-                        $scannerID,
-                        \%tarchiveInfo,0
-                    );
+        $scannerID, \%tarchiveInfo, 0, $upload_id
+);
 
 ################################################################
 ###### Get the SessionID #######################################

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -235,7 +235,7 @@ if ($tarchiveid_count==0)  {
 #### Verify the archive using the checksum from database #######
 ################################################################
 ################################################################
-$utility->validateArchive($tarchive,\%tarchiveInfo);
+$utility->validateArchive($tarchive, \%tarchiveInfo, $upload_id);
 
 ################################################################
 ### Verify PSC information using whatever field ################ 
@@ -270,9 +270,7 @@ my $subjectIDsref = $utility->determineSubjectID(
 ################################################################
 ################################################################
 $utility->CreateMRICandidates(
-    $subjectIDsref,$gender,
-    \%tarchiveInfo,$User,
-    $centerID
+    $subjectIDsref, $gender, \%tarchiveInfo, $User, $centerID, $upload_id
 );
 
 ################################################################
@@ -283,9 +281,7 @@ $utility->CreateMRICandidates(
 ## correct here. ###############################################
 ################################################################
 ################################################################
-my $CandMismatchError= $utility->validateCandidate(
-				$subjectIDsref,
-				$tarchiveInfo{'SourceLocation'});
+my $CandMismatchError= $utility->validateCandidate($subjectIDsref);
 if (defined $CandMismatchError) {
     print "$CandMismatchError \n";
     ##Note that the script will not exit, so that further down
@@ -295,7 +291,7 @@ if (defined $CandMismatchError) {
 ############ Get the SessionID #################################
 ################################################################
 my ($sessionID, $requiresStaging) = 
-    $utility->setMRISession($subjectIDsref, \%tarchiveInfo);
+    $utility->setMRISession($subjectIDsref, \%tarchiveInfo, $upload_id);
 
 ################################################################
 ### Extract the tarchive and feed the dicom data dir to ######## 
@@ -303,7 +299,8 @@ my ($sessionID, $requiresStaging) =
 ################################################################
 my ($ExtractSuffix,$study_dir,$header) = 
     $utility->extractAndParseTarchive(
-                $tarchive, $tarchiveInfo{'SourceLocation'});
+        $tarchive, $tarchiveInfo{'SourceLocation'}, $upload_id
+    );
 
 ################################################################
 # Optionally do extra filtering on the dicom data, if needed ###

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -179,6 +179,11 @@ $ArchiveLocation       =~ s/$tarchiveLibraryDir\/?//g;
                     $globArchiveLocation
                 );
 
+# grep the upload_id from the tarchive's source location
+my $upload_id = NeuroDB::MRIProcessingUtility::getUploadIDUsingTarchiveSrcLoc(
+    $tarchiveInfo{SourceLocation}
+);
+
 ################################################################
 ############### Get the tarchive-id ############################
 ################################################################
@@ -237,7 +242,7 @@ $utility->validateArchive($tarchive,\%tarchiveInfo);
 ### contains site string #######################################
 ################################################################
 my ($center_name, $centerID) =
-    $utility->determinePSC(\%tarchiveInfo,1);
+    $utility->determinePSC(\%tarchiveInfo, 1, $upload_id);
 
 ################################################################
 ################################################################
@@ -246,8 +251,7 @@ my ($center_name, $centerID) =
 ################################################################
 ################################################################
 my $scannerID = $utility->determineScannerID(
-                    \%tarchiveInfo,1,
-                    $centerID,$NewScanner
+        \%tarchiveInfo, 1, $centerID, $NewScanner, $upload_id
                 );
 
 ################################################################
@@ -256,8 +260,8 @@ my $scannerID = $utility->determineScannerID(
 ################################################################
 ################################################################
 my $subjectIDsref = $utility->determineSubjectID(
-                        $scannerID,\%tarchiveInfo,1
-                    );
+        $scannerID, \%tarchiveInfo, 1, $upload_id
+);
 
 ################################################################
 ################################################################


### PR DESCRIPTION
Add an `-upload_id` option that can be used to call the `minc_insertion.pl` script. Will keep the `-tarchivePath` option as well.

Running minc_insertion.pl now requires that either `-tarchivePath` or `-upload_id` options are set (but not both at the same time). 
=> If `-tarchivePath` is given, the corresponding `UploadID` is fetched at the beginning of the script. The `UploadID` is then passed to the different functions of `MRIProcessingUtility.pm` for logging purposes instead of querying the `UploadID` based on the `-tarchivePath` in each function.

With this change, no dependant anymore on the tarchive location for logging purposes.

Linked Redmine ticket: https://redmine.cbrain.mcgill.ca/issues/13936
