### PR TITLE
[documentation] Fix tarchiveLoader after it was perlified

### DIFF
--- a/docs/scripts_md/tarchiveLoader.md
+++ b/docs/scripts_md/tarchiveLoader.md
@@ -56,14 +56,9 @@ contents of the following tables:
 
 ## Methods
 
-### logHeader($date, $tarchive, $TmpDir)
+### logHeader()
 
 Function that adds a header with relevant information to the log file
-
-INPUTS:
- - $date       : Date and time of upload
- - $tarchive   : Location of source data
- - $TmpDir     : Location of the temporary directory
 
 # TO DO
 

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -753,18 +753,13 @@ exit 0;
 
 =pod
 
-=head3 logHeader($date, $tarchive, $TmpDir)
+=head3 logHeader()
 
 Function that adds a header with relevant information to the log file
 
-INPUTS:
- - $date       : Date and time of upload
- - $tarchive   : Location of source data
- - $TmpDir     : Location of the temporary directory
-
 =cut
 
-sub logHeader ($date, $tarchive, $TmpDir) {
+sub logHeader () {
     print LOG "
     ----------------------------------------------------------------
             AUTOMATED DICOM DATA UPLOAD


### PR DESCRIPTION
arguments were added in this pull request https://github.com/aces/Loris-MRI/pull/246; need to be removed (check minc_insertion.pl and tarchvive_validation.pl; none has the arguments in their logHeader() function).