### PR TITLE
Initial refactoring of DBI.pm

### DIFF
--- a/dicom-archive/updateMRI_Upload.pl
+++ b/dicom-archive/updateMRI_Upload.pl
@@ -1,9 +1,12 @@
-#!/usr/bin/perl 
+#!/usr/bin/perl -w
 # Zia Mohades 2014
 # zia.mohades@mcgill.ca
 # Perl tool to update the mri_upload table
 
 use strict;
+
+use constant GET_COUNT    => 1;
+use constant EXACT_MATCH  => 0;
 
 use Cwd qw/ abs_path /;
 use File::Basename qw/ dirname /;
@@ -14,7 +17,18 @@ use Getopt::Tabular;
 use File::Basename;
 use lib "$FindBin::Bin";
 use DICOM::DICOM;
-use NeuroDB::DBI;
+
+use NeuroDB::Database;
+use NeuroDB::DatabaseException;
+
+use NeuroDB::objectBroker::ObjectBrokerException;
+use NeuroDB::objectBroker::ConfigOB;
+use NeuroDB::objectBroker::TarchiveOB;
+use NeuroDB::objectBroker::MriUploadOB;
+
+use TryCatch;
+
+use DateTime;
 
 my $verbose = 0;
 my $profile    = undef;
@@ -22,14 +36,14 @@ my $source_location = '';
 my $tarchive = '';
 my $query = '';
 my $sth = undef;
-my $tarchiveID = 0;
 my $User             = `whoami`;
+chomp $User;
 my $versionInfo = sprintf "%d revision %2d", q$Revision: 1.24 $
     =~ /: (\d+)\.(\d+)/;
 
 
-my $globArchiveLocation = 0;   # whether to use strict ArchiveLocation strings
-                               # or to glob them (like '%Loc')
+my $globArchiveLocation = EXACT_MATCH;   # whether to use strict ArchiveLocation strings
+                                         # or to glob them (like '%Loc')
 
 my $Help = <<HELP;
 *******************************************************************************
@@ -116,8 +130,14 @@ unless (-e $source_location) {
 ################################################################
 #####establish database connection if database option is set####
 ################################################################
-my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db); 
 print "Connecting to database.\n" if $verbose;
+my $db = NeuroDB::Database->new(
+    databaseName => $Settings::db[0],
+    userName     => $Settings::db[1],
+    password     => $Settings::db[2],
+    hostName     => $Settings::db[3]
+);
+$db->connect();
 
 ################################################################
 #####check to see if the tarchiveid is already set or not#######
@@ -126,64 +146,55 @@ print "Connecting to database.\n" if $verbose;
 ################################################################
 
 # fetch tarchiveLibraryDir from ConfigSettings in the database
-my $tarchiveLibraryDir = &NeuroDB::DBI::getConfigSetting(
-                            \$dbh,'tarchiveLibraryDir'
-                            );
+
+my $configOB = NeuroDB::objectBroker::ConfigOB->new(db => $db);
+my $tarchiveLibraryDir = $configOB->getTarchiveLibraryDir();
+
 # determine tarchive path stored in the database (without tarchiveLibraryDir)
 my $tarchive_path = $tarchive;
-$tarchive_path    =~ s/$tarchiveLibraryDir\/?//g;  
+$tarchive_path    =~ s/$tarchiveLibraryDir\/?//g;
 
-my $where         = " WHERE t.ArchiveLocation =?";
+# Check if there is already an mri upload record for the tarchive
+my $mriUploadOB = NeuroDB::objectBroker::MriUploadOB->new(db => $db);
+my $resultRef = $mriUploadOB->getWithTarchive(
+    GET_COUNT, $tarchive_path, $globArchiveLocation
+);
 
-if ($globArchiveLocation) {
-    $where = " WHERE t.ArchiveLocation LIKE ?";
-    $tarchive_path = basename($tarchive);
-}
-
-($query = <<QUERY) =~ s/\n/ /gm;
-SELECT 
-  COUNT(*) 
-FROM 
-  mri_upload m 
-JOIN 
-  tarchive t ON (t.TarchiveID=m.TarchiveID) 
-QUERY
-$query .= $where;
-$sth = $dbh->prepare($query);
-$sth->execute($tarchive_path);
-my $count = $sth->fetchrow_array;
-if($count>0) {
-   print "\n\tERROR: the tarchive is already uploaded \n\n"; 
+if($resultRef->[0]->[0] > 0) {
+   print "\n\tERROR: the tarchive is already uploaded \n\n";
    exit 6;
-} 
-
+}
 
 ################################################################
 #####get the tarchiveid from tarchive table#####################
 ################################################################
-($query = <<QUERY) =~ s/\n/ /gm;
-SELECT 
-  t.TarchiveID 
-FROM 
-  tarchive t 
-QUERY
-$query .= $where;
-$sth = $dbh->prepare($query);
-$sth->execute("%".$tarchive_path."%");
-my $tarchiveID = $sth->fetchrow_array;
 
+my $tarchiveOB = NeuroDB::objectBroker::TarchiveOB->new(db => $db);
+$resultRef = $tarchiveOB->getByTarchiveLocation(
+    ['TarchiveID'], $tarchive_path, $globArchiveLocation
+);
+
+if(@$resultRef != 1) {
+    die sprintf(
+        "Unexpected number of tarchive records with location %s found: %d\n",
+        $tarchive_path,
+        scalar(@$resultRef)
+    );
+}
+my $tarchiveID = $resultRef->[0]->[0];
 
 ################################################################
  #####populate the mri_upload columns with the correct values####
 ################################################################
-($query = <<QUERY) =~ s/\n/ /gm;
-INSERT INTO mri_upload 
-  (UploadedBy, UploadDate, TarchiveID, DecompressedLocation) 
-VALUES
-  (?, now(), ?, ?)
-QUERY
-my $mri_upload_insert = $dbh->prepare($query);
-$mri_upload_insert->execute($User,$tarchiveID,$source_location);
+
+$mriUploadOB->insert(
+    {
+      UploadedBy           => $User,
+      UploadDate           => DateTime->now()->strftime('%Y-%m-%d %H:%M:%S'),
+      TarchiveID           => $tarchiveID,
+      DecompressedLocation => $source_location
+    }
+);
 
 print "Done updateMRI_upload.pl execution!\n" if $verbose;
 exit 0;

--- a/uploadNeuroDB/NeuroDB/Database.pm
+++ b/uploadNeuroDB/NeuroDB/Database.pm
@@ -1,0 +1,325 @@
+package NeuroDB::Database;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::Database -- Provides a set of methods to run SQL statements on a database
+
+=head1 SYNOPSIS
+
+  use NeuroDB::Database;
+  use TryCatch;
+
+  my $db = NeuroDB::Database->new(
+      userName     => 'user',
+      databaseName => 'my_db',
+      hostName     => 'my_hostname',
+      password     => 'pwd'
+  );
+
+  try {
+      $db->connect();
+  } catch(NeuroDB::DatabaseException $e) {
+      die sprintf(
+          "User %s failed to connect to %s on %s: %s (error code %d)\n",
+          'user',
+          'my_db',
+          'my_hostname',
+          $e->errorMessage,
+          $e->errorCode
+      );
+  }
+
+  .
+  .
+  .
+
+  try {
+      $db->pselect(
+          'SELECT * FROM candidate WHERE pscid = ?', 'MTL135'
+      );
+  } catch(NeuroDB::DatabaseException $e) {
+      die sprintf(
+          "SELECT on candidate table failed: %s (error code=%d)",
+          $e->errorMessage,
+          $e->errorCode
+      );
+  }
+
+=head1 DESCRIPTION
+
+This class provides the basic SELECT, INSERT, UPDATE and DELETE methods
+for all object brokers. The methods of this class should only be used by
+the object brokers themselves (except 'new' for creating a new database
+instance and 'connect'). Scripts and 'non-broker' classes that need access
+to the database should rely on an appropriate object broker class to handle
+the requests.
+
+=head2 Methods
+
+=cut
+
+use Moose;
+use MooseX::Privacy;
+use DBI;
+use TryCatch;
+
+use constant DEFAULT_DB_PORT => 3306;
+
+=pod
+
+=head3 C<< new(userName => $u, databaseName => $d, hostname => $h, password => $pwd, port =>$port) >>  (constructor)
+
+Create a new instance of this class, without actually trying to connect
+to the database specified. All parameters are required except 'port', which
+defaults to 3306 if not specified. If the user name, database name or host
+name are the empty string, the constructor will call C<die>.
+
+INPUT: a set of properties for the current database:
+
+=over
+
+=item userName
+
+name of the user for the (upcoming) connection
+
+=item databaseName
+
+name of the database
+
+=item hostName
+
+name of the host on which the database resides
+
+=item password
+
+password for the (upcoming) connection
+
+=item port
+
+port used for the (upcoming) connection (defaults to 3306 if not provided)
+
+=back
+
+RETURNS: new instance of this class.
+
+=cut
+
+has 'userName'     => (is  => 'ro', isa => 'Str', required => 1);
+
+has 'databaseName' => (is  => 'ro', isa => 'Str', required => 1);
+
+has 'hostName'     => (is  => 'ro', isa => 'Str', required => 1);
+
+has 'password'     => (is  => 'ro', isa => 'Str', required => 1);
+
+has 'port'         => (is  => 'ro', isa => 'Int', default => DEFAULT_DB_PORT);
+
+has 'dbh'          => (is  => 'rw', init_arg => undef, traits => [qw/Private/]);
+
+sub BUILD {
+    my $self = shift;
+
+    die "User name cannot be the empty string.\n"     if $self->userName     eq '';
+    die "Database name cannot be the empty string.\n" if $self->databaseName eq '';
+    die "Host name cannot be the empty string.\n"     if $self->hostName     eq '';
+}
+
+=pod
+
+=head3 C<connect()>
+
+Attempts to connect to the database using the connection parameters passed
+at construction time. This method will throw a DatabaseException if the
+connection could not be established.
+
+=cut
+
+sub connect {
+    my $self = shift;
+
+    my $connectStatement = sprintf(
+         "DBI:mysql:database=%s;host=%s;port=%d;",
+         $self->databaseName,
+         $self->hostName,
+         $self->port
+    );
+
+    try {
+        $self->dbh(
+            DBI->connect(
+                $connectStatement,
+                $self->userName,
+                $self->password,
+                { PrintError => 0, RaiseError => 1, AutoCommit => 1 }
+            )
+        );
+    } catch {
+        NeuroDB::DatabaseException->throw(
+            statement    => $connectStatement,
+            args         => [],
+            errorCode    => $DBI::err,
+            errorMessage => $DBI::errstr
+        );
+    }
+}
+
+=pod
+
+=head3 C<pselect($query, @args)>
+
+Executes a select query on the database. This method will first C<prepare>
+the statement passed as parameter before sending the request to the database.
+
+INPUTS: select query to execute (containing the argument placeholders if any)
+        list of arguments to replace the placeholders with.
+
+RETURNS: a reference to the array of records found. Each record is in fact a
+         reference to the list of values for the columns selected
+=cut
+
+sub pselect {
+    my $self = shift;
+    my($query, @args) = @_;
+
+    try {
+        my $sth = $self->dbh()->prepare($query);
+        $sth->execute(@args);
+
+        return $sth->fetchall_arrayref;
+    } catch {
+        NeuroDB::DatabaseException->throw(
+            statement    => $query,
+            args         => [@args],
+            errorCode    => $DBI::err,
+            errorMessage => $DBI::errstr
+        );
+    }
+}
+
+=pod
+
+=head3 C<insertOne($tableName, $valuesRef)>
+
+Inserts one record in a given database table with the specified column values.
+This method will throw a DatabaseException if the record cannot be inserted.
+
+INPUT: the name of the table in which to insert the record
+       a reference to a hash array describing the column names and their values
+       for the given record.
+
+RETURNS: the ID of the record inserted.
+
+=cut
+
+sub insertOne {
+    my $self = shift;
+    my($tableName, $valuesRef) = @_;
+
+    $self->insert($tableName, [ keys %$valuesRef ], [[ values %$valuesRef]]);
+
+    my $query = "SELECT last_insert_id()";
+    try {
+        my $sth = $self->dbh()->prepare($query);
+        $sth->execute();
+
+        return $sth->fetchrow_array;
+    } catch {
+        NeuroDB::DatabaseException->throw(
+            statement    => $query,
+            args         => undef,
+            errorCode    => $DBI::err,
+            errorMessage => $DBI::errstr
+        );
+    }
+}
+
+=pod
+
+=head3 C<insert($tableName, $columnNamesRef, $valuesRef)>
+
+Inserts one record in a given database table with the specified column values.
+This method will throw a C<DatabaseException> if the record cannot be inserted.
+
+INPUT: the name of the table in which to insert the record
+       a reference to an array containing the names of the columns whose values
+       will be modified by this C<insert> statement.
+       a reference to an array of array references. This "matrix" contains the
+       values of each column for each record.
+
+=cut
+
+sub insert {
+    my $self = shift;
+    my($tableName, $columnNamesRef, $valuesRef) = @_;
+
+    # @allValues = $valuesRef, flattened as one big array
+    my @valuesPlaceholders = ();
+    my @allValues = ();
+    foreach my $r (@$valuesRef) {
+        push(@valuesPlaceholders, join(',', map { '?' } @$r));
+        push(@allValues, @$r);
+    }
+
+    my $query = sprintf(
+        "INSERT INTO %s (%s) VALUES (%s)",
+        $tableName,
+        join(',', @$columnNamesRef),
+        join(',', @valuesPlaceholders)
+    );
+
+    try {
+        my $sth = $self->dbh()->prepare($query);
+        $sth->execute(@allValues);
+    } catch {
+        NeuroDB::DatabaseException->throw(
+            statement    => $query,
+            args         => [ @allValues ],
+            errorCode    => $DBI::err,
+            errorMessage => $DBI::errstr
+        );
+    }
+}
+
+=pod
+
+=head3 C<disconnect()>
+
+Terminates the connection previously instantiated to the database if a 
+connection was previously established.
+
+=cut
+
+sub disconnect {
+	my $self = shift;
+	
+        if($self->dbh) {
+	    try {
+	        $self->dbh->disconnect();
+	    } catch {
+	   	NeuroDB::DatabaseException->throw(
+                    statement    => 'Call to disconnect failed',
+                    args         => [],
+                    errorCode    => $DBI::err,
+                    errorMessage => $DBI::errstr
+                );
+            }
+	}
+}
+
+=pod
+
+=head3 C<DESTROY()>
+
+Object destructor: terminates the connection previously instantiated to the
+database (if any).
+
+=cut
+sub DESTROY {
+	my $self = shift;
+	
+	$self->disconnect();
+}
+
+1;

--- a/uploadNeuroDB/NeuroDB/DatabaseException.pm
+++ b/uploadNeuroDB/NeuroDB/DatabaseException.pm
@@ -1,0 +1,123 @@
+package NeuroDB::DatabaseException;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::DatabaseException -- Exception for database related errors.
+
+=head1 SYNOPSIS
+
+  use NeuroDB::DatabaseException;
+
+  .
+  .
+  .
+
+  NeuroDB::DatabaseException->throw(
+      statement    => 'SELECT * from Foo WHERE x=? AND y=?',
+      args         => [1, 2],
+      errorCode    => $DBI::err,
+      errorMessage => $DBI::errstr
+  );
+
+=head1 DESCRIPTION
+
+This class is the base class for database-related exceptions. You use this
+class by calling the C<throw> method with the specified parameters (all of
+which are required). This will build a new instance of this class and throw
+it as expected. The throw method of this class will call C<die> if the error
+code is zero and the error message is defined or if the error code is not
+0 and the error message is undefined.
+
+=cut
+
+use Moose;
+with 'Throwable';
+
+use overload '""' => 'toString';
+
+has 'statement'    => (is  => 'ro', isa => 'Str'            , required => 1);
+
+has 'args'         => (is  => 'ro', isa => 'Maybe[ArrayRef]', required => 1);
+
+has 'errorCode'    => (is  => 'ro', isa => 'Maybe[Int]'     , required => 1);
+
+has 'errorMessage' => (is  => 'ro', isa => 'Maybe[Str]'     , required => 1);
+
+sub BUILD {
+    my $self = shift;
+
+    if($self->errorCode == 0 && defined($self->errorMessage)) {
+        die "Cannot have a DatabaseTransactionResult with " .
+            "a zero error code and a non-empty error message";
+    }
+
+    if($self->errorCode != 0 && !defined($self->errorMessage)) {
+        die "Cannot have a DatabaseTransactionResult with " .
+            "a non-zero error code and an empty error message";
+    }
+}
+
+=pod
+
+=head3 C<toString()>
+
+Default representation of this exception when used in a string context.
+Among other things, the returned string will be used for uncaught exceptions
+that make a script die. Note that the returned string can be useful for debugging
+purposes when trying to diagnose why a particular SQL statement did not execute
+successfully.
+
+=cut
+sub toString {
+    my $self = shift;
+
+    my $toString;
+    
+    # For anything other than a connection error
+    if($self->statement =~ /^(select|insert|update|delete)/i) {
+		$toString = "The following database commands failed:\n";
+		# Write the statement used to prepare $self->statement
+		# Make sure that single quotes are escaped the interpolating $self->statement
+        my $formattedStatement = $self->statement;
+        $formattedStatement =~ s#'#\\'#g;
+        $toString .= sprintf("\tPREPARE s FROM '%s';\n", $formattedStatement);
+        
+        # Write the statement that sets the MySQL variables and values foreach
+        if(@{$self->args} ) {
+			my @definedArgs = grep(defined $_, @{$self->args});
+			map { $_ =~ s#'#\\'#g } @definedArgs;
+		    $toString .= sprintf(
+		        "\tSET %s;\n",
+		        join(',', map { "\@x$_='$definedArgs[$_-1]'" } 1..@definedArgs)
+		    );
+		}
+		
+		# Write EXECUTE statement 
+		$toString .= "\tEXECUTE s";
+		$toString .= sprintf(
+		    " USING %s",
+		    join(',', map { "\@x$_" } 1..@{ $self->args })
+		);
+		$toString .= ";\n";
+		$toString .= sprintf(
+		    "Error obtained:%s (error code %s)\n",
+		    $self->errorMessage,
+		    $self->errorCode 
+		);
+	}
+	# For connection errors
+    else {
+		$toString = sprintf(
+		    "Connection command '%s' failed\nError returned: %s (error code %s)\n",
+		    $self->statement,
+		    $self->errorMessage,
+		    $self->errorCode,
+		)
+	}
+
+    return $toString;
+};
+
+1;

--- a/uploadNeuroDB/NeuroDB/objectBroker/ConfigOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/ConfigOB.pm
@@ -1,0 +1,142 @@
+package NeuroDB::objectBroker::ConfigOB;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::objectBroker::ConfigOB -- An object broker for configuration settings
+
+=head1 SYNOPSIS
+
+  use NeuroDB::Database;
+  use NeuroDB::objectBroker::ConfigOB;
+  use TryCatch;
+
+  my $db = NeuroDB::Database->new(
+      userName     => 'user',
+      databaseName => 'my_db',
+      hostName     => 'my_hostname',
+      password     => 'pwd'
+  );
+
+  try {
+      $db->connect();
+  } catch(NeuroDB::DatabaseException $e) {
+      die sprintf(
+          "User %s failed to connect to %s on %s: %s (error code %d)\n",
+          'user',
+          'my_db',
+          'my_hostname',
+          $e->errorMessage,
+          $e->errorCode
+      );
+  }
+
+  .
+  .
+  .
+
+  my $configOB = NeuroDB::objectBroker::ConfigOB(db => $db);
+  my $tarchiveLibraryPath;
+  try {
+      $tarchiveLibraryPath = $configOB->getTarchiveLibraryPath();
+  } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+      die sprintf(
+          "Failed to retrieve tarchive library path: %s",
+          $e->errorMessage
+      );
+  }
+
+=head1 DESCRIPTION
+
+This class provides a set of methods to fetch specific configuration settings
+from the C<Config> LORIS database.
+
+=head2 Methods
+
+=cut
+
+use Moose;
+use MooseX::Privacy;
+
+use NeuroDB::Database;
+use NeuroDB::DatabaseException;
+use NeuroDB::objectBroker::ObjectBrokerException;
+
+use TryCatch;
+
+use constant TARCHIVE_LIBRARY_DIR => 'tarchiveLibraryDir';
+
+=pod
+
+=head3 new(db => $db) >> (constructor)
+
+Create a new instance of this class. The only parameter to provide is the
+C<Database> object used to access the database.
+
+INPUT: the database object used to fetch the settings.
+
+RETURNS: new instance of this class.
+
+=cut
+
+has 'db'     => (is  => 'rw', isa => 'NeuroDB::Database', required => 1);
+
+
+=head3 &$getConfigSettingRef($setting)
+
+Private method. This method fetches setting C<$setting> from the LORIS table 
+Config. It will throw a C<NeuroDB::objectBroker::ObjectBrokerException> if either
+the database transaction failed for some reason or it succeeded but returned no
+results (i.e. setting $setting does not exist).
+
+INPUT: name of the setting to fetch.
+
+RETURNS: the setting value (as a string). If the setting value is NULL, then this
+         method will return C<undef>.
+
+=cut
+
+my $getConfigSettingRef = sub {
+    my($self, $setting) = @_;
+
+    my $result;
+    try {
+        $result = $self->db->pselect(
+            'SELECT c.value FROM Config c '
+                . 'JOIN ConfigSettings cs ON (cs.ID=c.ConfigID) '
+                . 'WHERE cs.Name = ?',
+            $setting
+        );
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf("Failed to get config setting '%s': %s",
+                                    $setting, $e->errorMessage)
+        );
+    }
+
+    if(@$result == 0) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => "Setting '$setting' does not exist in database table Config"
+        );
+    }
+
+    return $result->[0]->[0];
+};
+
+=head3 getTarchiveLibraryDir()
+
+Gets the tarchive library dir.
+
+RETURNS: value (string) of the tarchive library dir in the Config table.
+
+=cut
+
+sub getTarchiveLibraryDir {
+    my $self = shift;
+
+    return &$getConfigSettingRef($self, TARCHIVE_LIBRARY_DIR);
+}
+
+
+1;

--- a/uploadNeuroDB/NeuroDB/objectBroker/MriUploadOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriUploadOB.pm
@@ -1,0 +1,184 @@
+package NeuroDB::objectBroker::MriUploadOB;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::objectBroker::MriUploadOB -- An object broker for MRI uploads
+
+=head1 SYNOPSIS
+
+  use NeuroDB::Database;
+  use NeuroDB::objectBroker::MriUploadOB;
+  use TryCatch;
+
+  my $db = NeuroDB::Database->new(
+      userName     => 'user',
+      databaseName => 'my_db',
+      hostName     => 'my_hostname',
+      password     => 'pwd'
+  );
+
+  try {
+      $db->connect();
+  } catch(NeuroDB::DatabaseException $e) {
+      die sprintf(
+          "User %s failed to connect to %s on %s: %s (error code %d)\n",
+          'user',
+          'my_db',
+          'my_hostname',
+          $e->errorMessage,
+          $e->errorCode
+      );
+  }
+
+  .
+  .
+  .
+
+  my $mriUploadOB = NeuroDB::objectBroker::MriUploadOB->new(db => $db);
+  my $mriUploadsRef;
+  try {
+      $mriUploadsRef= $mriUploadOB->getWithTarchive(
+          1, '/tmp/my_tarchive.tar.gz', 1
+      );
+  } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+      die sprintf(
+          "Failed to retrieve MRI uploads: %s",
+          $e->errorMessage
+      );
+  }
+
+=head1 DESCRIPTION
+
+This class provides a set of methods to either fetch or insert mri upload
+records. The operations are always performed on database table C<mri_upload>.
+Each method will throw a C<NeuroDB::objectBroker::ObjectBrokerException> if 
+the request could not be performed successfully.
+
+=head2 Methods
+
+=cut
+
+use Moose;
+use MooseX::Privacy;
+
+use File::Basename;
+
+use NeuroDB::Database;
+use NeuroDB::DatabaseException;
+use NeuroDB::objectBroker::ObjectBrokerException;
+
+use TryCatch;
+
+# These are the only fields modified when inserting a new MRI upload record
+my @MRI_UPLOAD_FIELDS = ('UploadedBy' ,'UploadDate','TarchiveID','DecompressedLocation');
+
+=pod
+
+=head3 new(db => $db) >> (constructor)
+
+Create a new instance of this class. The only parameter to provide is the
+C<Database> object used to access the database.
+
+INPUT: the database object used to read/modify the C<mri_upload> table.
+
+RETURNS: new instance of this class.
+
+=cut
+
+has 'db'     => (is  => 'rw', isa => 'NeuroDB::Database', required => 1);
+
+=pod
+
+=head3 getWithTarchive($isCount, $tarchiveLocation, $isBaseNameMatch)
+
+Fetches the entries in the C<mri_upload> table that have a specific archive
+location. This method throws a C<NeuroDB::objectBroker::ObjectBrokerException>
+if the operation could not be completed successfully.
+
+INPUT: a boolean indicating if only a count of the records found is needed
+       of the full record properties
+       the path of the archive location
+       a boolean indicating if a match is sought on the full archive name
+       or only the basename
+
+RETURNS: a reference to an array of array references. If C<$isCount> is true, then
+         C<$returnValue->[0]->[0]> will contain the count of records sought. Otherwise
+         C<$returnValue->[x]->[y]> will contain the value of the yth column (in array
+         C<@MRI_UPLOAD_FIELDS> for the xth record retrieved.
+
+=cut
+
+sub getWithTarchive {
+    my($self, $isCount, $tarchiveLocation, $isBaseNameMatch) = @_;
+
+    my $select = $isCount         ? 'COUNT(*)'   : join(',', @MRI_UPLOAD_FIELDS);
+    my $where  = $isBaseNameMatch ? 'LIKE ?' : '=?';
+
+    my $query = "SELECT $select "
+        .       "FROM mri_upload "
+        .       "JOIN tarchive USING(TarchiveID) "
+        .       "WHERE ArchiveLocation $where ";
+
+    try {
+        return $self->db->pselect(
+            $query,
+            $isBaseNameMatch ? ('%' . basename($tarchiveLocation) . '%') : $tarchiveLocation
+        );
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to retrieve mri upload records. Reason:\n%s",
+                $e
+            )
+        );
+    }
+}
+
+=pod
+
+=head3 insert($valuesRef)
+
+Inserts a new record in the C<mri_upload> table with the specified column values.
+This method throws a C<NeuroDB::objectBroker::ObjectBrokerException> if the operation
+could not be completed successfully.
+
+INPUT: a reference to a hash of the values to insert. The hash contains the column
+       names and associated record values used during insertion. All the keys of
+       C<%$valuesRef> must exist in C<@MRI_UPLOAD_FIELDS> or an exception will be thrown.
+
+RETURNS: the index of the MRI upload record inserted.
+
+=cut
+
+sub insert {
+    my($self, $valuesRef) = @_;
+
+    if(!keys %$valuesRef) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => "MRI upload insertion failed: no values specified"
+        );
+    }
+
+    foreach my $v (keys %$valuesRef) {
+        if(!grep($v eq $_, @MRI_UPLOAD_FIELDS)) {
+            NeuroDB::objectBroker::ObjectBrokerException->throw(
+                errorMessage => "MRI upload insertion failed: invalid MRI upload field $v"
+            );
+        }
+    }
+
+    try {
+        return $self->db->insertOne('mri_upload', $valuesRef);
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to insert mri_upload record. Reason:\n%s",
+                $e
+            )
+        );
+    }
+}
+
+1;

--- a/uploadNeuroDB/NeuroDB/objectBroker/ObjectBrokerException.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/ObjectBrokerException.pm
@@ -1,0 +1,57 @@
+package NeuroDB::objectBroker::ObjectBrokerException;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::objectBroker::ObjectBrokerException -- Exception for all unexpected errors
+related to an object broker
+
+=head1 SYNOPSIS
+
+  use NeuroDB::objectBroker::ObjectBrokerException;
+
+  .
+  .
+  .
+
+  NeuroDB::objectBroker::ObjectBrokerException->throw(
+      errorMessage => 'Failed to perform the requested task'
+  );
+
+=head1 DESCRIPTION
+
+This class is the base class for object broker related exceptions. All object
+brokers should use this class to report unexpected errors/behaviour. You use this
+class by calling the C<throw> method with a specific error message (passed
+as argument). This will build a new instance of this class and throw
+it as expected.
+
+=cut
+
+use Moose;
+with 'Throwable';
+
+use overload '""' => 'toString';
+
+has 'errorMessage' => (is  => 'ro', isa => 'Str', required => 1);
+
+=pod
+
+=head3 C<toString()>
+
+Default string representation of this exception: its associated error
+message.
+
+=cut
+sub toString {
+    my $self = shift;
+
+    my $msg = sprintf("ERROR: %s", $self->errorMessage);
+    $msg .= "\n" unless $msg =~ /\n/;
+    
+    return $msg;
+};
+
+1;
+1;

--- a/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
@@ -1,0 +1,140 @@
+package NeuroDB::objectBroker::TarchiveOB;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::objectBroker::TarchiveOB -- An object broker for tarchive records
+
+=head1 SYNOPSIS
+
+  use NeuroDB::Database;
+  use NeuroDB::objectBroker::TarchiveOB;
+  use TryCatch;
+
+  my $db = NeuroDB::Database->new(
+      userName     => 'user',
+      databaseName => 'my_db',
+      hostName     => 'my_hostname',
+      password     => 'pwd'
+  );
+
+  try {
+      $db->connect();
+  } catch(NeuroDB::DatabaseException $e) {
+      die sprintf(
+          "User %s failed to connect to %s on %s: %s (error code %d)\n",
+          'user',
+          'my_db',
+          'my_hostname',
+          $e->errorMessage,
+          $e->errorCode
+      );
+  }
+
+  .
+  .
+  .
+
+  my $tarchiveOB = NeuroDB::objectBroker::TarchiveOB->new(db => $db);
+  my $tarchivesRef;
+  try {
+      $tarchivesRef = $tarchiveOB->getByTarchiveLocation(
+          [ 'TarchiveID' ], '/tmp/my_tarchive.tar.gz', 1
+      );
+  } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+      die sprintf(
+          "Failed to retrieve tarchive records: %s",
+          $e->errorMessage
+      );
+  }
+
+=head1 DESCRIPTION
+
+This class provides a set of methods to either fetch records from the C<tarchive>
+table, insert new entries in it or update existing ones. If an operation cannot
+be executed successfully, a C<NeuroDB::objectBroker::ObjectBrokerException> is thrown.
+
+=head2 Methods
+
+=cut
+
+use Moose;
+use MooseX::Privacy;
+
+use NeuroDB::Database;
+use NeuroDB::DatabaseException;
+use NeuroDB::objectBroker::ObjectBrokerException;
+
+use File::Basename;
+
+use TryCatch;
+
+my @TARCHIVE_FIELDS = qw(TarchiveID ArchiveLocation);
+
+=pod
+
+=head3 new(db => $db) >> (constructor)
+
+Create a new instance of this class. The only parameter to provide is the
+C<Database> object used to access the database.
+
+INPUT: the database object used to read/modify the C<tarchive> table.
+
+RETURNS: new instance of this class.
+
+=cut
+
+has 'db' => (is  => 'rw', isa => 'NeuroDB::Database', required => 1);
+
+=pod
+
+=head3 getByTarchiveLocation($fieldsRef, $tarchiveLocation, $baseNameMatch)
+
+Fetches the records from the C<tarchive> table that have a specific archive location.
+
+INPUT: a reference to an array of the column names to return for each record found.
+       Each element of this array must exist in C<@TARCHIVE_FIELDS> or an exception
+       will be thrown.
+       the path of the archive used during the search
+       a boolean indicating if an exact match is sought (false) or if only basenames
+       should be used when comparing two archive locations (true)
+
+RETURNS: a reference to an array of array references. This "matrix" contains the
+         values of each colum for each record.
+
+=cut
+
+sub getByTarchiveLocation {
+    my($self, $fieldsRef, $tarchiveLocation, $baseNameMatch) = @_;
+
+    foreach my $f (@$fieldsRef) {
+        if(!grep($f eq $_, @TARCHIVE_FIELDS)) {
+            NeuroDB::objectBroker::ObjectBrokerException->throw(
+                errorMessage => "Failed to retrieve tarchive record: invalid tarchive field $f"
+            );
+        }
+    }
+
+    my $query = sprintf(
+        "SELECT %s FROM tarchive WHERE ArchiveLocation %s",
+        join(',', (@$fieldsRef ? @$fieldsRef : @TARCHIVE_FIELDS)),
+        $baseNameMatch ? 'LIKE ?' : '=?'
+    );
+
+    try {
+        return $self->db->pselect(
+            $query,
+            $baseNameMatch ? ('%' . basename($tarchiveLocation) . '%') : $tarchiveLocation
+        );
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to get tarchive records by tarchive location. Reason:\n%s",
+                $e
+            )
+        );
+    }
+}
+
+1;


### PR DESCRIPTION
This is PR #277 reissued on branch major. I added the corrections suggested by @cmadjar and a new feature: a toString() method for all exception classes that returns the string representation of an exception instance. With this method, if a script dies because an exception was not caught a (hopefully) meaningful message will be displayed instead of "Exception ObjectBrokerException thrown".