### PR TITLE
Improve minc_insertion.pl command line validation

### DIFF
--- a/uploadNeuroDB/NeuroDB/ExitCodes.pm
+++ b/uploadNeuroDB/NeuroDB/ExitCodes.pm
@@ -106,6 +106,10 @@ our $ARG_FILE_DOES_NOT_EXIST = 5; # if file given as an argument does not exist
 # called from minc_insertion.pl & register_processed_data.pl
 our $FILE_NOT_UNIQUE = 6; # if file to register is not unique & already
                            # inserted
+                           
+# Used when an environment variable is either missing or has an invalid
+# value
+our $INVALID_ENVIRONMENT_VAR = 7;
 
 
 

--- a/uploadNeuroDB/NeuroDB/ExitCodes.pm
+++ b/uploadNeuroDB/NeuroDB/ExitCodes.pm
@@ -111,6 +111,7 @@ our $FILE_NOT_UNIQUE = 6; # if file to register is not unique & already
 # value
 our $INVALID_ENVIRONMENT_VAR = 7;
 
+our $INVALID_ARG             = 8; # if one of the program argument is invalid
 
 
 

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -263,10 +263,16 @@ if ($tarchive) {
 
     if(!defined $is_valid) {
 		my $errorMessage = $globArchiveLocation
-		    ? "No mri_upload with the same archive location basename as '$tarchive'"
-		    : "No mri_upload with archive location '$tarchive'";
-		die "$errorMessage\n";
-	} 
+		    ? "No mri_upload with the same archive location basename as '$tarchive'\n"
+		    : "No mri_upload with archive location '$tarchive'\n";
+        $utility->writeErrorLog(
+                $errorMessage, $NeuroDB::ExitCodes::INVALID_ARG, $logfile
+        );
+        $notifier->spool('tarchive validation', $errorMessage, 0,
+                         'minc_insertion.pl', $upload_id, 'Y', 
+                         $notify_notsummary);
+        exit $NeuroDB::ExitCodes::INVALID_ARG;
+ 	} 
 	
     ## Setup  for the notification_spool table ##
     # get the tarchive_srcloc from $tarchive
@@ -278,10 +284,17 @@ if ($tarchive) {
     
     if(!defined $tarchive_srcloc) {
 		my $errorMessage = $globArchiveLocation
-		    ? "No tarchive with the same source location basename as '$tarchive'"
-		    : "No tarchive with source location '$tarchive'";
-		die "$errorMessage\n";
-	} 
+		    ? "No tarchive with the same source location basename as '$tarchive'\n"
+		    : "No tarchive with source location '$tarchive'\n";
+		    
+        $utility->writeErrorLog(
+                $errorMessage, $NeuroDB::ExitCodes::INVALID_ARG, $logfile
+        );
+        $notifier->spool('tarchive validation', $errorMessage, 0,
+                         'minc_insertion.pl', $upload_id, 'Y', 
+                         $notify_notsummary);
+        exit $NeuroDB::ExitCodes::INVALID_ARG;
+    } 
 
     # get the $upload_id from $tarchive_srcloc
     $query =

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -149,7 +149,7 @@ USAGE
 
 if (!$ENV{LORIS_CONFIG}) {
 	print STDERR "\n\tERROR: Environment variable 'LORIS_CONFIG' not set\n\n";
-	exit 1;  # TODO replace by appropriate exit code from ExitCodes once it is defined
+	exit $NeuroDB::ExitCodes::INVALID_ENVIRONMENT_VAR; 
 }
 
 if (!defined $profile || !-e "$ENV{LORIS_CONFIG}/.loris_mri/$profile") {

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -254,7 +254,7 @@ if ($tarchive) {
     my $where = "WHERE t.ArchiveLocation='$tarchive'";
     if ($globArchiveLocation) {
         $where = "WHERE t.ArchiveLocation LIKE '%/" . quotemeta(basename($tarchive)) . "' "
-            .    "OR t.ArchiveLocation LIKE '" . quotemeta(basename($tarchive)) . "'";
+            .    "OR t.ArchiveLocation = '" . quotemeta(basename($tarchive)) . "'";
     }
     my $query = "SELECT m.IsTarchiveValidated FROM mri_upload m " .
         "JOIN tarchive t on (t.TarchiveID = m.TarchiveID) $where ";

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -253,7 +253,8 @@ if ($tarchive) {
 
     my $where = "WHERE t.ArchiveLocation='$tarchive'";
     if ($globArchiveLocation) {
-        $where = "WHERE t.ArchiveLocation LIKE '%/" . basename($tarchive) . "'";
+        $where = "WHERE t.ArchiveLocation LIKE '%/" . quotemeta(basename($tarchive)) . "' "
+            .    "OR t.ArchiveLocation LIKE '" . quotemeta(basename($tarchive)) . "'";
     }
     my $query = "SELECT m.IsTarchiveValidated FROM mri_upload m " .
         "JOIN tarchive t on (t.TarchiveID = m.TarchiveID) $where ";


### PR DESCRIPTION
This PR adds validation to the arguments passed on the command line and also gets rid of some warnings that were popping up when I tested this script. It also makes sure that the `globArchiveLocation` option behaves like it should by correcting the MySQL statement used to fetch a `tarchive` based on its `ArchiveSource`'s base name