### PR TITLE
Refactoring of MriProcessingUtility::getUploadIDUsingTarchiveSrcLoc()

### DIFF
--- a/tools/BackPopulateSNRAndAcquisitionOrder.pl
+++ b/tools/BackPopulateSNRAndAcquisitionOrder.pl
@@ -59,6 +59,15 @@ if ($profile && !@Settings::db) {
 ######### Establish database connection ########################
 ################################################################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+
+my $db = NeuroDB::Database->new(
+    databaseName => $Settings::db[0],
+    userName     => $Settings::db[1],
+    password     => $Settings::db[2],
+    hostName     => $Settings::db[3]
+);
+$db->connect();
+
 print "\nSuccessfully connected to database \n";
 
 ################################################################
@@ -89,7 +98,7 @@ my $logfile  = "$LogDir/$templog.log";
 ################## Instantiate MRIProcessingUtility ############
 ################################################################
 my $utility = NeuroDB::MRIProcessingUtility->new(
-                  \$dbh,$debug,$TmpDir,$logfile,
+                  $db, \$dbh,$debug,$TmpDir,$logfile,
                   $LogDir,$verbose
               );
 

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -26,7 +26,7 @@ my $date = sprintf(
                 "%4d-%02d-%02d %02d:%02d:%02d",
                 $year+1900,$mon+1,$mday,$hour,$min,$sec
            );
-my $debug       = 0;  
+my $debug       = 1;  
 my $message     = '';
 my $tarchive_srcloc = '';
 my $upload_id   = undef;
@@ -177,6 +177,14 @@ unless (-e $minc) {
 ################################################################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 
+my $db = NeuroDB::Database->new(
+    databaseName => $Settings::db[0],
+    userName     => $Settings::db[1],
+    password     => $Settings::db[2],
+    hostName     => $Settings::db[3]
+);
+$db->connect();
+
 ################################################################
 ########### Create the Specific Log File #######################
 ################################################################
@@ -212,7 +220,7 @@ print LOG "\n==> Successfully connected to database \n" if $verbose;
 ################## MRIProcessingUtility object #################
 ################################################################
 my $utility = NeuroDB::MRIProcessingUtility->new(
-                  \$dbh,$debug,$TmpDir,$logfile,
+                  $db, \$dbh,$debug,$TmpDir,$logfile,
                   $verbose
               );
 

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -172,6 +172,15 @@ if (!$ARGV[0] || !$profile) {
 ######### Establish database connection ########################
 ################################################################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+
+my $db = NeuroDB::Database->new(
+    databaseName => $Settings::db[0],
+    userName     => $Settings::db[1],
+    password     => $Settings::db[2],
+    hostName     => $Settings::db[3]
+);
+$db->connect();
+
 $message ="\n==> Successfully connected to database \n";
 
 my $tarchive = $ARGV[0];
@@ -263,7 +272,7 @@ extracting information ... if there is
 ################## Instantiate MRIProcessingUtility ############
 ################################################################
 my $utility = NeuroDB::MRIProcessingUtility->new(
-                  \$dbh,$debug,$TmpDir,$logfile,
+                  $db, \$dbh,$debug,$TmpDir,$logfile,
                   $LogDir,$verbose
               );
 

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -136,6 +136,14 @@ unless (-e $tarchive) {
 ################################################################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 
+my $db = NeuroDB::Database->new(
+    databaseName => $Settings::db[0],
+    userName     => $Settings::db[1],
+    password     => $Settings::db[2],
+    hostName     => $Settings::db[3]
+);
+$db->connect();
+
 ################################################################
 ########## Create the Specific Log File ########################
 ################################################################
@@ -160,7 +168,7 @@ print LOG "\n==> Successfully connected to database \n";
 ################ MRIProcessingUtility object ###################
 ################################################################
 my $utility = NeuroDB::MRIProcessingUtility->new(
-                  \$dbh,$debug,$TmpDir,$logfile,
+                  $db, \$dbh,$debug,$TmpDir,$logfile,
                   $verbose
               );
 


### PR DESCRIPTION
Refactored method `getUploadIDUsingTarchiveSrcLoc()` in module `MriProcessingUtility` so it uses the new `Database.pm` module. All scripts that create an instance of `MriProcessingUtility` were also updated: they now create a NeuroDB::Database object and pass it to the `MriProcessingUtility` constructor, which can then use it for specific method calls. The old (DBI style) database handle object is kept for now but will eventually disappear once all modules/scripts have been updated. 