### PR TITLE
Remove links to scripts in uploadNeuroDB/bin and update environment file

### DIFF
--- a/Mincinfo_wrapper
+++ b/Mincinfo_wrapper
@@ -1,1 +1,0 @@
-uploadNeuroDB/bin/Mincinfo_wrapper

--- a/concat_mri.pl
+++ b/concat_mri.pl
@@ -1,1 +1,0 @@
-uploadNeuroDB/bin/concat_mri.pl

--- a/environment
+++ b/environment
@@ -1,4 +1,4 @@
-export PATH=%MINC_TOOLKIT_DIR%/bin:/data/%PROJECT%/bin/mri:/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/dicom-archive:$PATH
+export PATH=/data/%PROJECT%/bin/mri/uploadNeuroDB/bin:%MINC_TOOLKIT_DIR%/bin:/data/%PROJECT%/bin/mri:/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/dicom-archive:$PATH
 export PERL5LIB=/data/%PROJECT%/bin/mri/uploadNeuroDB:$PERL5LIB
 export TMPDIR=/tmp
 export LORIS_CONFIG=/data/%PROJECT%/bin/mri/dicom-archive

--- a/environment
+++ b/environment
@@ -1,4 +1,4 @@
-export PATH=/data/%PROJECT%/bin/mri/uploadNeuroDB/bin:%MINC_TOOLKIT_DIR%/bin:/data/%PROJECT%/bin/mri:/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/dicom-archive:$PATH
+export PATH=%MINC_TOOLKIT_DIR%/bin:/data/%PROJECT%/bin/mri:/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/uploadNeuroDB/bin:/data/%PROJECT%/bin/mri/dicom-archive:$PATH
 export PERL5LIB=/data/%PROJECT%/bin/mri/uploadNeuroDB:$PERL5LIB
 export TMPDIR=/tmp
 export LORIS_CONFIG=/data/%PROJECT%/bin/mri/dicom-archive

--- a/minc2jiv.pl
+++ b/minc2jiv.pl
@@ -1,1 +1,0 @@
-uploadNeuroDB/bin/minc2jiv.pl

--- a/mincpik
+++ b/mincpik
@@ -1,1 +1,0 @@
-uploadNeuroDB/bin/mincpik

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -42,6 +42,7 @@ use File::Basename;
 use Data::Dumper;
 use Carp;
 use Time::Local;
+use FindBin;
 
 $VERSION = 0.2;
 @ISA = qw(Exporter);

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1180,7 +1180,7 @@ sub make_pics {
     my $check_pic_filename = $mincbase."_check.jpg";
     my $do_horizontal = "";
     $do_horizontal = "-horizontal" if $horizontalPics;
-    my $cmd = "mincpik -triplanar $do_horizontal $minc MIFF:- | convert -box black -font Courier -pointsize 12 -stroke white -draw 'text 10,15 \"$rowhr->{'CandID'}.$rowhr->{'Visit_label'}.$acquisitionProtocol\"' MIFF:- $pic/$check_pic_filename";
+    my $cmd = "$FindBin::Bin/bin/mincpik -triplanar $do_horizontal $minc MIFF:- | convert -box black -font Courier -pointsize 12 -stroke white -draw 'text 10,15 \"$rowhr->{'CandID'}.$rowhr->{'Visit_label'}.$acquisitionProtocol\"' MIFF:- $pic/$check_pic_filename";
     `$cmd`;
     # update mri table
     $file->setParameter('check_pic_filename', $rowhr->{'CandID'}.'/'.$check_pic_filename);
@@ -1208,7 +1208,7 @@ sub make_jiv {
 
     # generate jiv into temp dir
     my $tempdir = tempdir(CLEANUP=>1);
-    `minc2jiv.pl -quiet -force -clobber -output_path $tempdir $minc`;
+    `$FindBin::Bin/bin/minc2jiv.pl -quiet -force -clobber -output_path $tempdir $minc`;
 
     # rename jiv files to add fileid
     opendir(DIR, $tempdir);

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -42,7 +42,6 @@ use File::Basename;
 use Data::Dumper;
 use Carp;
 use Time::Local;
-use FindBin;
 
 $VERSION = 0.2;
 @ISA = qw(Exporter);
@@ -1181,7 +1180,7 @@ sub make_pics {
     my $check_pic_filename = $mincbase."_check.jpg";
     my $do_horizontal = "";
     $do_horizontal = "-horizontal" if $horizontalPics;
-    my $cmd = "$FindBin::Bin/bin/mincpik -triplanar $do_horizontal $minc MIFF:- | convert -box black -font Courier -pointsize 12 -stroke white -draw 'text 10,15 \"$rowhr->{'CandID'}.$rowhr->{'Visit_label'}.$acquisitionProtocol\"' MIFF:- $pic/$check_pic_filename";
+    my $cmd = "mincpik -triplanar $do_horizontal $minc MIFF:- | convert -box black -font Courier -pointsize 12 -stroke white -draw 'text 10,15 \"$rowhr->{'CandID'}.$rowhr->{'Visit_label'}.$acquisitionProtocol\"' MIFF:- $pic/$check_pic_filename";
     `$cmd`;
     # update mri table
     $file->setParameter('check_pic_filename', $rowhr->{'CandID'}.'/'.$check_pic_filename);
@@ -1209,7 +1208,7 @@ sub make_jiv {
 
     # generate jiv into temp dir
     my $tempdir = tempdir(CLEANUP=>1);
-    `$FindBin::Bin/bin/minc2jiv.pl -quiet -force -clobber -output_path $tempdir $minc`;
+    `minc2jiv.pl -quiet -force -clobber -output_path $tempdir $minc`;
 
     # rename jiv files to add fileid
     opendir(DIR, $tempdir);


### PR DESCRIPTION
Sent a new PR for the 20.0 release. See #320

### Spring cleaning!

Instead of having links in the main directory to the scripts stored in uploadNeuroDB/bin, add the path to uploadNeuroDB/bin in the environment file.


### Caveat for existing projects:

Need to add in your environment file the following path at the beginning of the export PATH line:
/data/%PROJECT%/bin/mri/uploadNeuroDB/bin
where %PROJECT% should be replaced by the name of your project

### Note: 

Need to add this uploadNeuroDB/bin path at the beginning of the PATH variable to make sure your project is using the mincpik from LORIS-MRI instead of the mincpik from the MINC tools.