### PR TITLE
Modified dcmdump command to grep the patient information from the Config module

### DIFF
--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -10,6 +10,7 @@ use File::Find;
 use NeuroDB::FileDecompress;
 use NeuroDB::Notify;
 use NeuroDB::ExitCodes;
+use NeuroDB::DBI;
 use File::Temp qw/ tempdir /;
 
 
@@ -410,7 +411,12 @@ Arguments:
 sub PatientNameMatch {
     my $this         = shift;
     my ($dicom_file) = @_;
-    my $cmd          = "dcmdump $dicom_file | grep PatientName";
+
+    my $lookupCenterNameUsing = NeuroDB::DBI::getConfigSetting(
+        $this->{'dbhr'},'lookupCenterNameUsing'
+    );
+
+    my $cmd = "dcmdump +P $lookupCenterNameUsing $dicom_file";
     my $patient_name_string =  `$cmd`;
     if (!($patient_name_string)) {
 	my $message = "\nThe patient name cannot be extracted \n";


### PR DESCRIPTION
In ImagingUpload.pm, the PatientName was hard coded during the validation of the DICOM study. 
Instead of hardcoding this, it is now using the lookupCenterNameUsing Config option when performing the validation of the DICOM study.

In addition, as @driusan suggested during an imaging meeting, modified the dcmdump command from `dcmdump $dicom | grep` to `dcmdump +P $lookupCenterNameUsing $dicom` which gives the same result but is a bit cleaner.

Associated redmine ticket: https://redmine.cbrain.mcgill.ca/issues/14088