### PR TITLE
Removing PendingStaging field from the files table

### DIFF
--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -74,44 +74,16 @@ RETURNS: the `CandID` or (if none exists) undef
 
 ### getSessionID($subjectIDref, $studyDate, $dbhr, $objective, $noStagingCheck)
 
-Gets (or creates) the session ID, given `CandID` and visit label (contained
-inside the hash ref `$subjectIDref`).  Unless `$noStagingCheck` is true, it
-also determines whether staging is required using the `$studyDate`
-(formatted YYYYMMDD) to determine whether staging is required based on a
-simple algorithm:
-
-> \- If there exists a session with the same visit label, then that is
->    the session ID to use.  If any dates (either existing MRI data or
->    simply a date of visit) exist associated with that session, then
->    if they are outside of some (arbitrary) time window, staging is
->    required.  If no dates exist, no staging is required.
->
-> \- If no sessions exist, then if there is any other date associated
->    with another session of the same subject within a time window,
->    staging is required.
->
-> \- Otherwise, staging is not required.
+Gets (or creates) the session ID, given CandID and visitLabel (contained
+inside the hashref `$subjectIDref`). 
 
 INPUTS:
-  - $subjectIDref  : hash reference of subject IDs
-  - $studyDate     : study date
-  - $dbhr          : database handle reference
-  - $objective     : the objective of the study
-  - $noStagingCheck: a no staging check flag
+  - $subjectIDref: hash reference of subject IDs
+  - $studyDate   : study date
+  - $dbhr        : database handle reference
+  - $objective   : the objective of the study
 
-RETURNS: a list of two items, (`sessionID`, `requiresStaging`)
-
-### checkMRIStudyDates($studyDateJD, $dbhr, @fileIDs)
-
-This method tries to figure out if there may have been labelling problems which
-would put the files in a staging area that does not actually exist.
-
-INPUTS:
-  - $studyDateJD: study date
-  - $dbhr       : database handle reference
-  - @fileIDs    : array of `fileIDs` to check the study date
-
-RETURNS: 1 if the file requires staging, 0 otherwise
+RETURNS: the session ID of the visit
 
 ### getObjective($subjectIDsref, $dbhr)
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1577,8 +1577,7 @@ sub setMRISession {
     $message = "\n==> Getting session ID\n";
     $this->{LOG}->print($message);
     $this->spool($message, 'N', $upload_id, $notify_detailed);
-    my ($sessionID, $requiresStaging) =
-        NeuroDB::MRI::getSessionID(
+    my ($sessionID) = NeuroDB::MRI::getSessionID(
             $subjectIDsref, 
             $tarchiveInfo->{'DateAcquired'}, 
             $this->{dbhr}, 
@@ -1587,7 +1586,6 @@ sub setMRISession {
     $message = "\nSessionID: $sessionID\n";    
     $this->{LOG}->print($message);
     $this->spool($message, 'N', $upload_id, $notify_detailed);
-    # Staging: $requiresStaging\n";
     ############################################################
     # Make sure MRI Scan Done is set to yes, because now ####### 
     # there is data. ###########################################
@@ -1599,7 +1597,7 @@ sub setMRISession {
         }
         ${$this->{'dbhr'}}->do($query);
     }
-    return ($sessionID, $requiresStaging);
+    return ($sessionID);
 }
 
 

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -195,8 +195,8 @@ The program does the following:
 
 - Loads the created MINC file and then sets the appropriate parameter for
   the loaded object (i.e ScannerID, SessionID,SeriesUID, EchoTime, 
-                     PendingStaging, CoordinateSpace , OutputType , FileType
-                     ,TarchiveSource and Caveat)
+                     CoordinateSpace , OutputType , FileType,
+                     TarchiveSource and Caveat)
 - Extracts the correct acquition protocol
 - Registers the scan into db by first changing the minc-path and setting extra
   parameters
@@ -496,10 +496,9 @@ if (defined($CandMismatchError)) {
 }
 
 ################################################################
-####### Get the $sessionID and $requiresStaging ################
+####### Get the $sessionID  ####################################
 ################################################################
-my ($sessionID, $requiresStaging) =
-    NeuroDB::MRI::getSessionID( 
+my ($sessionID) = NeuroDB::MRI::getSessionID(
         $subjectIDsref, 
         $tarchiveInfo{'DateAcquired'},
         \$dbh, $subjectIDsref->{'subprojectID'}
@@ -527,7 +526,6 @@ $file->setFileData('ScannerID', $scannerID);
 $file->setFileData('SessionID', $sessionID);
 $file->setFileData('SeriesUID', $file->getParameter('series_instance_uid'));
 $file->setFileData('EchoTime', $file->getParameter('echo_time'));
-$file->setFileData('PendingStaging', $requiresStaging);
 $file->setFileData('CoordinateSpace', 'native');
 $file->setFileData('OutputType', 'native');
 $file->setFileData('FileType', 'mnc');

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -256,8 +256,7 @@ print LOG "\t -> Set ScannerID to $scannerID.\n";
 # ----- STEP 4: Determine using sourceFileID: 
 #                   - subject's identifiers 
 #                   - sessionID 
-#                   - requiresStaging 
-my ($sessionID,$requiresStaging,$subjectIDsref)    =   getSessionID($sourceFileID,$dbh);
+my ($sessionID,$subjectIDsref)    =   getSessionID($sourceFileID,$dbh);
 if  (!defined($sessionID))  {
     print LOG "\nERROR: could not determine sessionID based on sourceFileID "
               . "$sourceFileID. Are you sure the sourceFile was registered "
@@ -388,10 +387,7 @@ sub getSessionID    {
         return undef;
     }
 
-    # set requiresStaging to null as long as don't have any more information on this field
-    my $requiresStaging =   0;
-
-    return  ($sessionID,$requiresStaging,\%subjectIDsref);
+    return  ($sessionID, \%subjectIDsref);
 }
 
 

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -436,7 +436,7 @@ if (!defined($subjectIDsref->{'visitLabel'})) {
         \$dbh
     ); 
 }
-my ($sessionID, $requiresStaging) =
+my ($sessionID) =
     NeuroDB::MRI::getSessionID(
          $subjectIDsref, $tarchiveInfo{'DateAcquired'},
          \$dbh, $subjectIDsref->{'subprojectID'}

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -371,7 +371,7 @@ if (defined $CandMismatchError) {
 ################################################################
 ############ Get the SessionID #################################
 ################################################################
-my ($sessionID, $requiresStaging) = 
+my ($sessionID) =
     $utility->setMRISession($subjectIDsref, \%tarchiveInfo, $upload_id);
 
 ################################################################


### PR DESCRIPTION
This pull request removes the unused PendingStaging field from the files table as was discussed during the LORIS imaging meeting of February 2nd, 2018.

See also:
- associated redmine ticket: https://redmine.cbrain.mcgill.ca/issues/13876
- associate PR on the LORIS side: https://github.com/aces/Loris/pull/3569

Note for reviewers: 
I removed all the code associated to this PendingStaging field. I checked IBIS and PREVENT-AD, this field is always filled with 0. Maybe you could check your DB just to be sure but at this point, I am fairly confident this is not used.