### PR TITLE
Fix tarchive being named without the patient name

### DIFF
--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -75,11 +75,11 @@ sub new {
 =cut
 
 sub database {
-    my $self   = shift;
-    my $dbh    = shift;
-    my $meta   = shift;
-    my $update = shift;
-    
+    my $self     = shift;
+    my $dbh      = shift;
+    my $metafile = shift;
+    my $update   = shift;
+
     # these are only available if you run dicomTar
     my $tarType     = shift;
     my $tarLog      = shift;
@@ -133,8 +133,7 @@ QUERY
 
     # INSERT or UPDATE 
     # get acquisition metadata
-    my $sfile = "$self->{tmpdir}/$meta.meta";
-    my $metacontent = &read_file($sfile);
+    my $metacontent = &read_file($metafile);
     
     (my $common_query_part = <<QUERY) =~ s/\n/ /gm;  
       tarchive SET  


### PR DESCRIPTION
When using the imaging uploader to upload a DICOM study, the `tarchive` used to be named as follows:
`DCM_2018-01-26_ImagingUpload-$hour-$minute-XXXXXX.tar`

Now the `tarchive` will include the patient name information as follows:
`DCM_2018-01-26_ImagingUpload-$hour-$minute-XXXXXX_$PatientName.tar`

Here are two examples of how the `tarchive` will be named depending on whether `dicomTar.pl` was run directly on the folder `MTL0021_917380_PREEN00_20120730_144819638` (first line) or via the imaging uploader (second line): 
```
DCM_2012-07-30_MTL0021_917380_PREEN00_20120730_144819638_MTL0021_917380_PREEN00.tar
DCM_2017-04-10_ImagingUpload-13-39-cTsG8e_MTL0609_138233_PREBL00.tar
```

Associated Redmine ticket: https://redmine.cbrain.mcgill.ca/issues/13933

I added the flag "add to release note" to let people know that the way we name the tarchive has changed.