### PR TITLE
Refactored methods scan_type_text_to_id and scan_type_id_to_text of MRI.pm

### DIFF
--- a/tools/BackPopulateSNRAndAcquisitionOrder.pl
+++ b/tools/BackPopulateSNRAndAcquisitionOrder.pl
@@ -10,6 +10,8 @@ use Cwd;
 use NeuroDB::DBI;
 use NeuroDB::MRIProcessingUtility;
 
+use NeuroDB::Database;
+
 my $verbose = 1;
 my $debug = 1;
 my $profile = undef;
@@ -59,6 +61,14 @@ if ($profile && !@Settings::db) {
 ######### Establish database connection ########################
 ################################################################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+
+my $db = NeuroDB::Database->new(
+    databaseName => $Settings::db[0],
+    userName     => $Settings::db[1],
+    password     => $Settings::db[2],
+    hostName     => $Settings::db[3]
+);
+$db->connect();
 print "\nSuccessfully connected to database \n";
 
 ################################################################
@@ -89,7 +99,7 @@ my $logfile  = "$LogDir/$templog.log";
 ################## Instantiate MRIProcessingUtility ############
 ################################################################
 my $utility = NeuroDB::MRIProcessingUtility->new(
-                  \$dbh,$debug,$TmpDir,$logfile,
+                  $db, \$dbh,$debug,$TmpDir,$logfile,
                   $LogDir,$verbose
               );
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -44,6 +44,8 @@ use Carp;
 use Time::Local;
 use FindBin;
 
+use NeuroDB::objectBroker::MriScanTypeOB;
+
 $VERSION = 0.2;
 @ISA = qw(Exporter);
 
@@ -391,7 +393,7 @@ sub getObjective
 
 =pod
 
-B<identify_scan_db( C<$center_name>, C<$objective>, C<$fileref>, C<$dbhr> )>
+B<identify_scan_db( C<$center_name>, C<$objective>, C<$fileref>, C<$dbhr>, C<$db> )>
 
 Determines the type of the scan described by minc headers based on mri_protocol in the database
 
@@ -401,7 +403,7 @@ Returns: Textual name of scan type
 
 sub identify_scan_db {
 
-    my  ($psc, $subjectref, $tarchiveInfoRef, $fileref, $dbhr,$minc_location
+    my  ($psc, $subjectref, $tarchiveInfoRef, $fileref, $dbhr, $db, $minc_location
     ) = @_;
 
     my $candid = ${subjectref}->{'CandID'};
@@ -488,7 +490,7 @@ sub identify_scan_db {
     while($rowref = $sth->fetchrow_hashref()) {
         my $sd_regex = $rowref->{'series_description_regex'};
         if(0) {
-            print "\tChecking ".&scan_type_id_to_text($rowref->{'Scan_type'}, $dbhr)." ($rowref->{'Scan_type'}) ($series_description =~ $sd_regex)\n";
+            print "\tChecking ".&scan_type_id_to_text($rowref->{'Scan_type'}, $db)." ($rowref->{'Scan_type'}) ($series_description =~ $sd_regex)\n";
             print "\t";
             if($sd_regex && ($series_description =~ /$sd_regex/i)) {print "series_description\t";}
             print &in_range($tr, $rowref->{'TR_range'}) ? "TR\t" : '';
@@ -507,7 +509,7 @@ sub identify_scan_db {
         
 	if ($sd_regex) {
             if ($series_description =~ /$sd_regex/i) {
-                return &scan_type_id_to_text($rowref->{'Scan_type'}, $dbhr);
+                return &scan_type_id_to_text($rowref->{'Scan_type'}, $db);
             }
 	}
 	else {
@@ -524,7 +526,7 @@ sub identify_scan_db {
                 && (!$rowref->{'ystep_range'} || &in_range($ystep, $rowref->{'ystep_range'}))
                 && (!$rowref->{'zstep_range'} || &in_range($zstep, $rowref->{'zstep_range'}))
                 && (!$rowref->{'time_range'} || &in_range($time, $rowref->{'time_range'}))) {
-                    return &scan_type_id_to_text($rowref->{'Scan_type'}, $dbhr);
+                    return &scan_type_id_to_text($rowref->{'Scan_type'}, $db);
             }
         }
     }
@@ -603,7 +605,7 @@ sub debug_inrange {
 
 =pod
 
-B<scan_type_id_to_text( C<$typeID>, C<$dbhr> )>
+B<scan_type_id_to_text( C<$typeID>, C<$db> )>
 
 Determines the type of the scan identified by scan type id
 
@@ -612,19 +614,18 @@ Returns: Textual name of scan type
 =cut
 
 sub scan_type_id_to_text {
-    my ($ID, $dbhr) = @_;
+    my ($ID, $db) = @_;
 
-    my $query = "SELECT Scan_type FROM mri_scan_type WHERE ID='$ID'";
-    my $sth = $${dbhr}->prepare($query);
-    $sth->execute();
-    return 'unknown' unless $sth->rows;
-    my @results = $sth->fetchrow_array();
-    return $results[0];
+    my $mriScanTypeOB = NeuroDB::objectBroker::MriScanTypeOB->new(
+        db => $db
+    );
+    my $mriScanTypeRef = $mriScanTypeOB->get(0, { ID => $ID });
+    return @$mriScanTypeRef ? $mriScanTypeRef->[0]->[0] : 'unknown';
 }
 
 =pod
 
-B<scan_type_text_to_id( C<$type>, C<$dbhr> )>
+B<scan_type_text_to_id( C<$type>, C<$db> )>
 
 Determines the type of the scan identified by scan type
 
@@ -633,15 +634,22 @@ Returns: ID of the scan type
 =cut
 
 sub scan_type_text_to_id {
-    my $type = shift;
-    my $dbhr = shift;
+    my($type, $db) = @_;
 
-    my $query = "SELECT ID FROM mri_scan_type WHERE Scan_type='$type'";
-    my $sth = $${dbhr}->prepare($query);
-    $sth->execute();
-    return &scan_type_text_to_id('unknown', $dbhr) unless $sth->rows;
-    my @results = $sth->fetchrow_array();
-    return $results[0];
+    my $mriScanTypeRef = $this->getMriScanTypeOB()->get(
+        0, { Scan_type => $acquisitionProtocol }
+    );
+    $mriScanTypeRef = $this->getMriScanTypeOB()->get(0, { Scan_type => 'unknown' }) if !@$mriScanTypeRef;
+    if(!@$mriScanTypeRef) {
+        NeuroDB::UnexpectedValueException->throw(
+            errorMessage => sprintf(
+                "Unknown acquisition protocol %s and scan type 'unknown' does not exist in the database",
+                $acquisitionProtocol
+            ) 
+        );
+    }
+    
+    return $mriScanTypeRef->[0]->[0];
 }
 
 =pod
@@ -1157,7 +1165,7 @@ Returns: 1 if the pic was generated or 0 otherwise.
 =cut
 
 sub make_pics {
-    my ($fileref, $data_dir, $dest_dir, $horizontalPics) = @_;
+    my ($fileref, $data_dir, $dest_dir, $horizontalPics, $db) = @_;
     my $file = $$fileref;
     my $dbhr = $file->getDatabaseHandleRef();
     
@@ -1165,7 +1173,7 @@ sub make_pics {
     $sth->execute();
     my $rowhr = $sth->fetchrow_hashref();
     
-    my $acquisitionProtocol = scan_type_id_to_text($file->getFileDatum('AcquisitionProtocolID'), $dbhr);
+    my $acquisitionProtocol = scan_type_id_to_text($file->getFileDatum('AcquisitionProtocolID'), $db);
     my $minc = $data_dir . '/' . $file->getFileDatum('File');
     my $mincbase = basename($minc);
     $mincbase =~ s/\.mnc(\.gz)?$//;

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -77,29 +77,6 @@ sub new {
     return bless $self, $params;
 }
 
-=pod
-
-=head3 C<getMriScanTypeOB()>
-
-Fetches the MRI scan type object broker associated to the instance of this class. Note
-that if the object broker has not been created yet, this method will create it and store
-the value as a class attribute.
-
-RETURN: the MRI scan type object broker associated to the instance of this class.
-=cut
-
-sub getMriScanTypeOB {
-	my $self = shift;
-	
-	if(!$self->{'mriScanTypeOB'}) {
-		$self->{'mriScanTypeOB'} = NeuroDB::objectBroker::MriScanTypeOB->new(
-		    db => $self->{'db'}
-		);
-	}
-	
-	return $self->{'mriScanTypeOB'};
-}
-
 ################################################################
 ## writeErrorLog and update Notification Table##################
 ## this is a useful function that will close the log and write #

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -12,9 +12,6 @@ use NeuroDB::MRI;
 use NeuroDB::DBI;
 use NeuroDB::Notify;
 
-use NeuroDB::UnexpectedValueException;
-use NeuroDB::objectBroker::MriScanTypeOB;
-
 use Path::Class;
 use Scalar::Util qw(blessed);
 
@@ -71,8 +68,6 @@ sub new {
     $self->{'TmpDir'} = $TmpDir;
     $self->{'logfile'} = $logfile;
     $self->{'db'} = $db;
-    
-    $self->{'mriScanTypeOB'} = undef;
     
     return bless $self, $params;
 }

--- a/uploadNeuroDB/NeuroDB/UnexpectedValueException.pm
+++ b/uploadNeuroDB/NeuroDB/UnexpectedValueException.pm
@@ -1,0 +1,53 @@
+package NeuroDB::UnexpectedValueException;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::UnexpectedValueException -- Exception used to signal that an unexpected value was found
+     during program execution.
+
+=head1 SYNOPSIS
+
+  use NeuroDB::UnexpectedValueException;
+
+  .
+  .
+  .
+
+  NeuroDB::UnexpectedValueException->throw(
+      errorMessage => "Scan ID should be a number"
+  );
+
+=head1 DESCRIPTION
+
+This class is used when an unexpected value is obtained during execution of a command, like
+a database query, reading text from a file, etc... 
+
+=cut
+
+use Moose;
+with 'Throwable';
+
+use overload '""' => 'toString';
+
+has 'errorMessage' => (is  => 'ro', isa => 'Str', required => 1);
+
+=pod
+
+=head3 C<toString()>
+
+Default representation of this exception when used in a string context.
+Among other things, the returned string will be used for uncaught exceptions
+that make a script die. Note that the returned string can be useful for debugging
+purposes when trying to diagnose why a particular SQL statement did not execute
+successfully.
+
+=cut
+sub toString {
+    my $self = shift;
+
+    return "$self->{errorMessage}\n";
+};
+
+1;

--- a/uploadNeuroDB/NeuroDB/objectBroker/MriScanTypeOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriScanTypeOB.pm
@@ -1,0 +1,138 @@
+package NeuroDB::objectBroker::MriScanTypeOB;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::objectBroker::MriScanTypeOB -- An object broker for mri_scan_type records
+
+=head1 SYNOPSIS
+
+  use NeuroDB::Database;
+  use NeuroDB::objectBroker::MriScanTypeOB;
+  use TryCatch;
+
+  my $db = NeuroDB::Database->new(
+      userName     => 'user',
+      databaseName => 'my_db',
+      hostName     => 'my_hostname',
+      password     => 'pwd'
+  );
+
+  try {
+      $db->connect();
+  } catch(NeuroDB::DatabaseException $e) {
+      die sprintf(
+          "User %s failed to connect to %s on %s: %s (error code %d)\n",
+          'user',
+          'my_db',
+          'my_hostname',
+          $e->errorMessage,
+          $e->errorCode
+      );
+  }
+
+  .
+  .
+  .
+
+  my $mriScanTypeOB = NeuroDB::objectBroker::MriScanTypeOB->new(db => $db);
+  my $mriScanTypeRef;
+  try {
+      $mriScanTypeRef = $mriScanTypeOB->get(
+          0, { ScanType => 'dti' }
+      );
+  } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+      die sprintf(
+          "Failed to retrieve tarchive records: %s",
+          $e->errorMessage
+      );
+  }
+
+=head1 DESCRIPTION
+
+This class provides a set of methods to fetch records from the C<mri_scan_type>
+table. If an operation cannot be executed successfully, a C<NeuroDB::objectBroker::ObjectBrokerException>
+will be thrown.
+
+=head2 Methods
+
+=cut
+
+use Moose;
+use MooseX::Privacy;
+
+use NeuroDB::Database;
+use NeuroDB::DatabaseException;
+use NeuroDB::objectBroker::ObjectBrokerException;
+
+use TryCatch;
+
+my @MRI_SCAN_TYPE_FIELDS = qw(ID Scan_type);
+
+=pod
+
+=head3 new(db => $db) >> (constructor)
+
+Create a new instance of this class. The only parameter to provide is the
+C<Database> object used to access the database.
+
+INPUT: the database object used to query the C<mri_scan_type> table.
+
+RETURN: new instance of this class.
+
+=cut
+
+has 'db' => (is  => 'rw', isa => 'NeuroDB::Database', required => 1);
+
+=pod
+=head3 get($isCount, $columnValuesRef))
+Fetches the entries in the C<mri_upload> table that have specific column
+values. This method throws a C<NeuroDB::objectBroker::ObjectBrokerException>
+if the operation could not be completed successfully.
+INPUTS:
+    - boolean indicating if only a count of the records found is needed
+      or the full record properties.
+    - reference to a hash array that contains the column values that the MRI records
+      should have in order to be part of the result set (key: column name, value: column
+      value).
+      
+RETURNS: either a count of the records found or a reference to an array of hashes, each 
+         hash being an MRI record found, with all the columns set to whatever was found
+         in the database.
+=cut
+
+sub get {
+	my($self, $isCount, $columnValuesRef) = @_;
+
+    my @where;
+    
+    if (%$columnValuesRef) {
+        foreach my $k (keys %$columnValuesRef) {
+            if(!grep($k eq $_, @MRI_SCAN_TYPE_FIELDS)) {
+                NeuroDB::objectBroker::ObjectBrokerException->throw(
+                    errorMessage => "MRI scan type get failed: invalid MRI scan type field $k"
+                );
+            }
+            push(@where, "$k=?");
+        }
+	}
+
+    my $select = $isCount ? 'COUNT(*)' : '*';
+
+    my $query = "SELECT $select FROM mri_scan_type";
+    $query .= sprintf(' WHERE %s', join(' AND ', @where)) if @where;
+
+    try {
+        return $self->db->pselect($query, values(%$columnValuesRef));
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to retrieve MRI scan type records. Reason:\n%s",
+                $e
+            )
+        );
+    }
+}
+
+1;

--- a/uploadNeuroDB/mass_pic.pl
+++ b/uploadNeuroDB/mass_pic.pl
@@ -7,6 +7,9 @@ use Getopt::Tabular;
 use NeuroDB::DBI;
 use NeuroDB::File;
 use NeuroDB::MRI;
+
+use NeuroDB::Database;
+
 ################################################################
 ################## Set stuff for GETOPT ########################
 ################################################################
@@ -59,6 +62,15 @@ if (!$profile) {
 ################################################################
 print "Connecting to database.\n" if $verbose;
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+
+my $db = NeuroDB::Database->new(
+    databaseName => $Settings::db[0],
+    userName     => $Settings::db[1],
+    password     => $Settings::db[2],
+    hostName     => $Settings::db[3]
+);
+$db->connect();
+
 
 ################################################################
 # Where the pics should go #####################################
@@ -120,7 +132,7 @@ while(my $rowhr = $sth->fetchrow_hashref()) {
     unless(
         &NeuroDB::MRI::make_pics(
             \$file, $data_dir, 
-            $pic_dir, $horizontalPics
+            $pic_dir, $horizontalPics, $db
         )
     ) {
         print "FAILURE!\n";

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -18,6 +18,8 @@ use NeuroDB::DBI;
 use NeuroDB::Notify;
 use NeuroDB::MRIProcessingUtility;
 
+use NeuroDB::Database;
+
 my $versionInfo = sprintf "%d revision %2d", q$Revision: 1.24 $ 
     =~ /: (\d+)\.(\d+)/;
 my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) 
@@ -177,6 +179,14 @@ unless (-e $minc) {
 ################################################################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 
+my $db = NeuroDB::Database->new(
+    databaseName => $Settings::db[0],
+    userName     => $Settings::db[1],
+    password     => $Settings::db[2],
+    hostName     => $Settings::db[3]
+);
+$db->connect();
+
 ################################################################
 ########### Create the Specific Log File #######################
 ################################################################
@@ -212,7 +222,7 @@ print LOG "\n==> Successfully connected to database \n" if $verbose;
 ################## MRIProcessingUtility object #################
 ################################################################
 my $utility = NeuroDB::MRIProcessingUtility->new(
-                  \$dbh,$debug,$TmpDir,$logfile,
+                  $db, \$dbh,$debug,$TmpDir,$logfile,
                   $verbose
               );
 

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -11,6 +11,7 @@ use NeuroDB::DBI;
 use NeuroDB::File;
 use NeuroDB::MRI;
 
+use NeuroDB::Database;
 
 my  $profile    = undef;
 my  $filename;
@@ -82,6 +83,14 @@ unless  (-r $filename)  { print "Cannot read $filename\n"; exit 1;}
 
 # Establish database connection
 my $dbh     =   &NeuroDB::DBI::connect_to_db(@Settings::db);
+
+my $db = NeuroDB::Database->new(
+    databaseName => $Settings::db[0],
+    userName     => $Settings::db[1],
+    password     => $Settings::db[2],
+    hostName     => $Settings::db[3]
+);
+$db->connect();
 
 # These settings are in the config file (profile)
 my $data_dir = NeuroDB::DBI::getConfigSetting(
@@ -262,7 +271,7 @@ if  ($file->getFileDatum('FileType') eq 'mnc')  {
     
     # make the browser pics
     print "Making browser pics\n";
-    &NeuroDB::MRI::make_pics(\$file, $data_dir, $pic_dir, $horizontalPics);
+    &NeuroDB::MRI::make_pics(\$file, $data_dir, $pic_dir, $horizontalPics, $db);
 }
 
 # tell the user we've done so and include the MRIID for reference

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -36,6 +36,8 @@ use Cwd qw/ abs_path /;
 # These are the NeuroDB modules to be used
 use lib "$FindBin::Bin";
 
+use NeuroDB::Database;
+
 use NeuroDB::File;
 use NeuroDB::MRI;
 use NeuroDB::DBI;
@@ -172,6 +174,15 @@ if (!$ARGV[0] || !$profile) {
 ######### Establish database connection ########################
 ################################################################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+
+my $db = NeuroDB::Database->new(
+    databaseName => $Settings::db[0],
+    userName     => $Settings::db[1],
+    password     => $Settings::db[2],
+    hostName     => $Settings::db[3]
+);
+$db->connect();
+
 $message ="\n==> Successfully connected to database \n";
 
 my $tarchive = $ARGV[0];
@@ -263,7 +274,7 @@ extracting information ... if there is
 ################## Instantiate MRIProcessingUtility ############
 ################################################################
 my $utility = NeuroDB::MRIProcessingUtility->new(
-                  \$dbh,$debug,$TmpDir,$logfile,
+                  $db, \$dbh,$debug,$TmpDir,$logfile,
                   $LogDir,$verbose
               );
 

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -19,6 +19,8 @@ use NeuroDB::DBI;
 use NeuroDB::Notify;
 use NeuroDB::MRIProcessingUtility;
 
+use NeuroDB::Database;
+
 my $versionInfo = sprintf "%d revision %2d", q$Revision: 1.24 $ 
                 =~ /: (\d+)\.(\d+)/;
 my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =localtime(time);
@@ -136,6 +138,14 @@ unless (-e $tarchive) {
 ################################################################
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 
+my $db = NeuroDB::Database->new(
+    databaseName => $Settings::db[0],
+    userName     => $Settings::db[1],
+    password     => $Settings::db[2],
+    hostName     => $Settings::db[3]
+);
+$db->connect();
+
 ################################################################
 ########## Create the Specific Log File ########################
 ################################################################
@@ -160,7 +170,7 @@ print LOG "\n==> Successfully connected to database \n";
 ################ MRIProcessingUtility object ###################
 ################################################################
 my $utility = NeuroDB::MRIProcessingUtility->new(
-                  \$dbh,$debug,$TmpDir,$logfile,
+                  $db, \$dbh,$debug,$TmpDir,$logfile,
                   $verbose
               );
 


### PR DESCRIPTION
This is the refactoring of methods scan_type_text_to_id and scan_type_id_to_text of MRI.pm to make them use the new Database.pm module. All modules/scripts that use these methods either directly or indirectly have also been refactored.