### PR TITLE
ExitCodes refactoring so that their number fit in the range 0-255

### DIFF
--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -131,7 +131,7 @@ print LOG "\n==> DTI output directory is: $DTIPrep_subdir\n";
 my ($protXMLrefs)   = &DTI::readDTIPrepXMLprot($DTIPrepProtocol);
 if (!$protXMLrefs) {
     print LOG "\n\tERROR: DTIPrep XML protocol could not be read.\n";
-    exit $NeuroDB::ExitCodes::UNREADABLE_DTIPREP_PROTOCOL;
+    exit $NeuroDB::ExitCodes::UNREADABLE_FILE;
 }
 
 # 1.b Create a hash containing names of all outputs created by DTIPrep/mincdiffusion pipeline
@@ -151,7 +151,7 @@ if  (!$DTIrefs) {
 if ((!$mincdiffVersion) && ($DTIrefs->{$dti_file}->{'Postproc'}->{'Tool'} eq "mincdiffusion")) {
     print LOG "\n$Usage\nERROR:\n\tYou must specify which version of "
               . "mincdiffusion tools was used to post-process the DTI.\n";
-    exit $NeuroDB::ExitCodes::NO_MINCDIFFUSION_VERSION;
+    exit $NeuroDB::ExitCodes::MISSING_TOOL_VERSION;
 }
 
 
@@ -168,13 +168,13 @@ my  ($XMLProtocol, $QCReport, $XMLReport, $mri_files)   = &getFiles($dti_file, $
 # If $QCed_minc is not defined, means that getFiles returned undef for all output files => ERROR.
 if  (!$QCReport) {
     print LOG "\nERROR:\n\tSome process files are missing in $DTIPrep_subdir.\n";
-    exit $NeuroDB::ExitCodes::MISSING_PREPROCESSED_FILES;
+    exit $NeuroDB::ExitCodes::MISSING_FILES;
 }
 # If $QCed2_step is set, QCed2_minc should be defined in %mri_files hash! 
 if  (($QCed2_step) && (!$mri_files->{'Preproc'}{'QCed2'}{'minc'})) {
     print LOG "\nERROR:\n\tSecondary QCed DTIPrep nrrd & minc outputs are "
               . "missing in $DTIPrep_subdir.\n";
-    exit $NeuroDB::ExitCodes::MISSING_POSTPROCESSED_FILES;
+    exit $NeuroDB::ExitCodes::MISSING_FILES;
 }
 # => If we could pass step 2, then all the files to be registered were found in the filesystem!
 
@@ -191,7 +191,7 @@ my ($registeredXMLprotocolID)   = &register_XMLProt($XMLProtocol,
                                                     "DTIPrep");
 if (!$registeredXMLprotocolID) {
     print LOG "\nERROR: no XML protocol file was registered in the database\n";
-    exit $NeuroDB::ExitCodes::FILE_REGISTRATION_FAILURE;
+    exit $NeuroDB::ExitCodes::INSERT_FAILURE;
 } else {
     print LOG "\nRegistered XML protocol with ID $registeredXMLprotocolID.\n";
     $mri_files->{'Preproc'}{'QCProt'}{'xml'} = $registeredXMLprotocolID; 
@@ -216,7 +216,7 @@ my ($registeredXMLReportFile)   = &register_XMLFile($XMLReport,
                                                     $DTIPrepVersion);
 if (!$registeredXMLReportFile) {
     print LOG "\nERROR: no XML report file was registered in the database\n";
-    exit $NeuroDB::ExitCodes::FILE_REGISTRATION_FAILURE;
+    exit $NeuroDB::ExitCodes::INSERT_FAILURE;
 } else {
     print LOG "\nRegistered XML report $registeredXMLReportFile.\n";
     $mri_files->{'Preproc'}{'QCReport'}{'xml'}  = $registeredXMLReportFile;
@@ -239,7 +239,7 @@ my ($registeredQCReportFile)    = &register_QCReport($QCReport,
                                                      $DTIPrepVersion);
 if (!$registeredQCReportFile) {
     print LOG "\nERROR: no QC report file was registered in the database\n";
-    exit $NeuroDB::ExitCodes::FILE_REGISTRATION_FAILURE;
+    exit $NeuroDB::ExitCodes::INSERT_FAILURE;
 } else {
     print LOG "\nRegistered QC report $registeredQCReportFile.\n";
     $mri_files->{'Preproc'}{'QCReport'}{'txt'}  = $registeredQCReportFile;
@@ -575,7 +575,7 @@ sub register_XMLFile {
     if  (!$toolName)    {
         print STDERR "WARNING: This should not happen as long as the pipeline "
                      . "versioning of DTIPrep is not fixed!";
-        exit $NeuroDB::ExitCodes::NO_TOOL_NAME_VERSION;
+        exit $NeuroDB::ExitCodes::MISSING_TOOL_VERSION;
         # Will need to program this part once DTIPrep fixed!
         #($src_pipeline, $src_tool)=getToolName($XMLFile);
     }else   {
@@ -655,7 +655,7 @@ sub register_QCReport {
     if  (!$toolName)    {
         print STDERR "WARNING: This should not happen as long as the pipeline "
                      . "versioning of DTIPrep is not fixed!";
-        exit $NeuroDB::ExitCodes::NO_TOOL_NAME_VERSION;
+        exit $NeuroDB::ExitCodes::MISSING_TOOL_VERSION;
         # Will need to program this part once DTIPrep fixed!
         #($src_pipeline, $src_tool)=getToolName($QCReport);
     }else   {
@@ -961,7 +961,7 @@ sub getToolName {
                   . "which tool was used manually with the option "
                   . "-DTIPrepVersion or -mincdiffusionVersion as input of the "
                   . "script DTIPrepRegister.pl.";
-        exit $NeuroDB::ExitCodes::NO_TOOL_NAME_VERSION;
+        exit $NeuroDB::ExitCodes::MISSING_TOOL_VERSION;
     }else   {
         #remove leading spaces, trailing spaces and all instances of "
         $src_tool       =~s/"//g;
@@ -1332,7 +1332,7 @@ sub register_nrrd {
     if  (!$toolName)    {
         print STDERR "WARNING: This should not happen as long as the pipeline "
                      . "versioning of DTIPrep is not fixed!";
-        exit $NeuroDB::ExitCodes::NO_TOOL_NAME_VERSION;
+        exit $NeuroDB::ExitCodes::MISSING_TOOL_VERSION;
         # Will need to program this part once DTIPrep fixed!
         #($src_pipeline, $src_tool)=getToolName($XMLFile);
     }else   {

--- a/DTIPrep/DTIPrep_pipeline.pl
+++ b/DTIPrep/DTIPrep_pipeline.pl
@@ -83,7 +83,7 @@ if (!$DTIPrepVersion) {
                  . "via the path to DTIPrep binary. You need to specify which "
                  . "version of DTIPrep you will be using with -DTIPrepVersion "
                  . "option.\n\n";
-    exit $NeuroDB::ExitCodes::NO_DTIPREP_VERSION;
+    exit $NeuroDB::ExitCodes::MISSING_TOOL_VERSION;
 }
 
 # Establish database connection
@@ -169,14 +169,14 @@ foreach my $nativedir (@nativedirs)   {
         if (!$mincdiffVersion) {
             print STDERR "\n\tERROR: mincdiffusion tool's version could "
                   . "not be determined.\n\n";
-            exit $NeuroDB::ExitCodes::NO_MINCDIFFUSION_VERSION;
+            exit $NeuroDB::ExitCodes::MISSING_TOOL_VERSION;
         }
         # Exit program if $niak_path is not set
         if  (!$niak_path) {
             print STDERR "\n\tERROR: variable niak_path need to be set in the "
                          . "config file if you plan to use mincdiffusion tools "
                          . "to process the DTI files.\n\n";
-            exit $NeuroDB::ExitCodes::NO_NIAK_PATH;
+            exit $NeuroDB::ExitCodes::INVALID_PATH;
         }
     }
 
@@ -230,7 +230,7 @@ foreach my $nativedir (@nativedirs)   {
     } else {
         print LOG "\n\tERROR: Post processing tools won't be run for this dataset. \n";
         print LOG "--------------------------------\n";
-        exit $NeuroDB::ExitCodes::NO_POST_PROCESSING_TO_RUN;
+        exit $NeuroDB::ExitCodes::PROGRAM_EXECUTION_FAILURE;
     }
 
 

--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -251,6 +251,6 @@ sub insertIntoMRIUpload {
     return $upload_id;
 }
 
-## exit 0 for find to consider this -cmd true (in case we ever run it that way...)
+## exit $NeuroDB::ExitCodes::SUCCESS for find to consider this -cmd true (in case we ever run it that way...)
 exit $NeuroDB::ExitCodes::SUCCESS;
 

--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -148,7 +148,7 @@ foreach my $input (@resultsarray)
     if (($type ne '.tgz') && ($type ne '.tar.gz') && ($type ne '.zip')) {
 	print STDERR "The file on line $counter is not of type .tgz, tar.gz, or "
                  . ".zip and will not be processed\n";
-	exit $NeuroDB::ExitCodes::UPLOADED_FILE_TYPE_FAILURE;
+	exit $NeuroDB::ExitCodes::FILE_TYPE_CHECK_FAILURE;
     }
     if (($phantom eq '') || (($phantom ne 'N') && ($phantom ne 'Y'))) {
 	print STDERR "Make sure the Phantom entry is filled out "
@@ -167,7 +167,7 @@ foreach my $input (@resultsarray)
         if ($patientname ne '') {
        	    print STDERR "Please leave the patient name blank for phantom "
        	                 . "entries\n";
-	        exit $NeuroDB::ExitCodes::PNAME_PHANTOM_MISMATCH;
+	        exit $NeuroDB::ExitCodes::PNAME_FILENAME_MISMATCH;
 	}
 	else {
 	    $patientname = 'NULL';

--- a/batch_uploads_tarchive
+++ b/batch_uploads_tarchive
@@ -3,6 +3,8 @@ use strict;
 use warnings;
 no warnings 'once';
 use NeuroDB::DBI;
+use NeuroDB::ExitCodes;
+
 
 #####Get config setting#######################################################
 # checking for profile settings
@@ -88,5 +90,5 @@ print MAIL "Subject: BATCH_UPLOADS_TARCHIVE: ".scalar(@submitted)." studies subm
 print MAIL join("\n", @submitted)."\n";
 close MAIL;
 
-## exit 0 for find to consider this -cmd true (in case we ever run it that way...)
-exit(0);
+## exit $NeuroDB::ExitCodes::SUCCESS for find to consider this -cmd true (in case we ever run it that way...)
+exit $NeuroDB::ExitCodes::SUCCESS;

--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -23,6 +23,8 @@ use Digest::MD5;
 
 # more specific stuff
 use DICOM::DICOM;
+use NeuroDB::ExitCodes;
+
 
 # The constructor 
 sub new {
@@ -119,13 +121,14 @@ QUERY
 	    print "\n\nPROBLEM:\n The user \'$row[3]\' has already inserted this study. \n The unique study ID is $row[0]\n";
 	    print " This is the information retained from the first time the study was inserted:\n $row[1]\n\n";
 	    print " Last update of record :\n $row[2]\n\n";
-	    exit 33;
+	    exit $NeuroDB::ExitCodes::FILE_NOT_UNIQUE;
 	}
 	# do not allow to run diccomSummary with database option if the study has already been archived
 	elsif (!$Archivemd5 && $row[3] ne "") { 
 	    print "\n\n PROBLEM: This study has already been archived. You can only re-archive it using dicomTar!\n";
 	    print " This is the information retained from the first time the study has been archived:\n $row[1]\n\n";
-	    exit 33; }
+	    exit $NeuroDB::ExitCodes::FILE_NOT_UNIQUE;
+        ; }
 	
     } else {
 	$update = 0;
@@ -437,7 +440,7 @@ sub dcm_count {
     }
     if ($count == 0) {
 	print "\n\t The target directory does not contain a single DICOM file. \n\n\n";
-	    exit 33;
+	    exit $NeuroDB::ExitCodes::MISSING_FILES;
     }
     else { return $count;}
 }
@@ -681,7 +684,7 @@ sub confirm_single_study {
 	foreach my $studyUID (keys(%hash)) {
 	    print "'$studyUID'\n";
 	}
-	exit 33; 
+	exit $NeuroDB::ExitCodes::FILE_TYPE_CHECK_FAILURE;
     }
     else {
 	my $studyid;

--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -128,7 +128,7 @@ QUERY
 	    print "\n\n PROBLEM: This study has already been archived. You can only re-archive it using dicomTar!\n";
 	    print " This is the information retained from the first time the study has been archived:\n $row[1]\n\n";
 	    exit $NeuroDB::ExitCodes::FILE_NOT_UNIQUE;
-        ; }
+    }
 	
     } else {
 	$update = 0;
@@ -684,7 +684,7 @@ sub confirm_single_study {
 	foreach my $studyUID (keys(%hash)) {
 	    print "'$studyUID'\n";
 	}
-	exit $NeuroDB::ExitCodes::FILE_TYPE_CHECK_FAILURE;
+	exit $NeuroDB::ExitCodes::NOT_A_SINGLE_STUDY;
     }
     else {
 	my $studyid;

--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -98,7 +98,7 @@ if (-d $dcm_source && -d $targetlocation) {
     $targetlocation =~ s/^(.*)\/$/$1/;
 } else {
     print STDERR "\nERROR: source and target must be existing directories!\n\n";
-    exit $NeuroDB::ExitCodes::ARG_FILE_DOES_NOT_EXIST;
+    exit $NeuroDB::ExitCodes::INVALID_PATH;
 }
 
 # The tar target 
@@ -220,7 +220,7 @@ if ($dbase) {
         print "\nDone adding archive info into database\n" if $verbose;
     } else {
         print STDERR "\nThe database command failed\n";
-        exit $NeuroDB::ExitCodes::TARCHIVE_INSERT_FAILURE;
+        exit $NeuroDB::ExitCodes::INSERT_FAILURE;
     }
 }
 
@@ -232,7 +232,7 @@ if ($mri_upload_update) {
     my $output = system($script);
     if ($output!=0)  {
         print STDERR "\n\tERROR: the script updateMRI_Upload.pl has failed\n\n";
-        exit $NeuroDB::ExitCodes::UPDATE_MRI_UPLOAD_FAILURE;
+        exit $NeuroDB::ExitCodes::UPDATE_FAILURE;
     }
 }
 

--- a/dicom-archive/updateMRI_Upload.pl
+++ b/dicom-archive/updateMRI_Upload.pl
@@ -102,7 +102,7 @@ if ( !@Settings::db ) {
 unless (-e $tarchive) {
     print STDERR "\nERROR: Could not find archive $tarchive.\n"
                  . "Please, make sure the path to the archive is valid.\n\n";
-    exit $NeuroDB::ExitCodes::ARG_FILE_DOES_NOT_EXIST;
+    exit $NeuroDB::ExitCodes::INVALID_PATH;
 }
 
 ################################################################
@@ -111,7 +111,7 @@ unless (-e $tarchive) {
 unless (-e $source_location) {
     print STDERR "\nERROR: Could not find sourcelocation $source_location\n"
                  . "Please, make sure the sourcelocation is valid.\n\n";
-    exit $NeuroDB::ExitCodes::ARG_FILE_DOES_NOT_EXIST;
+    exit $NeuroDB::ExitCodes::INVALID_PATH;
 }
 ################################################################
 #####establish database connection if database option is set####
@@ -154,7 +154,7 @@ $sth->execute($tarchive_path);
 my $count = $sth->fetchrow_array;
 if($count>0) {
    print STDERR "\n\tERROR: the tarchive is already uploaded \n\n";
-   exit $NeuroDB::ExitCodes::TARCHIVE_ALREADY_UPLOADED;
+   exit $NeuroDB::ExitCodes::FILE_NOT_UNIQUE;
 } 
 
 

--- a/docs/scripts_md/ExitCodes.md
+++ b/docs/scripts_md/ExitCodes.md
@@ -29,41 +29,37 @@ input error checking and setting failures). Note that not all of the possible
 exit codes are used by each script, giving some room to add some later on if
 needed.
 
-Below is a list of the possible exit codes organized per script:
+Below is a list of the possible exit codes:
 
-1\. Common exit codes to most insertion scripts (exit codes from 0 to 19, 0 =
-exit script with success status)
+\##### ---- SECTION 1:  EXIT CODES COMMON TO MOST IMAGING INSERTION SCRIPTS
 
-2\. Exit codes from batch\_uploads\_imageuploader (exit codes from 20 to 39)
+1\. Success: exit code = 0 upon success.
 
-3\. Exit codes from batch\_uploads\_tarchive (no exit codes available yet, exit
-codes will be from 40 to 59)
+2\. Common input error checking and setting failures (exit codes from 1 to 19)
 
-4\. Exit codes from dicom-archive/dicomTar.pl (exit codes from 60 to 79)
+3\. Common database related failures (exit codes from 20 to 39)
 
-5\. Exit codes from dicom-archive/updateMRI\_upload (exit codes from 80 to 99)
+4\. Common configuration failures (exit codes from 40 to 59)
 
-6\. Exit codes from DTIPrep/DTIPrep\_pipeline.pl (exit codes from 100 to 119)
+5\. Common file manipulation failures (exit codes from 60 to 79)
 
-7\. Exit codes from DTIPrep/DTIPrepRegister.pl (exit codes from 120 to 139)
+6\. Common other generic failures (exit codes from 80 to 149)
 
-8\. Exit codes from uploadNeuroDB/imaging\_upload\_file.pl (exit codes from 140
-to 159)
+\##### ---- SECTION 2: SCRIPT SPECIFIC EXIT CODES NOT COVERED IN SECTION 1
 
-9\. Exit codes from uploadNeuroDB/NeuroDB/ImagingUpload.pm (exit codes from 160
-to 179)
+7\. Exit codes from batch\_uploads\_imageuploader (exit codes from 150 to 159)
 
-10\. Exit codes from uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm (exit codes
- from 180 to 199)
+8\. Exit codes from DTIPrep/DTIPrepRegister.pl (exit codes from 160 to 169)
 
-11\. Exit codes from uploadNeuroDB/minc\_deletion.pl (exit codes from 200 to 219)
+9\. Exit codes from uploadNeuroDB/NeuroDB/ImagingUpload.pm (exit codes from
+170 to 179)
 
-12\. Exit codes from uploadNeuroDB/minc\_insertion.pl (exit codes from 220 to 239)
+11\. Exit codes from uploadNeuroDB/minc\_insertion.pl (exit codes from 180 to 189)
 
-13\. Exit codes from uploadNeuroDB/register\_processed\_data.pl (exit codes from
-240 to 259)
+12\. Exit codes from uploadNeuroDB/tarchiveLoader (exit codes from 190 to 199)
 
-14\. Exit codes from uploadNeuroDB/tarchiveLoader (exit codes from 260 to 279)
+13\. Exit codes from uploadNeuroDB/NeuroDB/bin/minc2jiv.pl (exit codes from 200
+to 210)
 
 # LICENSING
 

--- a/uploadNeuroDB/NeuroDB/ExitCodes.pm
+++ b/uploadNeuroDB/NeuroDB/ExitCodes.pm
@@ -37,44 +37,38 @@ input error checking and setting failures). Note that not all of the possible
 exit codes are used by each script, giving some room to add some later on if
 needed.
 
-Below is a list of the possible exit codes organized per script:
+Below is a list of the possible exit codes:
 
-1. Common exit codes to most insertion scripts (exit codes from 0 to 19, 0 =
-exit script with success status)
+##### ---- SECTION 1:  EXIT CODES COMMON TO MOST IMAGING INSERTION SCRIPTS
 
-2. Exit codes from batch_uploads_imageuploader (exit codes from 20 to 39)
+1. Success: exit code = 0 upon success.
 
-3. Exit codes from batch_uploads_tarchive (no exit codes available yet, exit
-codes will be from 40 to 59)
+2. Common input error checking and setting failures (exit codes from 1 to 19)
 
-4. Exit codes from dicom-archive/dicomTar.pl (exit codes from 60 to 79)
+3. Common database related failures (exit codes from 20 to 39)
 
-5. Exit codes from dicom-archive/updateMRI_upload (exit codes from 80 to 99)
+4. Common configuration failures (exit codes from 40 to 59)
 
-6. Exit codes from DTIPrep/DTIPrep_pipeline.pl (exit codes from 100 to 119)
+5. Common file manipulation failures (exit codes from 60 to 79)
 
-7. Exit codes from DTIPrep/DTIPrepRegister.pl (exit codes from 120 to 139)
+6. Common other generic failures (exit codes from 80 to 149)
 
-8. Exit codes from uploadNeuroDB/imaging_upload_file.pl (exit codes from 140
-to 159)
 
-9. Exit codes from uploadNeuroDB/NeuroDB/ImagingUpload.pm (exit codes from 160
-to 179)
+##### ---- SECTION 2: SCRIPT SPECIFIC EXIT CODES NOT COVERED IN SECTION 1
 
-10. Exit codes from uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm (exit codes
- from 180 to 199)
+7. Exit codes from batch_uploads_imageuploader (exit codes from 150 to 159)
 
-11. Exit codes from uploadNeuroDB/minc_deletion.pl (exit codes from 200 to 219)
+8. Exit codes from DTIPrep/DTIPrepRegister.pl (exit codes from 160 to 169)
 
-12. Exit codes from uploadNeuroDB/minc_insertion.pl (exit codes from 220 to 239)
+9. Exit codes from uploadNeuroDB/NeuroDB/ImagingUpload.pm (exit codes from
+170 to 179)
 
-13. Exit codes from uploadNeuroDB/register_processed_data.pl (exit codes from
-240 to 259)
+11. Exit codes from uploadNeuroDB/minc_insertion.pl (exit codes from 180 to 189)
 
-14. Exit codes from uploadNeuroDB/tarchiveLoader (exit codes from 260 to 279)
+12. Exit codes from uploadNeuroDB/tarchiveLoader (exit codes from 190 to 199)
 
-15. Exit codes from uploadNeuroDB/NeuroDB/bin/minc2jiv.pl (exit codes from 280
-to 300)
+13. Exit codes from uploadNeuroDB/NeuroDB/bin/minc2jiv.pl (exit codes from 200
+to 210)
 
 
 =head1 LICENSING
@@ -92,244 +86,101 @@ Neuroscience
 
 
 
-#### --- EXIT CODES COMMON TO MOST IMAGING INSERTION SCRIPTS
+##### ---- SECTION 1:  EXIT CODES COMMON TO MOST IMAGING INSERTION SCRIPTS
 
-# script ran successfully
+## -- Script ran successfully
 our $SUCCESS = 0; # yeah!! Success!!
 
-# input error checking and setting failures
-our $GETOPT_FAILURE          = 1; # if no getOptions were set
-our $PROFILE_FAILURE         = 2; # if no profile file specified
-our $MISSING_ARG             = 3; # if missing script's argument(s)
-our $DB_SETTINGS_FAILURE     = 4; # if DB settings in profile file are not set
-our $ARG_FILE_DOES_NOT_EXIST = 5; # if file given as an argument does not exist
-                                  # in the file system
 
-# database related failure
-# called from minc_insertion.pl & register_processed_data.pl
-our $FILE_NOT_UNIQUE = 6; # if file to register is not unique & already
-                          # inserted
-
-# Used when an environment variable is either missing or has an invalid
-# value
-our $INVALID_ENVIRONMENT_VAR = 7;
-
-our $INVALID_ARG             = 8; # if one of the program argument is invalid
-
-# other generic failure
-our $FILE_OR_FOLDER_DOES_NOT_EXIST = 9; # if file or folder does not exist
-                           
+## -- Common input error checking and setting failures (exit codes from 1 to 19)
+our $GETOPT_FAILURE       = 1; # if no getOptions were set
+our $PROFILE_FAILURE      = 2; # if no profile file specified
+our $MISSING_ARG          = 3; # if missing script's argument(s)
+our $DB_SETTINGS_FAILURE  = 4; # if DB settings in profile file are not set
+our $INVALID_PATH         = 5; # if path to file or folder does not exist
+our $INVALID_ARG          = 6; # if one of the program argument is invalid
 
 
+## -- Common database related failures (exit codes from 20 to 39)
+our $FILE_NOT_UNIQUE = 20; # if file to register is not unique & already
+                           # inserted
+our $INSERT_FAILURE  = 21; # if an INSERT query failed
+our $CORRUPTED_FILE  = 22; # if mismatch between the file's md5sum and the hash
+                           # stored in the database
+our $SELECT_FAILURE  = 23; # if a SELECT query did not return anything
+our $UPDATE_FAILURE  = 24; # if an UPDATE query failed
 
 
-#### --- FROM batch_uploads_imageuploader
-
-# validation failures
-our $UPLOADED_FILE_TYPE_FAILURE = 20; # if the uploaded file is not a .tgz,
-                                      # tar.gz or .zip file
-our $PHANTOM_ENTRY_FAILURE      = 21; # if the phantom entry in the text file is
-                                      # not 'N' nor 'Y'
-our $PNAME_FILENAME_MISMATCH    = 22; # if patient name and beginning of
-                                      # uploaded filename do not match
-our $PNAME_PHANTOM_MISMATCH     = 23; # if patient name provided in the text
-                                      # file but phantom is set to 'Y'
+## -- Common configuration failures (exit codes from 40 to 59)
+our $INVALID_ENVIRONMENT_VAR       = 40; # used when an environment variable is
+                                         # either missing or has an invalid
+                                         # value
+our $PROJECT_CUSTOMIZATION_FAILURE = 41; # used when either missing a function
+                                         # or a customization variable
 
 
+## -- Common file manipulation failures (exit codes from 60 to 79)
+our $EXTRACTION_FAILURE      = 60; # if archive extraction failed
+our $FILE_TYPE_CHECK_FAILURE = 61; # if different file type from what's expected
+our $INVALID_DICOM           = 62; # if DICOM is invalid
+our $MISSING_FILES           = 63; # if there are missing files compared to
+                                   # what is expected
+our $UNREADABLE_FILE         = 64; # if could not properly read a file content
 
 
-
-
-#### --- FROM batch_uploads_tarchive
-
-#TODO: TO BE DONE LATER ON (ERROR CODES WOULD BE BETWEEN 40 & 59)
-
-
-
-
-
-
-#### --- FROM dicom-archive/dicomTar.pl
-
-# input error checking and setting failures
-our $TARGET_EXISTS_NO_CLOBBER  = 60; # if tarchive already exists but option
+## -- Common other generic failures (exit codes from 80 to 149)
+our $CLEANUP_FAILURE           = 80; # if cleanup after script execution failed
+our $MISSING_TOOL_VERSION      = 81; # if missing the tool version information
+our $PROGRAM_EXECUTION_FAILURE = 82; # if script execution failed
+our $TARGET_EXISTS_NO_CLOBBER  = 83; # if tarchive already exists but option
                                      # -clobber was not set
-
-# database related failures
-our $TARCHIVE_INSERT_FAILURE   = 61; # if insertion in tarchive tables failed
-
-# script execution failures
-our $UPDATE_MRI_UPLOAD_FAILURE = 62; # if updateMRI_Upload.pl execution failed
+our $UNKNOWN_PROTOCOL          = 84; # if could not find acquisition protocol
+                                     # protocol of the file to be inserted
 
 
 
 
 
+##### ---- SECTION 2: SCRIPT SPECIFIC EXIT CODES NOT COVERED IN SECTION 1
 
-#### --- FROM dicom-archive/updateMRI_upload.pl
+
+## -- FROM batch_uploads_imageuploader (exit codes from 150 to 159)
 
 # validation failures
-our $TARCHIVE_ALREADY_UPLOADED = 80; # if the tarchive was already uploaded
+our $PHANTOM_ENTRY_FAILURE   = 150; # if the phantom entry in the text file is
+                                    # not 'N' nor 'Y'
+our $PNAME_FILENAME_MISMATCH = 151; # if patient name and filename do not match
 
 
-
-
-
-
-#### --- FROM DTIPrep/DTIPrep_pipeline.pl
+## -- FROM DTIPrep/DTIPrepRegister.pl (exit codes from 160 to 169)
 
 # validation failures
-our $NO_DTIPREP_VERSION       = 100; # if no DTIPrep version could be found
-our $NO_MINCDIFFUSION_VERSION = 101; # if no mincdiffusion version could be
-                                     # found
-                                    # NOTE: ALSO USED BY DTIPrepRegister.pl
-our $NO_NIAK_PATH             = 102; # if no valid NIAK path could be found
-
-# processing exits
-our $NO_POST_PROCESSING_TO_RUN = 103; # if no post-processing will be run
+our $GET_OUTPUT_LIST_FAILURE = 160; # if could not get the list of outputs
+                                    # for the DTI file
 
 
-
-
-
-
-#### --- FROM DTIPrep/DTIPrepRegister.pl
+## -- FROM uploadNeuroDB/NeuroDB/ImagingUpload.pm (exit codes from 170 to 179)
 
 # validation failures
-our $UNREADABLE_DTIPREP_PROTOCOL = 120; # if DTIPrep XML protocol cannot be
-# read
-our $GET_OUTPUT_LIST_FAILURE     = 121; # if could not get the list of outputs
-                                        # for the DTI file
-our $MISSING_PREPROCESSED_FILES  = 122; # if some preprocess files are missing
-our $MISSING_POSTPROCESSED_FILES = 123; # if some post-process files are missing
-our $NO_TOOL_NAME_VERSION        = 124; # if tool name & version not available
+our $DICOM_PNAME_EXTRACTION_FAILURE = 170; # if patient name cannot be
+                                           # extracted from the DICOM files
 
 
-
-
-
-#### --- FROM uploadNeuroDB/imaging_upload_file.pl
-
-# input error checking and setting failures
-our $UPLOAD_ID_PATH_MISMATCH = 140; # if upload path given as an argument does
-                                    # not match the path stored in the
-                                    # mri_upload table for the UploadID given
-                                    # as an argument
-our $INVALID_DICOM_CAND_INFO = 141; # if files in tarchive are not all DICOMs
-                                    # or if at least one patient name mismatch
-                                    # between the one stored in DICOM files and
-                                    # the one stored in mri_upload
-
-# script execution failures
-our $DICOMTAR_FAILURE        = 142; # if dicomTar.pl execution failed
-our $TARCHIVELOADER_FAILURE  = 143; # if tarchiveLoader execution failed
-
-our $CLEANUP_UPLOAD_FAILURE  = 144; # if removal/clean up of the uploaded
-                                    # file in the incoming folder failed
-
-
-
-
-
-
-#### --- FROM uploadNeuroDB/NeuroDB/ImagingUpload.pm
+## -- FROM uploadNeuroDB/minc_insertion.pl (exit codes from 180 to 189)
 
 # validation failures
-our $DICOM_PNAME_EXTRACTION_FAILURE = 160; # if tarchive was already uploaded
-
-
-
-
-
-
-#### --- FROM uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
-
-# database related failures
-our $TARCHIVE_NOT_IN_DB        = 180; # if tarchive not found in the database
-our $GET_PSC_FAILURE           = 181; # if could not determine PSC from the DB
-our $GET_SCANNERID_FAILURE     = 182; # if could not determine scannerID from DB
-our $CAND_REGISTRATION_FAILURE = 183; # if candidate registration failed
-
-
-# file related failures
-our $EXTRACT_ARCHIVE_FAILURE = 184; # if extraction of the archive failed
-our $CORRUPTED_TARCHIVE      = 185; # if mismatch between md5sum stored in the
-                                    # tarchive table and the md5sum of the
-                                    # tarchive from the file system
-
-# study related failures
-our $GET_SUBJECT_ID_FAILURE = 186; # if the getSubjectIDs function from the
-                                   # profile does not return subject IDs
-
-
-
-
-
-
-#### --- FROM uploadNeuroDB/minc_deletion.pl
-
-# validation failures
-our $FILEID_SERIESUID_ARG_FAILURE = 200; # if seriesUID and fileID both provided
-                                         # as input to the file (it should
-                                         # always be one or the other)
-
-
-
-
-
-
-#### --- FROM uploadNeuroDB/minc_insertion.pl
-
-# validation failures
-our $INVALID_TARCHIVE   = 220; # if tarchive validation is not set to 1 in the
+our $INVALID_TARCHIVE   = 180; # if tarchive validation is not set to 1 in the
                                # mri_upload table
-our $CANDIDATE_MISMATCH = 221; # if candidate PSCID and CandID do not match
-our $UNKNOW_PROTOCOL    = 222; # if could not find acquisition protocol of the
-                               # MINC
-our $PROTOCOL_NOT_IN_PROFILE = 223; # if the acquisition protocol could be
-                                    # determined but is not included in the
-                                    # isFileToBeRegisteredGivenProtocol function
-                                    # of the profile file
+our $CANDIDATE_MISMATCH = 181; # if candidate PSCID and CandID do not match
 
 
-
-
-
-
-#### --- FROM uploadNeuroDB/register_processed_data.pl
-
-# validation failures
-our $INVALID_SOURCEFILEID = 240; # if source file ID argument is not valid
-
-# database related failures
-our $GET_SESSIONID_FROM_SOURCEFILEID_FAILURE = 241; # if failed to get SessionID
-                                                    # from the sourceFileID
-our $GET_ACQUISITION_PROTOCOL_ID_FAILURE     = 242; # if failed to determine the
-                                                    # acquisition protocol ID
-our $FILE_REGISTRATION_FAILURE               = 243; # if file registration
-                                                    # into the database failed
-
-
-
-
-
-
-#### --- FROM uploadNeuroDB/tarchiveLoader
-
-# script execution failures
-our $TARCHIVE_VALIDATION_FAILURE = 260; # if tarchive_validation.pl failed
+## -- FROM uploadNeuroDB/tarchiveLoader (exit codes from 190 to 199)
 
 # file related failures
-our $NO_VALID_MINC_CREATED = 261; # if no valid MINC file was created
+our $NO_VALID_MINC_CREATED = 190; # if no valid MINC file was created
                                   # (non-localizers)
-our $NO_MINC_INSERTED      = 262; # if no MINC files was inserted (invalid
-                                  # study)
 
 
+## -- FROM uploadNeuroDB/NeuroDB/bin/minc2jiv.pl (exit codes from 200 to 210)
 
-
-
-
-#### --- FROM uploadNeuroDB/NeuroDB/bin/minc2jiv.pl
-
-our $REGISTER_PROGRAM_FAILURE = 280; # if MNI::Spawn::RegisterPrograms failed
+our $REGISTER_PROGRAM_FAILURE = 220; # if MNI::Spawn::RegisterPrograms failed

--- a/uploadNeuroDB/NeuroDB/ExitCodes.pm
+++ b/uploadNeuroDB/NeuroDB/ExitCodes.pm
@@ -98,7 +98,7 @@ our $PROFILE_FAILURE      = 2; # if no profile file specified
 our $MISSING_ARG          = 3; # if missing script's argument(s)
 our $DB_SETTINGS_FAILURE  = 4; # if DB settings in profile file are not set
 our $INVALID_PATH         = 5; # if path to file or folder does not exist
-our $INVALID_ARG          = 6; # if one of the program argument is invalid
+our $INVALID_ARG          = 6; # if one of the program arguments is invalid
 
 
 ## -- Common database related failures (exit codes from 20 to 39)
@@ -136,6 +136,7 @@ our $TARGET_EXISTS_NO_CLOBBER  = 83; # if tarchive already exists but option
                                      # -clobber was not set
 our $UNKNOWN_PROTOCOL          = 84; # if could not find acquisition protocol
                                      # protocol of the file to be inserted
+our $NOT_A_SINGLE_STUDY        = 85; # if the upload regroups multiple studies
 
 
 
@@ -183,4 +184,6 @@ our $NO_VALID_MINC_CREATED = 190; # if no valid MINC file was created
 
 ## -- FROM uploadNeuroDB/NeuroDB/bin/minc2jiv.pl (exit codes from 200 to 210)
 
-our $REGISTER_PROGRAM_FAILURE = 220; # if MNI::Spawn::RegisterPrograms failed
+our $REGISTER_PROGRAM_FAILURE = 200; # if MNI::Spawn::RegisterPrograms failed
+
+## -- FROM

--- a/uploadNeuroDB/NeuroDB/ExitCodes.pm
+++ b/uploadNeuroDB/NeuroDB/ExitCodes.pm
@@ -135,7 +135,7 @@ our $PROGRAM_EXECUTION_FAILURE = 82; # if script execution failed
 our $TARGET_EXISTS_NO_CLOBBER  = 83; # if tarchive already exists but option
                                      # -clobber was not set
 our $UNKNOWN_PROTOCOL          = 84; # if could not find acquisition protocol
-                                     # protocol of the file to be inserted
+                                     # of the file to be inserted
 our $NOT_A_SINGLE_STUDY        = 85; # if the upload regroups multiple studies
 
 

--- a/uploadNeuroDB/NeuroDB/ExitCodes.pm
+++ b/uploadNeuroDB/NeuroDB/ExitCodes.pm
@@ -51,7 +51,7 @@ Below is a list of the possible exit codes:
 
 5. Common file manipulation failures (exit codes from 60 to 79)
 
-6. Common other generic failures (exit codes from 80 to 149)
+6. Other common generic failures (exit codes from 80 to 149)
 
 
 ##### ---- SECTION 2: SCRIPT SPECIFIC EXIT CODES NOT COVERED IN SECTION 1
@@ -63,11 +63,11 @@ Below is a list of the possible exit codes:
 9. Exit codes from uploadNeuroDB/NeuroDB/ImagingUpload.pm (exit codes from
 170 to 179)
 
-11. Exit codes from uploadNeuroDB/minc_insertion.pl (exit codes from 180 to 189)
+10. Exit codes from uploadNeuroDB/minc_insertion.pl (exit codes from 180 to 189)
 
-12. Exit codes from uploadNeuroDB/tarchiveLoader (exit codes from 190 to 199)
+11. Exit codes from uploadNeuroDB/tarchiveLoader (exit codes from 190 to 199)
 
-13. Exit codes from uploadNeuroDB/NeuroDB/bin/minc2jiv.pl (exit codes from 200
+12. Exit codes from uploadNeuroDB/NeuroDB/bin/minc2jiv.pl (exit codes from 200
 to 210)
 
 
@@ -128,7 +128,7 @@ our $MISSING_FILES           = 63; # if there are missing files compared to
 our $UNREADABLE_FILE         = 64; # if could not properly read a file content
 
 
-## -- Common other generic failures (exit codes from 80 to 149)
+## -- Other common generic failures (exit codes from 80 to 149)
 our $CLEANUP_FAILURE           = 80; # if cleanup after script execution failed
 our $MISSING_TOOL_VERSION      = 81; # if missing the tool version information
 our $PROGRAM_EXECUTION_FAILURE = 82; # if script execution failed

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -172,7 +172,7 @@ sub extract_tarchive {
         print STDERR $message;
         print @tars . "\n";
         $this->spool($message, 'Y', $upload_id, $notify_notsummary);
-        exit $NeuroDB::ExitCodes::EXTRACT_ARCHIVE_FAILURE;
+        exit $NeuroDB::ExitCodes::EXTRACTION_FAILURE;
     }
 
     my $dcmtar = $tars[0];
@@ -226,10 +226,10 @@ sub determineSubjectID {
             my $message =  "\nERROR: Profile does not contain getSubjectIDs ".
                            "routine. Upload will exit now.\n\n";
             $this->writeErrorLog(
-                $message, $NeuroDB::ExitCodes::GET_SUBJECT_ID_FAILURE
+                $message, $NeuroDB::ExitCodes::PROJECT_CUSTOMIZATION_FAILURE
             );
 	    $this->spool($message, 'Y', $upload_id, $notify_notsummary);
-	    exit $NeuroDB::ExitCodes::GET_SUBJECT_ID_FAILURE;
+	    exit $NeuroDB::ExitCodes::PROJECT_CUSTOMIZATION_FAILURE;
         }
     }
     my $subjectIDsref = Settings::getSubjectIDs(
@@ -282,11 +282,11 @@ sub createTarchiveArray {
         my $message = "\nERROR: Only archived data can be uploaded.".
                       "This seems not to be a valid archive for this study!".
                       "\n\n";
-        $this->writeErrorLog($message, $NeuroDB::ExitCodes::TARCHIVE_NOT_IN_DB);
+        $this->writeErrorLog($message, $NeuroDB::ExitCodes::SELECT_FAILURE);
 	# no $tarchive can be fetched so $upload_id is undef
 	# in the notification_spool
         $this->spool($message, 'Y', undef, $notify_notsummary);
-        exit $NeuroDB::ExitCodes::TARCHIVE_NOT_IN_DB;
+        exit $NeuroDB::ExitCodes::SELECT_FAILURE;
     }
 
     return %tarchiveInfo;
@@ -313,10 +313,10 @@ sub determinePSC {
 
             my $message = "\nERROR: No center found for this candidate \n\n";
             $this->writeErrorLog(
-                $message, $NeuroDB::ExitCodes::GET_PSC_FAILURE
+                $message, $NeuroDB::ExitCodes::SELECT_FAILURE
             );
 	    $this->spool($message, 'Y', $upload_id, $notify_notsummary);
-            exit $NeuroDB::ExitCodes::GET_PSC_FAILURE;
+            exit $NeuroDB::ExitCodes::SELECT_FAILURE;
         }
         my $message =
             "\n==> Verifying acquisition center\n-> " .
@@ -360,10 +360,10 @@ sub determineScannerID {
                           "your profile or this archive can not be ".
                           "uploaded.\n\n";
             $this->writeErrorLog(
-                $message, $NeuroDB::ExitCodes::GET_SCANNERID_FAILURE
+                $message, $NeuroDB::ExitCodes::SELECT_FAILURE
             );
        	    $this->spool($message, 'Y', $upload_id, $notify_notsummary);
-            exit $NeuroDB::ExitCodes::GET_SCANNERID_FAILURE;
+            exit $NeuroDB::ExitCodes::SELECT_FAILURE;
         }
     }
     if ($to_log) {
@@ -1041,10 +1041,10 @@ sub CreateMRICandidates {
                        "The dicom header PatientName is: ". 
                        $tarchiveInfo->{'PatientName'}. "\n\n";
             $this->writeErrorLog(
-                $message, $NeuroDB::ExitCodes::CAND_REGISTRATION_FAILURE
+                $message, $NeuroDB::ExitCodes::INSERT_FAILURE
             );
             $this->spool($message, 'Y', $upload_id, $notify_notsummary);
-            exit $NeuroDB::ExitCodes::CAND_REGISTRATION_FAILURE;
+            exit $NeuroDB::ExitCodes::INSERT_FAILURE;
      }
 }
 
@@ -1126,9 +1126,9 @@ sub validateArchive {
         $message =  "\nerror: archive seems to be corrupted or modified. ".
                        "upload will exit now.\nplease read the creation logs ".
                        " for more  information!\n\n";
-        $this->writeErrorLog($message, $NeuroDB::ExitCodes::CORRUPTED_TARCHIVE);
+        $this->writeErrorLog($message, $NeuroDB::ExitCodes::CORRUPTED_FILE);
         $this->spool($message, 'Y', $upload_id, $notify_notsummary);
-        exit $NeuroDB::ExitCodes::CORRUPTED_TARCHIVE;
+        exit $NeuroDB::ExitCodes::CORRUPTED_FILE;
     }
 }
 

--- a/uploadNeuroDB/bin/minc2jiv.pl
+++ b/uploadNeuroDB/bin/minc2jiv.pl
@@ -95,7 +95,7 @@ my $compress= ($gzip ? "| gzip -c9 " : "") ;
 
 my %base_names_seen;
 MNI::FileUtilities::check_output_path("$TmpDir/")
-    or exit $NeuroDB::ExitCodes::FILE_OR_FOLDER_DOES_NOT_EXIST;
+    or exit $NeuroDB::ExitCodes::INVALID_PATH;
 
 foreach my $in_mnc (@ARGV) {
 
@@ -112,7 +112,7 @@ foreach my $in_mnc (@ARGV) {
     #
     my $local_file= "$TmpDir/${base}.mnc"; 
     MNI::FileUtilities::check_output_path( $local_file)
-        or exit $NeuroDB::ExitCodes::FILE_OR_FOLDER_DOES_NOT_EXIST;
+        or exit $NeuroDB::ExitCodes::INVALID_PATH;
     Spawn( ( $ext =~ m/mnc$/ ) ?  
 	   "cp $in_mnc $local_file" : 
 	   "mincexpand $in_mnc $local_file" 
@@ -155,7 +155,7 @@ foreach my $in_mnc (@ARGV) {
 
     my $out_header = "$dir/${base}.header";
     MNI::FileUtilities::check_output_path( $out_header)
-        or exit $NeuroDB::ExitCodes::FILE_OR_FOLDER_DOES_NOT_EXIST;
+        or exit $NeuroDB::ExitCodes::INVALID_PATH;
     write_file( $out_header, $header );
     print "\nVolume header info written to $out_header\n\n"
 	if $Verbose;
@@ -193,7 +193,7 @@ foreach my $in_mnc (@ARGV) {
 
 	$dir= "$output_path/$base/$slice_dirname{$dim}/";
         MNI::FileUtilities::check_output_path($dir)
-            or exit $NeuroDB::ExitCodes::FILE_OR_FOLDER_DOES_NOT_EXIST;
+            or exit $NeuroDB::ExitCodes::INVALID_PATH;
 
 	for( $s= 0 ; $s < $length[ $order->[$dim] ]; ++$s) {
 
@@ -218,7 +218,7 @@ foreach my $in_mnc (@ARGV) {
 
 if( $cfg_file) {
     MNI::FileUtilities::check_output_path( $cfg_file)
-        or exit $NeuroDB::ExitCodes::FILE_OR_FOLDER_DOES_NOT_EXIST;
+        or exit $NeuroDB::ExitCodes::INVALID_PATH;
     write_file( $cfg_file, $cfg );
     print "\nConfig file written to $cfg_file\n\n"
 	if $Verbose;

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -129,7 +129,7 @@ unless ( -e $uploaded_file ) {
     print STDERR "\nERROR: Could not find the uploaded file $uploaded_file.\n"
                  . "Please, make sure the path to the uploaded file is "
                  . "valid.\n\n" ;
-    exit $NeuroDB::ExitCodes::ARG_FILE_DOES_NOT_EXIST;
+    exit $NeuroDB::ExitCodes::INVALID_PATH;
 }
 
 ################################################################
@@ -146,7 +146,7 @@ my $expected_file = getFilePathUsingUploadID($upload_id);
 if ( basename($expected_file) ne basename($uploaded_file)) {
     print STDERR "$Usage\nERROR: The specified upload_id $upload_id does not "
                  . "correspond to the provided file path $uploaded_file.\n\n";
-    exit $NeuroDB::ExitCodes::UPLOAD_ID_PATH_MISMATCH;
+    exit $NeuroDB::ExitCodes::INVALID_ARG;
 }
 
 ################################################################
@@ -217,7 +217,7 @@ if ( !($is_candinfovalid) ) {
     $message = "\nThe candidate info validation has failed.\n";
     spool($message,'Y', $notify_notsummary);
     print STDERR $message;
-    exit $NeuroDB::ExitCodes::INVALID_DICOM_CAND_INFO;
+    exit $NeuroDB::ExitCodes::INVALID_DICOM;
 }
 
 $message = "\nThe candidate info validation has passed.\n";
@@ -233,7 +233,7 @@ if ( !$output ) {
     $message = "\nThe dicomTar.pl execution has failed.\n";
     spool($message,'Y', $notify_notsummary);
     print STDERR $message;
-    exit $NeuroDB::ExitCodes::DICOMTAR_FAILURE;
+    exit $NeuroDB::ExitCodes::PROGRAM_EXECUTION_FAILURE;
 }
 $message = "\nThe dicomTar.pl execution has successfully completed\n";
 spool($message,'N', $notify_notsummary);
@@ -247,7 +247,7 @@ if ( !$output ) {
     $message = "\nThe tarchiveLoader insertion script has failed.\n";
     spool($message,'Y', $notify_notsummary); 
     print STDERR $message;
-    exit $NeuroDB::ExitCodes::TARCHIVELOADER_FAILURE;
+    exit $NeuroDB::ExitCodes::PROGRAM_EXECUTION_FAILURE;
 }
 
 ################################################################
@@ -259,7 +259,7 @@ if ( !$isCleaned ) {
     $message = "\nThe uploaded file " . $uploaded_file . " was not removed\n";
     spool($message,'Y', $notify_notsummary);
     print STDERR $message;
-    exit $NeuroDB::ExitCodes::CLEANUP_UPLOAD_FAILURE;
+    exit $NeuroDB::ExitCodes::CLEANUP_FAILURE;
 }
 $message = "\nThe uploaded file " . $uploaded_file . " has been removed\n\n";
 spool($message,'N', $notify_notsummary);

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -113,7 +113,7 @@ if (!$seriesuid && !$fileid) {
 if ($seriesuid && $fileid) {
     print STDERR " ERROR: You cannot specify both -seriesuid and -fileid "
                  . "options.\n\n";
-    exit $NeuroDB::ExitCodes::FILEID_SERIESUID_ARG_FAILURE;
+    exit $NeuroDB::ExitCodes::INVALID_ARG;
 }
 
 

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -161,7 +161,7 @@ if (!defined $profile || !-e "$ENV{LORIS_CONFIG}/.loris_mri/$profile") {
 if (defined $tarchive && !(-e $tarchive) ) {
     print STDERR "\nERROR: Could not find archive $tarchive. \nPlease, make sure "
         . " the path to the archive is correct. Upload will exit now.\n\n\n";
-    exit $NeuroDB::ExitCodes::ARG_FILE_DOES_NOT_EXIST;
+    exit $NeuroDB::ExitCodes::INVALID_PATH;
 }
 
 if ( !($tarchive xor $upload_id) ) {
@@ -174,7 +174,7 @@ if ( !($tarchive xor $upload_id) ) {
 if (!defined $minc || !-e $minc) {
     print STDERR "$Usage\n\tERROR: You must specify a valid and existing "
         . "MINC file with -minc.\n\n";  
-    exit $NeuroDB::ExitCodes::ARG_FILE_DOES_NOT_EXIST;
+    exit $NeuroDB::ExitCodes::INVALID_PATH;
 }
 
 # input option error checking
@@ -494,7 +494,7 @@ if($acquisitionProtocol =~ /unknown/) {
    $notifier->spool('minc insertion', $message, 0,
                    'minc_insertion.pl', $upload_id, 'Y', 
                    $notify_notsummary);
-   exit $NeuroDB::ExitCodes::UNKNOW_PROTOCOL;
+   exit $NeuroDB::ExitCodes::UNKNOWN_PROTOCOL;
 }
 
 ################################################################
@@ -519,7 +519,7 @@ if ((!defined$acquisitionProtocolIDFromProd)
    $notifier->spool('minc insertion', $message, 0,
                    'minc_insertion', $upload_id, 'Y',
                    $notify_notsummary);
-    exit $NeuroDB::ExitCodes::PROTOCOL_NOT_IN_PROFILE;
+    exit $NeuroDB::ExitCodes::PROJECT_CUSTOMIZATION_FAILURE;
 }
 ################################################################
 ### Add series notification ####################################

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -80,13 +80,13 @@ unless  ($filename && $sourceFileID && $sourcePipeline && $scanType
 unless  ((defined($sourceFileID)) && ($sourceFileID =~ /^[0-9]+$/)) {
     print STDERR "Files to be registered require the -sourceFileID option "
                  . "with a valid FileID as an argument\n";
-    exit $NeuroDB::ExitCodes::INVALID_SOURCEFILEID;
+    exit $NeuroDB::ExitCodes::INVALID_ARG;
 }
 
 # Make sure we have permission to read the file
 unless  (-r $filename)  {
     print STDERR "Cannot read $filename\n";
-    exit $NeuroDB::ExitCodes::ARG_FILE_DOES_NOT_EXIST;
+    exit $NeuroDB::ExitCodes::INVALID_PATH;
 }
 
 # Establish database connection
@@ -151,7 +151,7 @@ if  ($file->getFileDatum('FileType') eq 'mnc')  {
     my  $psc    =   $center_name;
     if  (!$psc)     { 
         print LOG "\nERROR: No center found for this candidate \n\n"; 
-        exit $NeuroDB::ExitCodes::GET_PSC_FAILURE;
+        exit $NeuroDB::ExitCodes::SELECT_FAILURE;
     }
     print LOG  "\n==> Verifying acquisition center\n - Center Name  : $center_name\n - CenterID     : $centerID\n";
 }
@@ -182,7 +182,7 @@ if  ($file->getFileDatum('FileType') eq 'mnc')  {
 if  (!defined($scannerID))  {
     print LOG "\nERROR: could not determine scannerID based on sourceFileID "
               . "$sourceFileID.\n\n";
-    exit $NeuroDB::ExitCodes::GET_SCANNERID_FAILURE;
+    exit $NeuroDB::ExitCodes::SELECT_FAILURE;
 }
 $file->setFileData('ScannerID',$scannerID);
 print LOG "\t -> Set ScannerID to $scannerID.\n";
@@ -197,7 +197,7 @@ if  (!defined($sessionID))  {
     print LOG "\nERROR: could not determine sessionID based on sourceFileID "
               . "$sourceFileID. Are you sure the sourceFile was registered "
               . "in DB?\n\n";
-    exit $NeuroDB::ExitCodes::GET_SESSIONID_FROM_SOURCEFILEID_FAILURE;
+    exit $NeuroDB::ExitCodes::SELECT_FAILURE;
 }
 print LOG "\n==> Data found for candidate   : $subjectIDsref->{'CandID'} - Visit: $subjectIDsref->{'visitLabel'}\n";
 $file->setFileData('SessionID', $sessionID);
@@ -210,7 +210,7 @@ print LOG "\t -> Set SourceFileID to $sourceFileID.\n";
 my  ($acqProtID)    =   getAcqProtID($scanType,$dbh);
 if  (!defined($acqProtID))  {
     print LOG "\nERROR: could not determine AcquisitionProtocolID based on scanType $scanType.\n\n";
-    exit $NeuroDB::ExitCodes::GET_ACQUISITION_PROTOCOL_ID_FAILURE;
+    exit $NeuroDB::ExitCodes::UNKNOWN_PROTOCOL;
 }
 $file->setFileData('AcquisitionProtocolID',$acqProtID);
 print LOG "\t -> Set AcquisitionProtocolID to $acqProtID.\n";
@@ -257,7 +257,7 @@ unless  ($fileID)   {
     # tell the user something went wrong
     print LOG "\n==> FAILED TO REGISTER FILE $filename!\n\n";    
     # and exit
-    exit $NeuroDB::ExitCodes::FILE_REGISTRATION_FAILURE;
+    exit $NeuroDB::ExitCodes::INSERT_FAILURE;
 }
 
 # Insert into files_intermediary the intermediary inputs stored in inputFileIDs.

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -191,7 +191,7 @@ unless ($tarchive =~ m/$tarchivePath/i) {
 unless (-e $tarchive) {
     print STDERR "\nERROR: Could not find archive $tarchive.\n"
                  . "Please, make sure the path to the archive is correct.\n\n";
-    exit $NeuroDB::ExitCodes::ARG_FILE_DOES_NOT_EXIST;
+    exit $NeuroDB::ExitCodes::INVALID_PATH;
 }
 
 
@@ -337,12 +337,12 @@ if (($output != 0)  && ($force==0)) {
             "validation again and fix the problem. Or re-run ".
             "tarchiveLoader using -force to force the execution.\n\n";
  $utility->writeErrorLog(
-     $message, $NeuroDB::ExitCodes::TARCHIVE_VALIDATION_FAILURE, $logfile
+     $message, $NeuroDB::ExitCodes::PROGRAM_EXECUTION_FAILURE, $logfile
  );
  $notifier->spool('tarchive validation', $message, 0, 
 		'tarchiveLoader', $upload_id, 'Y',
 		$notify_notsummary);
- exit $NeuroDB::ExitCodes::TARCHIVE_VALIDATION_FAILURE;
+ exit $NeuroDB::ExitCodes::PROGRAM_EXECUTION_FAILURE;
 }
 
 ################################################################
@@ -684,7 +684,7 @@ if (!$valid_study) {
     $notifier->spool('mri invalid study', $message, 0,
 		    'tarchiveLoader', $upload_id, 'Y', 
 		    $notify_notsummary);
-    exit $NeuroDB::ExitCodes::NO_MINC_INSERTED;
+    exit $NeuroDB::ExitCodes::INSERT_FAILURE;
 }
 
 ###############################################################

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -132,7 +132,7 @@ $tarchive = abs_path($ARGV[0]);
 unless (-e $tarchive) {
     print STDERR "\nERROR: Could not find archive $tarchive.\n"
                  . "Please, make sure the path to the archive is valid.\n\n";
-    exit $NeuroDB::ExitCodes::ARG_FILE_DOES_NOT_EXIST;
+    exit $NeuroDB::ExitCodes::INVALID_PATH;
 }
 
 ################################################################


### PR DESCRIPTION
As @nicolasbrossard pointed out in PR #289, the exit codes are limited to the range 0-255. If a value outside that range is used as an exit code, it is truncated to 8 bits.

In order to refactor this, the follow google doc has been created to map the old and new exit codes:
https://docs.google.com/spreadsheets/d/1QsDQl9rXvut6Li62Rba7iUFRBT8mq6bDfX9JjYRsVQY/edit#gid=0

NOTE: since the exit codes were not yet part of any release, it is the perfect time to refactor them within the upcoming release of 19.1.

Redmine ticket: https://redmine.cbrain.mcgill.ca/issues/14247