### PR TITLE
DeepQC interoperability 

### DIFF
--- a/tools/BackPopulateDeepQC.pl
+++ b/tools/BackPopulateDeepQC.pl
@@ -126,9 +126,13 @@ if($sth->rows > 0) {
 	# Create tarchive list hash with old and new location
     while ( my $rowhr = $sth->fetchrow_hashref()) {
         my $TarchiveID = $rowhr->{'TarchiveID'};
+        my $SourceLocation = $rowhr->{'SourceLocation'};
 		print "Currently updating the DeepQC for applicable files in parameter_file table ".
             "for tarchiveID $TarchiveID\n";
-        $utility->computeDeepQC($TarchiveID, $profile);
+        my $upload_id = NeuroDB::MRIProcessingUtility::getUploadIDUsingTarchiveSrcLoc(
+                        $SourceLocation
+                    );
+        $utility->computeDeepQC($TarchiveID, $upload_id, $profile);
 		print "Finished updating DeepQC for for TarchiveID $TarchiveID\n";
 	}
 }

--- a/tools/BackPopulateDeepQC.pl
+++ b/tools/BackPopulateDeepQC.pl
@@ -97,7 +97,7 @@ my $logfile  = "$LogDir/$templog.log";
 ################## Instantiate MRIProcessingUtility ############
 ################################################################
 my $utility = NeuroDB::MRIProcessingUtility->new(
-                  $db, \$dbh,$debug,$TmpDir,$logfile,
+                  \$dbh,$debug,$TmpDir,$logfile,
                   $LogDir,$verbose
               );
 

--- a/tools/BackPopulateDeepQC.pl
+++ b/tools/BackPopulateDeepQC.pl
@@ -9,6 +9,7 @@ use File::Find;
 use Cwd;
 use NeuroDB::DBI;
 use NeuroDB::MRIProcessingUtility;
+use NeuroDB::ExitCodes;
 
 my $verbose = 1;
 my $debug = 1;
@@ -116,11 +117,11 @@ if (!defined($TarchiveID)) {
 else {
     $query = "SELECT TarchiveID " .
         "FROM tarchive ".
-        "WHERE TarchiveID = $TarchiveID ";
+        "WHERE TarchiveID = ?";
 }
 
 my $sth = $dbh->prepare($query);
-$sth->execute();
+$sth->execute($TarchiveID);
 
 if($sth->rows > 0) {
 	# Create tarchive list hash with old and new location
@@ -133,11 +134,11 @@ if($sth->rows > 0) {
                         $SourceLocation
                     );
         $utility->computeDeepQC($TarchiveID, $upload_id, $profile);
-		print "Finished updating DeepQC for for TarchiveID $TarchiveID\n";
+		print "Finished updating DeepQC for TarchiveID $TarchiveID\n";
 	}
 }
 else {
-	print "No tarchives to be updated \n";
+	print "No tarchive to be updated \n";
 }
 
 $dbh->disconnect();

--- a/tools/BackPopulateDeepQC.pl
+++ b/tools/BackPopulateDeepQC.pl
@@ -1,0 +1,140 @@
+#! /usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Tabular;
+use File::Temp qw/ tempdir /;
+use File::Basename;
+use File::Find;
+use Cwd;
+use NeuroDB::DBI;
+use NeuroDB::MRIProcessingUtility;
+
+my $verbose = 1;
+my $debug = 1;
+my $profile = undef;
+my $TarchiveID = undef;
+my $query;
+
+my @opt_table = (
+    [ "-profile", "string", 1, \$profile,
+      "name of config file in ../dicom-archive/.loris_mri"
+    ],
+    [ "-tarchive_id", "string", 1, \$TarchiveID,
+      "tarchive_id of the DICOM archive to be processed from tarchive table"
+    ]
+);
+
+my $Help = <<HELP;
+
+This script will back populate the parameter_file table with DeepQC entries.
+It can take in TarchiveID as an argument if only a specific DICOM archive is to be
+processed; otherwise, all DICOM archive in the tarchive tables are processed.
+HELP
+
+my $Usage = <<USAGE;
+
+Usage: $0 -help to list options
+
+USAGE
+
+&Getopt::Tabular::SetHelp($Help, $Usage);
+&Getopt::Tabular::GetOptions(\@opt_table, \@ARGV) || exit 1;
+
+################################################################
+################### input option error checking ################
+################################################################
+if (!$ENV{LORIS_CONFIG}) {
+	print STDERR "\n\tERROR: Environment variable 'LORIS_CONFIG' not set\n\n";
+	exit $NeuroDB::ExitCodes::INVALID_ENVIRONMENT_VAR;
+}
+
+if (!defined $profile || !-e "$ENV{LORIS_CONFIG}/.loris_mri/$profile") {
+    print $Help;
+    print STDERR "$Usage\n\tERROR: You must specify a valid and existing profile.\n\n";
+    exit $NeuroDB::ExitCodes::PROFILE_FAILURE;
+}
+
+{ package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
+
+if ( !@Settings::db ) {
+    print STDERR "\n\tERROR: You don't have a \@db setting in the file "
+                 . "$ENV{LORIS_CONFIG}/.loris_mri/$profile \n\n";
+    exit $NeuroDB::ExitCodes::DB_SETTINGS_FAILURE;
+}
+
+################################################################
+######### Establish database connection ########################
+################################################################
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+print "\nSuccessfully connected to database \n";
+
+################################################################
+######### Initialize variables #################################
+################################################################
+my $data_dir = &NeuroDB::DBI::getConfigSetting(
+                    \$dbh,'dataDirBasepath'
+                    );
+my $tarchiveLibraryDir = &NeuroDB::DBI::getConfigSetting(
+                       \$dbh,'tarchiveLibraryDir'
+                       );
+$tarchiveLibraryDir    =~ s/\/$//g;
+my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)
+    =localtime(time);
+my $template = "TarLoad-$hour-$min-XXXXXX"; # for tempdir
+my $TmpDir = tempdir(
+                 $template, TMPDIR => 1, CLEANUP => 1
+             );
+my @temp     = split(/\//, $TmpDir);
+my $templog  = $temp[$#temp];
+my $LogDir   = "$data_dir/logs";
+if (!-d $LogDir) {
+    mkdir($LogDir, 0770);
+}
+my $logfile  = "$LogDir/$templog.log";
+
+################################################################
+################## Instantiate MRIProcessingUtility ############
+################################################################
+my $utility = NeuroDB::MRIProcessingUtility->new(
+                  $db, \$dbh,$debug,$TmpDir,$logfile,
+                  $LogDir,$verbose
+              );
+
+################################################################
+# Grep tarchive list for all those entries with         ########
+# NULL in ArchiveLocationPerModality                    ########
+################################################################
+
+# Query to grep all tarchive entries
+if (!defined($TarchiveID)) {
+    $query = "SELECT TarchiveID " .
+        "FROM tarchive";
+}
+# Selecting tarchiveID is redundant here but it makes the while() loop
+# applicable to both cases; when a TarchiveID is specified or not
+else {
+    $query = "SELECT TarchiveID " .
+        "FROM tarchive ".
+        "WHERE TarchiveID = $TarchiveID ";
+}
+
+my $sth = $dbh->prepare($query);
+$sth->execute();
+
+if($sth->rows > 0) {
+	# Create tarchive list hash with old and new location
+    while ( my $rowhr = $sth->fetchrow_hashref()) {
+        my $TarchiveID = $rowhr->{'TarchiveID'};
+		print "Currently updating the DeepQC for applicable files in parameter_file table ".
+            "for tarchiveID $TarchiveID\n";
+        $utility->computeDeepQC($TarchiveID, $profile);
+		print "Finished updating DeepQC for for TarchiveID $TarchiveID\n";
+	}
+}
+else {
+	print "No tarchives to be updated \n";
+}
+
+$dbh->disconnect();
+exit 0;

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -65,6 +65,8 @@ use NeuroDB::DBI;
 use NeuroDB::Notify;
 use NeuroDB::ExitCodes;
 use Path::Class;
+use LWP::UserAgent;
+use JSON::PP ();
 
 
 ## Define Constants ##
@@ -1668,8 +1670,8 @@ sub computeDeepQC {
     my $t1_scan_type = NeuroDB::DBI::getConfigSetting(
                             $this->{dbhr},'t1_scan_type'
                             );
-    my $acqID_query = "SELECT ID FROM mri_scan_type WHERE Scan_type=?"
-    my $acqID_for_t1_scan = $($this->{'dbhr'}}->prepare($acqID_query);
+    my $acqID_query = "SELECT ID FROM mri_scan_type WHERE Scan_type=?";
+    my $acqID_for_t1_scan = ${$this->{'dbhr'}}->prepare($acqID_query);
     $acqID_for_t1_scan->execute($t1_scan_type);
 
     my $query = "SELECT FileID, file, AcquisitionProtocolID from files f WHERE f.TarchiveSource=?";

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1641,6 +1641,89 @@ sub computeSNR {
     }
 }
 
+=pod
+
+=head3 computeDeepQC($tarchiveID, $tarchive_srcloc, $profile)
+
+Calls the DeepQC app on T1 MNC files to get the probability of passing QC.
+
+INPUTS: tarchive ID, tarchive source location, configuration file (usually prod)
+
+=cut
+
+################################################################
+#######################  computeDeepQC #############################
+################################################################
+sub computeDeepQC {
+    my $this = shift;
+    my ($row, $filename, $fileID, $base, $fullpath, $message);
+    my ($tarchiveID, $upload_id, $profile)= @_;
+    my $data_dir = NeuroDB::DBI::getConfigSetting(
+                        $this->{dbhr},'dataDirBasepath'
+                        );
+    my $ua = LWP::UserAgent->new;
+    my $json = 'JSON::PP'->new;
+    # note: url must be changed to production version later
+    # note 2: include DeepQC modality in prod file
+    my $t1_scan_type = NeuroDB::DBI::getConfigSetting(
+                            $this->{dbhr},'t1_scan_type'
+                            );
+    my $acqID_query = "SELECT ID FROM mri_scan_type WHERE Scan_type=?"
+    my $acqID_for_t1_scan = $($this->{'dbhr'}}->prepare($acqID_query);
+    $acqID_for_t1_scan->execute($t1_scan_type);
+
+    my $query = "SELECT FileID, file, AcquisitionProtocolID from files f WHERE f.TarchiveSource=?";
+
+    if ($this->{debug}) {
+        print $query . "\n";
+    }
+    my $minc_file_arr = ${$this->{'dbhr'}}->prepare($query);
+    $minc_file_arr->execute($tarchiveID);
+
+    while ($row = $minc_file_arr->fetchrow_hashref()) {
+        $filename = $row->{'file'};
+        my $fileID = $row->{'FileID'};
+        my $acqID = $row->{'AcquisitionProtocolID'};
+        $base = basename($filename);
+        $fullpath = $data_dir . "/" . $filename;
+        if (-e $fullpath) {
+            if ($acqID == $acqID_for_t1_scan) {
+                my $url = 'http://127.0.0.1:5000/deepqc/' . $fileID;
+                my $resp = $ua->post($url,
+                  Content_Type => 'multipart/form-data',
+                  Content => [
+                    'file' => [ $fullpath ]
+                  ]
+                );
+                my $DeepQC = $json->decode($resp->content);
+                $DeepQC = $DeepQC->{'prediction'};
+                print "DeepQC Prediction is: " . $DeepQC . "\n" if ($this->{verbose});
+                my $file = NeuroDB::File->new($this->{dbhr});
+                $file->loadFile($fileID);
+                my $DeepQC_old = $file->getParameter('DeepQC');
+                if ($DeepQC ne '') {
+                    if (($DeepQC_old ne '') && ($DeepQC_old ne $DeepQC)) {
+                        $message = "The DeepQC value will be updated from " .
+                            "$DeepQC_old to $DeepQC. \n";
+                        $this->{LOG}->print($message);
+                        $this->spool($message, 'N', $upload_id, $notify_detailed);
+                    }
+                    $file->setParameter('DeepQC', $DeepQC);
+                }
+            }
+            else {
+                $message = "The DeepQC probability can not be computed for $base. ".
+                    "The imaging modality is not ".
+                    "supported by the DeepQC computation. \n";
+                $this->{LOG}->print($message);
+                $this->spool($message, 'N', $upload_id, $notify_detailed);
+            }
+        } else {
+            print "File doesn't exist.\n"
+        }
+    }
+}
+
 
 =pod
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1722,7 +1722,7 @@ sub computeDeepQC {
                 $this->spool($message, 'N', $upload_id, $notify_detailed);
             }
         } else {
-            print "File doesn't exist.\n"
+            print "File $fullpath not found in the filesystem.\n"
         }
     }
 }

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -570,6 +570,10 @@ foreach my $minc (@minc_files) {
 ################################################################
 $utility->computeSNR($tarchiveInfo{TarchiveID}, $upload_id, $profile);
 ################################################################
+############### Compute DeepQC on T1W images ###################
+################################################################
+$utility->computeDeepQC($tarchiveInfo{TarchiveID}, $profile);
+################################################################
 ####### Add order of acquisition for similar modalities ########
 ####### within the same session based on series number #########
 ################################################################

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -572,7 +572,7 @@ $utility->computeSNR($tarchiveInfo{TarchiveID}, $upload_id, $profile);
 ################################################################
 ############### Compute DeepQC on T1W images ###################
 ################################################################
-$utility->computeDeepQC($tarchiveInfo{TarchiveID}, $profile);
+$utility->computeDeepQC($tarchiveInfo{TarchiveID}, $upload_id, $profile);
 ################################################################
 ####### Add order of acquisition for similar modalities ########
 ####### within the same session based on series number #########


### PR DESCRIPTION
This PR replaces #304 so as to be based off of the minor branch. I've addressed almost all the changes that were requested by @cmadjar and @MounaSafiHarab in the original PR. 

`computeDeepQC`:  
- [x] computeDeepQC takes as input the `profile`, `upload_id`, and `tarchive_id`. 
- [x] `computeDeepQC` determines the project specific `AcquisitionProtocolID` for T1 scans based on the `t1_scan_type` config setting. 
- [x] For any T1 MNC file associated with the `tarchive_id`, a POST request is made to the DeepQC app to compute the probability of passing QC. The response of this request is a JSON object with the prediction and confidence of the the most up to date algorithm. 
- [x] The JSON object is parsed, and the prediction value is used to update the `DeepQC` parameter in the `parameter_files` table. 
- [ ] Should the confidence also be added to the parameter_files table? or can it be added along with the prediction as a JSON object? 
- [ ] LWP::Agent & JSON::PP must be installed for existing projects. 

`BackPopulateDeepQC`: 
- [x] can either be run with a single `tarchive_id` passed or without `tarchive_id` as an argument in order to run DeepQC on every single T1 MNC the project has. 
- [ ] add Perldoc documentation
