### PR TITLE
Removing trailing / of data_dir in DTIPrep_pipeline and DTIPrepRegister scripts

### DIFF
--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -156,14 +156,13 @@ if (!$DTIPrepVersion) {
 my  $dbh    =   &NeuroDB::DBI::connect_to_db(@Settings::db);
 
 # Needed for log file
-my $data_dir = &NeuroDB::DBI::getConfigSetting(
-                    \$dbh,'dataDirBasepath'
-                    );
-my  $log_dir     =  "$data_dir/logs/DTIPrep_register";
+my $data_dir = &NeuroDB::DBI::getConfigSetting(\$dbh, 'dataDirBasepath');
+$data_dir    =~ s/\/$//;   # removing trailing / in $data_dir
+my  $log_dir = "$data_dir/logs/DTIPrep_register";
 system("mkdir -p -m 770 $log_dir") unless (-e $log_dir);
-my  ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)=localtime(time);
-my  $date        =  sprintf("%4d-%02d-%02d_%02d:%02d:%02d",$year+1900,$mon+1,$mday,$hour,$min,$sec);
-my  $log         =  "$log_dir/DTIregister$date.log";
+my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)=localtime(time);
+my $date = sprintf("%4d-%02d-%02d_%02d:%02d:%02d",$year+1900,$mon+1,$mday,$hour,$min,$sec);
+my $log  = "$log_dir/DTIregister$date.log";
 open(LOG,">>$log");
 print LOG "\n==> Successfully connected to database \n";
 print LOG "Log file, $date\n\n";

--- a/DTIPrep/DTIPrep_pipeline.pl
+++ b/DTIPrep/DTIPrep_pipeline.pl
@@ -173,28 +173,14 @@ if (!$DTIPrepVersion) {
 my  $dbh    =   &NeuroDB::DBI::connect_to_db(@Settings::db);
 
 # These settings are in the ConfigSettings table
-my  $data_dir       =   &NeuroDB::DBI::getConfigSetting(
-                        \$dbh,'dataDirBasepath'
-                        );
-my  $t1_scan_type   =   &NeuroDB::DBI::getConfigSetting(
-                        \$dbh,'t1_scan_type'
-                        );
-my  $DTI_volumes    =   &NeuroDB::DBI::getConfigSetting(
-                        \$dbh,'DTI_volumes'
-                        );
-my  $reject_thresh  =   &NeuroDB::DBI::getConfigSetting(
-                        \$dbh,'reject_thresh'
-                        );
-my  $niak_path      =   &NeuroDB::DBI::getConfigSetting(
-                        \$dbh,'niak_path'
-                        );
-my  $QCed2_step     =   &NeuroDB::DBI::getConfigSetting(
-                        \$dbh,'QCed2_step'
-                        );
-
-my  $site           =   &NeuroDB::DBI::getConfigSetting(
-                        \$dbh,'prefix'
-                        );
+my  $t1_scan_type  = &NeuroDB::DBI::getConfigSetting(\$dbh, 't1_scan_type');
+my  $DTI_volumes   = &NeuroDB::DBI::getConfigSetting(\$dbh, 'DTI_volumes');
+my  $reject_thresh = &NeuroDB::DBI::getConfigSetting(\$dbh, 'reject_thresh');
+my  $niak_path     = &NeuroDB::DBI::getConfigSetting(\$dbh, 'niak_path');
+my  $QCed2_step    = &NeuroDB::DBI::getConfigSetting(\$dbh,'QCed2_step');
+my  $site          = &NeuroDB::DBI::getConfigSetting(\$dbh, 'prefix');
+my  $data_dir      = &NeuroDB::DBI::getConfigSetting(\$dbh, 'dataDirBasepath');
+$data_dir          =~ s/\/$//;   # removing trailing / in $data_dir
 
 # Needed for log file
 my  ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)   =   localtime(time);


### PR DESCRIPTION
DTIPrepRegister.pl and DTIPrep_pipeline.pl crashes when there is a trailing / in the data_dir variable set in the Config module. This PR removes the trailing / when it exists from the data_dir variable.

Redmine ticket: https://redmine.cbrain.mcgill.ca/issues/14351