### PR TITLE
Moving the filterParameters() function out of the profileTemplate file

### DIFF
--- a/dicom-archive/profileTemplate
+++ b/dicom-archive/profileTemplate
@@ -108,23 +108,6 @@ sub isFileToBeRegisteredGivenProtocol {
 }
 
 # ----------- OPTIONAL SUBROUTINE
-# Takes a NeuroDB::File object, and manipulates its parameters
-# in this case, removes all parameters of length > 1000
-sub filterParameters {
-    my $fileRef = shift;
-    my $file = $$fileRef;
-    my $parametersRef = $file->getParameters();
-
-    foreach my $key (keys %{$parametersRef}) {
-        if(($key ne 'header') && (length($parametersRef->{$key}) > 1000)) {
-            #print "\n\tFilter active on: $key with length ".length($parametersRef->{$key})."\n"; 
-            $file->removeParameter($key);
-        }
-    }
-}
-
-
-# ----------- OPTIONAL SUBROUTINE
 # Fetch CandID and Visit info from DTI folder.
 sub  get_DTI_CandID_Visit {
     my ($native_dir) =   @_;

--- a/docs/02-Install.md
+++ b/docs/02-Install.md
@@ -200,10 +200,6 @@ if($acquisitionProtocol eq 't1' or $acquisitionProtocol eq 't2' or $acquisitionP
 
     Routine to parse candidate’s PSCID, CandID, Center (determined from the PSCID), and visit 
     label. 
-
-- `filterParameters()`
-
-    Routine that takes in a file as an object and removes all parameters of length > 1000
     
 - `get_DTI_CandID_Visit()`
 

--- a/docs/scripts_md/File.md
+++ b/docs/scripts_md/File.md
@@ -168,6 +168,11 @@ INPUT: variable to remove white space from (string or array)
 
 RETURNS: string or array of the value without white spaces
 
+### filterParameters
+
+Manipulates the NeuroDB::File object's parameters and removes all parameters of
+length > 1000
+
 # TO DO
 
 Other operations should be added: perhaps `get*` methods for those fields in

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -55,6 +55,7 @@ class will croak.
 use strict;
 
 my $VERSION = sprintf "%d.%03d", q$Revision: 1.6 $ =~ /: (\d+)\.(\d+)/;
+my $MAX_DICOM_PARAMETER_LENGTH = 1000;
 
 =pod
 
@@ -515,7 +516,7 @@ sub removeWhitespace {
 =head3 filterParameters
 
 Manipulates the NeuroDB::File object's parameters and removes all parameters of
-length > 1000
+length > $MAX_DICOM_PARAMETER_LENGTH
 
 =cut
 sub filterParameters {
@@ -524,7 +525,8 @@ sub filterParameters {
     my $parametersRef = $this->getParameters();
 
     foreach my $key (keys %{$parametersRef}) {
-        if(($key ne 'header') && (length($parametersRef->{$key}) > 1000)) {
+        if(($key ne 'header')
+            && (length($parametersRef->{$key}) > $MAX_DICOM_PARAMETER_LENGTH)) {
             $this->removeParameter($key);
         }
     }

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -509,6 +509,27 @@ sub removeWhitespace {
         return @vars;
     }
 }
+
+=pod
+
+=head3 filterParameters
+
+Manipulates the NeuroDB::File object's parameters and removes all parameters of
+length > 1000
+
+=cut
+sub filterParameters {
+    my $this = shift;
+
+    my $parametersRef = $this->getParameters();
+
+    foreach my $key (keys %{$parametersRef}) {
+        if(($key ne 'header') && (length($parametersRef->{$key}) > 1000)) {
+            $this->removeParameter($key);
+        }
+    }
+}
+
     
 1;
 

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -54,8 +54,9 @@ class will croak.
 
 use strict;
 
+use constant MAX_DICOM_PARAMETER_LENGTH => 1000;
+
 my $VERSION = sprintf "%d.%03d", q$Revision: 1.6 $ =~ /: (\d+)\.(\d+)/;
-my $MAX_DICOM_PARAMETER_LENGTH = 1000;
 
 =pod
 
@@ -526,7 +527,7 @@ sub filterParameters {
 
     foreach my $key (keys %{$parametersRef}) {
         if(($key ne 'header')
-            && (length($parametersRef->{$key}) > $MAX_DICOM_PARAMETER_LENGTH)) {
+            && (length($parametersRef->{$key}) > MAX_DICOM_PARAMETER_LENGTH)) {
             $this->removeParameter($key);
         }
     }

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -448,14 +448,11 @@ my $candlogSth = $dbh->prepare($logQuery);
 ################################################################
 my $file = $utility->loadAndCreateObjectFile($minc, $upload_id);
 
-################################################################
-##### Optionally do extra filtering, if needed #################
-################################################################
-if (defined(&Settings::filterParameters)) {
-    print LOG "\n--> using user-defined filterParameters for $minc\n"
-    if $verbose;
-    Settings::filterParameters(\$file);
-}
+# filters out parameters of length > 1000
+$message = "\n--> filters out parameters of length > 1000 for $minc\n";
+print LOG $message if $verbose;
+$file->filterParameters();
+
 
 ################################################################
 # We already know the PatientName is bad from step 5a, but #####

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -448,8 +448,9 @@ my $candlogSth = $dbh->prepare($logQuery);
 ################################################################
 my $file = $utility->loadAndCreateObjectFile($minc, $upload_id);
 
-# filters out parameters of length > 1000
-$message = "\n--> filters out parameters of length > 1000 for $minc\n";
+# filters out parameters of length > NeuroDB::File::MAX_DICOM_PARAMETER_LENGTH
+$message = "\n--> filters out parameters of length > "
+           . NeuroDB::File::MAX_DICOM_PARAMETER_LENGTH . " for $minc\n";
 print LOG $message if $verbose;
 $file->filterParameters();
 

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -182,11 +182,10 @@ if  ($file->getFileDatum('FileType') eq 'mnc')  {
     &NeuroDB::MRI::mapDicomParameters(\$file);
     print LOG "\n==>Mapped DICOM parameters\n";
 
-    # Optionally do extra filtering, if needed
-    if  (defined(&Settings::filterParameters))  {
-        print LOG "\t -> using user-defined filterParameters for $filename\n" ;
-        Settings::filterParameters(\$file);     
-    }
+    # filters out parameters of length > 1000
+    print LOG "\t -> filters out parameters of length > 1000 for $filename\n";
+    $file->filterParameters();
+
 }
 
 

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -182,8 +182,9 @@ if  ($file->getFileDatum('FileType') eq 'mnc')  {
     &NeuroDB::MRI::mapDicomParameters(\$file);
     print LOG "\n==>Mapped DICOM parameters\n";
 
-    # filters out parameters of length > 1000
-    print LOG "\t -> filters out parameters of length > 1000 for $filename\n";
+    # filters out parameters of length > NeuroDB::File::MAX_DICOM_PARAMETER_LENGTH
+    print LOG "\t -> filters out parameters of length > "
+              . NeuroDB::File::MAX_DICOM_PARAMETER_LENGTH . " for $filename\n";
     $file->filterParameters();
 
 }


### PR DESCRIPTION
This PR moves the `filterParameters()` function out of the `profileTemplate` file to the `File.pm` library.

On April 6th, 2018, an email was sent to all LORIS-MRI users to ask whether any project had customized that function in their profile file. As of May 31st, no project has mentioned that they customized that function so it should be safe to go ahead and move that function back into the LORIS-MRI code.

**See Redmine ticket**: https://redmine.cbrain.mcgill.ca/issues/13934

**Note for testers**: I tested changing the length in the filterParameters function that I moved to File.pm to 10 and it decreased the amount of entries in parameter_file, ergo, it works as expected. I then put back that value to 1000 as originally specified in the profileTemplate