### PR TITLE
Select statements in the new database framework now return a reference to an array of hash references.

### DIFF
--- a/dicom-archive/updateMRI_Upload.pl
+++ b/dicom-archive/updateMRI_Upload.pl
@@ -100,8 +100,6 @@ use File::Basename;
 use lib "$FindBin::Bin";
 use DICOM::DICOM;
 
-use NeuroDB::MRI;
-
 use NeuroDB::Database;
 use NeuroDB::DatabaseException;
 
@@ -236,9 +234,6 @@ my $db = NeuroDB::Database->new(
     hostName     => $Settings::db[3]
 );
 $db->connect();
-
-my $xxxxx = &NeuroDB::MRI::scan_type_text_to_id('scout', $db);
-my $yyyyy = &NeuroDB::MRI::scan_type_id_to_text(52, $db);
 
 ################################################################
 #####check to see if the tarchiveid is already set or not#######

--- a/dicom-archive/updateMRI_Upload.pl
+++ b/dicom-archive/updateMRI_Upload.pl
@@ -100,6 +100,8 @@ use File::Basename;
 use lib "$FindBin::Bin";
 use DICOM::DICOM;
 
+use NeuroDB::MRI;
+
 use NeuroDB::Database;
 use NeuroDB::DatabaseException;
 
@@ -235,6 +237,9 @@ my $db = NeuroDB::Database->new(
 );
 $db->connect();
 
+my $xxxxx = &NeuroDB::MRI::scan_type_text_to_id('scout', $db);
+my $yyyyy = &NeuroDB::MRI::scan_type_id_to_text(52, $db);
+
 ################################################################
 #####check to see if the tarchiveid is already set or not#######
 ######if it's already in the mri_upload table then it will######
@@ -256,7 +261,7 @@ my $resultRef = $mriUploadOB->getWithTarchive(
     GET_COUNT, $tarchive_path, $globArchiveLocation
 );
 
-if($resultRef->[0]->[0] > 0) {
+if($resultRef->[0]->{'COUNT(*)'} > 0) {
    print "\n\tERROR: the tarchive is already uploaded \n\n";
    exit $NeuroDB::ExitCodes::FILE_NOT_UNIQUE;
 }
@@ -277,7 +282,7 @@ if(@$resultRef != 1) {
         scalar(@$resultRef)
     );
 }
-my $tarchiveID = $resultRef->[0]->[0];
+my $tarchiveID = $resultRef->[0]->{'TarchiveID'};
 
 ################################################################
  #####populate the mri_upload columns with the correct values####

--- a/uploadNeuroDB/NeuroDB/Database.pm
+++ b/uploadNeuroDB/NeuroDB/Database.pm
@@ -176,8 +176,15 @@ INPUTS:
     - select query to execute (containing the argument placeholders if any)
     - list of arguments to replace the placeholders with.
 
-RETURN: a reference to the array of records found. Each record is in fact a
-        reference to the list of values for the columns selected
+RETURN: a reference to an array of hash references. Every hash contains the values
+        for a given row returned by the select statement: the key/value pairs hold
+        the name of a column (as it appears in the C<SELECT> statement) and the value it 
+        contains, respectively. As an example, suppose array C<$r> is assigned the result 
+        of a C<pselect> call with query C<SELECT TarchiveId, SourceLocation FROM tarchive>.
+        One would fetch the C<TarchiveId> of the 4th record returned using C<$r->[3]->{'TarchiveId'}>.
+        If the query is of the form C<SELECT COUNT(*) FROM....>, then the method returns
+        a reference to an array containing a single hash reference, its unique key being 
+        C<'COUNT(*)'> with the associated value set to the selected count.
 =cut
 
 sub pselect {
@@ -188,7 +195,7 @@ sub pselect {
         my $sth = $self->dbh()->prepare($query);
         $sth->execute(@args);
 
-        return $sth->fetchall_arrayref;
+        return $sth->fetchall_arrayref({});
     } catch {
         NeuroDB::DatabaseException->throw(
             statement    => $query,

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -729,7 +729,7 @@ sub scan_type_id_to_text {
         );
     }
     
-    return $mriScanTypeRef->[0]->[1];
+    return $mriScanTypeRef->[0]->{'Scan_type'};
 }
 
 =pod
@@ -763,7 +763,7 @@ sub scan_type_text_to_id {
         );
     }
     
-    return $mriScanTypeRef->[0]->[0];
+    return $mriScanTypeRef->[0]->{'ID'};
 }
 
 

--- a/uploadNeuroDB/NeuroDB/objectBroker/ConfigOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/ConfigOB.pm
@@ -121,7 +121,7 @@ my $getConfigSettingRef = sub {
         );
     }
 
-    return $result->[0]->[0];
+    return $result->[0]->{'value'};
 };
 
 =head3 getTarchiveLibraryDir()

--- a/uploadNeuroDB/NeuroDB/objectBroker/MriScanTypeOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriScanTypeOB.pm
@@ -97,9 +97,15 @@ INPUTS:
       should have in order to be part of the result set (key: column name, value: column
       value).
       
-RETURNS: either a count of the records found or a reference to an array of hashes, each 
-         hash being an MRI record found, with all the columns set to whatever was found
-         in the database.
+RETURNS: a reference to an array of hash references. Every hash contains the values
+        for a given row returned by the method call: the key/value pairs contain
+        the name of a column (see C<@MRI_SCAN_TYPE_FIELDS>) and the value it 
+        holds, respectively. As an example, suppose array C<$r> contains the result of a
+        given call to this function. One would fetch the C<Scan_type> of the 2nd record 
+        returned using C<$r->[1]->{'Scan_type'}>.
+        If the method is called with C<$isCount> set to true, then it will return
+        a reference to an array containing a single hash reference, its unique key being 
+        C<'COUNT(*)'> with the associated value set to the selected count.
 =cut
 
 sub get {

--- a/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
@@ -101,9 +101,12 @@ INPUTS:
     - boolean indicating if an exact match is sought (false) or if only basenames
       should be used when comparing two archive locations (true)
 
-RETURN: a reference to an array of array references. This "matrix" contains the
-        values of each colum for each record.
-
+RETURN: a reference to an array of hash references. Every hash contains the values for a given 
+        row returned by the function call: the key/value pairs contain the name of a column 
+        (as it appears in the array referenced by C<$fieldsRef>) and the value it holds, respectively.
+        As an example, suppose array C<$r> contains the result of a call to this method with 
+        C<@$fieldsRef> set to C<('TarchiveID', 'SourceLocation'> one would fetch the C<TarchiveID> 
+        of the 4th record returned using C<$r->[3]->{'TarchiveID'}>.
 =cut
 
 sub getByTarchiveLocation {


### PR DESCRIPTION
When a `SELECT` statement is executed with the new database framework, a reference to an array of hash references is returned. The key/value pairs of this hash are the column names (as specified in the `SELECT` statement) and their values. This consequently modifies the behaviour of all object brokers. 

Basically, in the past you had code like:

```perl
# First array: what you want
# Second array: constraints in the where clause
$r = $objectBroker->get( ['col1', 'col4', 'col12'], { col2 => 'nbro', col7 => 5 });

 # col12 is accessed using its column index in the get call
$col12ForFourthRecord = $r->[3]->[2];   
```    

Whereas now, you would see:

```perl
# First array: what you want
# Second array: constraints in the where clause
$r = $objectBroker->get( ['col1', 'col4', 'col12'], { col2 => 'nbro', col7 => 5 });

 # col12 is accessed directly
$col12ForFourthRecord = $r->[3]->{'col12'};   
```    