### PR TITLE
Perldoc harmonization

### DIFF
--- a/DTIPrep/DTI/DTI.pm
+++ b/DTIPrep/DTI/DTI.pm
@@ -180,14 +180,14 @@ sub getAnatFile {
 =head3 getRawDTIFiles($nativedir, $DTI_volumes)
 
 Function that parses files in the native MRI directories and fetches DTI files.
-This function will also concatenate together multiple DTI files if DTI
-acquisition performed across several DTI scans.
+This function will also concatenate together multiple DTI files if the DTI
+acquisition was performed across several DTI scans.
 
 INPUTS:
   - $nativedir  : native directory
   - $DTI_volumes: DTI's number of volumes
 
-RETURNS: list of matching DTI files found in native directory
+RETURNS: list of matching DTI files found in the native directory
 
 =cut
 

--- a/DTIPrep/DTI/DTI.pm
+++ b/DTIPrep/DTI/DTI.pm
@@ -224,12 +224,12 @@ sub getRawDTIFiles{
 
 =head3 copyDTIPrepProtocol($DTIPrepProtocol, $QCProt)
 
-Function that will copy the DTIPrep protocol to the output directory of
-DTIPrep.
+Function that will copy the C<DTIPrep> protocol to the output directory of
+C<DTIPrep>.
 
 INPUTS:
-  - $DTIPrepProtocol: DTIPrep protocol to be copied
-  - $QCProt         : future path of copied DTIPrep protocol
+  - $DTIPrepProtocol: C<DTIPrep> protocol to be copied
+  - $QCProt         : future path of copied C<DTIPrep> protocol
 
 RETURNS: 1 on success, undef on failure
 
@@ -253,11 +253,11 @@ sub copyDTIPrepProtocol {
 
 =head3 readDTIPrepXMLprot($DTIPrepProtocol)
 
-Read DTIPrep XML protocol and return information into a hash.
+Read C<DTIPrep> XML protocol and return information into a hash.
 
-INPUT: XML protocol used (or that has been used) to run DTIPrep
+INPUT: XML protocol used (or that has been used) to run C<DTIPrep>
 
-RETURNS: reference to a hash containing DTIPrep protocol as follows:
+RETURNS: reference to a hash containing C<DTIPrep> protocol as follows:
 
   entry   => 'QC_QCOutputDirectory'     => {}
           => 'QC_QCedDWIFileNameSuffix' => {
@@ -316,9 +316,9 @@ INPUTS:
   - $DTIs_list      : list of native DTI files to be processed
   - $anat           : anatomical file to be used for processing
   - $QCoutdir       : processed output directory
-  - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
-  - $protXMLrefs    : hash containing info about DTIPrep's protocol
-  - $QCed2_step     : optionally, step name at which DTIPrep will
+  - $DTIPrepProtocol: C<DTIPrep> XML protocol used to run C<DTIPrep>
+  - $protXMLrefs    : hash containing info about C<DTIPrep>'s protocol
+  - $QCed2_step     : optionally, step name at which C<DTIPrep> will
                        produce a secondary QCed file
 
 RETURNS: hash containing outputs naming convention
@@ -351,17 +351,18 @@ sub createDTIhashref {
 
 =head3 determinePreprocOutputs($QCoutdir, $dti_file, $DTIPrepProtocol, $protXMLrefs)
 
-Function that will determine pre processing output names (for either DTIPrep
+Function that will determine pre processing output names (for either C<DTIPrep>
 or C<mincdiffusion> postprocessing) and append them to C<$DTIrefs>.
 
 INPUTS:
   - $QCoutdir       : directory that will contain output files
   - $dti_file       : raw DWI file to be processed
-  - $DTIPrepProtocol: DTIPrep protocol to copy into output directory
-  - $protXMLrefs    : hash containing info from DTIPrep XML protocol
+  - $DTIPrepProtocol: C<DTIPrep> protocol to copy into output directory
+  - $protXMLrefs    : hash containing info from C<DTIPrep> XML protocol
                        (including suffix for the different outputs)
 
-RETURNS: $DTIrefs{$dti_file}{'Preproc'}{'Output'} fields for DTIPrep processing
+RETURNS: $DTIrefs{$dti_file}{'Preproc'}{'Output'} fields for C<DTIPrep>
+processing
 
 =cut
 
@@ -403,19 +404,19 @@ sub determinePreprocOutputs {
 
 =head3 determinePostprocOutputs($QCoutdir, $dti_file, $anat, $protXMLrefs)
 
-Function that will determine post processing output names (for either DTIPrep
+Function that will determine post processing output names (for either C<DTIPrep>
 or C<mincdiffusion> postprocessing) and append them to C<$DTIrefs>.
 
 INPUTS:
   - $QCoutdir   : directory that will contain output files
   - $dti_file   : raw DWI file to be processed
   - $anat       : T1 image to be used for C<mincdiffusion> postprocessing
-  - $protXMLrefs: hash containing info from DTIPrep XML protocol
+  - $protXMLrefs: hash containing info from C<DTIPrep> XML protocol
                    (including suffix for the different outputs)
 
 RETURNS:
   - $DTIrefs{$dti_file}{'Postproc'}{'Tool'} with postprocessing used
-  - $DTIrefs{$dti_file}{'Postproc'}{'Output'} fields for DTIPrep postprocessing
+  - $DTIrefs{$dti_file}{'Postproc'}{'Output'} fields for C<DTIPrep> postprocessing
 
 =cut
 
@@ -447,15 +448,15 @@ sub determinePostprocOutputs {
 
 =head3 determineDTIPrepPostprocOutputs($QCoutdir, $dti_file, $protXMLrefs)
 
-Function that will determine DTIPrep's postprocessing output names (based on
+Function that will determine C<DTIPrep>'s postprocessing output names (based on
 the XML protocol) and append them to C<$DTIrefs>
 
 INPUTS:
   - $QCoutdir   : directory that will contain output files
   - $dti_file   : raw DWI file to be processed
-  - $protXMLrefs: hash containing info from DTIPrep XML protocol
+  - $protXMLrefs: hash containing info from C<DTIPrep> XML protocol
 
-RETURNS: $DTIrefs{$dti_file}{'Postproc'}{'Output'} fields for DTIPrep
+RETURNS: $DTIrefs{$dti_file}{'Postproc'}{'Output'} fields for C<DTIPrep>
 postprocessing
 
 =cut
@@ -612,12 +613,12 @@ sub convert_DTI {
 
 =head3 runDTIPrep($raw_nrrd, $protocol, $QCed_nrrd, $QCed2_nrrd)
 
-Function that runs DTIPrep on NRRD file.
+Function that runs C<DTIPrep> on NRRD file.
 
 INPUTS:
-  - $raw_nrrd  : raw DTI NRRD file to be processed through DTIPrep
-  - $protocol  : DTIPrep protocol used
-  - $QCed_nrrd : QCed file produced by DTIPrep
+  - $raw_nrrd  : raw DTI NRRD file to be processed through C<DTIPrep>
+  - $protocol  : C<DTIPrep> protocol used
+  - $QCed_nrrd : QCed file produced by C<DTIPrep>
   - $QCed2_nrrd: optionally, secondary QCed file
 
 RETURNS: 1 on success, under on failure
@@ -661,8 +662,8 @@ INPUTS:
   - $raw_file      : raw DTI MINC file to grep header information
   - $data_dir      : data dir as defined in the profile file
   - $processed_minc: processed MINC file in which to insert header information
-  - $QC_report     : DTIPrep QC report text file
-  - $DTIPrepVersion: DTIPrep version used to obtain processed file
+  - $QC_report     : C<DTIPrep> QC report text file
+  - $DTIPrepVersion: C<DTIPrep> version used to obtain processed file
   - $is_anat       : if set, will only insert processing, patient & study info
 
 RETURNS: 1 on success, undef on failure
@@ -703,8 +704,8 @@ INPUTS:
   - $raw_dti       : raw DTI MINC file to grep header information from
   - $data_dir      : data dir as defined in the profile file
   - $processed_minc: processed MINC file in which to insert header info
-  - $QC_report     : DTIPrep QC report text file
-  - $DTIPrepVersion: DTIPrep version used to obtain processed file
+  - $QC_report     : C<DTIPrep> QC report text file
+  - $DTIPrepVersion: C<DTIPrep> version used to obtain processed file
 
 RETURNS: 1 on success, undef on failure
 
@@ -1070,14 +1071,14 @@ sub RGBpik_creation {
 
 =head3 convert_DTIPrep_postproc_outputs($dti_file, $DTIrefs, $data_dir, $DTIPrepVersion)
 
-This function will check if all DTIPrep NRRD files were created and convert
+This function will check if all C<DTIPrep> NRRD files were created and convert
 them into MINC files with relevant header information inserted.
 
 INPUTS:
-  - $dti_file      : raw DTI dataset that was processed through DTIPrep
+  - $dti_file      : raw DTI dataset that was processed through C<DTIPrep>
   - $DTIrefs       : hash containing information about output names
   - $data_dir      : directory containing raw DTI dataset
-  - $DTIPrepVersion: DTIPrep version used to process the DWI dataset
+  - $DTIPrepVersion: C<DTIPrep> version used to process the DWI dataset
 
 RETURNS:
   - $nrrds_found  : 1 if all NRRD outputs found, undef otherwise
@@ -1146,12 +1147,13 @@ sub convert_DTIPrep_postproc_outputs {
 
 =head3 getRejectedDirections($data_dir, $XMLReport)
 
-Summarize which directions were rejected by DTIPrep for slice-wise correlations,
+Summarize which directions were rejected by C<DTIPrep> for slice-wise
+correlations,
 inter-lace artifacts, inter-gradient artifacts.
 
 INPUTS:
   - $data_dir: data_dir defined in the config file
-  - $QCReport: DTIPrep's QC txt report to extract rejected directions
+  - $QCReport: C<DTIPrep>'s QC txt report to extract rejected directions
 
 RETURNS: 
   - number of directions rejected due to slice wise correlations

--- a/DTIPrep/DTI/DTI.pm
+++ b/DTIPrep/DTI/DTI.pm
@@ -46,8 +46,8 @@ DTI data (particularly with regards to performing DTI QC)
 
 =head1 DESCRIPTION
 
-Really a mishmash of utility functions, primarily used by DTIPrep_pipeline.pl
-and DTIPrepRegister.pl.
+A mishmash of utility functions, primarily used by C<DTIPrep_pipeline.pl>
+and C<DTIPrepRegister.pl>.
 
 =head2 Methods
 
@@ -84,10 +84,10 @@ INPUTS:
   - $protocol  : DTIPrep XML protocol to use (or used) to run DTIPrep
   - $runDTIPrep: if set, will run DTIPrep and create the output dir.
 
-Note: If $runDTIPrep is not set, then DTIPrep was already run and the
+Note: If C<$runDTIPrep> is not set, then DTIPrep was already run and the
 output folder already exists.
 
-RETURNS: candidate/visit/protocol folder that will store DTIPrep outputs.
+RETURNS: C<candidate/visit/protocol> folder that will store DTIPrep outputs.
 
 =cut
 
@@ -147,7 +147,7 @@ sub getFilesList {
 =head3 getAnatFile($nativedir, $t1_scan_type)
 
 Function that parses files in the native MRI directory and grabs
-the T1 acquisition based on $t1_scan_type.
+the T1 acquisition based on C<$t1_scan_type>.
 
 INPUTS:
   - $nativedir   : native directory
@@ -180,14 +180,14 @@ sub getAnatFile {
 =head3 getRawDTIFiles($nativedir, $DTI_volumes)
 
 Function that parses files in the native MRI directories and fetches DTI files.
-This function will also concatenate together multipleDTI files if DTI 
-acquisition performed accross several DTI scans.
+This function will also concatenate together multiple DTI files if DTI
+acquisition performed across several DTI scans.
 
 INPUTS:
   - $nativedir  : native directory
   - $DTI_volumes: DTI's number of volumes
 
-RETURNS: list of matching DTIs found in native directory
+RETURNS: list of matching DTI files found in native directory
 
 =cut
 
@@ -298,7 +298,7 @@ sub readDTIPrepXMLprot {
 
 =pod
 
-=head3 createDTIhashref($DTIs_list, $anat, $QCoutdir, $DTIPrepProtocol, ...)
+=head3 createDTIhashref($DTIs_list, $anat, $QCoutdir, $DTIPrepProtocol, $protXMLrefs, $QCed2_step)
 
 Function that will determine output names based on each DTI file dataset and
 return a hash of DTIref:
@@ -314,7 +314,7 @@ return a hash of DTIref:
 
 INPUTS:
   - $DTIs_list      : list of native DTI files to be processed
-  - $anat           : anat file to be used for processing
+  - $anat           : anatomical file to be used for processing
   - $QCoutdir       : processed output directory
   - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
   - $protXMLrefs    : hash containing info about DTIPrep's protocol
@@ -349,15 +349,15 @@ sub createDTIhashref {
 
 =pod
 
-=head3 determinePreprocOutputs($QCoutdir, $dti_file, $DTIPrepProtocol, ...)
+=head3 determinePreprocOutputs($QCoutdir, $dti_file, $DTIPrepProtocol, $protXMLrefs)
 
 Function that will determine pre processing output names (for either DTIPrep
-or mincdiffusion postprocessing) and append them to C<$DTIrefs>.
+or C<mincdiffusion> postprocessing) and append them to C<$DTIrefs>.
 
 INPUTS:
   - $QCoutdir       : directory that will contain output files
   - $dti_file       : raw DWI file to be processed
-  - $DTIPrepProtocol: DTIPrepProtocol to copy into output directory
+  - $DTIPrepProtocol: DTIPrep protocol to copy into output directory
   - $protXMLrefs    : hash containing info from DTIPrep XML protocol
                        (including suffix for the different outputs)
 
@@ -404,12 +404,12 @@ sub determinePreprocOutputs {
 =head3 determinePostprocOutputs($QCoutdir, $dti_file, $anat, $protXMLrefs)
 
 Function that will determine post processing output names (for either DTIPrep
-or mincdiffusion postprocessing) and append them to C<$DTIrefs>.
+or C<mincdiffusion> postprocessing) and append them to C<$DTIrefs>.
 
 INPUTS:
   - $QCoutdir   : directory that will contain output files
   - $dti_file   : raw DWI file to be processed
-  - $anat       : T1 image to be used for mincdiffusion postprocessing
+  - $anat       : T1 image to be used for C<mincdiffusion> postprocessing
   - $protXMLrefs: hash containing info from DTIPrep XML protocol
                    (including suffix for the different outputs)
 
@@ -445,9 +445,10 @@ sub determinePostprocOutputs {
 
 =pod
 
-=head3 determineDTIPrepPostprocOutputs($QCoutdir, $dti_file, ...)
+=head3 determineDTIPrepPostprocOutputs($QCoutdir, $dti_file, $protXMLrefs)
 
-Function that will determine DTIPrep's postprocessing output names (based on the XML protocol) and append them to $DTIrefs
+Function that will determine DTIPrep's postprocessing output names (based on
+the XML protocol) and append them to C<$DTIrefs>
 
 INPUTS:
   - $QCoutdir   : directory that will contain output files
@@ -523,9 +524,10 @@ sub determineDTIPrepPostprocOutputs {
 
 =pod
 
-=head3 determineMincdiffusionPostprocOutputs($QCoutdir, $dti_file, ...)
+=head3 determineMincdiffusionPostprocOutputs($QCoutdir, $dti_file, $QCed_suffix, $anat)
 
-Function that will determine mincdiffusion postprocessing output names and append them to $DTIrefs
+Function that will determine C<mincdiffusion> postprocessing output names and
+append them to C<$DTIrefs>
 
 INPUTS:
   - $QCoutdir   : directory that will contain output files
@@ -533,7 +535,7 @@ INPUTS:
   - $QCed_suffix: QCed suffix for QCed NRRD & postprocessing file names
   - $anat       : anatomic T1 file to use for DWI-anat registration
 
-RETURNS: $DTIrefs{$dti_file}{'Postproc'} for mincdiffusion postprocessing
+RETURNS: $DTIrefs{$dti_file}{'Postproc'} for C<mincdiffusion> postprocessing
 
 =cut
 
@@ -575,12 +577,12 @@ sub determineMincdiffusionPostprocOutputs {
 =head3 convert_DTI($file_in, $file_out, $options)
 
 Function that converts MINC file to NRRD or NRRD file to MINC.
-(depending on $options)
+(depending on C<$options>)
 
 INPUTS:
   - $file_in : file to be converted
   - $file_out: converted file
-  - $options : conversion options (mnc2nrrd or nrrd2mnc)
+  - $options : conversion options (C<mnc2nrrd> or C<nrrd2mnc>)
 
 RETURNS: 1 on success, undef on failure
 
@@ -610,13 +612,13 @@ sub convert_DTI {
 
 =head3 runDTIPrep($raw_nrrd, $protocol, $QCed_nrrd, $QCed2_nrrd)
 
-Function that runs DTIPrep on nrrd file.
+Function that runs DTIPrep on NRRD file.
 
 INPUTS:
-  - $raw_nrrd  : raw DTI nrrd file to be processed through DTIPrep
+  - $raw_nrrd  : raw DTI NRRD file to be processed through DTIPrep
   - $protocol  : DTIPrep protocol used
   - $QCed_nrrd : QCed file produced by DTIPrep
-  - $QCed2_nrrd: optionaly, secondary QCed file
+  - $QCed2_nrrd: optionally, secondary QCed file
 
 RETURNS: 1 on success, under on failure
 
@@ -641,7 +643,7 @@ sub runDTIPrep {
 
 =pod
 
-=head3 insertMincHeader($raw_file, $data_dir, $processed_minc, ...)
+=head3 insertMincHeader($raw_file, $data_dir, $processed_minc, $QC_report, $DTIPrepVersion, $is_anat)
 
 Inserts in the MINC header all the acquisition arguments except:
   - acquisition:bvalues
@@ -916,7 +918,7 @@ INPUTS:
   - $splitter: delimiter used to split list of fields stored in C<$fields>
   - $fields  : list header arguments/values to insert in the MINC header
 
-RETURNS: - $list: array of header arguments and values' list
+RETURNS: - $list     : array of header arguments and values' list
          - $list_size: size of the array $list
 
 =cut
@@ -943,8 +945,8 @@ sub get_header_list {
 
 =head3 mincdiff_preprocess($dti_file, $DTIrefs, $QCoutdir)
 
-Function that runs diff_preprocess.pl script from the mincdiffusion tools on
-the QCed MINC and raw anat dataset.
+Function that runs C<diff_preprocess.pl> script from the C<mincdiffusion>
+tools on the QCed MINC and raw anat dataset.
 
 INPUTS:
   - $dti_file: hash key to use to fetch file names (e.g. raw DWI file)
@@ -986,8 +988,8 @@ sub mincdiff_preprocess {
 
 =head3 mincdiff_minctensor($dti_file, $DTIrefs, $QCoutdir, $niak_path)
 
-Function that runs minctensor.pl script from the mincdiffusion tools on the
-mincdiff preprocessed MINC and anatomical mask images.
+Function that runs C<minctensor.pl> script from the C<mincdiffusion> tools on
+the C<mincdiff> preprocessed MINC and anatomical mask images.
 
 INPUTS:
   - $dti_file: hash key to use to fetch file names (e.g. raw DWI file)
@@ -1033,7 +1035,7 @@ sub mincdiff_minctensor {
 
 =head3 RGBpik_creation($dti_file, $DTIrefs)
 
-Function that runs mincpik on the RGB map.
+Function that runs C<mincpik> on the RGB map.
 
 INPUTS:
   - $dti_file: hash key to use to fetch file names (e.g. raw DWI file)
@@ -1066,9 +1068,9 @@ sub RGBpik_creation {
 
 =pod
 
-=head3 convert_DTIPrep_postproc_outputs($dti_file, $DTIrefs, $data_dir, ...)
+=head3 convert_DTIPrep_postproc_outputs($dti_file, $DTIrefs, $data_dir, $DTIPrepVersion)
 
-This function will check if all DTIPrep nrrd files were created and convert
+This function will check if all DTIPrep NRRD files were created and convert
 them into MINC files with relevant header information inserted.
 
 INPUTS:
@@ -1231,14 +1233,6 @@ __END__
 
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -4,7 +4,7 @@
 
 =head1 NAME
 
-DTIPrepRegister.pl -- registers DTIPrep outputs in the LORIS database
+DTIPrepRegister.pl -- registers C<DTIPrep> outputs in the LORIS database
 
 =head1 SYNOPSIS
 
@@ -14,17 +14,17 @@ Available options are:
 
 -profile        : name of the config file in C<../dicom-archive/.loris-mri>
 
--DTIPrep_subdir : DTIPrep subdirectory storing the processed files to
+-DTIPrep_subdir : C<DTIPrep> subdirectory storing the processed files to
                    be registered
 
--DTIPrepProtocol: DTIPrep protocol used to obtain the output files
+-DTIPrepProtocol: C<DTIPrep> protocol used to obtain the output files
 
 -DTI_file       : native DWI file used to obtain the output files
 
 -anat_file      : native anatomical dataset used to create FA, RGB and
                    other post-processed maps using C<mincdiffusion> tools
 
--DTIPrepVersion : DTIPrep version used if it cannot be found in MINC
+-DTIPrepVersion : C<DTIPrep> version used if it cannot be found in MINC
                    files' C<processing:pipeline> header field
 
 -mincdiffusionVersion: C<mincdiffusion> release version used if it cannot be
@@ -41,14 +41,14 @@ Registers DWI QC pipeline's output files of interest into the LORIS database
 via C<register_processed_data.pl>.
 
 The following output files will be inserted:
-  - QCed MINC file produced by DTIPrep pre-processing step (i.e. DWI
-     dataset without the bad directions detected by DTIPrep)
+  - QCed MINC file produced by C<DTIPrep> pre-processing step (i.e. DWI
+     dataset without the bad directions detected by C<DTIPrep>)
   - Text QC report produced by DTPrep
-  - XML QC report produced by DTIPrep
-  - RGB map produced by either DTIPrep or C<mincdiffusion> post-processing
-  - MD map produced by either DTIPrep or C<mincdiffusion> post-processing
-  - FA map produced by either DTIPrep or C<mincdiffusion> post-processing
-  - baseline image produced by DTIPrep or C<mincdiffusion> post-processing
+  - XML QC report produced by C<DTIPrep>
+  - RGB map produced by either C<DTIPrep> or C<mincdiffusion> post-processing
+  - MD map produced by either C<DTIPrep> or C<mincdiffusion> post-processing
+  - FA map produced by either C<DTIPrep> or C<mincdiffusion> post-processing
+  - baseline image produced by C<DTIPrep> or C<mincdiffusion> post-processing
   - DTI mask produced by C<mincdiffusion> post-processing (only if
      C<mincdiffusion> was used to post-process the data)
 
@@ -389,9 +389,9 @@ yet in the database, it will register it in the database and return the
 C<ProcessProtocolID> of the registered protocol file.
 
 INPUTS:
-  - $XMLProtocol: XML protocol file of DTIPrep to be registered
+  - $XMLProtocol: XML protocol file of C<DTIPrep> to be registered
   - $data_dir   : data directory from the C<Config> table, tool name of the
-                   protocol (a.k.a. "DTIPrep")
+                   protocol (a.k.a. C<DTIPrep>)
 
 RETURNS: ID of the registered protocol file
 
@@ -425,7 +425,7 @@ protocol to the C<$data_dir/protocols/DTIPrep> folder.
 INPUTS:
   - $protocol: protocol file to be registered
   - $md5sum  : MD5 sum of the protocol file to be registered
-  - $tool    : tool of the protocol file (DTIPrep)
+  - $tool    : tool of the protocol file (C<DTIPrep>)
   - $data_dir: data directory (C</data/$PROJECT/data>)
 
 RETURNS: ID of the registered protocol file
@@ -506,8 +506,8 @@ INPUTS:
   - $inputs                : input files of the file to be registered
   - $pipelineName          : name of the pipeline used to obtain the MINC file
   - $toolName              : tool name and version used
-  - $registeredXMLFile     : registered DTIPrep XML report
-  - $registeredQCReportFile: registered DTIPrep text report
+  - $registeredXMLFile     : registered C<DTIPrep> XML report
+  - $registeredQCReportFile: registered C<DTIPrep> text report
   - $scanType              : scan type of the MINC file to register
   - $registered_nrrd       : optional, registered NRRD file used to create the MINC file
 
@@ -627,17 +627,17 @@ sub register_minc {
 
 =head3 register_XMLFile($XMLFile, $raw_file, $data_dir, $QCReport, $inputs, $pipelineName, $toolName)
 
-Sets parameters needed to register the XML report/protocol of DTIPrep
+Sets parameters needed to register the XML report/protocol of C<DTIPrep>
 and calls registerFile to register the XML file via register_processed_data.pl.
 
 INPUTS:
   - $XMLFile     : XML file to be registered
-  - $raw_file    : native DWI file used to obtain the DTIPrep outputs
+  - $raw_file    : native DWI file used to obtain the C<DTIPrep> outputs
   - $data_dir    : data directory (e.g. C</data/$PROJECT/data>)
-  - $QCReport    : DTIPrep QC text report
-  - $inputs      : input files used to process data through DTIPrep
+  - $QCReport    : C<DTIPrep> QC text report
+  - $inputs      : input files used to process data through C<DTIPrep>
   - $pipelineName: pipeline name used to process DWIs (C<DTIPrepPipeline>)
-  - $toolName    : DTIPrep name and version used to process the DWI file
+  - $toolName    : C<DTIPrep> name and version used to process the DWI file
 
 RETURNS: the registered XNL file if it was registered in the database or undef
 
@@ -716,17 +716,17 @@ sub register_XMLFile {
 
 =head3 register_QCReport($QCReport, $raw_file, $data_dir, $inputs, $pipelineName, $toolName)
 
-Sets parameters needed to register the QCreport of DTIPrep and calls
+Sets parameters needed to register the QCreport of C<DTIPrep> and calls
 C<&registerFile> to register the QCreport file via
 C<register_processed_data.pl>.
 
 INPUTS:
   - $QCReport    : QC report file to be registered
-  - $raw_file    : native DWI file used to obtain the DTIPrep outputs
+  - $raw_file    : native DWI file used to obtain the C<DTIPrep> outputs
   - $data_dir    : data directory (e.g. C</data/$PROJECT/data>)
-  - $inputs      : input files used to process data through DTIPrep
+  - $inputs      : input files used to process data through C<DTIPrep>
   - $pipelineName: pipeline name used to process DTIs (C<DTIPrepPipeline>)
-  - $toolName    : DTIPrep name and version used to process the DWI file
+  - $toolName    : C<DTIPrep> name and version used to process the DWI file
 
 RETURNS: registered QCReport file if it was registered in the database or undef
 
@@ -809,9 +809,9 @@ INPUTS:
   - $DTIref  : hash containing all output paths and tool information
 
 RETURNS:
-  - $XMLProtocol    : DTIPrep XML protocol found in the file system
-  - $QCReport       : DTIPrep QC text report found in the file system
-  - $XMLReport      : DTIPrep QC XML report found in the file system
+  - $XMLProtocol    : C<DTIPrep> XML protocol found in the file system
+  - $QCReport       : C<DTIPrep> QC text report found in the file system
+  - $XMLReport      : C<DTIPrep> QC XML report found in the file system
   - $QCed_minc      : QCed MINC file created after conversion of QCed NRRD file
   - $RGB_minc       : RGB MINC file found in the file system
   - $FA_minc        : FA MINC file found in the file system
@@ -819,7 +819,7 @@ RETURNS:
   - $baseline_minc  : baseline MINC file found in the file system
   - $brain_mask_minc: brain mask MINC file found in the file system
   - $QCed2_minc     : optional, secondary QCed MINC file created after
-                       conversion of secondary QCed DTIPrep NRRD file
+                       conversion of secondary QCed C<DTIPrep> NRRD file
   - returns undef if there are some missing files (except for C<QCed2_minc>
      which is optional)
 
@@ -847,7 +847,7 @@ sub getFiles {
 
 =head3 checkPreprocessFiles($dti_file, $DTIrefs, $mri_files)
 
-Function that checks if all DTIPrep pre-processing files are present in the
+Function that checks if all C<DTIPrep> pre-processing files are present in the
 file system.
 
 INPUTS:
@@ -857,12 +857,12 @@ INPUTS:
                 registered
 
 RETURNS:
-  - $XMLProtocol: DTIPrep XML protocol found in the file system
-  - $QCReport   : DTIPrep text QC report found in the file system
-  - $XMLReport  : DTIPrep XML QC report found in the file system
+  - $XMLProtocol: C<DTIPrep> XML protocol found in the file system
+  - $QCReport   : C<DTIPrep> text QC report found in the file system
+  - $XMLReport  : C<DTIPrep> XML QC report found in the file system
   - $QCed_minc  : QCed MINC file created after conversion of QCed NRRD file
   - $QCed2_minc : optional, secondary QCed MINC file created after
-                   conversion of secondary QCed DTIPrep NRRD file
+                   conversion of secondary QCed C<DTIPrep> NRRD file
   - returns undef if one of the file listed above is missing (except
      for C<QCed2_minc> which is optional)
 
@@ -923,7 +923,7 @@ RETURNS:
   - $MD_minc        : MD map
   - $baseline_minc  : baseline (or frame-0) map
   - $brain_mask_minc: brain mask produced by C<mincdiffusion> tools (not
-                       available if DTIPrep was run to obtain the
+                       available if C<DTIPrep> was run to obtain the
                        post-processing outputs)
   - will return undef if one of the file listed above is missing
 
@@ -1116,7 +1116,7 @@ sub getToolName {
 
 =head3 getPipelineDate($file, $data_dir, $QCReport)
 
-Fetches the date at which the DTIPrep pipeline was run either in the processed
+Fetches the date at which the C<DTIPrep> pipeline was run either in the processed
 MINC file's header or in the QC text report.
 
 INPUTS:
@@ -1179,13 +1179,13 @@ sub getPipelineDate {
 
 =head3 insertReports($minc, $registeredXMLFile, $registeredQCReportFile)
 
-Inserts the path to DTIPrep's QC text, XML reports and XML protocol in the
+Inserts the path to C<DTIPrep>'s QC text, XML reports and XML protocol in the
 MINC file's header.
 
 INPUTS:
   - $minc                  : MINC file for which the header should be modified
-  - $registeredXMLfile     : path to the registered DTIPrep's QC XML report
-  - $registeredQCReportFile: path to the registered DTIPrep's QC text report
+  - $registeredXMLfile     : path to the registered C<DTIPrep>'s QC XML report
+  - $registeredQCReportFile: path to the registered C<DTIPrep>'s QC text report
 
 RETURNS:
  - $Txtreport_insert: 1 on text report path insertion success, undef otherwise
@@ -1217,7 +1217,7 @@ sub insertReports {
 
 =head3 insertPipelineSummary($minc, $data_dir, $XMLReport, $scanType)
 
-Inserts in the MINC header a summary of DTIPrep reports. This summary consists
+Inserts in the MINC header a summary of C<DTIPrep> reports. This summary consists
 of the directions rejected due to slice wise correlation, the directions
 rejected due to interlace correlation, and the directions rejected due to
 gradient wise correlation.
@@ -1225,7 +1225,7 @@ gradient wise correlation.
 INPUTS:
   - $minc     : MINC file in which the summary will be inserted
   - $data_dir : data directory (e.g. C</data/$PROJECT/data>)
-  - $XMLReport: DTIPrep's XML QC report from which the summary will be extracted
+  - $XMLReport: C<DTIPrep>'s XML QC report from which the summary will be extracted
 
 RETURNS: 1 on success, undef on failure
 
@@ -1296,7 +1296,7 @@ INPUTS:
   - $file           : file to be registered in the database
   - $src_fileID     : source file's FileID
   - $src_pipeline   : pipeline used to obtain the file (C<DTIPrepPipeline>)
-  - $src_tool       : name and version of the tool (DTIPrep or C<mincdiffusion>)
+  - $src_tool       : name and version of the tool (C<DTIPrep> or C<mincdiffusion>)
   - $pipelineDate   : file's creation date (= pipeline date)
   - $coordinateSpace: file's coordinate space (= native, T1 ...)
   - $scanType       : file's scan type (= C<DTIPrepReg>, C<DTIPrepDTIFA>,
@@ -1407,7 +1407,7 @@ sub fetchRegisteredFile {
 
 =head3 register_DTIPrep_files($minc, $nrrd, $raw_file, $data_dir, $inputs, $registeredXMLProtocolID, $pipelineName, $DTIPrepVersion, $registeredXMLReportFile, $registeredQCReport, $scanType)
 
-Registers DTIPrep NRRD and MINC files. The MINC file will have a link to the
+Registers C<DTIPrep> NRRD and MINC files. The MINC file will have a link to the
 registered NRRD file (C<&register_minc> function will modify the MINC header to
 include this information) in addition to the links toward QC reports and
 protocol.
@@ -1423,7 +1423,7 @@ INPUTS:
   - $registeredXMLProtocolID: registered XML protocol file
   - $pipelineName           : name of the pipeline that created the file to be
                                registered (C<DTIPrepPipeline>)
-  - $DTIPrepVersion         : DTIPrep's version
+  - $DTIPrepVersion         : C<DTIPrep>'s version
   - $registeredXMLReportFile: registered QC XML report file
   - $registeredQCReport     : registered QC text report file
   - $scanType               : scan type to use to label/register the MINC file
@@ -1490,18 +1490,18 @@ sub register_DTIPrep_files {
 
 =head3 register_nrrd($nrrd, $raw_file, $data_dir, $QCReport, $inputs, $pipelineName, $toolName, $scanType)
 
-Sets parameters needed to register the NRRD file produced by DTIPrep
+Sets parameters needed to register the NRRD file produced by C<DTIPrep>
 and calls registerFile to register the NRRD file via
 C<register_processed_data.pl>.
 
 INPUTS:
   - $nrrd        : NRRD file to be registered
-  - $raw_file    : native DWI file used to obtain the DTIPrep outputs
+  - $raw_file    : native DWI file used to obtain the C<DTIPrep> outputs
   - $data_dir    : data directory (e.g. C</data/$PROJECT/data>)
-  - $QCReport    : DTIPrep QC text report
-  - $inputs      : input files used to process data through DTIPrep
+  - $QCReport    : C<DTIPrep> QC text report
+  - $inputs      : input files used to process data through C<DTIPrep>
   - $pipelineName: pipeline name used to process DTIs (C<DTIPrepPipeline>)
-  - $toolName    : DTIPrep name and version used to process the DWI file
+  - $toolName    : C<DTIPrep> name and version used to process the DWI file
   - $scanType    : NRRD file's scan type
 
 RETURNS: registered NRRD file or undef on insertion's failure
@@ -1578,7 +1578,7 @@ sub register_nrrd {
 
 =head3 register_Preproc($mri_files, $dti_file, $data_dir, $pipelineName, $toolName, $process_step, $proc_file)
 
-Gathers all DTIPrep preprocessed files to be registered in the database
+Gathers all C<DTIPrep> preprocessed files to be registered in the database
 and calls C<&register_DTIPrep_files> on all of them. Will register first the
 NRRD file and then the MINC file for each scan type.
 
@@ -1633,14 +1633,14 @@ sub register_Preproc {
 
 Function to register processed images in the database depending on the tool
 used to obtain them. Will call C<&register_DTIPrep_files> if files to be
-registered are obtained via DTIPrep or C<&register_minc> if files to be
+registered are obtained via C<DTIPrep> or C<&register_minc> if files to be
 registered are obtained using C<mincdiffusion> tools.
 
 INPUTS:
   - $mri_files   : hash with information about the files to be registered
   - $raw_file    : source raw image
   - $data_dir    : data directory (e.g. C</data/$PROJECT/data>)
-  - $pipelineName: name of the pipeline used (a.k.a DTIPrep)
+  - $pipelineName: name of the pipeline used (a.k.a C<DTIPrep>)
   - $toolName    : tool's version and name
   - $process_step: processing step (pre-processing, post-processing)
 

--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -12,7 +12,7 @@ perl DTIPrepRegister.pl C<[options]>
 
 Available options are:
 
--profile        : name of the config file in ../dicom-archive/.loris-mri
+-profile        : name of the config file in C<../dicom-archive/.loris-mri>
 
 -DTIPrep_subdir : DTIPrep subdirectory storing the processed files to
                    be registered
@@ -22,12 +22,12 @@ Available options are:
 -DTI_file       : native DWI file used to obtain the output files
 
 -anat_file      : native anatomical dataset used to create FA, RGB and
-                   other post-processed maps using mincdiffusion tools
+                   other post-processed maps using C<mincdiffusion> tools
 
 -DTIPrepVersion : DTIPrep version used if it cannot be found in MINC
                    files' C<processing:pipeline> header field
 
--mincdiffusionVersion: mincdiffusion release version used if it cannot be
+-mincdiffusionVersion: C<mincdiffusion> release version used if it cannot be
                         found in minc files' C<processing:pipeline>
                         header field
 
@@ -43,14 +43,14 @@ via C<register_processed_data.pl>.
 The following output files will be inserted:
   - QCed MINC file produced by DTIPrep pre-processing step (i.e. DWI
      dataset without the bad directions detected by DTIPrep)
-  - QCReport produced by DTPrep
-  - XMLQCResult produced by DTIPrep
-  - RGB map produced by either DTIPrep or mincdiffusion post-processing
-  - MD map produced by either DTIPrep or mincdiffusion post-processing
-  - FA map produced by either DTIPrep or mincdiffusion post-processing
-  - baseline image produced by DTIPrep or mincdiffusion post-processing
-  - DTI mask produced by mincdiffusion post-processing (only if
-     mincdiffusion was used to post-process the data)
+  - Text QC report produced by DTPrep
+  - XML QC report produced by DTIPrep
+  - RGB map produced by either DTIPrep or C<mincdiffusion> post-processing
+  - MD map produced by either DTIPrep or C<mincdiffusion> post-processing
+  - FA map produced by either DTIPrep or C<mincdiffusion> post-processing
+  - baseline image produced by DTIPrep or C<mincdiffusion> post-processing
+  - DTI mask produced by C<mincdiffusion> post-processing (only if
+     C<mincdiffusion> was used to post-process the data)
 
 =head2 Methods
 
@@ -384,9 +384,9 @@ exit $NeuroDB::ExitCodes::SUCCESS;
 Registers XML protocol file into the C<mri_processing_protocol> table. It will
 first check if protocol file was already registered in the database. If the
 protocol file is already registered in the database, it will return the
-ProcessProtocolID from the database. If the protocol file is not registered yet
-in the database, it will register it in the database and return the
-ProcessProtocolID of the registered protocol file.
+Process Protocol ID from the database. If the protocol file is not registered
+yet in the database, it will register it in the database and return the
+C<ProcessProtocolID> of the registered protocol file.
 
 INPUTS:
   - $XMLProtocol: XML protocol file of DTIPrep to be registered
@@ -424,9 +424,9 @@ protocol to the C<$data_dir/protocols/DTIPrep> folder.
 
 INPUTS:
   - $protocol: protocol file to be registered
-  - $md5sum  : md5sum of the protocol file to be registered
+  - $md5sum  : MD5 sum of the protocol file to be registered
   - $tool    : tool of the protocol file (DTIPrep)
-  - $data_dir: data_dir of the prod file
+  - $data_dir: data directory (C</data/$PROJECT/data>)
 
 RETURNS: ID of the registered protocol file
 
@@ -463,9 +463,9 @@ sub registerProtocol {
 =head3 fetchProtocolID($md5sum)
 
 Fetches the protocol ID in the C<mri_processing_protocol> table based on
-the XML protocol's md5sum.
+the XML protocol's MD5 sum.
 
-INPUT: md5sum of the XML protocol
+INPUT: MD5 sum of the XML protocol
 
 RETURNS: ID of the registered protocol file
 
@@ -493,7 +493,7 @@ sub fetchProtocolID {
 
 =pod
 
-=head3 register_minc($minc, $raw_file, $data_dir, $inputs, ...)
+=head3 register_minc($minc, $raw_file, $data_dir, $inputs, $pipelineName, $toolName, $registeredXMLFile, $registeredQCReportFile, $scanType, $registered_nrrd)
 
 Sets the different parameters needed for MINC files' registration
 and calls C<&registerFile> to register the MINC file in the database
@@ -504,14 +504,13 @@ INPUTS:
   - $raw_file              : source file of the MINC file to register
   - $data_dir              : data_dir directory from the config table
   - $inputs                : input files of the file to be registered
-  - $pipelineName          : name of the pipeline used to obtain the
-                              MINC file
-  - $toolName              : tool name & version used
+  - $pipelineName          : name of the pipeline used to obtain the MINC file
+  - $toolName              : tool name and version used
   - $registeredXMLFile     : registered DTIPrep XML report
-  - $registeredQCReportFile: registered DTIPrep txt report
+  - $registeredQCReportFile: registered DTIPrep text report
   - $scanType              : scan type of the MINC file to register
-  - $registered_nrrd       : optional, registered NRRD file used to
-                              create the MINC file
+  - $registered_nrrd       : optional, registered NRRD file used to create
+                              the MINC file
 
 RETURNS: registered MINC file on success, undef otherwise
 
@@ -627,23 +626,21 @@ sub register_minc {
 
 =pod
 
-=head3 register_XMLFile($XMLFile, $raw_file, $data_dir, $QCReport, ...)
+=head3 register_XMLFile($XMLFile, $raw_file, $data_dir, $QCReport, $inputs, $pipelineName, $toolName)
 
 Sets parameters needed to register the XML report/protocol of DTIPrep
 and calls registerFile to register the XML file via register_processed_data.pl.
 
-INPUT:
+INPUTS:
   - $XMLFile     : XML file to be registered
   - $raw_file    : native DWI file used to obtain the DTIPrep outputs
-  - $data_dir    : data_dir from the config table
-                    (e.g. /data/project/data)
-  - $QCReport    : DTIPrep QCreport
+  - $data_dir    : data directory (e.g. C</data/$PROJECT/data>)
+  - $QCReport    : DTIPrep QC text report
   - $inputs      : input files used to process data through DTIPrep
-  - $pipelineName: pipeline name used to process DWIs (DTIPrepPipeline)
-  - $toolName    : DTIPrep name & version used to process the DWI file
+  - $pipelineName: pipeline name used to process DWIs (C<DTIPrepPipeline>)
+  - $toolName    : DTIPrep name and version used to process the DWI file
 
-RETURNS: the registered XNL file if it was registered in the database, undef
-          otherwise
+RETURNS: the registered XNL file if it was registered in the database or undef
 
 =cut
 
@@ -718,7 +715,7 @@ sub register_XMLFile {
 
 =pod
 
-=head3 register_QCReport($QCReport, $raw_file, $data_dir, $inputs, ...)
+=head3 register_QCReport($QCReport, $raw_file, $data_dir, $inputs, $pipelineName, $toolName)
 
 Sets parameters needed to register the QCreport of DTIPrep and calls
 C<&registerFile> to register the QCreport file via
@@ -727,14 +724,12 @@ C<register_processed_data.pl>.
 INPUTS:
   - $QCReport    : QC report file to be registered
   - $raw_file    : native DWI file used to obtain the DTIPrep outputs
-  - $data_dir    : data_dir from the config table
-                    (e.g. /data/project/data)
+  - $data_dir    : data directory (e.g. C</data/$PROJECT/data>)
   - $inputs      : input files used to process data through DTIPrep
-  - $pipelineName: pipeline name used to process DTIs (DTIPrepPipeline)
-  - $toolName    : DTIPrep name & version used to process the DWI file
+  - $pipelineName: pipeline name used to process DTIs (C<DTIPrepPipeline>)
+  - $toolName    : DTIPrep name and version used to process the DWI file
 
-RETURNS: registered QCReport file if it was registered in the database, undef
-          otherwise
+RETURNS: registered QCReport file if it was registered in the database or undef
 
 =cut
 
@@ -816,10 +811,9 @@ INPUTS:
 
 RETURNS:
   - $XMLProtocol    : DTIPrep XML protocol found in the file system
-  - $QCReport       : DTIPrep text QCReport found in the file system
-  - $XMLReport      : DTIPrep XML QCReport found in the file system
-  - $QCed_minc      : QCed MINC file created after conversion of
-                       QCed NRRD file
+  - $QCReport       : DTIPrep QC text report found in the file system
+  - $XMLReport      : DTIPrep QC XML report found in the file system
+  - $QCed_minc      : QCed MINC file created after conversion of QCed NRRD file
   - $RGB_minc       : RGB MINC file found in the file system
   - $FA_minc        : FA MINC file found in the file system
   - $MD_minc        : MD MINC file found in the file system
@@ -827,8 +821,8 @@ RETURNS:
   - $brain_mask_minc: brain mask MINC file found in the file system
   - $QCed2_minc     : optional, secondary QCed MINC file created after
                        conversion of secondary QCed DTIPrep NRRD file
-  - returns undef if there are some missing files (except for
-     QCed2_minc which is optional)
+  - returns undef if there are some missing files (except for C<QCed2_minc>
+     which is optional)
 
 =cut
 
@@ -858,21 +852,20 @@ Function that checks if all DTIPrep pre-processing files are present in the
 file system.
 
 INPUTS:
-  - $dti_file: raw DTI dataset that is used as a key in $DTIrefs hash
+  - $dti_file: raw DTI dataset that is used as a key in C<$DTIrefs> hash
   - DTIrefs  : hash containing all output paths and tool information
   - mri_files: list of processed outputs to register or that have been
                 registered
 
 RETURNS:
   - $XMLProtocol: DTIPrep XML protocol found in the file system
-  - $QCReport   : DTIPrep text QCReport found in the file system
-  - $XMLReport  : DTIPrep XML QCReport found in the file system
-  - $QCed_minc  : QCed MINC file created after conversion of
-                   QCed NRRD file
+  - $QCReport   : DTIPrep text QC report found in the file system
+  - $XMLReport  : DTIPrep XML QC report found in the file system
+  - $QCed_minc  : QCed MINC file created after conversion of QCed NRRD file
   - $QCed2_minc : optional, secondary QCed MINC file created after
                    conversion of secondary QCed DTIPrep NRRD file
   - returns undef if one of the file listed above is missing (except
-     for QCed2_minc which is optional)
+     for C<QCed2_minc> which is optional)
 
 =cut
 
@@ -918,20 +911,19 @@ sub checkPreprocessFiles {
 =head3 checkPostprocessFiles($dti_file, $DTIrefs, $mri_files)
 
 Function that checks if all postprocessing files (from DTIPrep or
-mincdiffusion) are present in the file system.
+C<mincdiffusion>) are present in the file system.
 
 INPUTS:
-  - $dti_file : raw DTI dataset that is used as a key in $DTIrefs hash
+  - $dti_file : raw DTI dataset that is used as a key in C<$DTIrefs> hash
   - $DTIrefs  : hash containing all output paths and tool information
-  - $mri_files: list of processed outputs to register or that
-                 have been registered
+  - $mri_files: list of processed outputs to register or that have been registered
 
 RETURNS:
   - $RGB_minc       : RGB map
   - $FA_minc        : FA map
   - $MD_minc        : MD map
   - $baseline_minc  : baseline (or frame-0) map
-  - $brain_mask_minc: brain mask produced by mincdiffusion tools (not
+  - $brain_mask_minc: brain mask produced by C<mincdiffusion> tools (not
                        available if DTIPrep was run to obtain the
                        post-processing outputs)
   - will return undef if one of the file listed above is missing
@@ -1042,13 +1034,12 @@ sub checkPostprocessFiles {
 
 =head3 getFileID($file, $src_name)
 
-Fetches the source FileID from the database based on the src_name file
-identified by getFileName.
+Fetches the source FileID from the database based on the C<$src_name> file
+identified by C<getFileName>.
 
 INPUTS:
   - $file    : output filename
-  - $src_name: source filename (file that has been used to obtain the output
-                file $file)
+  - $src_name: source filename (file that has been used to obtain C<$file>)
 
 RETURNS: source File ID (file ID of the source file that has been used to
           obtain $file)
@@ -1085,14 +1076,14 @@ sub getFileID {
 =head3 getToolName($file)
 
 Fetches tool information stored either in the MINC file's header or in the
-QCReport.
+QC text report.
 
-INPUT: MINC or QC report to look for tool information
+INPUT: MINC or QC text report to look for tool information
 
 RETURNS:
-  - $src_pipeline: name of the pipeline used to obtain $file (DTIPrepPipeline)
-  - $src_tool    : name and version of the tool used to obtain $file
-                    (DTIPrep_v1.1.6, mincdiffusion_v...)
+  - $src_pipeline: name of the pipeline used to obtain C<$file> (C<DTIPrepPipeline>)
+  - $src_tool    : name and version of the tool used to obtain C<$file>
+                    (C<DTIPrep_v1.1.6>, C<mincdiffusion_v...>)
 
 =cut
 
@@ -1127,12 +1118,12 @@ sub getToolName {
 =head3 getPipelineDate($file, $data_dir, $QCReport)
 
 Fetches the date at which the DTIPrep pipeline was run either in the processed
-MINC file's header or in the QCReport.
+MINC file's header or in the QC text report.
 
 INPUTS:
-  - MINC or QC report to look for tool information
-  - data_dir from the C<Config> table
-  - QC report created when C<$file> was created
+  - $file    : MINC or QC text report to look for tool information
+  - $data_dir: data directory (e.g. C</data/$PROJECT/data>)
+  - $QCReport: QC text report created when C<$file> was created
 
 RETURNS: date at which the pipeline has been run to obtain C<$file>
 
@@ -1194,14 +1185,12 @@ MINC file's header.
 
 INPUTS:
   - $minc                  : MINC file for which the header should be modified
-  - $registeredXMLfile     : path to the registered DTIPrep's XML report
+  - $registeredXMLfile     : path to the registered DTIPrep's QC XML report
   - $registeredQCReportFile: path to the registered DTIPrep's QC text report
 
 RETURNS:
- - $Txtreport_insert: 1 if on text report path insertion success,
-                       undef otherwise
- - $XMLreport_insert: 1 if on  xml report path insertion success,
-                       undef otherwise
+ - $Txtreport_insert: 1 on text report path insertion success, undef otherwise
+ - $XMLreport_insert: 1 on XML report path insertion success, undef otherwise
 
 =cut
 
@@ -1236,7 +1225,7 @@ gradient wise correlation.
 
 INPUTS:
   - $minc     : MINC file in which the summary will be inserted
-  - $data_dir : C<data_dir> from the C<Config> table
+  - $data_dir : data directory (e.g. C</data/$PROJECT/data>)
   - $XMLReport: DTIPrep's XML QC report from which the summary will be extracted
 
 RETURNS: 1 on success, undef on failure
@@ -1299,23 +1288,21 @@ sub insertPipelineSummary   {
 
 =pod
 
-=head3 registerFile($file, $src_fileID, $src_pipeline, $src_tool, ...)
+=head3 registerFile($file, $src_fileID, $src_pipeline, $src_tool, $pipelineDate, $coordinateSpace, $scanType, $outputType, $inputs)
 
-Registers file into the database via register_processed_data.pl with all
+Registers file into the database via C<register_processed_data.pl> with all
 options.
 
 INPUTS:
   - $file           : file to be registered in the database
   - $src_fileID     : source file's FileID
-  - $src_pipeline   : pipeline used to obtain the file
-                       (DTIPrepPipeline)
-  - $src_tool       : name and version of the tool
-                       (DTIPrep or mincdiffusion)
+  - $src_pipeline   : pipeline used to obtain the file (C<DTIPrepPipeline>)
+  - $src_tool       : name and version of the tool (DTIPrep or C<mincdiffusion>)
   - $pipelineDate   : file's creation date (= pipeline date)
   - $coordinateSpace: file's coordinate space (= native, T1 ...)
-  - $scanType       : file's scan type (= DTIPrepReg, DTIPrepDTIFA,
-                       DTIPrepDTIMD, DTIPrepDTIColorFA...)
-  - $outputType     : file's output type (.xml, .txt, .mnc...)
+  - $scanType       : file's scan type (= C<DTIPrepReg>, C<DTIPrepDTIFA>,
+                       C<DTIPrepDTIMD>, C<DTIPrepDTIColorFA>...)
+  - $outputType     : file's output type (C<.xml>, C<.txt>, C<.mnc>...)
   - $inputs         : input files that were used to create the file to
                        be registered (intermediary files)
 
@@ -1371,7 +1358,7 @@ sub registerFile  {
 
 =pod
 
-=head3 fetchRegisteredFile($src_fileID, $src_pipeline, $pipelineDate, ...)
+=head3 fetchRegisteredFile($src_fileID, $src_pipeline, $pipelineDate, $coordinateSpace, $scanType, $outputType)
 
 Fetches the registered file from the database to link it to the MINC files.
 
@@ -1419,7 +1406,7 @@ sub fetchRegisteredFile {
 
 =pod
 
-=head3 register_DTIPrep_files($minc, $nrrd, $raw_file, $data_dir, ...)
+=head3 register_DTIPrep_files($minc, $nrrd, $raw_file, $data_dir, $inputs, $registeredXMLProtocolID, $pipelineName, $DTIPrepVersion, $registeredXMLReportFile, $registeredQCReport, $scanType)
 
 Registers DTIPrep NRRD and MINC files. The MINC file will have a link to the
 registered NRRD file (C<&register_minc> function will modify the MINC header to
@@ -1431,15 +1418,15 @@ INPUTS:
   - $nrrd                   : NRRD file to be registered
   - $raw_file               : raw DWI file used to create the MINC file to
                                register
-  - $data_dir               : C<data_dir> from the C<Config> table
+  - $data_dir               : data directory (e.g. C</data/$PROJECT/data>)
   - $inputs                 : input files that were used to create the file to
                                be registered (intermediary files)
   - $registeredXMLProtocolID: registered XML protocol file
   - $pipelineName           : name of the pipeline that created the file to be
-                               registered (DTIPrepPipeline)
+                               registered (C<DTIPrepPipeline>)
   - $DTIPrepVersion         : DTIPrep's version
-  - $registeredXMLReportFile: registered XML report file
-  - $registeredQCReport     : registered QC text file
+  - $registeredXMLReportFile: registered QC XML report file
+  - $registeredQCReport     : registered QC text report file
   - $scanType               : scan type to use to label/register the MINC file
 
 
@@ -1502,7 +1489,7 @@ sub register_DTIPrep_files {
 
 =pod
 
-=head3 register_nrrd($nrrd, $raw_file, $data_dir, $QCReport, $inputs, ...)
+=head3 register_nrrd($nrrd, $raw_file, $data_dir, $QCReport, $inputs, $pipelineName, $toolName, $scanType)
 
 Sets parameters needed to register the NRRD file produced by DTIPrep
 and calls registerFile to register the NRRD file via
@@ -1511,13 +1498,11 @@ C<register_processed_data.pl>.
 INPUTS:
   - $nrrd        : NRRD file to be registered
   - $raw_file    : native DWI file used to obtain the DTIPrep outputs
-  - $data_dir    : data_dir from the config table
-                    (a.k.a. /data/project/data)
-  - $QCReport    : DTIPrep QCreport
+  - $data_dir    : data directory (e.g. C</data/$PROJECT/data>)
+  - $QCReport    : DTIPrep QC text report
   - $inputs      : input files used to process data through DTIPrep
-  - $pipelineName: pipeline name used to process DTIs
-                    (DTIPrepPipeline)
-  - $toolName    : DTIPrep name & version used to process the DWI file
+  - $pipelineName: pipeline name used to process DTIs (C<DTIPrepPipeline>)
+  - $toolName    : DTIPrep name and version used to process the DWI file
   - $scanType    : NRRD file's scan type
 
 RETURNS: registered NRRD file or undef on insertion's failure
@@ -1592,7 +1577,7 @@ sub register_nrrd {
 
 =pod
 
-=head3 register_Preproc($mri_files, $dti_file, $data_dir, ...)
+=head3 register_Preproc($mri_files, $dti_file, $data_dir, $pipelineName, $toolName, $process_step, $proc_file)
 
 Gathers all DTIPrep preprocessed files to be registered in the database
 and calls C<&register_DTIPrep_files> on all of them. Will register first the
@@ -1601,12 +1586,12 @@ NRRD file and then the MINC file for each scan type.
 INPUTS:
   - $mri_files   : hash containing all DTI output information
   - $dti_file    : native DWI file (that will be used as a key
-                    for $mri_files)
-  - $data_dir    : data_dir defined in the config file
-  - $pipelineName: pipeline name (DTIPrepPipeline)
+                    for C<$mri_files>)
+  - $data_dir    : data directory (e.g. C</data/$PROJECT/data>)
+  - $pipelineName: pipeline name (C<DTIPrepPipeline>)
   - $toolName    : tool's name and version
-  - $process_step: processing step ('Preproc' or 'Postproc')
-  - $proc_file   : processed file key ('QCed', 'QCed2'...)
+  - $process_step: processing step (C<'Preproc'> or C<'Postproc'>)
+  - $proc_file   : processed file key (C<'QCed'>, C<'QCed2'>...)
 
 RETURNS: path to the MINC file that was registered
 
@@ -1645,25 +1630,24 @@ sub register_Preproc {
 
 =pod
 
-=head3 register_images($mri_files, $raw_file, $data_dir, $pipelineName, ...)
+=head3 register_images($mri_files, $raw_file, $data_dir, $pipelineName, $toolName, $process_step)
 
 Function to register processed images in the database depending on the tool
 used to obtain them. Will call C<&register_DTIPrep_files> if files to be
 registered are obtained via DTIPrep or C<&register_minc> if files to be
-registered are obtained using mincdiffusion tools.
+registered are obtained using C<mincdiffusion> tools.
 
 INPUTS:
   - $mri_files   : hash with information about the files to be registered
   - $raw_file    : source raw image
-  - $data_dir    : data directory from the Config table
+  - $data_dir    : data directory (e.g. C</data/$PROJECT/data>)
   - $pipelineName: name of the pipeline used (a.k.a DTIPrep)
   - $toolName    : tool's version and name
-  - $process_step: processing step (preprocessing, post-processing)
+  - $process_step: processing step (pre-processing, post-processing)
 
 RETURNS:
   - @registered        : list of registered files
-  - @failed_to_register: list of files that failed to be registered
-                          in the DB
+  - @failed_to_register: list of files that failed to be registered in the DB
 
 =cut
 
@@ -1740,7 +1724,7 @@ data separated by ';'.
 INPUTS:
   - $mri_files   : list of processed outputs to register or that
                     have been registered
-  - $data_dir    : data directory from the Config table
+  - $data_dir    : data directory (e.g. C</data/$PROJECT/data>)
   - $process_step: processing step used for the processed output
                     to determine inputs
   - $proc_file   : processing file to determine inputs used
@@ -1786,13 +1770,13 @@ sub getInputList {
 
 =head3 fetchRegisteredMD5($md5sum)
 
-Will check if md5sum has already been registered into the database.
+Will check if MD5 sum has already been registered into the database.
 
-INPUT: md5sum of the file
+INPUT: MD5 sum of the file
 
 RETURNS:
-  - $registeredFile    : registered FileID matching md5sum
-  - $registeredScanType: scan type of the registered FileID matching md5sum
+  - $registeredFile    : registered FileID matching MD5 sum
+  - $registeredScanType: scan type of the registered C<FileID> matching MD5 sum
 
 =cut
 
@@ -1820,14 +1804,6 @@ sub fetchRegisteredMD5 {
 __END__
 
 =pod
-
-=head1 TO DO
-
-Nothing planned (or things that are left to do)
-
-=head1 BUGS
-
-None reported (or list of bugs)
 
 =head1 LICENSING
 

--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -509,8 +509,7 @@ INPUTS:
   - $registeredXMLFile     : registered DTIPrep XML report
   - $registeredQCReportFile: registered DTIPrep text report
   - $scanType              : scan type of the MINC file to register
-  - $registered_nrrd       : optional, registered NRRD file used to create
-                              the MINC file
+  - $registered_nrrd       : optional, registered NRRD file used to create the MINC file
 
 RETURNS: registered MINC file on success, undef otherwise
 
@@ -910,7 +909,7 @@ sub checkPreprocessFiles {
 
 =head3 checkPostprocessFiles($dti_file, $DTIrefs, $mri_files)
 
-Function that checks if all postprocessing files (from DTIPrep or
+Function that checks if all postprocessing files (from C<DTIPrep> or
 C<mincdiffusion>) are present in the file system.
 
 INPUTS:
@@ -1590,8 +1589,8 @@ INPUTS:
   - $data_dir    : data directory (e.g. C</data/$PROJECT/data>)
   - $pipelineName: pipeline name (C<DTIPrepPipeline>)
   - $toolName    : tool's name and version
-  - $process_step: processing step (C<'Preproc'> or C<'Postproc'>)
-  - $proc_file   : processed file key (C<'QCed'>, C<'QCed2'>...)
+  - $process_step: processing step (C<Preproc> or C<Postproc>)
+  - $proc_file   : processed file key (C<QCed>, C<QCed2>...)
 
 RETURNS: path to the MINC file that was registered
 

--- a/DTIPrep/DTIPrep_pipeline.pl
+++ b/DTIPrep/DTIPrep_pipeline.pl
@@ -728,9 +728,8 @@ INPUTS:
   - $QCoutdir       : pre-processing output directory
   - $DTIPrepProtocol: DTIPrep XML protocol that was used to run DTIPrep
 
-RETURNS:
-  - undef if at least one output file is missing
-  - 1 if all output files were found
+RETURNS: undef if at least one output file is missing; 1 if all output files
+were found
 
 =cut
 

--- a/DTIPrep/DTIPrep_pipeline.pl
+++ b/DTIPrep/DTIPrep_pipeline.pl
@@ -4,7 +4,7 @@
 
 =head1 NAME
 
-DTIPrep_pipeline.pl -- Run DTIPrep and/or insert DTIPrep's outputs in the
+DTIPrep_pipeline.pl -- Run C<DTIPrep> and/or insert C<DTIPrep>'s outputs in the
 database.
 
 =head1 SYNOPSIS
@@ -18,15 +18,15 @@ perl DTIPrep_pipeline.p C<[options]>
 -list                : file containing the list of raw diffusion MINC
                         files (in C<assembly/DCCID/Visit/mri/native>)
 
--DTIPrepVersion      : DTIPrep version used (if cannot be found in
-                        DTIPrep binary path)
+-DTIPrepVersion      : C<DTIPrep> version used (if cannot be found in
+                        C<DTIPrep> binary path)
 
 -mincdiffusionVersion: C<mincdiffusion> release version used (if cannot be
                         found in C<mincdiffusion> scripts path)
 
--runDTIPrep          : if set, run DTIPrep on the raw MINC DTI data
+-runDTIPrep          : if set, run C<DTIPrep> on the raw MINC DTI data
 
--DTIPrepProtocol     : DTIPrep protocol to use (or used) to run DTIPrep
+-DTIPrepProtocol     : C<DTIPrep> protocol to use (or used) to run C<DTIPrep>
 
 -registerFilesInDB   : if set, registers outputs file in the database
 
@@ -38,32 +38,33 @@ do not need to be set if they can be found directly in the path of the binary
 tools.
 
 - the script can be run without the C<-runDTIPrep> option if execution of
-DTIPrep is not needed.
+C<DTIPrep> is not needed.
 
 - the script can be run without the C<-registerFilesInDB> option if
-registration of DTIPrep is not needed.
+registration of C<DTIPrep> is not needed.
 
 =head1 DESCRIPTION
 
-C<DTIPrep_pipeline.pl> can be used to run DTIPrep on native DWI datasets. It
-will also organize, convert and register the outputs of DTIPrep in the database.
+C<DTIPrep_pipeline.pl> can be used to run C<DTIPrep> on native DWI datasets. It
+will also organize, convert and register the outputs of C<DTIPrep> in the
+database.
 
-If C<-runDTIPrep> option is not set, DTIPrep processing will be skipped
-(DTIPrep outputs being already available, as well as the DTIPrep protocol that
-was used).
+If C<-runDTIPrep> option is not set, C<DTIPrep> processing will be skipped
+(C<DTIPrep> outputs being already available, as well as the C<DTIPrep> protocol
+that was used).
 
 B<This pipeline will:>
 
 1) grep native DWI files from list of given native directories (C<-list> option)
 
 2) create (or fetch if C<-runDTIPrep> not set) output directories based
-   on the DTIPrep version and protocol that are to be (or were) used
-   for DTIPrep processing
+   on the C<DTIPrep> version and protocol that are to be (or were) used
+   for C<DTIPrep> processing
 
-3) convert native DWI MINC file to NRRD and run DTIPrep if C<-runDTIPrep>
+3) convert native DWI MINC file to NRRD and run C<DTIPrep> if C<-runDTIPrep>
    option is set
 
-4) fetch DTIPrep pre-processing outputs (QCed.nrrd, QCReport.txt,
+4) fetch C<DTIPrep> pre-processing outputs (QCed.nrrd, QCReport.txt,
    QCXMLResults.xml & protocol.xml)
 
 5) convert pre-processed NRRD files back to MINC with all the header
@@ -405,7 +406,7 @@ sub getIdentifiers {
 
 =head3 getOutputDirectories($outdir, $subjID, $visit, $DTIPrepProtocol, $runDTIPrep)
 
-Determine pipeline's output directory based on the root C<$outdir>, DTIPrep
+Determine pipeline's output directory based on the root C<$outdir>, C<DTIPrep>
 protocol name, candidate ID C<CandID> and visit label:
 C<outdir/ProtocolName/CandID/VisitLabel>
 
@@ -414,14 +415,14 @@ C<outdir/ProtocolName/CandID/VisitLabel>
 - If C<$runDTIPrep> is not set, the function will check that the directory exists
 
 INPUTS:
-  - $outdir         : root directory for DTIPrep outputs (in
+  - $outdir         : root directory for C<DTIPrep> outputs (in
                        C</data/$PROJECT/data/pipelines/DTIPrep/DTIPrep_version>)
   - $subjID         : candidate ID of the DTI dataset to be processed
   - $visit          : visit label of the DTI dataset to be processed
-  - $DTIPrepProtocol: XML file with the DTIPrep protocol to use
+  - $DTIPrepProtocol: XML file with the C<DTIPrep> protocol to use
   - $runDTIPrep     : boolean, if output folders should be created in
                        the filesystem (before processing data through
-                       DTIPrep) if they don't exist
+                       C<DTIPrep>) if they don't exist
 
 RETURNS: directory where processed files for the candidate, visit label and
 DTIPrep protocol will be stored.
@@ -461,7 +462,7 @@ INPUTS:
   - $DTI_volumes    : number of volumes expected in the DWI dataset
   - $t1_scan_type   : the scan type name of the T1 weighted dataset
   - $QCoutdir       : directory to save processed files
-  - $DTIPrepProtocol: XML DTIPrep protocol to use
+  - $DTIPrepProtocol: XML C<DTIPrep> protocol to use
 
 RETURNS: undef if could not find any raw DWI dataset OR
   - $DTIs_list: list of raw DTIs found
@@ -499,14 +500,14 @@ sub fetchData {
 =head3 preprocessingPipeline($DTIs_list, $DTIrefs, $QCoutdir, $DTIPrepProtocol)
 
 Function that creates the output folders, gets the raw DTI files, converts them
-to NRRD and runs DTIPrep using a C<bcheck> protocol and a C<nobcheck> protocol.
+to NRRD and runs C<DTIPrep> using a C<bcheck> protocol and a C<nobcheck> protocol.
 
 INPUTS:
   - $DTIs_list      : list of DWI files to process for a given C<CandID/Visit>
   - $DTIrefs        : hash with output file names & paths for the
                        different DWI to process
   - $QCoutdir       : output directory to save preprocessed files
-  - $DTIPrepProtocol: XML DTIPrep protocol to use for pre-processing
+  - $DTIPrepProtocol: XML C<DTIPrep> protocol to use for pre-processing
 
 RETURNS:
   - 1 if at least one raw DWI dataset was successfully preprocessed
@@ -594,12 +595,12 @@ sub preproc_mnc2nrrd {
 
 =head3 preproc_DTIPrep($QCed_nrrd, $raw_nrrd, $DTIPrepProtocol, $QCed2_nrrd)
 
-This function will call C<&DTI::runDTIPrep> to run DTIPrep on the raw NRRD file.
+This function will call C<&DTI::runDTIPrep> to run C<DTIPrep> on the raw NRRD file.
 
 INPUTS:
-  - $QCed_nrrd      : QCed DWI NRRD file to be created by DTIPrep
-  - $raw_nrrd       : raw DWI NRRD file to process through DTIPrep
-  - $DTIPrepProtocol: DTIPrep XML Protocol to use to run DTIPrep
+  - $QCed_nrrd      : QCed DWI NRRD file to be created by C<DTIPrep>
+  - $raw_nrrd       : raw DWI NRRD file to process through C<DTIPrep>
+  - $DTIPrepProtocol: C<DTIPrep> XML Protocol to use to run C<DTIPrep>
 
 RETURNS: 1 on success, undef on failure
 
@@ -625,12 +626,12 @@ sub preproc_DTIPrep {
 =head3 preproc_copyXMLprotocol($QCProt, $QCoutdir, $DTIPrepProtocol)
 
 Function that will call C<&DTI::copyDTIPrepProtocol> if the XML protocol has
-not already been copied in DTIPrep QC directory.
+not already been copied in C<DTIPrep> QC directory.
 
 INPUTS:
   - $QCProt         : copied QC XML protocol (in QC output folder)
   - $QCoutdir       : QC output directory
-  - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
+  - $DTIPrepProtocol: C<DTIPrep> XML protocol used to run C<DTIPrep>
 
 RETURNS: 1 on success, undef on failure
 
@@ -664,8 +665,8 @@ INPUTS:
                        corresponding output names as values
   - $data_dir       : directory containing raw DWI dataset
   - $QCoutdir       : directory containing preprocessed outputs
-  - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
-  - $DTIPrepVersion : DTIPrep version that was run to pre-process images
+  - $DTIPrepProtocol: C<DTIPrep> XML protocol used to run C<DTIPrep>
+  - $DTIPrepVersion : C<DTIPrep> version that was run to pre-process images
 
 RETURNS:
   - undef if could not find pre-processed files or convert them to MINC
@@ -713,12 +714,12 @@ sub check_and_convertPreprocessedFiles {
 
 =head3 checkPreprocessOutputs($dti_file, $DTIrefs, $QCoutdir, $DTIPrepProtocol)
 
-Checks if all pre-processing DTIPrep files are in the output folder. They
+Checks if all pre-processing C<DTIPrep> files are in the output folder. They
 should include:
   - QCed NRRD file
-  - DTIPrep QC text report
-  - DTIPrep QC XML report
-  - a copy of the protocol used to run DTIPrep
+  - C<DTIPrep> QC text report
+  - C<DTIPrep> QC XML report
+  - a copy of the protocol used to run C<DTIPrep>
 
 Relevant information will also be printed in the log file.
 
@@ -726,7 +727,7 @@ INPUTS:
   - $dti_file       : raw DWI file that was processed
   - $DTIrefs        : hash containing output names
   - $QCoutdir       : pre-processing output directory
-  - $DTIPrepProtocol: DTIPrep XML protocol that was used to run DTIPrep
+  - $DTIPrepProtocol: C<DTIPrep> XML protocol that was used to run C<DTIPrep>
 
 RETURNS: undef if at least one output file is missing; 1 if all output files
 were found
@@ -770,14 +771,14 @@ sub checkPreprocessOutputs {
 
 =head3 convertPreproc2mnc($dti_file, $DTIrefs, $data_dir, $DTIPrepVersion)
 
-This function will convert to MINC DTI QCed NRRD file from DTIPrep and reinsert
+This function will convert to MINC DTI QCed NRRD file from C<DTIPrep> and reinsert
 all MINC header information.
 
 INPUTS:
   - $dti_file      : raw DWI file to be processed
   - $DTIrefs       : hash containing output names
   - $data_dir      : directory containing the raw dataset
-  - $DTIPrepVersion: DTIPrep version used to pre-process raw DWI
+  - $DTIPrepVersion: C<DTIPrep> version used to pre-process raw DWI
 
 RETURNS: 1 if QCed MINC file created and exists; undef otherwise
 
@@ -833,7 +834,7 @@ INPUTS:
   - $DTIrefs        : hash containing output names and paths
   - $data_dir       : directory hosting raw DWI dataset
   - $QCoutdir       : QC process output directory
-  - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
+  - $DTIPrepProtocol: C<DTIPrep> XML protocol used to run C<DTIPrep>
   - $mincdiffVersion: C<mincdiffusion> version
 
 RETURNS: 1 if all post-processing outputs found, undef otherwise
@@ -1025,7 +1026,7 @@ sub runMincdiffusionTools {
 =head3 check_and_convert_DTIPrep_postproc_outputs($DTIs_list, $DTIrefs, $data_dir, $QCoutdir, $DTIPrepVersion)
 
 Function that loops through DTI files acquired for the C<CandID> and session to
-check if DTIPrep post processed NRRD files have been created and converts them
+check if C<DTIPrep> post processed NRRD files have been created and converts them
 to MINC files with relevant header information.
 
 INPUTS:
@@ -1033,7 +1034,7 @@ INPUTS:
   - $DTIrefs       : hash containing references for DTI output naming
   - $data_dir      : directory containing the raw DTI dataset
   - $QCoutdir      : directory containing the processed data
-  - $DTIPrepVersion: version of DTIPrep used to process the data
+  - $DTIPrepVersion: version of C<DTIPrep> used to process the data
 
 RETURNS: 1 on success, undef on failure
 
@@ -1083,7 +1084,7 @@ INPUT:
   - $DTIrefs        : hash containing the processed filenames
   - $profile        : config file (in C<../dicom-archive/.loris_mri>)
   - $QCoutdir       : output directory containing the processed files
-  - $DTIPrepVersion : DTIPrep version used to obtain QCed files
+  - $DTIPrepVersion : C<DTIPrep> version used to obtain QCed files
   - $mincdiffVersion: C<mincdiffusion> tool version used
 
 =cut

--- a/DTIPrep/DTIPrep_pipeline.pl
+++ b/DTIPrep/DTIPrep_pipeline.pl
@@ -13,16 +13,16 @@ perl DTIPrep_pipeline.p C<[options]>
 
 
 -profile             : name of config file in
-                        ../dicom-archive/.loris_mri
+                        C<../dicom-archive/.loris_mri>
 
 -list                : file containing the list of raw diffusion MINC
-                        files (in assembly/DCCID/Visit/mri/native)
+                        files (in C<assembly/DCCID/Visit/mri/native>)
 
 -DTIPrepVersion      : DTIPrep version used (if cannot be found in
                         DTIPrep binary path)
 
--mincdiffusionVersion: mincdiffusion release version used (if cannot be
-                        found in mincdiffusion scripts path)
+-mincdiffusionVersion: C<mincdiffusion> release version used (if cannot be
+                        found in C<mincdiffusion> scripts path)
 
 -runDTIPrep          : if set, run DTIPrep on the raw MINC DTI data
 
@@ -40,7 +40,7 @@ tools.
 - the script can be run without the C<-runDTIPrep> option if execution of
 DTIPrep is not needed.
 
-- the script cab be run without the C<-registerFilesInDB> option if
+- the script can be run without the C<-registerFilesInDB> option if
 registration of DTIPrep is not needed.
 
 =head1 DESCRIPTION
@@ -54,14 +54,13 @@ was used).
 
 B<This pipeline will:>
 
-1) grep native DWI files from list of given native directories
-   (-list option)
+1) grep native DWI files from list of given native directories (C<-list> option)
 
 2) create (or fetch if C<-runDTIPrep> not set) output directories based
    on the DTIPrep version and protocol that are to be (or were) used
    for DTIPrep processing
 
-3) convert native DWI minc file to NRRD & run DTIPrep if C<-runDTIPrep>
+3) convert native DWI MINC file to NRRD and run DTIPrep if C<-runDTIPrep>
    option is set
 
 4) fetch DTIPrep pre-processing outputs (QCed.nrrd, QCReport.txt,
@@ -371,13 +370,14 @@ sub identify_tool_version {
 
 =head3 getIdentifiers($nativedir)
 
-Fetches CandID and visit label from the native directory of the dataset to
+Fetches C<CandID> and visit label from the native directory of the dataset to
 process. Relevant information will also be printed in the log file.
 
 INPUT: native directory of the dataset to process
 
-RETURNS: $candID & $visit_label information, or undef if the script could not
-determine the site, CandID or visit label.
+RETURNS: undef if could not determine the site, C<CandID>, visit OR
+  - $candID     : candidate DCCID
+  - $visit_label: visit label
 
 =cut
 
@@ -403,23 +403,23 @@ sub getIdentifiers {
 
 =pod
 
-=head3 getOutputDirectories($outdir, $subjID, $visit, $DTIPrepProtocol, ...)
+=head3 getOutputDirectories($outdir, $subjID, $visit, $DTIPrepProtocol, $runDTIPrep)
 
 Determine pipeline's output directory based on the root C<$outdir>, DTIPrep
 protocol name, candidate ID C<CandID> and visit label:
 C<outdir/ProtocolName/CandID/VisitLabel>
 
-- If $runDTIPrep is set, the function will create the output folders
+- If C<$runDTIPrep> is set, the function will create the output folders
 
-- If $runDTIPrep is not set, the function will check that the directory exists
+- If C<$runDTIPrep> is not set, the function will check that the directory exists
 
 INPUTS:
   - $outdir         : root directory for DTIPrep outputs (in
-                       C</data/project/data/pipelines/DTIPrep/DTIPrep_version>)
+                       C</data/$PROJECT/data/pipelines/DTIPrep/DTIPrep_version>)
   - $subjID         : candidate ID of the DTI dataset to be processed
   - $visit          : visit label of the DTI dataset to be processed
   - $DTIPrepProtocol: XML file with the DTIPrep protocol to use
-  - $runDTIPrep     : boolean, if OutputFolders should be created in
+  - $runDTIPrep     : boolean, if output folders should be created in
                        the filesystem (before processing data through
                        DTIPrep) if they don't exist
 
@@ -450,10 +450,10 @@ sub getOutputDirectories {
 
 =pod
 
-=head3 fetchData($nativedir, $DTI_volumes, $t1_scan_type, $QCoutdir, ...)
+=head3 fetchData($nativedir, $DTI_volumes, $t1_scan_type, $QCoutdir, $DTIPrepProtocol)
 
 Fetches the raw DWI datasets and foreach DWI, determines output names to be used
-and stores them into a hash ($DTIrefs). Will also print relevant information
+and stores them into a hash (C<$DTIrefs>). Will also print relevant information
 in the log file.
 
 INPUTS:
@@ -463,10 +463,9 @@ INPUTS:
   - $QCoutdir       : directory to save processed files
   - $DTIPrepProtocol: XML DTIPrep protocol to use
 
-RETURNS:
-  - list of raw DTIs found, a hash with the preprocessing output names
-     and paths if raw DWI dataset was found.
-  - undef if could not find any raw DWI dataset.
+RETURNS: undef if could not find any raw DWI dataset OR
+  - $DTIs_list: list of raw DTIs found
+  - $DTIrefs  : a hash with the pre-processing output names and paths
 
 =cut
 
@@ -497,14 +496,13 @@ sub fetchData {
 
 =pod
 
-=head3 preprocessingPipeline($DTIs_list, $DTIrefs, $QCoutdir, ...)
+=head3 preprocessingPipeline($DTIs_list, $DTIrefs, $QCoutdir, $DTIPrepProtocol)
 
 Function that creates the output folders, gets the raw DTI files, converts them
 to NRRD and runs DTIPrep using a C<bcheck> protocol and a C<nobcheck> protocol.
 
 INPUTS:
-  - $DTIs_list      : list of DWI files to process for a given
-                       CandID/Visit
+  - $DTIs_list      : list of DWI files to process for a given C<CandID/Visit>
   - $DTIrefs        : hash with output file names & paths for the
                        different DWI to process
   - $QCoutdir       : output directory to save preprocessed files
@@ -512,8 +510,7 @@ INPUTS:
 
 RETURNS:
   - 1 if at least one raw DWI dataset was successfully preprocessed
-  - undef if pre-processing was not successful on a least one raw DWI
-     dataset
+  - undef if pre-processing was not successful on a least one raw DWI dataset
 
 =cut
 
@@ -569,7 +566,9 @@ sub preprocessingPipeline {
 
 Function that converts MINC raw DWI file to NRRD and logs the conversion status.
 
-INPUTS: raw NRRD file to create, raw DWI file to convert to NRRD
+INPUTS:
+  - $raw_nrrd: raw NRRD file to create
+  - $dti_file: raw DWI file to convert to NRRD
 
 RETURNS: 1 on success, undef on failure
 
@@ -626,7 +625,7 @@ sub preproc_DTIPrep {
 =head3 preproc_copyXMLprotocol($QCProt, $QCoutdir, $DTIPrepProtocol)
 
 Function that will call C<&DTI::copyDTIPrepProtocol> if the XML protocol has
-not already been copied in DTIPrep QC outdir.
+not already been copied in DTIPrep QC directory.
 
 INPUTS:
   - $QCProt         : copied QC XML protocol (in QC output folder)
@@ -654,7 +653,7 @@ sub preproc_copyXMLprotocol {
 
 =pod
 
-=head3 check_and_convertPreprocessedFiles($DTIs_list, $DTIrefs, ...)
+=head3 check_and_convertPreprocessedFiles($DTIs_list, $DTIrefs, $data_dir, $QCoutdir, $DTIPrepProtocol, $DTIPrepVersion)
 
 This function will check pre-processing outputs and call
 C<&convertPreproc2mnc>, which will convert and reinsert headers into MINC file.
@@ -669,10 +668,8 @@ INPUTS:
   - $DTIPrepVersion : DTIPrep version that was run to pre-process images
 
 RETURNS:
-  - Will return undef if the function could not find preprocessed files
-     or convert them to MINC
-  - Will return 1 if conversion was a success and all
-     preprocessing files were found in QC output directory
+  - undef if could not find pre-processed files or convert them to MINC
+  - 1 if successful conversion & all pre-processing files found in the QC directory
 
 =cut
 
@@ -714,7 +711,7 @@ sub check_and_convertPreprocessedFiles {
 
 =pod
 
-=head3 checkPreprocessOutputs($dti_file, $DTIrefs, $QCoutdir, ...)
+=head3 checkPreprocessOutputs($dti_file, $DTIrefs, $QCoutdir, $DTIPrepProtocol)
 
 Checks if all pre-processing DTIPrep files are in the output folder. They
 should include:
@@ -728,11 +725,12 @@ Relevant information will also be printed in the log file.
 INPUTS:
   - $dti_file       : raw DWI file that was processed
   - $DTIrefs        : hash containing output names
-  - $QCoutdir       : preprocessing output directory
+  - $QCoutdir       : pre-processing output directory
   - $DTIPrepProtocol: DTIPrep XML protocol that was used to run DTIPrep
 
-RETURNS: 1 if all output files were found, undef if at least one output file
-is missing
+RETURNS:
+  - undef if at least one output file is missing
+  - 1 if all output files were found
 
 =cut
 
@@ -829,7 +827,7 @@ sub convertPreproc2mnc {
 
 Running post-processing pipeline that will check if post-processing outputs
 already exist. If they don't exist, it will call C<&runMincdiffusion> to run
-the mincdiffusion tools.
+the C<mincdiffusion> tools.
 
 INPUTS:
   - $DTIs_list      : list with raw DWI to post-process
@@ -837,7 +835,7 @@ INPUTS:
   - $data_dir       : directory hosting raw DWI dataset
   - $QCoutdir       : QC process output directory
   - $DTIPrepProtocol: DTIPrep XML protocol used to run DTIPrep
-  - $mincdiffVersion: mincdiffusion version
+  - $mincdiffVersion: C<mincdiffusion> version
 
 RETURNS: 1 if all post-processing outputs found, undef otherwise
 
@@ -900,7 +898,7 @@ sub mincdiffusionPipeline {
 Function that checks if all outputs are present in the QC output directory.
 
 INPUTS:
-  - $dti_file: raw DWI dataset to use as a key in $DTIrefs
+  - $dti_file: raw DWI dataset to use as a key in C<$DTIrefs>
   - $DTIrefs : hash containing output names
   - $QCoutdir: QC output directory
 
@@ -945,16 +943,16 @@ sub checkMincdiffusionPostProcessedOutputs {
 
 =pod
 
-=head3 runMincdiffusionTools($dti_file, $DTIrefs, $data_dir, $QCoutdir, ...)
+=head3 runMincdiffusionTools($dti_file, $DTIrefs, $data_dir, $QCoutdir, $mincdiffVersion)
 
 Will create FA, MD and RGB maps.
 
 INPUTS:
-  - $dti_file       : raw DWI file that is used as a key in $DTIrefs
+  - $dti_file       : raw DWI file that is used as a key in C<$DTIrefs>
   - $DTIrefs        : hash containing output names and paths
   - $data_dir       : directory containing raw datasets
   - $QCoutdir       : QC output directory
-  - $mincdiffVersion: mincdiffusion version used
+  - $mincdiffVersion: C<mincdiffusion> version used
 
 RETURNS: 1 on success, undef on failure
 
@@ -1025,9 +1023,9 @@ sub runMincdiffusionTools {
 
 =pod
 
-=head3 check_and_convert_DTIPrep_postproc_outputs($DTIs_list, $DTIrefs, ...)
+=head3 check_and_convert_DTIPrep_postproc_outputs($DTIs_list, $DTIrefs, $data_dir, $QCoutdir, $DTIPrepVersion)
 
-Function that loops through DTI files acquired for the CandID and session to
+Function that loops through DTI files acquired for the C<CandID> and session to
 check if DTIPrep post processed NRRD files have been created and converts them
 to MINC files with relevant header information.
 
@@ -1076,7 +1074,7 @@ sub check_and_convert_DTIPrep_postproc_outputs {
 
 =pod
 
-=head3 register_processed_files_in_DB($DTIs_list, $DTIrefs, $profile, ...)
+=head3 register_processed_files_in_DB($DTIs_list, $DTIrefs, $profile, $QCoutdir, $DTIPrepVersion, $mincdiffVersion)
 
 Calls the script C<DTIPrepRegister.pl> to register processed files into the
 database.
@@ -1084,10 +1082,10 @@ database.
 INPUT:
   - $DTIs_list      : list of native DTI files processed
   - $DTIrefs        : hash containing the processed filenames
-  - $profile        : config file (../dicom-archive/.loris_mri/prod)
+  - $profile        : config file (in C<../dicom-archive/.loris_mri>)
   - $QCoutdir       : output directory containing the processed files
   - $DTIPrepVersion : DTIPrep version used to obtain QCed files
-  - $mincdiffVersion: mincdiffusion tool version used
+  - $mincdiffVersion: C<mincdiffusion> tool version used
 
 =cut
 
@@ -1122,14 +1120,6 @@ sub register_processed_files_in_DB {
 __END__
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -4,19 +4,18 @@
 
 =head1 NAME
 
-batch_uploads_imageuploader -- a script that runs imaging_upload_file.pl in
+batch_uploads_imageuploader -- a script that runs C<imaging_upload_file.pl> in
 batch mode
 
 =head1 SYNOPSIS
 
-./batch_uploads_imageuploader -profile prod < list_of_scans.txt > log_batch_imageuploader.txt 2>&1 `[options]`
+./batch_uploads_imageuploader -profile prod < list_of_scans.txt > log_batch_imageuploader.txt 2>&1 C[options]>
 
 Available options are:
 
--profile      : name of the config file in
-                C<../dicom-archive/.loris_mri>
+-profile: name of the config file in C<../dicom-archive/.loris_mri>
 
--verbose      : if set, be verbose
+-verbose: if set, be verbose
 
 
 =head1 DESCRIPTION
@@ -274,9 +273,9 @@ close MAIL;
 
 Function that inserts into the C<mri_upload> table entries for data coming from
 the list of scans in the text file provided when calling
-batch_upload_imageuploader
+C<batch_upload_imageuploader>
 
-INPUTS  :
+INPUTS:
     - $patientname  : The patient name
     - $phantom      : 'Y' if the entry is for a phantom,
                       'N' otherwise
@@ -319,14 +318,6 @@ exit $NeuroDB::ExitCodes::SUCCESS;
 __END__
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/batch_uploads_tarchive
+++ b/batch_uploads_tarchive
@@ -19,7 +19,7 @@ from C<STDIN>, one file name per line. Each file name is assumed to be a path
 relative to C<tarchiveLibraryDir> (see below).
 
 The following settings of file F<$ENV{LORIS_CONFIG}/.loris-mri/prod> affect the 
-behvaviour of batch_uploads_tarchive (where C<$ENV{LORIS_CONFIG}> is the
+behvaviour of C<batch_uploads_tarchive> (where C<$ENV{LORIS_CONFIG}> is the
 value of the Unix environment variable C<LORIS_CONFIG>):
 
 =over 4

--- a/batch_uploads_tarchive
+++ b/batch_uploads_tarchive
@@ -4,7 +4,8 @@
 
 =head1 NAME
 
-batch_uploads_tarchive - upload a batch of tarchives using script tarchiveLoader
+batch_uploads_tarchive - upload a batch of DICOM archives using script
+C<tarchiveLoader>
 
 =head1 SYNOPSIS
 
@@ -12,38 +13,39 @@ batch_uploads_tarchive - upload a batch of tarchives using script tarchiveLoader
 
 =head1 DESCRIPTION
 
-This script uploads a list of tarchive files to the database by calling script 
+This script uploads a list of DICOM archives to the database by calling script
 C<tarchiveLoader> on each file in succession. The list of files to process is read 
-from STDIN, one file name per line. Each file name is assumed to be a path relative 
-to C<tarchiveLibraryDir> (see below).
+from C<STDIN>, one file name per line. Each file name is assumed to be a path
+relative to C<tarchiveLibraryDir> (see below).
 
 The following settings of file F<$ENV{LORIS_CONFIG}/.loris-mri/prod> affect the 
-behvavior of batch_uploads_tarchive (where C<$ENV{LORIS_CONFIG}> is the value of
-the Unix environment variable LORIS_CONFIG):
+behvaviour of batch_uploads_tarchive (where C<$ENV{LORIS_CONFIG}> is the
+value of the Unix environment variable C<LORIS_CONFIG>):
 
 =over 4
 
 =item *
-B<dataDirBasepath> : controls where the STDOUT and STDERR of each qsub command
-  (see below) will go, namely in 
+B<dataDirBasepath> : controls where the C<STDOUT> and C<STDERR> of each qsub
+command (see below) will go, namely in
   F<< $dataDirBasepath/batch_output/tarstdout.log<index> >> and
   F<< $dataDirBasepath/batch_output/tarstderr.log<index> >>
-  (where C<< <index> >> is the index of the tarchive file processed, the first file having
-   index 1).
+  (where C<< <index> >> is the index of the DICOM archive processed, the
+  first file having index 1).
    
 =item * 
-B<tarchiveLibraryDir>: directory that contains the tarchive files to process. The path
-  of the files listed on STDIN should be relative to this directory.
+B<tarchiveLibraryDir>: directory that contains the DICOM archives to process.
+The path of the files listed on C<STDIN> should be relative to this directory.
   
 =item *
-B<is_qsub>: whether the output (STDOUT) of each tarchiveLoader command should be
-  processed by the qsub Unix command (allows batch execution of jobs on the 
-  Sun Grid Engine, if available). If set, then the qsub command will send its STDOUT
-  and STDERR according to the value of dataDirBasepath (see above). 
+B<is_qsub>: whether the output (STDOUT) of each C<tarchiveLoader> command
+should be processed by the C<qsub> Unix command (allows batch execution of jobs
+on the Sun Grid Engine, if available). If set, then the C<qsub> command will
+send its C<STDOUT> and C<STDERR> according to the value of C<dataDirBasepath>
+(see above).
   
 =item *
 B<mail_use>: upon completion of the script, an email will be sent to email address
-  $mail_user cointaining the list of files processed by batch_upload_tarchive
+  $mail_user containing the list of files processed by C<batch_uploads_tarchive>
   
 =back
 
@@ -69,10 +71,6 @@ The database hostname
 =head1 TO DO
 
 Code cleanup: remove unused C<-D> and C<-v> program arguments
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -99,7 +99,7 @@ INPUTS:
   - $tarType          : tar type version
   - $tarLog           : name of the .log file
   - $DCMmd5           : DICOM MD5SUM
-  - $Archivemd5       : DICOM archive MD5SUM
+  - $Archivemd5       : DICOM archive MD5 sum
   - $Archive          : archive location
   - $neurodbCenterName: center name
 

--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -35,9 +35,11 @@ use NeuroDB::ExitCodes;
 
 Creates a new instance of this class.
 
-INPUTS: DICOM directory, target location
+INPUTS:
+  - $dcm_dir: DICOM directory
+  - $tmp_dir: target location
 
-RETURNS: a DICOM::DCMSUM object
+RETURNS: a C<DICOM::DCMSUM> object
 
 =cut
 
@@ -86,18 +88,18 @@ sub new {
 
 =pod 
 
-=head3 database($dbh, $meta, $update, $tarType, $tarLog, $DCMmd5, ...)
+=head3 database($dbh, $meta, $update, $tarType, $tarLog, $DCMmd5, $Archivemd5, $Archive, $neurodbCenterName)
 
-Inserts or updates the tarchive tables.
+Inserts or updates the C<tarchive> tables.
 
 INPUTS:
   - $dbh              : database handle
   - $meta             : name of the .meta file
-  - $update           : set to 1 to update tarchive entry, 0 otherwise
+  - $update           : set to 1 to update C<tarchive> entry, 0 otherwise
   - $tarType          : tar type version
   - $tarLog           : name of the .log file
   - $DCMmd5           : DICOM MD5SUM
-  - $Archivemd5       : tarchive MD5SUM
+  - $Archivemd5       : DICOM archive MD5SUM
   - $Archive          : archive location
   - $neurodbCenterName: center name
 
@@ -431,7 +433,7 @@ QUERY
 
 =head3 read_file($file)
 
-Reads the content of a file (typically .meta file in the tarchive).
+Reads the content of a file (typically .meta file in the DICOM archive).
 
 INPUT: the file to be read
 
@@ -782,10 +784,10 @@ sub fill_header {
 =head3 confirm_single_study()
 
 Confirms that only one DICOM study is in the DICOM directory to be archived.
-Returns False if there is more than one StudyUID, otherwise it returns that
-StudyUID.
+Returns C<False> if there is more than one C<StudyUID>, otherwise it returns
+that C<StudyUID>.
 
-RETURNS: StudyUID found in the DICOM directory, or false if more than one
+RETURNS: C<StudyUID> found in the DICOM directory, or C<false> if more than one
 study was found
 
 =cut
@@ -1149,9 +1151,10 @@ sub date_format {
 
 =head3 md5sum($filename)
 
-Computes the MD5 sum of a file and outputs a format similar to md5sum on Linux.
+Computes the MD5 sum of a file and outputs a format similar to C<md5sum> on
+Linux.
 
-INPUT: file name to use to computer MD5 sum
+INPUT: file name to use to compute MD5 sum
 
 RETURNS: MD5 sum of the file
 
@@ -1171,10 +1174,6 @@ sub md5sum {
 =head1 TO DO
 
 Fix comments written as #fixme in the code.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/dicom-archive/DICOM/DICOM.pm
+++ b/dicom-archive/DICOM/DICOM.pm
@@ -19,7 +19,7 @@ medical image files conforming to DICOM standards.
 
 DICOM (Digital Imaging and Communications in Medicine) is a standard
 designed to allow medical image files to be transferred, stored and
-viewed on different makes of computers. Perl is a multiplatform
+viewed on different makes of computers. Perl is a multi-platform
 language that excels at system tasks such as file manipulation. It's
 easy to learn, particularly if you are familiar with C or the Unix
 shells and utility programs.
@@ -65,11 +65,11 @@ BEGIN {
 
 =pod
 
-=head3 new()
+=head3 new() >> (constructor)
 
 Creates a new instance of this class.
 
-RETURNS: a DICOM::DICOM object
+RETURNS: a C<DICOM::DICOM> object
 
 =cut
 
@@ -115,7 +115,9 @@ sub processOpts {
 
 Fills in hash with header members from given file.
 
-INPUTS: file, (optionally, big endian image)
+INPUTS:
+  - $infile          : file
+  - $big_endian_image: big endian image (optional)
 
 RETURNS: 1 if duplication, 0 on success
 
@@ -163,7 +165,7 @@ sub fill {
 =head3 write($outfile)
 
 Writes currently open file to given file name, or to current name if no new
-name specified.  All fields before value are written verbatim; value field
+name specified. All fields before value are written verbatim; value field
 is stored as is (possibly edited).
 
 INPUT: file to write into
@@ -288,7 +290,9 @@ sub getIndex {
 
 Returns value of the element at (group, element).
 
-INPUTS: group, element
+INPUTS:
+  - $gp: group
+  - $el: element
 
 RETURNS: value of the element
 
@@ -309,7 +313,10 @@ sub value {
 
 Returns field of given index from element.
 
-INPUTS: group, element, field index.
+INPUTS:
+  - $gp       : group
+  - $el       : element
+  - $fieldname: field index
 
 RETURNS: field of given index from element
 
@@ -393,7 +400,10 @@ sub fieldByName {
 
 Replaces value of given element.
 
-INPUTS: group, element, new value
+INPUTS:
+  - $gp      : group
+  - $el      : element
+  - $newvalue: new value
 
 =cut
 
@@ -472,10 +482,6 @@ Better documentation for:
   - hexadecimally() -- non public?
   - loop - doesn't do anything in non-graphical case. investigate if this
   function is used, if not, remove
-
-=head1 BUGS
-
-None reported.
 
 =head1 COPYRIGHT AND LICENSE
 

--- a/dicom-archive/DICOM/Element.pm
+++ b/dicom-archive/DICOM/Element.pm
@@ -4,7 +4,7 @@ package DICOM::Element;
 
 =head1 NAME
 
-DICOM::Element -- Element routines for DICOM::DICOM module
+DICOM::Element -- Element routines for C<DICOM::DICOM> module
 
 =head1 SYNOPSIS
 
@@ -14,7 +14,7 @@ DICOM::Element -- Element routines for DICOM::DICOM module
 
 =head1 DESCRIPTION
 
-Element routines for DICOM::DICOM module to read binary DICOM headers.
+Element routines for C<DICOM::DICOM> module to read binary DICOM headers.
 
 Each element is a hash with the following keys:
   - group  : group (hex)
@@ -56,7 +56,7 @@ BEGIN {
 
 =pod
 
-=head3 new() (constructor)
+=head3 new() >> (constructor)
 
 Creates a new instance of this class.
 
@@ -73,7 +73,7 @@ sub new {
 
 =pod
 
-=head3 fill($IN, $dictref, $big_endian_image)
+=head3 fill($IN, $dictref)
 
 Fills in C<self> from file.
 
@@ -195,7 +195,7 @@ string and writes them in a file
 
 INPUTS:
   - $OUT  : output file
-  - $bytes: number of bytes (2 for shorts 4 for ints) in the field
+  - $bytes: number of bytes (2 for shorts 4 for integers) in the field
 
 =cut
 
@@ -573,10 +573,6 @@ Better documentation of the following functions:
   - readLength($IN)
   - writeInt($OUT, $bytes)
   - byteswap($valref)
-
-=head1 BUGS
-
-None reported (or list of bugs)
 
 =head1 LICENSING
 

--- a/dicom-archive/DICOM/Fields.pm
+++ b/dicom-archive/DICOM/Fields.pm
@@ -1978,14 +1978,6 @@ END_DICOM_FIELDS
 
 =pod
 
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
-
 =head1 LICENSING
 
 License: GPLv3

--- a/dicom-archive/DICOM/Private.pm
+++ b/dicom-archive/DICOM/Private.pm
@@ -57,14 +57,6 @@ END_DICOM_PRIVATE
 
 =pod
 
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
-
 =head1 LICENSING
 
 License: GPLv3

--- a/dicom-archive/DICOM/VRfields.pm
+++ b/dicom-archive/DICOM/VRfields.pm
@@ -107,14 +107,6 @@ END_VR
 
 =pod
 
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
-
 =head1 LICENSING
 
 License: GPLv3

--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -24,7 +24,7 @@ Available options are:
                           Just trying will fail miserably
 
 -mri_upload_update      : Update the C<mri_upload> table by inserting the
-                          correct tarchiveID
+                          correct C<tarchiveID>
 
 -clobber                : Specify the name of the config file which resides in
                           C<.loris_mri> in the current directory
@@ -44,7 +44,7 @@ target directory which will be the archive location.
 
 - If the source contains only one valid STUDY worth of DICOM it will create a
   descriptive summary, a (gzipped) DICOM tarball. The tarball with the metadata
-  and a logfile will then be retarred into the final C<TARCHIVE>.
+  and a logfile will then be retarred into the final C<tarchive>.
 
 - MD5 sums are reported for every step.
 

--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -23,18 +23,18 @@ Available options are:
 -database               : Use a database if you have one set up for you.
                           Just trying will fail miserably
 
--mri_upload_update      : Update the mri_upload table by inserting the correct
-                          tarchiveID
+-mri_upload_update      : Update the C<mri_upload> table by inserting the
+                          correct tarchiveID
 
 -clobber                : Specify the name of the config file which resides in
-                          .loris_mri in the current directory
+                          C<.loris_mri> in the current directory
 
 -centerName             : Specify the symbolic center name to be stored
                           alongside the DICOM institution
 
 -verbose                : Be verbose if set
 
--version                : Print cvs version number and exit
+-version                : Print CVS version number and exit
 
 
 =head1 DESCRIPTION
@@ -44,9 +44,9 @@ target directory which will be the archive location.
 
 - If the source contains only one valid STUDY worth of DICOM it will create a
   descriptive summary, a (gzipped) DICOM tarball. The tarball with the metadata
-  and a logfile will then be retarred into the final TARCHIVE.
+  and a logfile will then be retarred into the final C<TARCHIVE>.
 
-- md5sums are reported for every step.
+- MD5 sums are reported for every step.
 
 - It can also be used with a MySQL database.
 
@@ -325,7 +325,7 @@ exit $NeuroDB::ExitCodes::SUCCESS;
 
 =head3 archive_head()
 
-Function that prints the tarchive header
+Function that prints the DICOM archive header
 
 =cut
 
@@ -366,9 +366,9 @@ format FORMAT_HEADER =
 
 Function that reads file contents into a variable
 
-INPUT   : $file : file to be read
+INPUT: file to be read
 
-RETURNS : $content : file contents
+RETURNS: file contents
 
 =cut
 
@@ -390,11 +390,7 @@ __END__
 
 =head1 TO DO
 
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
+Fix comments written as #fixme in the code.
 
 =head1 LICENSING
 

--- a/dicom-archive/updateMRI_Upload.pl
+++ b/dicom-archive/updateMRI_Upload.pl
@@ -65,15 +65,7 @@ C<DecompressedLocation>: argument of the C<-source_location> switch passed on th
 
 If there already is an entry in C<mri_upload> with the same C<ArchiveLocation> as C<T>'s, the script
 will exit with an error message saying that C<mri_upload> is already up to date with respect to
-C<T>. 
-
-=head1 TO DO
-
-Nothing.
-
-=head1 BUGS
-
-None reported.
+C<T>.
 
 =head1 LICENSING
 

--- a/tools/BackPopulateSNRAndAcquisitionOrder.pl
+++ b/tools/BackPopulateSNRAndAcquisitionOrder.pl
@@ -5,9 +5,9 @@
 =head1 NAME
 
 BackPopulateSNRAndAcquisitionOrder.pl -- a script that back populates the
-AcqOrderPerModality column of the files table, and the signal-to-noise ratio
-(SNR) values in the parameter_file table for inserted MINC files. The SNR is
-computed using MINC tools built-in algorithms.
+C<AcqOrderPerModality> column of the C<files> table, and the signal-to-noise
+ratio (SNR) values in the C<parameter_file> table for inserted MINC files. The
+SNR is computed using MINC tools built-in algorithms.
 
 
 =head1 SYNOPSIS
@@ -16,11 +16,10 @@ perl tools/BackPopulateSNRAndAcquisitionOrder.pl C<[options]>
 
 Available options are:
 
--profile        : name of the config file in
-                  C<../dicom-archive/.loris_mri>
+-profile    : name of the config file in C<../dicom-archive/.loris_mri>
 
--tarchive_id    : The Tarchive ID of the DICOM archive (.tar files) to be
-                  processed from the C<tarchive> table
+-tarchive_id: ID of the DICOM archive (.tar file) to be processed from the
+               C<tarchive> table
 
 
 
@@ -30,11 +29,10 @@ This script will back populate the C<files> table with entries for the
 C<AcqOrderPerModality> column; in reference to:
 https://github.com/aces/Loris-MRI/pull/160
 as well as populate the C<parameter_file> table with SNR entries in reference
-to:
-https://github.com/aces/Loris-MRI/pull/142
-It can take in TarchiveID as an argument if only a specific DICOM archive
-(.tar files) is to be processed; otherwise, all DICOM archives (.tar files) in
-the C<tarchive> table are processed.
+to: https://github.com/aces/Loris-MRI/pull/142
+It can take in C<TarchiveID> as an argument if only a specific DICOM archive
+(.tar files) is to be processed; otherwise, all DICOM archives (C<tar>
+files) in the C<tarchive> table are processed.
 
 
 =cut
@@ -197,14 +195,6 @@ exit $NeuroDB::ExitCodes::SUCCESS;
 __END__
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/tools/MakeArchiveLocationRelative.pl
+++ b/tools/MakeArchiveLocationRelative.pl
@@ -6,7 +6,7 @@
 
 MakeArchiveLocationRelative.pl -- Removes the root directory from the
 C<ArchiveLocation> field in the C<tarchive> table to make the path to the
-tarchive relative.
+DICOM archive relative.
 
 =head1 SYNOPSIS
 
@@ -14,7 +14,7 @@ perl MakeArchiveLocationRelative.pl C<[options]>
 
 Available option is:
 
--profile: name of the config file in ../dicom-archive/.loris_mri
+-profile: name of the config file in C<../dicom-archive/.loris_mri>
 
 =head1 DESCRIPTION
 
@@ -114,7 +114,9 @@ This function will grep all the C<TarchiveID> and associated C<ArchiveLocation>
 present in the C<tarchive> table and will create a hash of this information
 including new C<ArchiveLocation> to be inserted into the database.
 
-INPUTS database handle, location of the C<tarchive> directory
+INPUTS:
+  - $dbh               : database handle
+  - $tarchiveLibraryDir: location of the C<tarchive> directory
 
 RETURNS: hash with tarchive information and new archive location
 
@@ -162,7 +164,9 @@ QUERY
 
 This function will update the C<tarchive> table with the new C<ArchiveLocation>.
 
-INPUTS: database handle, hash with C<tarchive> information.
+INPUTS:
+  - $dbh          : database handle
+  - %tarchive_list: hash with C<tarchive> information.
 
 =cut
 
@@ -199,14 +203,6 @@ QUERY
 __END__
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/tools/ProdToConfig.pl
+++ b/tools/ProdToConfig.pl
@@ -4,8 +4,8 @@
 
 =head1 NAME
 
-ProdToConfig.pl -- a script that populates the `Config` table in the database
-with entries from the $profile file.
+ProdToConfig.pl -- a script that populates the C<Config> table in the database
+with entries from the C<$profile> file.
 
 =head1 SYNOPSIS
 
@@ -21,12 +21,12 @@ The available option is:
 
 
 This script needs to be run once during the upgrade to LORIS-MRI v18.0.0. Its
-purpose is to remove some variables defined in the $profile file to the
+purpose is to remove some variables defined in the C<$profile> file to the
 Configuration module within LORIS. This script assumes that the LORIS upgrade
 patch has been run, with table entries created and set to default values. This
 script will then update those values with those that already exist in the
-$profile file. If the table entry does not exist in the $profile, its value will
-be kept at the value of a new install.
+C<$profile> file. If the table entry does not exist in the C<$profile>, its
+value will be kept at the value of a new install.
 
 =head2 Methods
 
@@ -146,12 +146,12 @@ for my $index (0 .. $#config_name_arr) {
 
 =head3 updateConfigFromProd($config_name, $config_value)
 
-Function that updates the values in the `Config` table for the columns as
-specified in the $config_name
+Function that updates the values in the C<Config> table for the columns as
+specified in the C<$config_name> variable.
 
-INPUTS   :
- - $config_name     : Column to set in the Config table
- - $config_value    : Value to use in the Config table
+INPUTS:
+ - $config_name : column to set in the C<Config> table
+ - $config_value: value to use in the C<Config> table
 
 =cut
 
@@ -188,14 +188,6 @@ exit $NeuroDB::ExitCodes::SUCCESS;
 __END__
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/tools/database_files_update.pl
+++ b/tools/database_files_update.pl
@@ -13,7 +13,7 @@ perl database_files_update.pl C<[options]>
 
 Available option is:
 
--profile: name of the config file in ../dicom-archive/.loris_mri
+-profile: name of the config file in C<../dicom-archive/.loris_mri>
 
 =head1 DESCRIPTION
 
@@ -164,7 +164,9 @@ if  ($tarchive_location_refs) {
 
 Gets the list of MINC files to update the location in the C<files> table.
 
-INPUTS: data directory from the C<Config> tables, database handle
+INPUTS:
+  - $data_dir: data directory (e.g. C</data/$PROJECT/data>)
+  - $dbh     : database handle
 
 RETURNS: hash of MINC locations, array of FileIDs
 
@@ -201,7 +203,10 @@ sub get_minc_files {
 
 Updates the location of MINC files in the C<files> table.
 
-INPUTS: File ID, new MINC relative location, database handle
+INPUTS:
+  - $fileID           : file's ID
+  - $new_minc_location: new MINC relative location
+  - $dbh              : database handle
 
 RETURNS: Number of rows affected by the update (should always be 1)
 
@@ -227,9 +232,12 @@ sub update_minc_location {
 Gets list of JIV files to update location in the C<parameter_file> table by
 removing the root directory from the path.
 
-INPUTS: data directory, parameter type name for the JIV, database handle
+INPUTS:
+  - $data_dir      : data directory (e.g. C</data$PROJECT/data>)
+  - $parameter_type: name of the parameter type for the JIV
+  - $dbh           : database handle
 
-RETURNS: hash of JIV file locations, array of FileIDs
+RETURNS: hash of JIV file locations, array of C<FileIDs>
 
 =cut
 
@@ -264,12 +272,12 @@ sub get_parameter_files {
 
 =pod
 
-=head3 update_parameter_file_location($fileID, $new_file_location, ...)
+=head3 update_parameter_file_location($fileID, $new_file_location, $parameter_type, $dbh)
 
 Updates the location of JIV files in the C<parameter_file> table.
 
 INPUTS:
-  - $fileID           : FileID
+  - $fileID           : file's ID
   - $new_file_location: new location of the JIV file
   - $parameter_type   : parameter type name for the JIV
   - $dbh              : database handle
@@ -307,14 +315,6 @@ sub update_parameter_file_location {
 __END__
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/tools/example_scripts/deletemincsqlwrapper.pl
+++ b/tools/example_scripts/deletemincsqlwrapper.pl
@@ -176,14 +176,6 @@ __END__
 
 =pod
 
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
-
 =head1 LICENSING
 
 License: GPLv3

--- a/tools/seriesuid2fileid
+++ b/tools/seriesuid2fileid
@@ -6,28 +6,28 @@
 
 seriesuid2fileid -- a script that displays a report about the pipeline insertion
 progress and outcome (including MRI violation status) of imaging datasets, based
-on series UID(s) provided as STDIN.
+on series C<UID(s)> provided as C<STDIN>.
 
 =head1 SYNOPSIS
 
 perl tools/seriesuid2fileid
 
-There are no available options. Once the script is invoked, series UID can be
+There are no available options. Once the script is invoked, series C<UID> can be
 input to display the status. The C<$profile> file for database connection
 credentials is assumed to be C<prod>.
 
 
 =head1 DESCRIPTION
 
-The program takes series UID from STDIN and returns a report with:
+The program takes series C<UID> from C<STDIN> and returns a report with:
 
-  - SeriesUID
-  - SeriesDescription
-  - TarchiveID
-  - m_p_v_s_ID
-  - mri_v_log
-  - FileID
-  - FileName
+  - C<SeriesUID>
+  - C<SeriesDescription>
+  - C<TarchiveID>
+  - C<m_p_v_s_ID>
+  - C<mri_v_log>
+  - C<FileID>
+  - C<FileName>
 
 The C<m_p_v_s_ID> column displays, if present, the C<ID> record from the
 C<mri_protocol_violated_scans> table together with a count representing the
@@ -184,21 +184,13 @@ __END__
 
 =pod
 
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
-
 =head1 LICENSING
 
 License: GPLv3
 
 =head1 AUTHORS
 
-Gregory Luneau, LORIS community <loris.info@mcin.ca> and McGill Centre for
-Integrative Neuroscience
+Gregory Luneau,
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
 
 =cut

--- a/uploadNeuroDB/NeuroDB/DBI.pm
+++ b/uploadNeuroDB/NeuroDB/DBI.pm
@@ -38,12 +38,16 @@ use DBI;
 
 =head3 connect_to_db($db_name, $db_user, $db_pass, $db_host)
 
-This method connects to the LORIS database ($db_database) on host ($db_host)
-as username ($db_user) & password ($db_pass). The function dies with a
-database connection error when the connection failed or returns a DBI database
-handler.
+This method connects to the LORIS database (C<$db_database>) on host
+(C<$db_host>) as username (C<$db_user>) & password (C<$db_pass>). The function
+dies with a database connection error when the connection failed or returns a
+DBI database handler.
 
-INPUT: optional: database, username, password, host
+INPUTS:
+  - $db_name: database name (optional)
+  - $db_user: database user (optional)
+  - $db_pass: password for C<$db_user> (optional)
+  - $db_host: database host (optional)
 
 RETURNS: DBI database handler when connection is successful
 
@@ -69,10 +73,12 @@ sub connect_to_db
 
 =head3 getConfigSetting($dbh, $name)
 
-This method fetches the value ($value) stored in the C<Config> table for a
-specific config setting ($name) specified as an input.
+This method fetches the value (C<$value>) stored in the C<Config> table for a
+specific config setting (C<$name>) specified as an input.
 
-INPUT: database handler, name of the config setting
+INPUTS:
+  - $dbh : database handler
+  - $name: name of the config setting
 
 RETURNS: value corresponding to the config setting in the C<Config> table
          of LORIS
@@ -102,10 +108,6 @@ sub getConfigSetting
 =head1 TO DO
 
 Expand the package with more functions.
-
-=head1 BUGS
-
-None reported
 
 =head1 COPYRIGHT AND LICENSE
 

--- a/uploadNeuroDB/NeuroDB/ExitCodes.pm
+++ b/uploadNeuroDB/NeuroDB/ExitCodes.pm
@@ -56,19 +56,20 @@ Below is a list of the possible exit codes:
 
 ##### ---- SECTION 2: SCRIPT SPECIFIC EXIT CODES NOT COVERED IN SECTION 1
 
-7. Exit codes from batch_uploads_imageuploader (exit codes from 150 to 159)
+7. Exit codes from C<batch_uploads_imageuploader> (exit codes from 150 to 159)
 
-8. Exit codes from DTIPrep/DTIPrepRegister.pl (exit codes from 160 to 169)
+8. Exit codes from C<DTIPrep/DTIPrepRegister.pl> (exit codes from 160 to 169)
 
-9. Exit codes from uploadNeuroDB/NeuroDB/ImagingUpload.pm (exit codes from
+9. Exit codes from C<uploadNeuroDB/NeuroDB/ImagingUpload.pm> (exit codes from
 170 to 179)
 
-10. Exit codes from uploadNeuroDB/minc_insertion.pl (exit codes from 180 to 189)
+10. Exit codes from C<uploadNeuroDB/minc_insertion.pl> (exit codes from 180
+to 189)
 
-11. Exit codes from uploadNeuroDB/tarchiveLoader (exit codes from 190 to 199)
+11. Exit codes from C<uploadNeuroDB/tarchiveLoader> (exit codes from 190 to 199)
 
-12. Exit codes from uploadNeuroDB/NeuroDB/bin/minc2jiv.pl (exit codes from 200
-to 210)
+12. Exit codes from C<uploadNeuroDB/NeuroDB/bin/minc2jiv.pl> (exit codes from
+200 to 210)
 
 
 =head1 LICENSING
@@ -188,5 +189,3 @@ our $NO_VALID_MINC_CREATED = 190; # if no valid MINC file was created
 ## -- FROM uploadNeuroDB/NeuroDB/bin/minc2jiv.pl (exit codes from 200 to 210)
 
 our $REGISTER_PROGRAM_FAILURE = 200; # if MNI::Spawn::RegisterPrograms failed
-
-## -- FROM

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -128,8 +128,8 @@ sub loadFile {
 
 =head3 findFile($filename)
 
-Finds the FileID pertaining to a file as defined by parameter C<$filename>,
-which is a full /path/to/file.
+Finds the C<FileID> pertaining to a file as defined by parameter C<$filename>,
+which is a full C</path/to/file>.
 
 INPUT: full path to the file to look for an ID in the database.
 
@@ -368,7 +368,9 @@ sub loadFileFromDisk {
 
 Sets the fileData property named C<$propertyName> to the value of C<$value>.
 
-INPUT: name of the fileData property, value of the fileData property to be set
+INPUTS:
+  - $paramName: name of the C<fileData> property
+  - $value    : value of the C<fileData> property to be set
 
 =cut
 
@@ -393,7 +395,9 @@ sub setFileData {
 
 Sets the parameter named C<$parameterName> to the value of C<$value>.
 
-INPUT: name of the parameter, value of the parameter to be set
+INPUTS:
+  - $paramName: name of the parameter
+  - $value    : value of the parameter to be set
 
 =cut
 
@@ -443,12 +447,12 @@ sub removeParameter {
 
 =head3 getParameterTypeID($parameter)
 
-Gets the ParameterTypeID for the parameter C<$parameter>.  If C<$parameter>
+Gets the C<ParameterTypeID> for the parameter C<$parameter>.  If C<$parameter>
 does not exist, it will be created.
 
 INPUT: name of the parameter type
 
-RETURNS: (int) ParameterTypeID
+RETURNS: C<ParameterTypeID> (int)
 
 =cut
 
@@ -518,9 +522,7 @@ __END__
 Other operations should be added: perhaps C<get*> methods for those fields in
 the C<files> table which are lookup fields.
 
-=head1 BUGS
-
-None reported.
+Fix comments written as #fixme in the code.
 
 =head1 COPYRIGHT AND LICENSE
 

--- a/uploadNeuroDB/NeuroDB/FileDecompress.pm
+++ b/uploadNeuroDB/NeuroDB/FileDecompress.pm
@@ -137,14 +137,6 @@ sub getType {
 
 =pod
 
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported
-
 =head1 COPYRIGHT AND LICENSE
 
 License: GPLv3

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -78,10 +78,10 @@ moved to a final destination directory.
 INPUTS:
   - $dbhr                : database handler
   - $uploaded_temp_folder: temporary directory of the upload
-  - $upload_id           : uploadID from the mri_upload table
+  - $upload_id           : C<uploadID> from the C<mri_upload> table
   - $pname               : patient name
-  - $profile             : name of the configuration file
-                          (typically C<prod>)
+  - $profile             : name of the configuration file in
+                            C</data/$PROJECT/data> (typically C<prod>)
 
 RETURNS: new instance of this class
 
@@ -310,7 +310,7 @@ sub IsCandidateInfoValid {
 
 This method executes the following actions:
  - Runs C<dicomTar.pl> with C<-clobber -database -profile prod> options
- - Extracts the TarchiveID of the DICOM archive created by C<dicomTar.pl>
+ - Extracts the C<TarchiveID> of the DICOM archive created by C<dicomTar.pl>
  - Updates the C<mri_upload> table if C<dicomTar.pl> ran successfully
 
 RETURNS: 1 on success, 0 on failure
@@ -437,7 +437,7 @@ sub runTarchiveLoader {
 
 This method extracts the patient name field from the DICOM file header using
 C<dcmdump> and compares it with the patient name information stored in the
-mri_upload table.
+C<mri_upload> table.
 
 INPUT: full path to the DICOM file
 
@@ -543,11 +543,11 @@ sub runCommandWithExitCode {
 =head3 runCommand($command)
 
 This method will run any linux command given as an argument using back-tilt
-and will return the back-tilt return value (which is STDOUT).
+and will return the back-tilt return value (which is C<STDOUT>).
 
 INPUT: the linux command to be executed
 
-RETURNS: back-tilt return value (STDOUT)
+RETURNS: back-tilt return value (C<STDOUT>)
 
 =cut
 
@@ -565,7 +565,7 @@ sub runCommand {
 
 This method cleans up and removes the uploaded file from the data directory
 once the uploaded file has been inserted into the database and saved in the
-tarchive folder.
+C<tarchive> folder.
 
 RETURNS: 1 on success, 0 on failure
 
@@ -671,14 +671,6 @@ sub updateMRIUploadTable  {
 
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported
 
 =head1 COPYRIGHT AND LICENSE
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -641,12 +641,12 @@ INPUTS:
   - $te             : echo time of the scan
   - $ti             : inversion time of the scan
   - $slice_thickness: slice thickness of the image
-  - $xstep          : x-step of the image
-  - $ystep          : y-step of the image
-  - $zstep          : z-step of the image
-  - $xspace         : x-space of the image
-  - $yspace         : y-space of the image
-  - $zspace         : z-space of the image
+  - $xstep          : C<x-step> of the image
+  - $ystep          : C<y-step> of the image
+  - $zstep          : C<z-step> of the image
+  - $xspace         : C<x-space> of the image
+  - $yspace         : C<y-space> of the image
+  - $zspace         : C<z-space> of the image
   - $time           : time dimension of the scan
   - $seriesUID      : C<SeriesUID> of the scan
 
@@ -1169,7 +1169,7 @@ Creates a new C<CandID>.
 
 INPUT: database handle reference
 
-RETURNS: (int) C<CandID>
+RETURNS: C<CandID> (int)
 
 =cut
 
@@ -1192,7 +1192,7 @@ sub createNewCandID {
 =head3 getPSC($patientName, $dbhr)
 
 Looks for the site alias in whatever field (usually C<patient_name> or
-C<patient_id>) is provided and return the MRI alias and C<CenterID>.
+C<patient_id>) is provided and return the C<MRI_alias> and C<CenterID>.
 
 INPUTS:
   - $patientName: patient name
@@ -1435,7 +1435,7 @@ Creates NIfTI files associated with MINC files and append its path to the
 C<parameter_file> table using the C<parameter_type> C<check_nii_filename>.
 
 INPUTS:
-  - $fileref : file hashref
+  - $fileref : file hash ref
   - $data_dir: data directory (e.g. C</data/$PROJECT/data>)
 
 =cut

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -59,9 +59,12 @@ $FLOAT_EQUALS_NB_DECIMALS = 4;
 =head3 getSubjectIDs($patientName, $scannerID, $dbhr)
 
 Determines the candidate ID and visit label for the subject based on patient
-name and (for calibration data) scannerID.
+name and (for calibration data) scanner ID.
 
-INPUTS: patient name, scanner ID and database handle reference
+INPUTS:
+  - $patientName: patient name
+  - $scannerID  : scanner ID
+  - $dbhr       : database handle reference
 
 RETURNS: a reference to a hash containing elements including C<CandID>,
 C<visitLabel> and C<visitNo>, or, in the case of failure, C<undef>
@@ -96,11 +99,16 @@ sub getSubjectIDs {
 
 =pod
 
-=head3 subjectIDIsValid($CandID, $PSCID, $dbhr)
+=head3 subjectIDIsValid($CandID, $PSCID, $visit_label, $dbhr, $create_visit_label)
 
 Verifies that the subject IDs match.
 
-INPUTS: candidate's CandID, candidate's PSCID and the database handle reference
+INPUTS:
+  - $candID            : candidate's C<CandID>
+  - $pscid             : candidate's C<PSCID>
+  - $visit_label       : visit label
+  - $dbhr              : the database handle reference
+  - $create_visit_label: boolean, if true, will create the visit label
 
 RETURNS: 1 if the ID pair matches, 0 otherwise
 
@@ -129,9 +137,11 @@ sub subjectIDIsValid {
 
 =head3 subjectIDExists($CandID, $dbhr)
 
-Verifies that the subject ID (CandID) exists.
+Verifies that the subject ID (C<CandID>) exists.
 
-INPUTS: candidate's CandID and the database handle reference
+INPUTS:
+  - $candID: candidate's C<CandID>
+  - $dbhr  : the database handle reference
 
 RETURNS: 1 if the ID exists, 0 otherwise
 
@@ -152,11 +162,11 @@ sub subjectIDExists {
 
 =head3 getScannerCandID($scannerID, $dbhr)
 
-Retrieves the candidate (CandID) for the given scanner.
+Retrieves the candidate (C<CandID>) for the given scanner.
 
 INPUTS: the scanner ID and the database handle reference
 
-RETURNS: the CandID or (if none exists) undef
+RETURNS: the C<CandID> or (if none exists) undef
 
 =cut
 
@@ -178,10 +188,10 @@ sub getScannerCandID {
 
 =pod
 
-=head3 getSessionID($subjectIDref, $studyDate, $dbhr, $objective, ...)
+=head3 getSessionID($subjectIDref, $studyDate, $dbhr, $objective, $noStagingCheck)
 
-Gets (or creates) the session ID, given CandID and visitLabel (contained
-inside the hashref C<$subjectIDref>).  Unless C<$noStagingCheck> is true, it
+Gets (or creates) the session ID, given C<CandID> and visit label (contained
+inside the hash ref C<$subjectIDref>).  Unless C<$noStagingCheck> is true, it
 also determines whether staging is required using the C<$studyDate>
 (formatted YYYYMMDD) to determine whether staging is required based on a
 simple algorithm:
@@ -202,10 +212,14 @@ simple algorithm:
 
 =back
 
-INPUTS: hash reference of subject IDs, study date, database handle reference,
-the objective of the study and a no staging check flag.
+INPUTS:
+  - $subjectIDref  : hash reference of subject IDs
+  - $studyDate     : study date
+  - $dbhr          : database handle reference
+  - $objective     : the objective of the study
+  - $noStagingCheck: a no staging check flag
 
-RETURNS: a list of two items, (sessionID, requiresStaging)
+RETURNS: a list of two items, (C<sessionID>, C<requiresStaging>)
 
 =cut
 
@@ -354,8 +368,10 @@ sub getSessionID {
 This method tries to figure out if there may have been labelling problems which
 would put the files in a staging area that does not actually exist.
 
-INPUTS: study date, database handle reference and array of fileIDs to check the
-study date
+INPUTS:
+  - $studyDateJD: study date
+  - $dbhr       : database handle reference
+  - @fileIDs    : array of C<fileIDs> to check the study date
 
 RETURNS: 1 if the file requires staging, 0 otherwise
 
@@ -399,10 +415,12 @@ sub checkMRIStudyDates {
 
 =head3 getObjective($subjectIDsref, $dbhr)
 
-Attempts to determine the SubprojectID  of a timepoint given the subjectIDs
-hashref C<$subjectIDsref> and a database handle reference C<$dbhr>
+Attempts to determine the C<SubprojectID> of a timepoint given the subject IDs
+hash ref C<$subjectIDsref> and a database handle reference C<$dbhr>
 
-INPUTS: subjectIDs hashref and database handle reference
+INPUTS:
+  - $subjectIDsref: subjectIDs hashref
+  - $dbhr         : database handle reference
 
 RETURNS: the determined objective, or 0
 
@@ -451,8 +469,11 @@ sub getObjective
 Determines the type of the scan described by MINC headers based on
 C<mri_protocol> table in the database.
 
-INPUTS: center's name, objective of the study, file hashref, database handle
-reference
+INPUTS:
+  - $center_name: center's name
+  - $objective  : objective of the study
+  - $fileref    : file hash ref
+  - $dbhr       : database handle reference
 
 RETURNS: textual name of scan type from the C<mri_scan_type> table
 
@@ -602,7 +623,7 @@ sub identify_scan_db {
 
 =pod
 
-=head3 insert_violated_scans($dbhr, $series_desc, $minc_location, ...)
+=head3 insert_violated_scans($dbhr, $series_desc, $minc_location, $patient_name, $candid, $pscid, $visit, $tr, $te, $ti, $slice_thickness, $xstep, $ystep, $zstep, $xspace, $yspace, $zspace, $time, $seriesUID)
 
 Inserts scans that do not correspond to any of the defined protocol from the 
 C<mri_protocol> table into the C<mri_protocol_violated_scans> table of the
@@ -611,10 +632,10 @@ database.
 INPUTS:
   - $dbhr           : database handle reference
   - $series_desc    : series description of the scan
-  - $minc_location  : minc location of the file
+  - $minc_location  : location of the MINC file
   - $patient_name   : patient name of the scan
-  - $candid         : candidate's CandID
-  - $pscid          : candidate's PSCID
+  - $candid         : candidate's C<CandID>
+  - $pscid          : candidate's C<PSCID>
   - $visit          : visit of the scan
   - $tr             : repetition time of the scan
   - $te             : echo time of the scan
@@ -627,7 +648,7 @@ INPUTS:
   - $yspace         : y-space of the image
   - $zspace         : z-space of the image
   - $time           : time dimension of the scan
-  - $seriesUID      : seriesUID of the scan
+  - $seriesUID      : C<SeriesUID> of the scan
 
 =cut
 
@@ -673,7 +694,9 @@ QUERY
 
 Will evaluate whether the scalar C<$value> is in the specified C<$range>.
 
-INPUTS: scalar value, scalar range string
+INPUTS:
+  - $val  : scalar value to evaluate
+  - $range: scalar range string
 
 RETURNS: 1 if in range, 0 if not in range
 
@@ -699,7 +722,9 @@ sub debug_inrange {
 
 Determines the type of the scan identified by its scan type ID.
 
-INPUTS: scan type ID and database handle reference
+INPUTS:
+  - $typeID: scan type ID
+  - $dbhr  : database handle reference
 
 RETURNS: Textual name of scan type
 
@@ -722,7 +747,9 @@ sub scan_type_id_to_text {
 
 Determines the type of the scan identified by scan type.
 
-INPUTS: scan type and database handle reference
+INPUTS:
+  - $type: scan type
+  - $dbhr: database handle reference
 
 RETURNS: ID of the scan type
 
@@ -749,7 +776,9 @@ Determines whether numerical value falls within the range described by range
 string. Range string is a comma-separated list of range units. A single range
 unit follows the syntax either "X" or "X-Y".
 
-INPUTS: numerical value and the range to use
+INPUTS:
+  - $value       : numerical value to evaluate
+  - $range_string: the range to use
 
 RETURNS: 1 if the value is in range, 0 otherwise
 
@@ -786,10 +815,13 @@ sub in_range
 
 =head3 floats_are_equal($f1, $f2, $nb_decimals)
 
-Checks whether f1 and f2 are equal (considers only the first nb_decimals
-decimals).
+Checks whether float 1 and float 2 are equal (considers only the first
+C<$nb_decimals> decimals).
 
-INPUTS: float 1, float 2 and the number of first decimals
+INPUTS:
+  - $f1         : float 1
+  - $f2         : float 2
+  - $nb_decimals: the number of first decimals
 
 RETURNS: 1 if the numbers are relatively equal, 0 otherwise
 
@@ -811,8 +843,10 @@ C<$range_string> using the same C<$range_string> syntax as C<&in_range()>.
 It returns a scalar range SQL string appropriate to use as a WHERE condition
 (C<SELECT ... WHERE range_to_sql(...)>).
 
-INPUTS: scalar field, scalar range string that follows the same format as in
-C<&in_range()>
+INPUTS:
+  - $field       : scalar field
+  - $range_string: scalar range string that follows the same format as in
+                    C<&in_range()>
 
 RETURNS: scalar range SQL string
 
@@ -851,11 +885,12 @@ sub range_to_sql {
 
 =head3 register_db($file_ref)
 
-Registers the NeuroDB::File object referenced by C<$file_ref> into the database.
+Registers the C<NeuroDB::File> object referenced by C<$file_ref> into the
+database.
 
-INPUT: file hashref
+INPUT: file hash ref
 
-RETURNS: 0 if the file is already registered, the new FileID otherwise
+RETURNS: 0 if the file is already registered, the new C<FileID> otherwise
 
 =cut
 
@@ -918,10 +953,10 @@ sub register_db {
 
 =head3 mapDicomParameters($file_ref)
 
-Maps DICOM parameters to more meaningful names in the NeuroDB::File object
+Maps DICOM parameters to more meaningful names in the C<NeuroDB::File> object
 referenced by C<$file_ref>.
 
-INPUT: file hashref
+INPUT: file hash ref
 
 =cut
 
@@ -1037,11 +1072,11 @@ sub mapDicomParameters {
 }
 =pod
 
-=head3 findScannerID($manufacturer, $model, $serialNumber, ...)
+=head3 findScannerID($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $register_new)
 
-Finds the scannerID for the scanner as defined by C<$manufacturer>, C<$model>,
+Finds the scanner ID for the scanner as defined by C<$manufacturer>, C<$model>,
 C<$serialNumber>, C<$softwareVersion>, using the database attached to the DBI
-database handle reference C<$dbhr>. If no scannerID exists, one will be
+database handle reference C<$dbhr>. If no scanner ID exists, one will be
 created.
 
 INPUTS:
@@ -1077,7 +1112,7 @@ sub findScannerID {
 
 =pod
 
-=head3 registerScanner($manufacturer, $model, $serialNumber, ...)
+=head3 registerScanner($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr)
 
 Registers the scanner as defined by C<$manufacturer>, C<$model>,
 C<$serialNumber>, C<$softwareVersion>, into the database attached to the DBI
@@ -1130,11 +1165,11 @@ sub registerScanner {
 
 =head3 createNewCandID($dbhr)
 
-Creates a new CandID.
+Creates a new C<CandID>.
 
 INPUT: database handle reference
 
-RETURNS: (int) CandID
+RETURNS: (int) C<CandID>
 
 =cut
 
@@ -1156,14 +1191,16 @@ sub createNewCandID {
 
 =head3 getPSC($patientName, $dbhr)
 
-Looks for the site alias in whatever field (usually patient_name or
-patient_id) is provided and return the MRI alias and CenterID.
+Looks for the site alias in whatever field (usually C<patient_name> or
+C<patient_id>) is provided and return the MRI alias and C<CenterID>.
 
-INPUTS: patient name, database handle reference
+INPUTS:
+  - $patientName: patient name
+  - $dbhr       : database handle reference
 
 RETURNS: a two element array:
   - first is the MRI alias of the PSC or "UNKN"
-  - second is the centerID or 0
+  - second is the C<CenterID> or 0
 
 =cut
 
@@ -1205,10 +1242,10 @@ sub getPSC {
 
 =head3 compute_hash($file_ref)
 
-Semi-intelligently generates a hash (MD5 digest) for the NeuroDB::File object
+Semi-intelligently generates a hash (MD5 digest) for the C<NeuroDB::File> object
 referenced by C<$file_ref>.
 
-INPUT: file hashref
+INPUT: file hash ref
 
 RETURNS: the generated MD5 hash
 
@@ -1256,7 +1293,7 @@ sub compute_hash {
 =head3 is_unique_hash($file_ref)
 
 Determines if the file is unique using the hash (MD5 digest) from the
-NeuroDB::File object referenced by C<$file_ref>.
+C<NeuroDB::File> object referenced by C<$file_ref>.
 
 INPUT: file hashref
 
@@ -1294,9 +1331,8 @@ object referenced by C<$file_ref>.
 
 INPUTS:
   - $file_ref      : file hash ref
-  - $data_dir      : data directory (C</data/$PROJECT/data> typically)
-  - $dest_dir      : destination directory (C</data/$PROJECT/data/pic>
-                     typically)
+  - $data_dir      : data directory (e.g. C</data/$PROJECT/data>)
+  - $dest_dir      : destination directory (e.g. C</data/$PROJECT/data/pic>)
   - $horizontalPics: boolean, whether to create horizontal pics (1) or not (0)
 
 RETURNS: 1 if the pic was generated or 0 otherwise.
@@ -1343,10 +1379,9 @@ Generates JIV data for the Imaging Browser module for the C<NeuroDB::File>
 object referenced by C<$file_ref>.
 
 INPUTS:
-  - $file_ref      : file hash ref
-  - $data_dir      : data directory (C</data/$PROJECT/data> typically)
-  - $dest_dir      : destination directory (C</data/$PROJECT/data/jiv>
-                     typically)
+  - $file_ref: file hash ref
+  - $data_dir: data directory (e.g. C</data/$PROJECT/data>)
+  - $dest_dir: destination directory (e.g. C</data/$PROJECT/data/jiv>)
 
 RETURNS: 1 if the JIV data was generated or 0 otherwise.
 
@@ -1397,9 +1432,11 @@ sub make_jiv {
 =head3 make_nii($fileref, $data_dir)
 
 Creates NIfTI files associated with MINC files and append its path to the
-parameter_file table using the parameter_type "check_nii_filename".
+C<parameter_file> table using the C<parameter_type> C<check_nii_filename>.
 
-INPUTS: file hashref and data directory (typically C</data/project/data>)
+INPUTS:
+  - $fileref : file hashref
+  - $data_dir: data directory (e.g. C</data/$PROJECT/data>)
 
 =cut
 
@@ -1424,15 +1461,15 @@ sub make_nii {
 
 =pod
 
-=head3 make_minc_pics($dbhr, $TarchiveSource, $profile, $minFileID, ...)
+=head3 make_minc_pics($dbhr, $TarchiveSource, $profile, $minFileID, $debug, $verbose)
 
 Creates pics associated with MINC files.
 
 INPUTS:
   - $dbhr          : database handle reference
-  - $TarchiveSource: tarchiveID of the DICOM study
-  - $profile       : the profile (typically named C<prod>)
-  - $minFileID     : smaller FileID to be used to run C<mass_pic.pl>
+  - $TarchiveSource: C<TarchiveID> of the DICOM study
+  - $profile       : the profile file (typically named C<prod>)
+  - $minFileID     : smaller C<FileID> to be used to run C<mass_pic.pl>
   - $debug         : boolean, whether in debug mode (1) or not (0)
   - $verbose       : boolean, whether in verbose mode (1) or not (0)
 
@@ -1502,11 +1539,13 @@ sub DICOMDateToUnixTimestamp {
 
 =head3 lookupCandIDFromPSCID($pscid, $dbhr)
 
-Looks up the CandID for a given PSCID.
+Looks up the C<CandID> for a given C<PSCID>.
 
-INPUTS: candidate's PSCID, database handle reference
+INPUTS:
+  - $pscid: candidate's C<PSCID>
+  - $dbhr : database handle reference
 
-RETURNS: the CandID or 0 if the PSCID does not exist
+RETURNS: the C<CandID> or 0 if the C<PSCID> does not exist
 
 =cut
 
@@ -1539,11 +1578,7 @@ __END__
 
 =head1 TO DO
 
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
+Fix comments written as #fixme in the code.
 
 =head1 COPYRIGHT AND LICENSE
 
@@ -1555,6 +1590,5 @@ License: GPLv3
 =head1 AUTHORS
 
 Jonathan Harlap <jharlap@bic.mni.mcgill.ca>,
-LORIS community <loris.info@mcin.ca>  
-and McGill Centre for Integrative Neuroscience
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
 =cut    

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -78,7 +78,7 @@ my $notify_notsummary = 'N'; # notification_spool message flag for messages to b
 
 =head3 new($dbhr, $debug, $TmpDir, $logfile, $verbose) >> (constructor)
 
-Creates a new instance of this class. The parameter `\$dbhr` is a reference
+Creates a new instance of this class. The parameter C<$dbhr> is a reference
 to a DBI database handle, used to set the object's database handle, so that all
 the DB-driven methods will work.
 
@@ -136,7 +136,10 @@ sub new {
 Writes error log. This is a useful function that will close the log and write
 error messages in case of abnormal program termination.
 
-INPUTS: notification message, fail status of the process, log directory
+INPUTS:
+  - $message   : notification message
+  - $failStatus: fail status of the process
+  - $LogDir    : log directory
 
 =cut
 
@@ -156,12 +159,14 @@ sub writeErrorLog {
 
 =pod
 
-=head3 lookupNextVisitLabel($candID, $dbhr)
+=head3 lookupNextVisitLabel($CandID, $dbhr)
 
 Will look up for the next visit label of candidate C<CandID>. Useful only if
 the visit label IS NOT encoded somewhere in the patient ID or patient name.
 
-INPUTS: candidate's CandID, database handle reference
+INPUTS:
+  - $CandID: candidate's C<CandID>
+  - $dbhr  : database handle reference
 
 RETURNS: next visit label found for the candidate
 
@@ -192,11 +197,13 @@ sub lookupNextVisitLabel {
 =head3 getFileNamesfromSeriesUID($seriesuid, @alltarfiles)
 
 Will extract from the C<tarchive_files> table a list of DICOM files
-matching a given SeriesUID.
+matching a given C<SeriesUID>.
 
-INPUTS: seriesUID, list of tar files
+INPUTS:
+  - $seriesUID  : C<SeriesUID> to use for matching
+  - @alltarfiles: list of DICOM files matching the C<SeriesUID>
 
-RETURNS: list of DICOM files corresponding to the seriesUID
+RETURNS: list of DICOM files corresponding to the C<SeriesUID>
 
 =cut
 
@@ -241,7 +248,7 @@ sub getFileNamesfromSeriesUID {
 Extracts the DICOM archive so that data can actually be uploaded.
 
 INPUTS:
-  - $tarchive : path to the archive
+  - $tarchive : path to the DICOM archive
   - $upload_id: upload ID of the study
   - $seriesuid: optionally a series UID
 
@@ -298,7 +305,7 @@ sub extract_tarchive {
 Extracts and parses the DICOM archive.
 
 INPUTS:
-  - $tarchive : path to the archive
+  - $tarchive : path to the DICOM archive
   - $upload_id: upload ID of the study
   - $seriesuid: optionally a series UID
 
@@ -333,15 +340,15 @@ sub extractAndParseTarchive {
 
 =head3 determineSubjectID($scannerID, $tarchiveInfo, $to_log, $upload_id)
 
-Determines subject's ID based on scanner ID and archive information.
+Determines subject's ID based on scanner ID and DICOM archive information.
 
 INPUTS:
   - $scannerID   : scanner ID,
-  - $tarchiveInfo: archive information hashref,
+  - $tarchiveInfo: DICOM archive information hash ref,
   - $to_log      : boolean if this step should be logged
   - $upload_id   : upload ID of the study
 
-RETURNS: subject's ID hashref containing CandID, PSCID and Visit Label
+RETURNS: subject's ID hash ref containing C<CandID>, C<PSCID> and Visit Label
 information
 
 =cut
@@ -385,12 +392,14 @@ sub determineSubjectID {
 
 =head3 createTarchiveArray($tarchive, $globArchiveLocation)
 
-Creates the tarchive information hashref.
+Creates the DICOM archive information hash ref.
 
-INPUTS: tarchive's path, globArchiveLocation argument specified when running
-the insertion scripts
+INPUTS:
+  - $tarchive           : tarchive's path
+  - $globArchiveLocation: globArchiveLocation argument specified when running
+                           the insertion scripts
 
-RETURNS: tarchive information hashref
+RETURNS: DICOM archive information hash ref
 
 =cut
 
@@ -436,10 +445,10 @@ sub createTarchiveArray {
 
 =head3 determinePSC($tarchiveInfo, $to_log, $upload_id)
 
-Determines the PSC based on the DICOM archive information hashref.
+Determines the PSC based on the DICOM archive information hash ref.
 
 INPUTS:
-  - $tarchiveInfo: archive information hashref
+  - $tarchiveInfo: DICOM archive information hash ref
   - $to_log      : boolean, whether this step should be logged
   - $upload_id   : upload ID of the study
 
@@ -483,12 +492,12 @@ sub determinePSC {
 
 =pod
 
-=head3 determineScannerID($tarchiveInfo, $to_log, $centerID, $NewScanner, ...)
+=head3 determineScannerID($tarchiveInfo, $to_log, $centerID, $NewScanner, $upload_id)
 
 Determines which scanner ID was used for DICOM acquisitions.
 
 INPUTS:
-  - $tarchiveInfo: archive information hashref
+  - $tarchiveInfo: archive information hash ref
   - $to_log      : whether this step should be logged
   - $centerID    : center ID
   - $NewScanner  : whether a new scanner entry should be created if the scanner
@@ -569,7 +578,9 @@ sub get_acquisitions {
 
 Computes the MD5 hash of a file and makes sure it is unique.
 
-INPUTS: file to use to compute the MD5 hash, upload ID of the study
+INPUTS:
+  - $file     : file to use to compute the MD5 hash
+  - $upload_id: upload ID of the study
 
 RETURNS: 1 if the file is unique, 0 otherwise
 
@@ -594,7 +605,7 @@ sub computeMd5Hash {
 
 =pod
 
-=head3 getAcquisitionProtocol($file, $subjectIDsref, $tarchiveInfo, ...)
+=head3 getAcquisitionProtocol($file, $subjectIDsref, $tarchiveInfo, $center_name, $minc, $acquisitionProtocol, $bypass_extra_file_checks, $upload_id)
 
 Determines the acquisition protocol and acquisition protocol ID for the MINC
 file. If C<$acquisitionProtocol> is not set, it will look for the acquisition
@@ -604,16 +615,19 @@ true, then it will bypass the additional protocol checks from the
 C<mri_protocol_checks> table using C<&extra_file_checks>.
 
 INPUTS:
-  - $file                    : file's information hashref
-  - $subjectIDsref           : subject's information hashref
-  - $tarchiveInfo            : tarchive's information hashref
+  - $file                    : file's information hash ref
+  - $subjectIDsref           : subject's information hash ref
+  - $tarchiveInfo            : DICOM archive's information hash ref
   - $center_name             : center name
   - $minc                    : absolute path to the MINC file
   - $acquisitionProtocol     : acquisition protocol if already knows it
   - $bypass_extra_file_checks: boolean, if set bypass the extra checks
   - $upload_id               : upload ID of the study
 
-RETURNS: acquisition protocol, acquisition protocol ID, array of extra checks
+RETURNS:
+  - $acquisitionProtocol  : acquisition protocol
+  - $acquisitionProtocolID: acquisition protocol ID
+  - @checks               : array of extra checks
 
 =cut
 
@@ -689,8 +703,8 @@ this information here since the file isn't registered in the database yet.
 
 INPUTS:
   - $scan_type  : scan type of the file
-  - $file       : file information hashref
-  - $CandID     : candidate's CandID
+  - $file       : file information hash ref
+  - $CandID     : candidate's C<CandID>
   - $Visit_Label: visit label of the scan
   - $PatientName: patient name of the scan
 
@@ -771,9 +785,12 @@ sub extra_file_checks() {
 
 =head3 update_mri_acquisition_dates($sessionID, $acq_date)
 
-Updates the mri_acquisition_dates table by a new acquisition date C<$acq_date>.
+Updates the C<mri_acquisition_dates> table by a new acquisition date
+C<$acq_date>.
 
-INPUTS: session ID, acquisition date
+INPUTS:
+  - $sessionID: session ID
+  - $acq_date : acquisition date
 
 =cut
 
@@ -815,9 +832,11 @@ sub update_mri_acquisition_dates {
 
 Loads and creates the object file.
 
-INPUTS: location of the minc file, upload ID of the study
+INPUTS:
+  - $minc     : location of the minc file
+  - $upload_id: upload ID of the study
 
-RETURNS: file information hashref
+RETURNS: file information hash ref
 
 =cut
 
@@ -853,18 +872,18 @@ sub loadAndCreateObjectFile {
 
 =pod
 
-=head3 move_minc($minc, $subjectIDsref, $minc_type, $fileref, $prefix, ...)
+=head3 move_minc($minc, $subjectIDsref, $minc_type, $fileref, $prefix, $data_dir, $tarchive_srcloc, $upload_id)
 
 Renames and moves the MINC file.
 
 INPUTS:
   - $minc           : path to the MINC file
-  - $subjectIDsref  : subject's ID hashref
-  - $minc_type      : MINC file information hashref
-  - $fileref        : file information hashref
+  - $subjectIDsref  : subject's ID hash ref
+  - $minc_type      : MINC file information hash ref
+  - $fileref        : file information hash ref
   - $prefix         : study prefix
-  - $data_dir       : data directory (typically /data/project/data)
-  - $tarchive_srcloc: tarchive source location
+  - $data_dir       : data directory (e.g. C</data/$PROJECT/data>)
+  - $tarchive_srcloc: DICOM archive source location
   - $upload_id      : upload ID of the study
 
 RETURNS: new name of the MINC file with path relative to C<$data_dir>
@@ -922,14 +941,14 @@ sub move_minc {
 
 =pod
 
-=head3 registerScanIntoDB($minc_file, $tarchiveInfo, $subjectIDsref, ...)
+=head3 registerScanIntoDB($minc_file, $tarchiveInfo, $subjectIDsref, $acquisitionProtocol, $minc, $checks, $reckless, $sessionID, $upload_id)
 
 Registers the scan into the database.
 
 INPUTS:
-  - $minc_file          : MINC file information hashref
-  - $tarchiveInfo       : tarchive information hashref
-  - $subjectIDsref      : subject's ID information hashref
+  - $minc_file          : MINC file information hash ref
+  - $tarchiveInfo       : tarchive information hash ref
+  - $subjectIDsref      : subject's ID information hash ref
   - $acquisitionProtocol: acquisition protocol
   - $minc               : MINC file to register into the database
   - $checks             : failed checks to register with the file
@@ -1055,15 +1074,15 @@ sub registerScanIntoDB {
 
 =pod
 
-=head3 dicom_to_minc($study_dir, $converter, $get_dicom_info, $exclude, ...)
+=head3 dicom_to_minc($study_dir, $converter, $get_dicom_info, $exclude, $mail_user, $upload_id)
 
 Converts a DICOM study into MINC files.
 
 INPUTS:
   - $study_dir      : DICOM study directory to convert
   - $converter      : converter to be used
-  - $get_dicom_info : get DICOM information setting from the Config table
-  - $exclude        : which files to exclude from the dcm2mnc command
+  - $get_dicom_info : get DICOM information setting from the C<Config> table
+  - $exclude        : which files to exclude from the C<dcm2mnc> command
   - $mail_user      : mail of the user
   - $upload_id      : upload ID of the study
 
@@ -1120,7 +1139,9 @@ sub dicom_to_minc {
 
 Greps the created MINC files and returns a sorted list of those MINC files.
 
-INPUTS: empty array to store the list of MINC files, upload ID of the study
+INPUTS:
+  - $minc_files: empty array to store the list of MINC files
+  - $upload_id : upload ID of the study
 
 =cut
 
@@ -1234,14 +1255,14 @@ sub registerProgs() {
 =head3 moveAndUpdateTarchive($tarchive_location, $tarchiveInfo, $upload_id)
 
 Moves and updates the C<tarchive> table with the new location of the
-C<tarchive>.
+DICOM archive.
 
 INPUTS:
-  - $tarchive_location: C<tarchive location>,
-  - $tarchiveInfo     : C<tarchive> information hashref,
+  - $tarchive_location: DICOM archive location
+  - $tarchiveInfo     : DICOM archive information hash ref
   - $upload_id        : upload ID of the study
 
-RETURNS: the new C<tarchive> location
+RETURNS: the new DICOM archive location
 
 =cut
 
@@ -1299,14 +1320,14 @@ sub moveAndUpdateTarchive {
 
 =pod
 
-=head3 CreateMRICandidates($subjectIDsref, $gender, $tarchiveInfo, $User, ...)
+=head3 CreateMRICandidates($subjectIDsref, $gender, $tarchiveInfo, $User, $centerID, $upload_id)
 
-Registers a new candidate in the candidate table.
+Registers a new candidate in the C<candidate> table.
 
 INPUTS:
-  - $subjectIDsref: subject's ID information hashref
+  - $subjectIDsref: subject's ID information hash ref
   - $gender       : gender of the candidate
-  - $tarchiveInfo : tarchive information hashref
+  - $tarchiveInfo : tarchive information hash ref
   - $User         : user that is running the pipeline
   - $centerID     : center ID
   - upload_id     : upload ID of the study
@@ -1389,16 +1410,17 @@ sub CreateMRICandidates {
 
 Sets the imaging session ID. This function will call
 C<&NeuroDB::MRI::getSessionID> which in turn will either:
-  - grep sessionID if visit for that candidate already exists, or
-  - create a new session if visit label does not exist for that
-     candidate yet
+  - grep the session ID if visit for that candidate already exists, or
+  - create a new session if visit label does not exist for that candidate yet
 
 INPUTS:
-  - $subjectIDsref: subject's ID information hashref
-  - $tarchiveInfo : archive information hashref
+  - $subjectIDsref: subject's ID information hashr ef
+  - $tarchiveInfo : DICOM archive information hash ref
   - $upload_id    : upload ID of the study
 
-RETURNS: session ID, if the new session requires staging
+RETURNS:
+  - $sessionID      : session ID
+  - $requiresStaging: whether the new session requires staging
 
 =cut
 
@@ -1457,13 +1479,13 @@ sub setMRISession {
 =head3 validateArchive($tarchive, $tarchiveInfo, $upload_id)
 
 Validates the DICOM archive by comparing the MD5 of the C<$tarchive file> and
-the one stored in the tarchive information hashref C<$tarchiveInfo> derived
+the one stored in the tarchive information hash ref C<$tarchiveInfo> derived
 from the database. The function will exits with an error message if the
-tarchive is not validated.
+DICOM archive is not validated.
 
 INPUTS:
-  - $tarchive    : archive file
-  - $tarchiveInfo: archive information hashref
+  - $tarchive    : DICOM archive file
+  - $tarchiveInfo: DICOM archive information hash ref
   - $upload_id   : upload ID of the study
 
 =cut
@@ -1503,11 +1525,12 @@ sub validateArchive {
 
 Determines where the MINC files to be registered into the database will go.
 
-INPUTS: subject's ID information hashref, data directory (typically
-/data/project/data)
+INPUTS:
+   - $subjectIDsref: subject's ID information hashref
+   - $data_dir     : data directory (e.g. C</data/$PROJECT/data>)
 
 RETURNS: the final directory in which the registered MINC files will go
-(typically /data/project/data/assembly/CandID/visit/mri/)
+(typically C</data/$PROJECT/data/assembly/CandID/visit/mri/>)
 
 =cut
 
@@ -1524,13 +1547,13 @@ sub which_directory {
 
 =pod
 
-=head3 validateCandidate($subjectIDsref, $tarchive_srcloc)
+=head3 validateCandidate($subjectIDsref)
 
 Check that the candidate's information derived from the patient name field of
-the DICOM files is valid (CandID and PSCID of the candidate should correspond
-to the same subject in the database).
+the DICOM files is valid (C<CandID> and C<PSCID> of the candidate should
+correspond to the same subject in the database).
 
-INPUTS: subject's ID information hashref, tarchive source location
+INPUT: subject's ID information hash ref
 
 RETURNS: the candidate mismatch error, or undef if the candidate is validated
 or a phantom
@@ -1609,7 +1632,7 @@ Computes the SNR on the modalities specified in the C<getSNRModalities()>
 routine of the C<$profile> file.
 
 INPUTS:
-  - $tarchiveID: archive ID
+  - $tarchiveID: DICOM archive ID
   - $upload_id : upload ID of the study
   - $profile   : configuration file (usually prod)
 
@@ -1678,7 +1701,9 @@ sub computeSNR {
 
 Order imaging modalities by acquisition number.
 
-INPUTS: archive ID, upload ID of the study
+INPUTS:
+  - $tarchiveID: DICOM archive ID
+  - $uploadID  : upload ID of the study
 
 =cut
 
@@ -1788,13 +1813,13 @@ sub getUploadIDUsingTarchiveSrcLoc {
 
 =head3 spool($message, $error, $upload_id, $verb)
 
-Calls the Notify->spool function to log all messages.
+Calls the C<Notify->spool> function to log all messages.
 
 INPUTS:
   - $message   : message to be logged in the database
-  - $error     : if 'Y' it's an error log,
+  - $error     : 'Y' for an error log,
                  'N' otherwise
-  - $upload_id : the upload_id
+  - $upload_id : the ID of the upload
   - $verb      : 'N' for few main messages,
                  'Y' for more messages (developers)
 
@@ -1825,9 +1850,7 @@ Document the following functions:
 
 Remove function get_acqusitions($study_dir, \@acquisitions) that is not used
 
-=head1 BUGS
-
-None reported (or list of bugs)
+Fix comments written as #fixme in the code
 
 =head1 LICENSING
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -35,8 +35,7 @@ utilities
                       );
 
   my $CandMismatchError = $utility->validateCandidate(
-                            $subjectIDsref,
-                            $tarchiveInfo{'SourceLocation'}
+                            $subjectIDsref
                           );
 
   $utility->computeSNR($TarchiveID, $ArchLoc, $profile);
@@ -79,10 +78,10 @@ my $notify_notsummary = 'N'; # notification_spool message flag for messages to b
 =head3 new($dbhr, $debug, $TmpDir, $logfile, $verbose) >> (constructor)
 
 Creates a new instance of this class. The parameter C<$dbhr> is a reference
-to a DBI database handle, used to set the object's database handle, so that all
-the DB-driven methods will work.
+to a C<DBI> database handle, used to set the object's database handle, so that
+all the DB-driven methods will work.
 
-INPUT: DBI database handle
+INPUT: C<DBI> database handle
 
 RETURNS: new instance of this class.
 
@@ -1819,7 +1818,7 @@ INPUTS:
   - $message   : message to be logged in the database
   - $error     : 'Y' for an error log,
                  'N' otherwise
-  - $upload_id : the ID of the upload
+  - $upload_id : the upload ID
   - $verb      : 'N' for few main messages,
                  'Y' for more messages (developers)
 

--- a/uploadNeuroDB/NeuroDB/Notify.pm
+++ b/uploadNeuroDB/NeuroDB/Notify.pm
@@ -42,7 +42,7 @@ my $VERSION = sprintf "%d.%03d", q$Revision: 1.1.1.1 $ =~ /: (\d+)\.(\d+)/;
 
 =head3 new($dbh) >> (constructor)
 
-Creates a new instance of this class. The parameter C<\$dbh> is a
+Creates a new instance of this class. The parameter C<$dbh> is a
 reference to a DBI database handle, used to set the object's database
 handle, so that all the DB-driven methods will work.
 
@@ -67,7 +67,7 @@ sub new {
 
 =pod
 
-=head3 spool($type, $message, $centerID, $origin, $processID, ...)
+=head3 spool($type, $message, $centerID, $origin, $processID, $isError, $isVerb)
 
 Spools a new notification message, C<$message>, into the C<notification_spool>
 table for notification type C<$type>. If C<$centerID> is specified, only
@@ -137,7 +137,7 @@ sub spool {
 
 =head3 getTypeID($type)
 
-Gets the notification typeID for the notification of type C<$type>.
+Gets the notification type ID for the notification of type C<$type>.
 
 INPUT: notification type
 
@@ -170,7 +170,7 @@ sub getTypeID {
 
 Gets the notification types for which there are unsent messages spooled.
 
-RETURNS: an array of hashrefs, each of which has keys C<NotificationTypeID> and
+RETURNS: an array of hash ref, each of which has keys C<NotificationTypeID> and
 C<SubjectLine> and C<CenterID>
 
 =cut
@@ -201,9 +201,11 @@ sub getSpooledTypes {
 Gets the spooled messages for a given C<NotificationTypeID> specified by
 C<$typeID>, optionally directed to the center specified by C<$centerID>.
 
-INPUTS: notification type ID, (optionally the center ID)
+INPUTS:
+  - $typeID  : notification type ID
+  - $centerID: the center ID (optional)
 
-RETURNS: an array of hashrefs, each of which has keys C<TimeSpooled> and
+RETURNS: an array of hash refs, each of which has keys C<TimeSpooled> and
 C<Message>
 
 =cut
@@ -235,10 +237,12 @@ sub getSpooledMessagesByTypeID {
 
 =head3 getRecipientsByTypeID($typeID, $centerID)
 
-Gets the recipient list for a given NotificationTypeID specified by
+Gets the recipient list for a given C<NotificationTypeID> specified by
 C<$typeID>, optionally directed to the center specified by C<$centerID>.
 
-INPUTS: notification type ID, (optionally the center ID)
+INPUTS:
+  - $typeID  : notification type ID
+  - $centerID: the center ID (optional)
 
 RETURNS: an array of email addresses
 
@@ -270,10 +274,12 @@ sub getRecipientsByTypeID {
 
 =head3 markMessagesAsSentByTypeID($typeID, $centerID)
 
-Marks all messages as sent with a given NotificationTypeID specified by
+Marks all messages as sent with a given C<NotificationTypeID> specified by
 C<$typeID> and optionally C<$centerID>.
 
-INPUTS: notification type ID, (optionally the center ID)
+INPUTS:
+  - $typeID  : notification type ID
+  - $centerID: the center ID (optional)
 
 =cut
 
@@ -293,14 +299,6 @@ sub markMessagesAsSentByTypeID {
 __END__
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 COPYRIGHT
 

--- a/uploadNeuroDB/bin/concat_mri.pl
+++ b/uploadNeuroDB/bin/concat_mri.pl
@@ -28,8 +28,8 @@ B<-verbose> : print additional information while running
 B<-compress> : compress resulting output files with C<gzip>
     
 =item *
-B<-stdin> : do not read the names of the MINC files on the commmand line but read them
-from STDIN instead
+B<-stdin> : do not read the names of the MINC files on the command line but read them
+from C<STDIN> instead
 
 =item *
 B<-postfix text> : create output file names using the file name without its extension, followed
@@ -71,7 +71,7 @@ automatically.
 
 =head1 DESCRIPTION
 
-This script parses the MINC files passed on the command line (or read from STDIN) and 
+This script parses the MINC files passed on the command line (or read from C<STDIN>) and
 uses C<mincinfo> to extract specific header information from each of them. It then groups
 together the files that have identical values for the following properties: 
 patient name, study ID, contrast agent flag (unless C<-ignorecontrast> is specified, see 
@@ -82,14 +82,6 @@ a given group and for which stacking or interleaving occurs in the slice directi
 will be the first element in the list of dimension names). Note that C<mincresample> might 
 be called on a specific file before the actual merging takes place (see C<-nonslicetolerance>
 above). Finally, note that merging of the MINC files is done with C<mincconcat>. 
-
-=head1 TO DO
-
-Nothing.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/uploadNeuroDB/bin/mincpik
+++ b/uploadNeuroDB/bin/mincpik
@@ -28,8 +28,8 @@ B<-clobber> : if it exists, overwrite the output file. An error is produced if F
 and this option is not used.
 
 =item *
-B<-fake> : do not actually run the command but instead print on STDOUT all the calls to the
- scripts and external tools (see above) issued to generate the image
+B<-fake> : do not actually run the command but instead print on C<STDOUT> all
+the calls to the scripts and external tools (see above) issued to generate the image
  
 =item *
 B<-slice index> : C<index> (starts at 0) of the slice to use to generate the image. Defaults to
@@ -44,8 +44,8 @@ B<-width width> : autoscale the image so it has a fixed width (in number of pixe
 If this option is used, then the scaling factor (C<-scale> option) is ignored.
 
 =item *
-B<-depth 8|16> : bitdepth for resulting image (8 or 16). This option should be used 
-on big-endian machines only.
+B<-depth 8|16> : bit depth for resulting image (8 or 16). This option should
+be used on big-endian machines only.
 
 =item *
 B<-title> : whether the image should be generated with a title or not
@@ -130,14 +130,6 @@ dimension stacked in a horizontal row.
 The F<outfile> command line argument is optional. If not specified, output will be a PNG image
 written to STDOUT. If F<outfile> is specified, the file extension will determine the type of
 the generated image (F<.jpg> for JPEG images, F<.gif> for GIF images, etc...)
-
-=head1 TO DO
-
-Nothing
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/uploadNeuroDB/imaging_upload_file.pl
+++ b/uploadNeuroDB/imaging_upload_file.pl
@@ -9,12 +9,11 @@ and insertion pipeline sequence
 
 =head1 SYNOPSIS
 
-perl imaging_upload_file.pl </path/to/UploadedFile> `[options]`
+perl imaging_upload_file.pl </path/to/UploadedFile> C<[options]>
 
 Available options are:
 
--profile      : name of the config file in
-                C<../dicom-archive/.loris_mri>
+-profile      : name of the config file in C<../dicom-archive/.loris_mri>
 
 -upload_id    : The Upload ID of the given scan uploaded
 
@@ -23,18 +22,18 @@ Available options are:
 
 =head1 DESCRIPTION
 
-The program does the following
+The program does the following:
 
 - Gets the location of the uploaded file (.zip, .tar.gz or .tgz)
 
 - Unzips the uploaded file
 
-- Uses the ImagingUpload class to :
+- Uses the C<ImagingUpload> class to:
    1) Validate the uploaded file   (set the validation to true)
-   2) Run dicomTar.pl on the file  (set the dicomTar to true)
-   3) Run tarchiveLoader on the file (set the minc-created to true)
-   4) Removes the uploaded file once the previous steps have completed
-   5) Update the mri_upload table
+   2) Run C<dicomTar.pl> on the file  (set the C<dicomTar> to true)
+   3) Run C<tarchiveLoader> on the file (set the minc-created to true)
+   4) Remove the uploaded file once the previous steps have completed
+   5) Update the C<mri_upload> table
 
 =head2 Methods
 
@@ -314,9 +313,9 @@ spool($message,'N', $notify_notsummary);
 
 Function that gets the patient name using the upload ID
 
-INPUT   : $upload_id : The upload ID
+INPUT: The upload ID
 
-RETURNS : $patient_name : The patient name
+RETURNS: The patient name
 
 =cut
 
@@ -350,9 +349,9 @@ sub getPnameUsingUploadID {
 Functions that gets the file path from the `mri_upload` table using the upload
 ID
 
-INPUT   : $upload_id : The upload ID
+INPUT: The upload ID
 
-RETURNS : $file_path : The full path to the uploaded file
+RETURNS: The full path to the uploaded file
 
 =cut
 
@@ -387,10 +386,11 @@ sub getFilePathUsingUploadID {
 Function that gets the count of MINC files created and inserted using the
 upload ID
 
-INPUT   : $upload_id: The upload ID
+INPUT: The upload ID
 
-RETURNS : $minc_created and $minc_inserted: count of MINC files created and
-inserted
+RETURNS:
+  - $minc_created : count of MINC files created
+  - $minc_inserted: count of MINC files inserted
 
 =cut
 
@@ -427,14 +427,14 @@ sub getNumberOfMincFiles {
 
 =head3 spool()
 
-Function that calls the Notify->spool function to log all messages
+Function that calls the C<Notify->spool> function to log all messages
 
 INPUTS:
- - $this      : Reference to the class
- - $message   : Message to be logged in the database
- - $error     : If 'Y' it's an error log , 'N' otherwise
- - $verb      : 'N' for summary messages, 
-                'Y' for detailed messages (developers)
+ - $this   : Reference to the class
+ - $message: Message to be logged in the database
+ - $error  : If 'Y' it's an error log , 'N' otherwise
+ - $verb   : 'N' for summary messages,
+             'Y' for detailed messages (developers)
 
 =cut
 
@@ -460,10 +460,6 @@ __END__
 Add a check that the uploaded scan file is accessible by the front end user
 (i.e. that the user-group is set properly on the upload directory). Throw an
 error and log it, otherwise.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/uploadNeuroDB/imaging_upload_file_cronjob.pl
+++ b/uploadNeuroDB/imaging_upload_file_cronjob.pl
@@ -5,24 +5,23 @@
 =head1 NAME
 
 imaging_upload_file_cronjob.pl -- a wrapper script that calls the single step
-script `imaging_upload_file.pl` for uploaded scans on which the insertion
+script C<imaging_upload_file.pl> for uploaded scans on which the insertion
 pipeline has not been launched.
 
 =head1 SYNOPSIS
 
-perl imaging_upload_file_cronjob.pl `[options]`
+perl imaging_upload_file_cronjob.pl C<[options]>
 
 Available options are:
 
--profile      : Name of the config file in
-                C<../dicom-archive/.loris_mri>
+-profile      : Name of the config file in C<../dicom-archive/.loris_mri>
 
 -verbose      : If set, be verbose
 
 
 =head1 DESCRIPTION
 
-The program gets a series of rows from `mri_upload` on which the insertion
+The program gets a series of rows from C<mri_upload> on which the insertion
 pipeline has not been run yet, and launches it.
 
 =cut
@@ -143,14 +142,6 @@ exit $NeuroDB::ExitCodes::SUCCESS;
 __END__
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/uploadNeuroDB/mass_nii.pl
+++ b/uploadNeuroDB/mass_nii.pl
@@ -23,7 +23,7 @@ Available options are:
 
 =head1 DESCRIPTION
 
-This script generates NIfTI images for the inserted MINC files with a FileID
+This script generates NIfTI images for the inserted MINC files with a C<FileID>
 between the specified C<minFileID> and C<maxFileID>.
 
 =cut
@@ -196,14 +196,6 @@ exit $NeuroDB::ExitCodes::SUCCESS;
 __END__
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/uploadNeuroDB/mass_pic.pl
+++ b/uploadNeuroDB/mass_pic.pl
@@ -13,7 +13,7 @@ perl mass_pic.pl C<[options]>
 
 Available options are:
 
--profile   : name of the config file in ../dicom-archive/.loris_mri
+-profile   : name of the config file in C<../dicom-archive/.loris_mri>
 
 -mincFileID: integer, minimum C<FileID> to operate on
 
@@ -168,14 +168,6 @@ exit $NeuroDB::ExitCodes::SUCCESS;
 __END__
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -15,12 +15,11 @@ perl minc_deletion.pl C<[options]>
 
 Available options are:
 
--profile    : name of the config file in
-              C<../dicom-archive/.loris_mri>
+-profile   : name of the config file in C<../dicom-archive/.loris_mri>
 
--series_uid : the series UID of the file to be deleted
+-series_uid: the series UID of the file to be deleted
 
--fileid     : the file ID of the file to be deleted
+-fileid    : the file ID of the file to be deleted
 
 
 =head1 DESCRIPTION
@@ -29,7 +28,7 @@ This program deletes MINC files from LORIS by:
   - Moving the existing files (C<.mnc>, C<.nii>, C<.jpg>, C<.header>,
     C<.raw_byte.gz>) to the archive directory: C</data/$PROJECT/data/archive/>
   - Deleting all related data from C<parameter_file> & C<files> tables
-  - Deleting data from C<files_qcstatus> & C<feedback_mri_comments>
+  - Deleting data from C<files_qcstatus> and C<feedback_mri_comments>
     database tables if the C<-delqcdata> option is set. In most cases
     you would want to delete this when the images change
   - Deleting C<mri_acquisition_dates> entry if it is the last file
@@ -458,21 +457,13 @@ __END__
 
 =pod
 
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
-
 =head1 LICENSING
 
 License: GPLv3
 
 =head1 AUTHORS
 
-Gregory Luneau, the LORIS community <loris.info@mcin.ca> and McGill Centre
-for Integrative Neuroscience
+Gregory Luneau,
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
 
 =cut

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -12,8 +12,7 @@ perl minc_insertion.pl C<[options]>
 
 Available options are:
 
--profile     : name of the config file in
-               C<../dicom-archive/.loris_mri>
+-profile     : name of the config file in C<../dicom-archive/.loris_mri>
 
 -reckless    : uploads data to database even if study protocol
                is not defined or violated
@@ -645,7 +644,7 @@ exit $NeuroDB::ExitCodes::SUCCESS;
 
 =head3 logHeader()
 
-Creates and prints the LOG header.
+Function that adds a header with relevant information to the log file.
 
 =cut
 
@@ -665,14 +664,6 @@ sub logHeader () {
 __END__
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -13,7 +13,7 @@ perl register_processed_data.pl C<[options]>
 
 Available options are:
 
--profile        : name of config file in ../dicom-archive/.loris_mri
+-profile        : name of config file in C<../dicom-archive/.loris_mri>
 
 -file           : file that will be registered in the database
                    (full path from the root directory is required)
@@ -22,10 +22,10 @@ Available options are:
                    to obtain the file to be registered in the database
 
 -sourcePipeline : pipeline name that was used to obtain the file to be
-                   registered (example: DTIPrep_pipeline)
+                   registered (example: C<DTIPrep_pipeline>)
 
 -tool           : tool name and version that was used to obtain the
-                   file to be registered (example: DTIPrep_v1.1.6)
+                   file to be registered (example: C<DTIPrep_v1.1.6>)
 
 -pipelineDate   : date at which the processing pipeline was run
 
@@ -48,7 +48,7 @@ the database.
 
 =head1 DESCRIPTION
 
-This script inserts processed data in the files and parameter_file tables.
+This script inserts processed data in the C<files> and C<parameter_file> tables.
 
 =head2 Methods
 
@@ -350,7 +350,7 @@ exit $NeuroDB::ExitCodes::SUCCESS;
 
 =head3 getSessionID($sourceFileID, $dbh)
 
-This function returns the sessionID based on the provided sourceFileID.
+This function returns the C<SessionID> based on the provided C<sourceFileID>.
 
 INPUTS:
   - $sourceFileID: source FileID
@@ -395,10 +395,11 @@ sub getSessionID    {
 
 =head3 getScannerID($sourceFileID, $dbh)
 
-This function gets the ScannerID from the C<files> table using sourceFileID
+This function gets the C<ScannerID> from the C<files> table using
+C<sourceFileID>.
 
 INPUTS:
-  - $sourceFileID: source FileID
+  - $sourceFileID: source C<FileID>
   - $dbh         : database handle
 
 RETURNS: scanner ID
@@ -429,8 +430,8 @@ sub getScannerID    {
 
 =head3 getAcqProtID($scanType, $dbh)
 
-This function returns the AcquisitionProtocolID of the file to register in the
-database based on scanType in the C<mri_scan_type> table.
+This function returns the C<AcquisitionProtocolID> of the file to register in
+the database based on C<scanType> in the C<mri_scan_type> table.
 
 INPUTS:
   - $scanType: scan type
@@ -496,7 +497,7 @@ Moves files to C<assembly> folder.
 
 INPUTS:
   - $filename     : file to copy
-  - $subjectIDsref: subject ID hashref
+  - $subjectIDsref: subject ID hash ref
   - $scan_type    : scan type
   - $fileref      : file hash ref
 
@@ -552,7 +553,7 @@ sub copy_file {
 
 =head3 getSourceFilename($sourceFileID)
 
-Greps source file name from the database using SourceFileID.
+Greps source file name from the database using C<SourceFileID>.
 
 INPUT: ID of the source file
 
@@ -590,7 +591,7 @@ sub getSourceFilename {
 
 Determines where the MINC files will go.
 
-INPUT: subject ID hashref
+INPUT: subject ID hash ref
 
 RETURNS: directory where the MINC files will go
 
@@ -650,14 +651,6 @@ sub insert_intermedFiles {
 __END__
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -47,11 +47,11 @@ Available options are:
 
 -verbose                 : If set, be verbose
 
--seriesuid               : Only insert this SeriesUID
+-seriesuid               : Only insert this C<SeriesUID>
 
 -acquisition_protocol    : Suggest the acquisition protocol to use
 
--bypass_extra_file_checks: Bypass extra_file_checks
+-bypass_extra_file_checks: Bypass C<extra_file_checks>
 
 
 =head1 DESCRIPTION

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -7,7 +7,7 @@
 
 tarchiveLoader -- this script performs the following:
 
-- validation of the tarchive
+- validation of the DICOM archive
 
 - conversion of DICOM datasets into MINC files
 
@@ -22,43 +22,42 @@ perl uploadNeuroDB/tarchiveLoader </path/to/DICOM-tarchive> C<[options]>
 
 Available options are:
 
--profile                    : Name of the config file in
-                              C<../dicom-archive/.loris_mri>
+-profile                 : Name of the config file in C<../dicom-archive/.loris_mri>
 
--force                      : Force the script to run even if the validation
-                              has failed
+-force                   : Force the script to run even if the validation
+                           has failed
 
--reckless                   : Upload data to database even if study protocol is
-                              not defined or violated
+-reckless                : Upload data to database even if study protocol is
+                           not defined or violated
 
--globLocation               : Loosen the validity check of the tarchive allowing
-                              for the possibility that the tarchive was moved to
-                              a different directory
+-globLocation            : Loosen the validity check of the tarchive allowing
+                           for the possibility that the tarchive was moved to
+                           a different directory
 
--noJIV                      : Prevent the JIVs from being created
+-noJIV                   : Prevent the JIVs from being created
 
--newScanner                 : By default a new scanner will be registered if the
-                              data you upload requires it. You can risk turning
-                              it off
+-newScanner              : By default a new scanner will be registered if the
+                           data you upload requires it. You can risk turning
+                           it off
 
--keeptmp                    : Keep temporary directory. Make sense if have
-                              infinite space on your server
+-keeptmp                 : Keep temporary directory. Make sense if have
+                           infinite space on your server
 
--xlog                       : Open an xterm with a tail on the current log file
+-xlog                    : Open an xterm with a tail on the current log file
 
--verbose                    : If set, be verbose
+-verbose                 : If set, be verbose
 
--seriesuid                  : Only insert this SeriesUID
+-seriesuid               : Only insert this SeriesUID
 
--acquisition_protocol       : Suggest the acquisition protocol to use
+-acquisition_protocol    : Suggest the acquisition protocol to use
 
--bypass_extra_file_checks   : Bypass extra_file_checks
+-bypass_extra_file_checks: Bypass extra_file_checks
 
 
 =head1 DESCRIPTION
 
 
-This script interacts with the NeuroDB database system. It will fetch or modify
+This script interacts with the LORIS database system. It will fetch or modify
 contents of the following tables:
 C<session>, C<parameter_file>, C<parameter_type>, C<parameter_type_category>,
 C<files>, C<mri_staging>, C<notification_spool>
@@ -758,7 +757,7 @@ exit $NeuroDB::ExitCodes::SUCCESS;
 
 =head3 logHeader()
 
-Function that adds a header with relevant information to the log file
+Function that adds a header with relevant information to the log file.
 
 =cut
 
@@ -793,10 +792,7 @@ __END__
 
 - add to config file whether or not to autocreate scanners
 
-
-=head1 BUGS
-
-None reported.
+- fix comments written as #fixme in the code
 
 =head1 LICENSING
 

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -13,7 +13,7 @@ perl tarchive_validation.pl C<[options]>
 
 Available options are:
 
--profile     : name of the config file in ../dicom-archive/.loris-mri
+-profile     : name of the config file in C<../dicom-archive/.loris-mri>
 
 -reckless    : upload data to the database even if the study protocol
                is not defined or if it is violated
@@ -36,19 +36,19 @@ against the one inserted in the database using checksum
 - Verification of the PSC information using whatever field containing the site
 string (typically, the patient name or patient ID)
 
-- Verification of the ScannerID of the DICOM study archive (optionally
+- Verification of the C<ScannerID> of the DICOM study archive (optionally
 creates a new scanner entry in the database if necessary)
 
 - Optionally, creation of candidates as needed and standardization of gender
 information when creating the candidates (DICOM uses M/F, LORIS database uses
 Male/Female)
 
-- Check of the CandID/PSCID match. It's possible that the CandID exists, but
-that CandID and PSCID do not correspond to the same candidate. This would
-fail further down silently, so we explicitly check that this information is
-correct here.
+- Check of the C<CandID>/C<PSCID> match. It's possible that the C<CandID>
+exists, but that C<CandID> and C<PSCID> do not correspond to the same
+candidate. This would fail further down silently, so we explicitly check that
+this information is correct here.
 
-- Validation of the SessionID
+- Validation of the C<SessionID>
 
 - Optionally, completion of extra filtering on the DICOM dataset, if needed
 
@@ -394,7 +394,7 @@ exit $NeuroDB::ExitCodes::SUCCESS;
 
 =head3 logHeader()
 
-Creates and prints the LOG header.
+Function that adds a header with relevant information to the log file.
 
 =cut
 
@@ -413,14 +413,6 @@ __END__
 
 
 =pod
-
-=head1 TO DO
-
-Nothing planned.
-
-=head1 BUGS
-
-None reported.
 
 =head1 LICENSING
 


### PR DESCRIPTION
**Takes care of harmonizing the perl documentation:**
- remove empty todo sections and empty bugs sections
- harmonize /data/project/data/ to be /data/$PROJECT/data
- harmonize authorship for the LORIS team
- try to follow this pull request (#226) for the TODO section; i.e. use this: "Fix comments written as #fixme in the code." whenever appropriate in other scripts
- logHeader() function documented consistently (check #237 versus #246)
- ensure that all tables and variables and paths to files are written in a C<> format 
- consistent INPUT vs INPUTS in Methods
- consistency in the (constructor) method 
- INPUTS to functions when many inputs exist are now documented with (...), Nicolas raised this in this PR: #300; so PERHAPS reconsider revisiting all scripts to list all inputs anyway? (done)

Note: the .md files are not created yet. Writing a script to automatically create perldoc becomes I don't feel doing it by hand (the script will be committed in a separate PR and could be run before each release so that if we forget to update a MD file in a PR, we can always mass run the creation of MD files) 

Associated redmine ticket: https://redmine.cbrain.mcgill.ca/issues/13688 