### PR TITLE
getPSC() now checks the centerID from the session table first, if it exists, before it regex matches the patientname with the site Alias or MRI alias: Redmine 14422

### DIFF
--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -257,10 +257,10 @@ RETURNS: (int) CandID
 
 ### getPSC($patientName, $dbhr)
 
-Looks for the site alias using the session table CenterID as a first
-resource, for the cases where it is created using the front-end,
-otherwise, find the site alias in whatever field (usually patient\_name 
-or patient\_id) is provided, and return the MRI alias and CenterID.
+Looks for the site alias using the `session` table `CenterID` as 
+a first resource, for the cases where it is created using the front-end,
+otherwise, find the site alias in whatever field (usually `patient_name` 
+or `patient_id`) is provided, and return the `MRI_alias` and `CenterID`.
 
 INPUTS: patient name, database handle reference
 

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -257,8 +257,10 @@ RETURNS: (int) CandID
 
 ### getPSC($patientName, $dbhr)
 
-Looks for the site alias in whatever field (usually patient\_name or
-patient\_id) is provided and return the MRI alias and CenterID.
+Looks for the site alias using the session table CenterID as a first
+resource, for the cases where it is created using the front-end,
+otherwise, find the site alias in whatever field (usually patient\_name 
+or patient\_id) is provided, and return the MRI alias and CenterID.
 
 INPUTS: patient name, database handle reference
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1156,10 +1156,10 @@ sub createNewCandID {
 
 =head3 getPSC($patientName, $dbhr)
 
-Looks for the site alias using the session table CenterID as a first
-resource, for the cases where it is created using the front-end,
-otherwise, find the site alias in whatever field (usually patient_name 
-or patient_id) is provided, and return the MRI alias and CenterID.
+Looks for the site alias using the C<session> table C<CenterID> as 
+a first resource, for the cases where it is created using the front-end,
+otherwise, find the site alias in whatever field (usually C<patient_name> 
+or C<patient_id>) is provided, and return the C<MRI_alias> and C<CenterID>.
 
 INPUTS: patient name, database handle reference
 
@@ -1184,13 +1184,13 @@ sub getPSC {
     ## Get the CenterID from the session table, if the PSCID and visit labels exist 
     ## and could be extracted  
     if ($PSCID && $visitLabel) {
-    	my $query = "SELECT s.CenterID,p.MRI_alias FROM session s 
+    	my $query = "SELECT s.CenterID, p.MRI_alias FROM session s 
                     JOIN psc p on p.CenterID=s.CenterID  
                     JOIN candidate c on c.CandID=s.CandID  
-                    WHERE c.PSCID = '$PSCID' AND s.Visit_label = '$visitLabel'";
-
+                    WHERE c.PSCID = ? AND s.Visit_label = ?";
+        
         my $sth = $${dbhr}->prepare($query);
-	    $sth->execute();
+        $sth->execute($PSCID, $visitLabel);
 	    if ( $sth->rows > 0) {
             my $row = $sth->fetchrow_hashref();
     	    return ($row->{'MRI_alias'},$row->{'CenterID'});

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1191,10 +1191,10 @@ sub getPSC {
         
         my $sth = $${dbhr}->prepare($query);
         $sth->execute($PSCID, $visitLabel);
-	    if ( $sth->rows > 0) {
+        if ( $sth->rows > 0) {
             my $row = $sth->fetchrow_hashref();
-    	    return ($row->{'MRI_alias'},$row->{'CenterID'});
-	    }
+            return ($row->{'MRI_alias'},$row->{'CenterID'});
+        }
     }  
 
     ## Otherwise, use the patient name to match it to the site alias or MRI alias 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1156,8 +1156,10 @@ sub createNewCandID {
 
 =head3 getPSC($patientName, $dbhr)
 
-Looks for the site alias in whatever field (usually patient_name or
-patient_id) is provided and return the MRI alias and CenterID.
+Looks for the site alias using the session table CenterID as a first
+resource, for the cases where it is created using the front-end,
+otherwise, find the site alias in whatever field (usually patient_name 
+or patient_id) is provided, and return the MRI alias and CenterID.
 
 INPUTS: patient name, database handle reference
 
@@ -1169,34 +1171,41 @@ RETURNS: a two element array:
 
 sub getPSC {
     my ($patientName, $dbhr) = @_;
-    my $query = "SELECT CenterID, Alias, MRI_alias FROM psc WHERE mri_alias<>''";
-    my $sth = $${dbhr}->prepare($query);
+
+    my $subjectIDsref = Settings::getSubjectIDs(
+                            $patientName,
+                            null,
+                            null,
+                            $dbhr
+                        );
+    my $PSCID = $subjectIDsref->{'PSCID'};
+    my $visitLabel = $subjectIDsref->{'visitLabel'};
+
+    ## Get the CenterID from the session table, if the PSCID and visit labels exist 
+    ## and could be extracted  
+    if ($PSCID && $visitLabel) {
+    	my $query = "SELECT s.CenterID,p.MRI_alias FROM session s 
+                    JOIN psc p on p.CenterID=s.CenterID  
+                    JOIN candidate c on c.CandID=s.CandID  
+                    WHERE c.PSCID = '$PSCID' AND s.Visit_label = '$visitLabel'";
+
+        my $sth = $${dbhr}->prepare($query);
+	    $sth->execute();
+	    if ( $sth->rows > 0) {
+            my $row = $sth->fetchrow_hashref();
+    	    return ($row->{'MRI_alias'},$row->{'CenterID'});
+	    }
+    }  
+
+    ## Otherwise, use the patient name to match it to the site alias or MRI alias 
+    $query = "SELECT CenterID, Alias, MRI_alias FROM psc WHERE mri_alias<>''";
+    $sth = $${dbhr}->prepare($query);
     $sth->execute;
 
     while(my $row = $sth->fetchrow_hashref) {
         return ($row->{'MRI_alias'}, $row->{'CenterID'})
 	    if ($patientName =~ /$row->{'Alias'}/i) || ($patientName =~ /$row->{'MRI_alias'}/i);
     }
-
-    ###########################################################################	
-    ###Get the centerID using the PSCID########################################
-    ###########################################################################
-
-    #extract the PSCID from $patientName
-    $subjectIDsref = getSubjectIDs($patientName,null,$dbhr);
-    my $PSCID = $subjectIDsref->{'PSCID'};
-    if ($PSCID) {
-    ##Get the CenterID using PSCID
-	$query = "SELECT c.CenterID,p.MRI_alias FROM candidate c JOIN
-	psc p on p.CenterID=c.CenterID  WHERE c.PSCID = '$PSCID'";
-
-        $sth = $${dbhr}->prepare($query);
-	$sth->execute();
-	if ( $sth->rows > 0) {
-            my $row = $sth->fetchrow_hashref();
-	    return ($row->{'MRI_alias'},$row->{'CenterID'});
-	}
-    }  
 
     return ("UNKN", 0);
 }


### PR DESCRIPTION
So the logic of getPSC() now becomes:
check first if the visit label exists in the session table for that PSCID, if a match is found, then use that CenterID, otherwise, use regex matching on the PatientName (this was the default option from before the change in this PR)

In addition, the original script was using the `getSubjectIDs` routine in MRI.pm as opposed to the one in the `prod` file. Projects can not customize those in the script without deviating from the released MRI codebase, so now I make it point to the one in the `prod` file so that 1) the same `getSubjectIDs` routine is used consistently throughout the insertion scripts and 2) if projects customized the one in their `prod` file, their customization is fully propagated (as opposed to partially) throughout when calling this routine.
