### PR TITLE
Exit if comma separated values in mri_protocol checks ValidRange column

### DIFF
--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -388,7 +388,8 @@ INPUTS:
 
 ### isValidMRIProtocol()
 
-Ensures no column in the `mri_protocol` table has comma-separated values.
+Ensures no column in the `mri_protocol` nor the `mri_protocol_checks` 
+tables has comma-separated values.
 
 RETURNS: 1 on success, 0 on failure
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1849,7 +1849,7 @@ sub isValidMRIProtocol  {
     $sth->execute();
     my $count_mri_protocol_checks = $sth->fetchrow_array;
 
-    if ( $count > 0 || $count_mri_protocol_checks > 0) {
+    if ( $count_mri_protocol > 0 || $count_mri_protocol_checks > 0) {
         return 0;  
     } else {
         return 1;

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1815,7 +1815,8 @@ sub spool  {
 
 =head3 isValidMRIProtocol()
 
-Ensures no column in the C<mri_protocol> table has comma-separated values.
+Ensures no column in the C<mri_protocol> nor the C<mri_protocol_checks> 
+tables has comma-separated values.
 
 RETURNS: 1 on success, 0 on failure
 
@@ -1839,8 +1840,16 @@ sub isValidMRIProtocol  {
 
     my $sth = ${$this->{'dbhr'}}->prepare($query);
     $sth->execute();
-    my $count = $sth->fetchrow_array;
-    if ( $count > 0 ) {
+    my $count_mri_protocol = $sth->fetchrow_array;
+
+    $query = "SELECT COUNT(*) FROM mri_protocol_checks 
+                WHERE ValidRange LIKE '%,%'";
+
+    $sth = ${$this->{'dbhr'}}->prepare($query);
+    $sth->execute();
+    my $count_mri_protocol_checks = $sth->fetchrow_array;
+
+    if ( $count > 0 || $count_mri_protocol_checks > 0) {
         return 0;  
     } else {
         return 1;

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -491,8 +491,8 @@ my ($isMRIProtocolValid) = $utility->isValidMRIProtocol();
 
 if ( !($isMRIProtocolValid) ) {
     my $message = "\nComma separated ranges or values in the mri_protocol "
-                  . "table are no longer supported. Please modify your "
-                  . "mri_protocol table accordingly. Exiting now. \n";
+                  . "and mri_protocol_checks tables are no longer supported. "
+                  . "Please modify your tables accordingly. Exiting now. \n";
     $notifier->spool('tarchive loader', $message, 0,
 		    'tarchiveLoader', $upload_id, 'Y',
 		    $notify_notsummary);


### PR DESCRIPTION
follow up to PR #283

@llevitis PR in LORIS (https://github.com/aces/Loris/pull/3523) had 2 tables, so the MRI counterpart should ensure projects no longer have comma separated values in BOTH those tables. So add the `mri_protocol_checks` here besides the check in PR#283 for `mri_protocol`.