### PR TITLE
MRI exclusion scans such as localizers read from the Config module. 

### DIFF
--- a/uploadNeuroDB/NeuroDB/DBI.pm
+++ b/uploadNeuroDB/NeuroDB/DBI.pm
@@ -89,7 +89,16 @@ sub getConfigSetting
     $query = $query . $where;
     my $sth = $$dbh->prepare($query);
     $sth->execute($name);
-    if ( $sth->rows > 0 ) {
+
+    if ( $sth->rows > 1 ){
+        # if more than one row returned, push data into an array that will be
+        #  dereferenced into $value
+        my @values;
+        while (my $row = $sth->fetchrow_array()) {
+            push (@values, $row);
+        }
+        $value = \@values;
+    } elsif ( $sth->rows > 0 ) {
         $value = $sth->fetchrow_array();
     }
     return $value;

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1076,10 +1076,15 @@ sub dicom_to_minc {
 		$exclude,$mail_user, $upload_id) = @_;
     my ($d2m_cmd,$d2m_log,$exit_code);
     my $message = '';
+
+    # create the excluded series description regex necessary to exclude the
+    # series description specified in the Config Setting
+    # excluded_series_description
+    my $excluded_regex = join('|', map { quotemeta($_) } @$exclude);
     $d2m_cmd = "find $study_dir -type f | $get_dicom_info -studyuid -series".
                " -echo -image -file -series_descr -attvalue 0018 0024".
                " -stdin | sort -n -k1 -k2 -k6 -k3 -k7 -k4 | grep -iv".
-               " $exclude | cut -f 5 | ";
+               " -E \"($excluded_regex)\" | cut -f 5 | ";
     
     ############################################################
     #### use some other converter if specified in the config ###

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -274,7 +274,9 @@ my $mail_user = NeuroDB::DBI::getConfigSetting(
 my $get_dicom_info = NeuroDB::DBI::getConfigSetting(
                  \$dbh,'get_dicom_info'
                  );
-my $exclude          = "localizer"; # case insensitive
+my $exclude          = NeuroDB::DBI::getConfigSetting(
+                        \$dbh, 'excluded_series_description'
+                       );
 my $template         = "TarLoad-$hour-$min-XXXXXX"; # for tempdir
 my $User             = `whoami`;
 


### PR DESCRIPTION
Basically redoing #264 after catastrophic rebasing. Only took 3 hours of my time today...

Until now, the exclusion of localizers were hardcoded in the tarchiveLoader in the variable $exclude.

This PR allows the possibility to configure the sequences that a user might want to exclude from the dcm2mnc command (localizers, scouts and other). In the "Imaging Pipeline" section of the Config module, it is now possible to specify the different series descriptions to be excluded from the insertion pipeline. Two default example have been set in LORIS: is `localizer` and `scout` (see screenshot below)

![screen shot 2018-02-07 at 5 45 34 pm](https://user-images.githubusercontent.com/1402456/35945591-bef997d6-0c2e-11e8-92af-024855b4acf5.png)

The imaging script will then used the values stored in the Config modules for the `excluded_series_description` config setting and create a regular expression out of those values to use afterwards when calling dcm2mnc via the `find` command which will exclude the files matching the created regular expression pattern.

PR on the LORIS side with schema changes: https://github.com/aces/Loris/pull/3449
