### PR TITLE
Remove links to scripts for 20.0

### DIFF
--- a/Mincinfo_wrapper
+++ b/Mincinfo_wrapper
@@ -1,1 +1,0 @@
-uploadNeuroDB/bin/Mincinfo_wrapper

--- a/concat_mri.pl
+++ b/concat_mri.pl
@@ -1,1 +1,0 @@
-uploadNeuroDB/bin/concat_mri.pl

--- a/environment
+++ b/environment
@@ -1,4 +1,4 @@
-export PATH=%MINC_TOOLKIT_DIR%/bin:/data/%PROJECT%/bin/mri:/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/dicom-archive:$PATH
+export PATH=%MINC_TOOLKIT_DIR%/bin:/data/%PROJECT%/bin/mri:/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/uploadNeuroDB/bin:/data/%PROJECT%/bin/mri/dicom-archive:$PATH
 export PERL5LIB=/data/%PROJECT%/bin/mri/uploadNeuroDB:$PERL5LIB
 export TMPDIR=/tmp
 export LORIS_CONFIG=/data/%PROJECT%/bin/mri/dicom-archive

--- a/minc2jiv.pl
+++ b/minc2jiv.pl
@@ -1,1 +1,0 @@
-uploadNeuroDB/bin/minc2jiv.pl

--- a/mincpik
+++ b/mincpik
@@ -1,1 +1,0 @@
-uploadNeuroDB/bin/mincpik


### PR DESCRIPTION
Copy of PR #288 but rebased for 20.0 if time to test and merge it before the release. Leaving #288 open in the meantime but labeled as blocked.

### Spring cleaning!

Instead of having links in the main directory to the scripts stored in uploadNeuroDB/bin, add the path to uploadNeuroDB/bin in the environment file.


### Caveat for existing projects:

Need to add in your environment file the following path to the export PATH line:
/data/%PROJECT%/bin/mri/uploadNeuroDB/bin
where %PROJECT% should be replaced by the name of your project