### PR TITLE
Fixed warning about potentially undefined $oldCound in tarchiveLoader.

### DIFF
--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -609,7 +609,7 @@ if ($valid_study) {
 
     my $sth = $dbh->prepare($query);
     $sth->execute($tarchiveInfo{TarchiveID});
-    my $oldCount = $sth->fetchrow_array;
+    my $oldCount = $sth->rows == 0 ? 0 : $sth->fetchrow_array;
     my $newCount = $minc_inserted + $oldCount;
 
     $query = "UPDATE mri_upload SET number_of_mincInserted=?, ".


### PR DESCRIPTION
Set `$oldCount` to 0, if the SQL statement setting its value does not return anything. This is to remove a PERL warning that would be displayed in this case.