### PR TITLE
Fixed a statement in tarchiveLoader that would cause a PERL warning in specific circumstances.

### DIFF
--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -604,8 +604,8 @@ if ($valid_study) {
 
     my $sth = $dbh->prepare($query);
     $sth->execute($tarchiveInfo{TarchiveID});
-    my $oldCount = $sth->rows == 0 ? 0 : $sth->fetchrow_array;
-    my $newCount = $minc_inserted + $oldCount;
+    my $oldCount = $sth->fetchrow_hashref->{'number_of_mincInserted'};
+    my $newCount = $minc_inserted + ($oldCount ? $oldCount : 0);
 
     $query = "UPDATE mri_upload SET number_of_mincInserted=?, ".
                  "number_of_mincCreated=? ";

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -604,7 +604,7 @@ if ($valid_study) {
 
     my $sth = $dbh->prepare($query);
     $sth->execute($tarchiveInfo{TarchiveID});
-    my $oldCount = $sth->fetchrow_array;
+    my $oldCount = $sth->rows == 0 ? 0 : $sth->fetchrow_array;
     my $newCount = $minc_inserted + $oldCount;
 
     $query = "UPDATE mri_upload SET number_of_mincInserted=?, ".


### PR DESCRIPTION
A warning would be printed by `tarchiveLoader` if it tries to update a record in table `mri_upload` for which `number_of_mincInserted` is `NULL`. Variable `$oldCount` is undefined in this case. This PR sets `$oldCount` to `0` in this situation so it is always defined.