### PR TITLE
Added object brokers for tables mri_scanner and psc.

### DIFF
--- a/dicom-archive/profileTemplate
+++ b/dicom-archive/profileTemplate
@@ -44,7 +44,7 @@ sub getSNRModalities {
 # extracts the subject and timepoint identifiers from the patient name 
 # assumes identifers are stored as <PSCID>_<DCCID>_<visit> in PatientName field, where <visit> is 3 digits.
 sub getSubjectIDs {
-    my ($patientName, $patientID, $scannerID, $dbhr) = @_;
+    my ($patientName, $patientID, $scannerID, $dbhr, $db) = @_;
 
     my %subjectID; # Will stored subject IDs.
     
@@ -56,7 +56,7 @@ sub getSubjectIDs {
      #      b. 0 if imaging pipeline should not create the visit label (when visit label has not been created yet in the database. 
     if ($patientName =~ /PHA/i or $patientName =~ /TEST/i) {
 
-        $subjectID{'CandID'}    = NeuroDB::MRI::my_trim(NeuroDB::MRI::getScannerCandID($scannerID, $dbhr));
+        $subjectID{'CandID'}    = NeuroDB::MRI::my_trim(NeuroDB::MRI::getScannerCandID($scannerID, $db));
         $subjectID{'visitLabel'}= NeuroDB::MRI::my_trim($patientName);
         $subjectID{'createVisitLabel'} = 1; 
 

--- a/docs/scripts_md/GetRole.md
+++ b/docs/scripts_md/GetRole.md
@@ -9,9 +9,9 @@ NeuroDB::objectBroker::GetRole -- A role for basic SELECT operations on the data
 This class provides methods used to accomplish basic `SELECT` operations on the database.
 It allows the retrieval of records using a simple `WHERE` clause of the form 
 `WHERE constraint_1 AND constraint_2 AND ... AND constraint_n`.
-Subparts of the where clause can only be ANDed (OR is not supported). Each subpart of the 
-`WHERE` clause specifies that a field must be either equal to a given value, not equal to a 
-given value, NULL or NOT NULL. 
+Subparts of the `WHERE` clause can only be combined with `AND` (`OR` is not supported). 
+Each subpart of the `WHERE` clause specifies that a field must be either equal to a given 
+value, not equal to a given value, NULL or NOT NULL. 
 
 Classes using this role must implement methods `getColumnNames()`, `getTableName()` and `db()`.
 
@@ -52,27 +52,27 @@ INPUTS:
    - Reference on the hash of all field constraints.
    - Name of the field for which a string representation is sought.
    - Reference on the array of all constraints (in string form).
-   - Reference on the array of values each field in $columnValuesRef must be
+   - Reference on the array of values each field in `$columnValuesRef` must be
      equal or not equal to.
 
 RETURNS: 
-   - Nothing (adds an element to @$whereRef).
+   - Nothing (adds an element to `@$whereRef`).
 
 ### addWhereFunction($columnValuesRef, $k, $whereRef, $valsRef)
 
 Gets the string representation of a constraint that uses an SQL function or operator.
-Currently, only the operator `NOT` (i.e. field NOT equal to a given value or NOT NULL) is 
+Currently, only the operator `NOT` (i.e. field `NOT` equal to a given value or `NOT NULL`) is 
 supported.
 
 INPUTS:
    - Reference on the hash of all field constraints
    - Name of the field for which a string representation is sought.
    - Reference on the array of all constraints (in string form)
-   - Reference on the array of values each field in $columnValuesRef must be
+   - Reference on the array of values each field in `$columnValuesRef` must be
      equal or not equal to.
 
 RETURNS: 
-   - Nothing. Updates arrays @$whereRef (and @$valsRef if necessary).
+   - Nothing. Updates arrays `@$whereRef` (and `@$valsRef` if necessary).
 
 ### addWhereNotEquals($columnValuesRef, $k, $whereRef, $valsRef)
 
@@ -84,11 +84,11 @@ INPUTS:
    - Reference on the hash of all field constraints
    - Name of the field for which a string representation is sought.
    - Reference on the array of all constraints (in string form)
-   - Reference on the array of values each field in $columnValuesRef must be
+   - Reference on the array of values each field in `$columnValuesRef` must be
      equal or not equal to.
 
 RETURNS: 
-   - Nothing. Updates arrays @$whereRef (and @$valsRef if necessary).
+   - Nothing. Updates arrays `@$whereRef` (and `@$valsRef` if necessary).
 
 ### get($columnValuesRef)
 

--- a/docs/scripts_md/GetRole.md
+++ b/docs/scripts_md/GetRole.md
@@ -1,0 +1,140 @@
+# NAME
+
+NeuroDB::objectBroker::GetRole -- A role for basic SELECT operations on the database
+
+# SYNOPSIS
+
+# DESCRIPTION
+
+This class provides methods used to accomplish basic `SELECT` operations on the database.
+It allows the retrieval of records using a simple `WHERE` clause of the form 
+`WHERE constraint_1 AND constraint_2 AND ... AND constraint_n`.
+Subparts of the where clause can only be ANDed (OR is not supported). Each subpart of the 
+`WHERE` clause specifies that a field must be either equal to a given value, not equal to a 
+given value, NULL or NOT NULL. 
+
+Classes using this role must implement methods `getColumnNames()`, `getTableName()` and `db()`.
+
+## Methods
+
+### get($isCount, $columnValuesRef)
+
+Fetches the records in the table whose name is returned by method `getTableName()` that satisfy
+specific constraints. 
+
+Note that this method is private.
+
+INPUTS:
+   - boolean indicating if only a count of the records found is needed
+     or the full record properties.
+   - reference to a hash array that contains the column values that the records
+     should have in order to be part of the result set (key: column name, value: column
+     value).
+
+RETURNS: 
+   - a reference to an array of hash references. Every hash contains the values
+     for a given row returned by the method call: the key/value pairs contain
+     the name of a column (see `@MRI_SCAN_TYPE_FIELDS`) and the value it 
+     holds, respectively. As an example, suppose array `$r` contains the result of a
+     given call to this function. One would fetch the `Scan_type` of the 2nd record 
+     returned using `$r->[1]->{'Scan_type'}`.
+     If the method is called with `$isCount` set to true, then it will return
+     a reference to an array containing a single hash reference, its unique key being 
+     `'COUNT(*)'` with the associated value set to the selected count.
+
+### addWhereEquals($columnValuesRef, $k, $whereRef, $valsRef)
+
+Gets the string representation of a constraint of the form `field=value` and adds it
+to the current set of `WHERE` clauses. Note that constraints specifying that a field 
+must be NULL will be properly translated to `field IS NULL` (not `field=NULL`).
+
+INPUTS:
+   - Reference on the hash of all field constraints.
+   - Name of the field for which a string representation is sought.
+   - Reference on the array of all constraints (in string form).
+   - Reference on the array of values each field in $columnValuesRef must be
+     equal or not equal to.
+
+RETURNS: 
+   - Nothing (adds an element to @$whereRef).
+
+### addWhereFunction($columnValuesRef, $k, $whereRef, $valsRef)
+
+Gets the string representation of a constraint that uses an SQL function or operator.
+Currently, only the operator `NOT` (i.e. field NOT equal to a given value or NOT NULL) is 
+supported.
+
+INPUTS:
+   - Reference on the hash of all field constraints
+   - Name of the field for which a string representation is sought.
+   - Reference on the array of all constraints (in string form)
+   - Reference on the array of values each field in $columnValuesRef must be
+     equal or not equal to.
+
+RETURNS: 
+   - Nothing. Updates arrays @$whereRef (and @$valsRef if necessary).
+
+### addWhereNotEquals($columnValuesRef, $k, $whereRef, $valsRef)
+
+Gets the string representation of a constraint of the form `field != value` and adds it to
+the current set of `WHERE` clauses. Note that constraints specifying that a field must not be NULL 
+will be properly translated to `field IS NOT NULL` (not `field!=NULL`).
+
+INPUTS:
+   - Reference on the hash of all field constraints
+   - Name of the field for which a string representation is sought.
+   - Reference on the array of all constraints (in string form)
+   - Reference on the array of values each field in $columnValuesRef must be
+     equal or not equal to.
+
+RETURNS: 
+   - Nothing. Updates arrays @$whereRef (and @$valsRef if necessary).
+
+### get($columnValuesRef)
+
+Fetches the records in the table whose name is returned by method `getTableName()` that satisfy
+specific constraints. 
+
+INPUTS:
+   - reference to a hash array that contains the constraints on the column values that the records
+     should have in order to be part of the result set. The keys are column names and
+     the values are the constraints on each column. Each constraint can be expressed as
+     a single value or a reference to a hash (this hash describes a constraint involving an
+     SQL function or operator other than '='). Examples of a valid set of constraints:
+
+     {  
+       Field1 => 'Value1',
+       Field2 => { NOT => 3 },
+       Field3 => undef
+     }
+      
+
+RETURNS: 
+   - a reference to an array of hash references. Every hash contains the values
+     for a given row returned by the method call: the key/value pairs contain
+     the name of a column (as listed by `getColumnNames()`) and the value it 
+     holds, respectively. As an example, suppose array `$r` contains the result of a
+     given call to this function. One would fetch the `Scan_type` of the 2nd record 
+     returned using `$r->[1]->{'Scan_type'}`.
+
+### getCount($columnValuesRef)
+
+Fetches the number of records in the table whose name is returned by method `getTableName()` 
+that satisfy specific constraints. 
+
+INPUTS:
+   - reference to a hash array that contains the constraints on the column values that the records
+     should have in order to be part of the result set. The keys are column names and
+     the values are the constraints on each column. Each constraint can be expressed as
+     a single value or a reference to a hash (this hash describes a constraint involving an
+     SQL function or operator other than '='). Examples of a valid set of constraints:
+
+     {  
+       Field1 => 'Value1',
+       Field2 => { NOT => 3 },
+       Field3 => undef
+     }
+      
+
+RETURNS: 
+   - the number of records found.

--- a/docs/scripts_md/InsertRole.md
+++ b/docs/scripts_md/InsertRole.md
@@ -17,7 +17,7 @@ by `getTableName()`.
 
 INPUTS:
    - reference to a hash array that contains the column values for the record to insert.
-     Each key must be a valid field (i.e that exsists in the array returned by `getColumnNames()`
+     Each key must be a valid field (i.e that exists in the array returned by `getColumnNames()`
      and each value is the value for the given field. Use `undef` to set a field to `NULL`.
 
 RETURNS: 

--- a/docs/scripts_md/InsertRole.md
+++ b/docs/scripts_md/InsertRole.md
@@ -1,0 +1,25 @@
+# NAME
+
+NeuroDB::objectBroker::InsertRole -- A role for basic `INSERT` operations on the database.
+
+# DESCRIPTION
+
+This class provides a generic method to insert a given record in the database.
+If an operation cannot be executed successfully, a `NeuroDB::objectBroker::ObjectBrokerException`
+will be thrown. All classes that use this role must implement methods `getTableName()`, `getColumnNames()` and `db()`.
+
+## Methods
+
+### insertOne($valuesRef)
+
+Inserts the record with the properties passed as argument in the table whose name is returned
+by `getTableName()`.
+
+INPUTS:
+   - reference to a hash array that contains the column values for the record to insert.
+     Each key must be a valid field (i.e that exsists in the array returned by `getColumnNames()`
+     and each value is the value for the given field. Use `undef` to set a field to `NULL`.
+
+RETURNS: 
+   - the ID of the inserted record if the operation succeeded. A <NeuroDB::objectBroker::ObjectBrokerException>
+     will be thrown otherwise.

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -28,7 +28,7 @@ all of its children.
 
 ## Methods
 
-### getSubjectIDs($patientName, $scannerID, $dbhr)
+### getSubjectIDs($patientName, $scannerID, $dbhr, $db)
 
 Determines the candidate ID and visit label for the subject based on patient
 name and (for calibration data) scanner ID.
@@ -37,6 +37,7 @@ INPUTS:
   - $patientName: patient name
   - $scannerID  : scanner ID
   - $dbhr       : database handle reference
+  - $db         : database object
 
 RETURNS: a reference to a hash containing elements including `CandID`,
 `visitLabel` and `visitNo`, or, in the case of failure, `undef`
@@ -64,11 +65,11 @@ INPUTS:
 
 RETURNS: 1 if the ID exists, 0 otherwise
 
-### getScannerCandID($scannerID, $dbhr)
+### getScannerCandID($scannerID, $db)
 
 Retrieves the candidate (`CandID`) for the given scanner.
 
-INPUTS: the scanner ID and the database handle reference
+INPUTS: the scanner ID and the database object
 
 RETURNS: the `CandID` or (if none exists) undef
 
@@ -82,6 +83,7 @@ INPUTS:
   - $studyDate   : study date
   - $dbhr        : database handle reference
   - $objective   : the objective of the study
+  - $db          : database object
 
 RETURNS: the session ID of the visit
 
@@ -220,7 +222,7 @@ referenced by `$file_ref`.
 
 INPUT: file hash ref
 
-### findScannerID($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $register\_new)
+### findScannerID($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $register\_new, $db)
 
 Finds the scanner ID for the scanner as defined by `$manufacturer`, `$model`,
 `$serialNumber`, `$softwareVersion`, using the database attached to the DBI
@@ -235,10 +237,11 @@ INPUTS:
   - $centerID       : scanner's center ID
   - $dbhr           : database handle reference
   - $register\_new   : if set, will call the function `&registerScanner`
+  - $db             : database object
 
 RETURNS: (int) scanner ID
 
-### registerScanner($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr)
+### registerScanner($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $db)
 
 Registers the scanner as defined by `$manufacturer`, `$model`,
 `$serialNumber`, `$softwareVersion`, into the database attached to the DBI
@@ -251,6 +254,7 @@ INPUTS:
   - $softwareVersion: scanner's software version
   - $centerID       : scanner's center ID
   - $dbhr           : database handle reference
+  - $db             : database object
 
 RETURNS: (int) scanner ID
 
@@ -262,7 +266,7 @@ INPUT: database handle reference
 
 RETURNS: `CandID` (int)
 
-### getPSC($patientName, $dbhr)
+### getPSC($patientName, $dbhr, $db)
 
 Looks for the site alias using the `session` table `CenterID` as 
 a first resource, for the cases where it is created using the front-end,
@@ -272,6 +276,7 @@ or `patient_id`) is provided, and return the `MRI_alias` and `CenterID`.
 INPUTS:
   - $patientName: patient name
   - $dbhr       : database handle reference
+  - $db         : database object
 
 RETURNS: a two element array:
   - first is the MRI alias of the PSC or "UNKN"

--- a/docs/scripts_md/MriScannerOB.md
+++ b/docs/scripts_md/MriScannerOB.md
@@ -6,6 +6,9 @@ NeuroDB::objectBroker::MriScannerOB -- An object broker for mri\_scanner records
 
     use NeuroDB::Database;
     use NeuroDB::objectBroker::MriScannerOB;
+    use NeuroDB::DatabaseException;
+    use NeuroDB::objectBroker::ObjectBrokerException;
+    
     use TryCatch;
 
     my $db = NeuroDB::Database->new(
@@ -36,8 +39,31 @@ NeuroDB::objectBroker::MriScannerOB -- An object broker for mri\_scanner records
     my $mriScannerRef;
     try {
         $mriScannerRef = $mriScannerOB->get(
-            { CandID => 655660 }
+            { Software => 'my_software' }
         );
+        foreach(@$mriScannerRef) {
+            print "ID for scanner model $_->{'Model'} is $_->{'ID'}\n";
+        }
+        
+        # Fetch the scanner with a NULL manufacturer
+        $mriScannerRef = $mriScannerOB->get(
+            { Manufacturer => undef }
+        );
+        
+        # Fetch the scanners with a CandID != 999999
+        $mriScannerRef = $mriScannerOB->get(
+            { CandID => { NOT => 999999 } }
+        );
+        
+        # Create a new scanner with the given properties
+        mriScannerOB->insertOne({
+            ID            => 7,
+            Manufacturer  => 'SIEMENS',
+            Model         => 'Prisma_fit',
+            Serial_number => 67094,
+            Software      => 'syngo MR E11',
+            CandID        => 151581
+        });
     } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
         die sprintf(
             "Failed to retrieve mri_scanner records: %s",
@@ -51,15 +77,6 @@ This class provides a set of methods to fetch records from the `mri_scanner`
 table. If an operation cannot be executed successfully, a `NeuroDB::objectBroker::ObjectBrokerException`
 will be thrown. See the documentation for `GetRole` and `InsertRole` for information on how to perform
 basic `INSERT`/`SELECT` operations using this object broker.
-
-### new(db => $db) >> (constructor inherited from `ObjectBroker`)
-
-Creates a new instance of this class. The only parameter to provide is the
-`Database` object used to access the database.
-
-INPUT: the database object used to query the `mri_scanner` table.
-
-RETURN: new instance of this class.
 
 ### getTableName()
 

--- a/docs/scripts_md/MriScannerOB.md
+++ b/docs/scripts_md/MriScannerOB.md
@@ -1,0 +1,78 @@
+# NAME
+
+NeuroDB::objectBroker::MriScannerOB -- An object broker for mri\_scanner records
+
+# SYNOPSIS
+
+    use NeuroDB::Database;
+    use NeuroDB::objectBroker::MriScannerOB;
+    use TryCatch;
+
+    my $db = NeuroDB::Database->new(
+        userName     => 'user',
+        databaseName => 'my_db',
+        hostName     => 'my_hostname',
+        password     => 'pwd'
+    );
+
+    try {
+        $db->connect();
+    } catch(NeuroDB::DatabaseException $e) {
+        die sprintf(
+            "User %s failed to connect to %s on %s: %s (error code %d)\n",
+            'user',
+            'my_db',
+            'my_hostname',
+            $e->errorMessage,
+            $e->errorCode
+        );
+    }
+
+    .
+    .
+    .
+
+    my $mriScannerOB = NeuroDB::objectBroker::MriScannerOB->new(db => $db);
+    my $mriScannerRef;
+    try {
+        $mriScannerRef = $mriScannerOB->get(
+            { CandID => 655660 }
+        );
+    } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+        die sprintf(
+            "Failed to retrieve mri_scanner records: %s",
+            $e->errorMessage
+        );
+    }
+
+# DESCRIPTION
+
+This class provides a set of methods to fetch records from the `mri_scanner`
+table. If an operation cannot be executed successfully, a `NeuroDB::objectBroker::ObjectBrokerException`
+will be thrown. See the documentation for `GetRole` and `InsertRole` for information on how to perform
+basic `INSERT`/`SELECT` operations using this object broker.
+
+### new(db => $db) >> (constructor inherited from `ObjectBroker`)
+
+Creates a new instance of this class. The only parameter to provide is the
+`Database` object used to access the database.
+
+INPUT: the database object used to query the `mri_scanner` table.
+
+RETURN: new instance of this class.
+
+### getTableName()
+
+Gets the name of the database table with which this object broker interacts.
+
+INPUT: None
+
+RETURN: name of the database table with which this object broker interacts.
+
+### getColumnNames()
+
+Gets the column names for table mri\_scanner.
+
+INPUT: None
+
+RETURN: Column names for table mri\_scanner.

--- a/docs/scripts_md/ObjectBroker.md
+++ b/docs/scripts_md/ObjectBroker.md
@@ -1,0 +1,19 @@
+# NAME
+
+NeuroDB::objectBroker::ObjectBroker -- Superclass for all object brokers.
+
+# DESCRIPTION
+
+This class provides the set of methods common to all object brokers. Any object broker used 
+by the MRI pipeline or associated scripts should extend this class.
+
+## Methods
+
+### new(db => $db) >> (constructor)
+
+Create a new instance of this class. The only parameter to provide is the
+`Database` object used to access the database.
+
+INPUT: the database object used to perform queries on the database tables.
+
+RETURN: new instance of this class.

--- a/docs/scripts_md/PSCOB.md
+++ b/docs/scripts_md/PSCOB.md
@@ -1,0 +1,80 @@
+# NAME
+
+NeuroDB::objectBroker::PSCOB -- An object broker for records stored in table `psc`.
+
+# SYNOPSIS
+
+    use NeuroDB::Database;
+    use NeuroDB::objectBroker::PSCOB;
+    use TryCatch;
+
+    my $db = NeuroDB::Database->new(
+        userName     => 'user',
+        databaseName => 'my_db',
+        hostName     => 'my_hostname',
+        password     => 'pwd'
+    );
+
+    try {
+        $db->connect();
+    } catch(NeuroDB::DatabaseException $e) {
+        die sprintf(
+            "User %s failed to connect to %s on %s: %s (error code %d)\n",
+            'user',
+            'my_db',
+            'my_hostname',
+            $e->errorMessage,
+            $e->errorCode
+        );
+    }
+
+    .
+    .
+    .
+
+    my $pscOB = NeuroDB::objectBroker::PSCOB->new(db => $db);
+    my $pscRef;
+    try {
+        $pscRef = $pscOB->get(
+            { Alias => 'DCC' }
+        );
+    } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+        die sprintf(
+            "Failed to retrieve psc records: %s",
+            $e->errorMessage
+        );
+    }
+
+# DESCRIPTION
+
+This class provides a set of methods to fetch records from the `psc`
+table. If an operation cannot be executed successfully, a `NeuroDB::objectBroker::ObjectBrokerException`
+will be thrown. See the documentation for `GetRole` and `InsertRole` for information on how to perform
+basic `INSERT`/`SELECT` operations using this object broker.
+
+## Methods
+
+### new(db => $db) >> (constructor inherited from `ObjectBroker`)
+
+Create a new instance of this class. The only parameter to provide is the
+`Database` object used to access the database.
+
+INPUT: the database object used to query the `psc` table.
+
+RETURN: new instance of this class.
+
+### getTableName()
+
+Gets the name of the database table with which this object broker interacts.
+
+INPUT: None
+
+RETURN: name of the database table with which this object broker interacts.
+
+### getColumnNames()
+
+Gets the column names for table psc.
+
+INPUT: None
+
+RETURN: Column names for table psc.

--- a/docs/scripts_md/PSCOB.md
+++ b/docs/scripts_md/PSCOB.md
@@ -5,7 +5,10 @@ NeuroDB::objectBroker::PSCOB -- An object broker for records stored in table `ps
 # SYNOPSIS
 
     use NeuroDB::Database;
+    use NeuroDB::DatabaseException;
     use NeuroDB::objectBroker::PSCOB;
+    use NeuroDB::objectBroker::ObjectBrokerException;
+    
     use TryCatch;
 
     my $db = NeuroDB::Database->new(
@@ -36,7 +39,20 @@ NeuroDB::objectBroker::PSCOB -- An object broker for records stored in table `ps
     my $pscRef;
     try {
         $pscRef = $pscOB->get(
-            { Alias => 'DCC' }
+            { MRI_alias => 'my_alias' }
+        );
+        foreach (@$pscRef) {
+            printf "ID for PSC named $_->{'Name'} is $_->{'ID'}\n";
+        }
+
+        # Fetch the PSC with a NULL Alias
+        $pscRef = $pscOB->get(
+            { Alias => undef }
+        );
+        
+        # Fetch all PSCs except the DCC
+        $pscRef = $pscOB->get(
+            { Name => { NOT => 'Data Coordinating Center' } }
         );
     } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
         die sprintf(
@@ -49,19 +65,10 @@ NeuroDB::objectBroker::PSCOB -- An object broker for records stored in table `ps
 
 This class provides a set of methods to fetch records from the `psc`
 table. If an operation cannot be executed successfully, a `NeuroDB::objectBroker::ObjectBrokerException`
-will be thrown. See the documentation for `GetRole` and `InsertRole` for information on how to perform
-basic `INSERT`/`SELECT` operations using this object broker.
+will be thrown. See the documentation for `GetRole` for information on how to perform
+basic `SELECT` operations using this object broker.
 
 ## Methods
-
-### new(db => $db) >> (constructor inherited from `ObjectBroker`)
-
-Create a new instance of this class. The only parameter to provide is the
-`Database` object used to access the database.
-
-INPUT: the database object used to query the `psc` table.
-
-RETURN: new instance of this class.
 
 ### getTableName()
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -197,6 +197,7 @@ INPUTS:
   - $studyDate   : study date
   - $dbhr        : database handle reference
   - $objective   : the objective of the study
+  - $db          : database object
 
 RETURNS: the session ID of the visit
 
@@ -995,7 +996,7 @@ sub mapDicomParameters {
 }
 =pod
 
-=head3 findScannerID($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $register_new)
+=head3 findScannerID($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $register_new, $db)
 
 Finds the scanner ID for the scanner as defined by C<$manufacturer>, C<$model>,
 C<$serialNumber>, C<$softwareVersion>, using the database attached to the DBI
@@ -1039,7 +1040,7 @@ sub findScannerID {
 
 =pod
 
-=head3 registerScanner($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr)
+=head3 registerScanner($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $db)
 
 Registers the scanner as defined by C<$manufacturer>, C<$model>,
 C<$serialNumber>, C<$softwareVersion>, into the database attached to the DBI
@@ -1052,7 +1053,7 @@ INPUTS:
   - $softwareVersion: scanner's software version
   - $centerID       : scanner's center ID
   - $dbhr           : database handle reference
-  - $db             : database obnject
+  - $db             : database object
 
 RETURNS: (int) scanner ID
 
@@ -1112,7 +1113,7 @@ sub createNewCandID {
 
 =pod
 
-=head3 getPSC($patientName, $dbhr)
+=head3 getPSC($patientName, $dbhr, $db)
 
 Looks for the site alias using the C<session> table C<CenterID> as 
 a first resource, for the cases where it is created using the front-end,
@@ -1122,6 +1123,7 @@ or C<patient_id>) is provided, and return the C<MRI_alias> and C<CenterID>.
 INPUTS:
   - $patientName: patient name
   - $dbhr       : database handle reference
+  - $db         : database object
 
 RETURNS: a two element array:
   - first is the MRI alias of the PSC or "UNKN"
@@ -1134,6 +1136,7 @@ sub getPSC {
 
     my $subjectIDsref = Settings::getSubjectIDs(
                             $patientName,
+                            null,
                             null,
                             $dbhr,
                             $db

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1134,7 +1134,7 @@ sub getPSC {
     my $subjectIDsref = Settings::getSubjectIDs(
                             $patientName,
                             null,
-                            null,
+                            $dbhr,
                             $db
                         );
     my $PSCID = $subjectIDsref->{'PSCID'};

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -383,7 +383,8 @@ sub determineSubjectID {
                             $tarchiveInfo->{'PatientName'},
                             $tarchiveInfo->{'PatientID'},
                             $scannerID,
-                            $this->{dbhr}
+                            $this->{dbhr},
+                            $this->{'db'}
                         );
     if ($to_log) {
         my $message = "\n==> Data found for candidate   : ".
@@ -477,7 +478,8 @@ sub determinePSC {
     my ($center_name, $centerID) =
     NeuroDB::MRI::getPSC(
         $tarchiveInfo->{$lookupCenterNameUsing},
-        $this->{dbhr}
+        $this->{dbhr},
+        $this->{'db'}
     );
     if ($to_log) {
         if (!$center_name) {
@@ -538,7 +540,8 @@ sub determineScannerID {
             $tarchiveInfo->{'ScannerSoftwareVersion'},
             $centerID,
             $this->{dbhr},
-            $NewScanner 
+            $NewScanner,
+            $this->{'db'}
         );
     if ($scannerID == 0) {
         if ($to_log) {
@@ -1581,7 +1584,8 @@ sub setMRISession {
             $subjectIDsref, 
             $tarchiveInfo->{'DateAcquired'}, 
             $this->{dbhr}, 
-            $subjectIDsref->{'subprojectID'}
+            $subjectIDsref->{'subprojectID'},
+            $this->{'db'}
         );
     $message = "\nSessionID: $sessionID\n";    
     $this->{LOG}->print($message);

--- a/uploadNeuroDB/NeuroDB/objectBroker/GetRole.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/GetRole.pm
@@ -13,9 +13,9 @@ NeuroDB::objectBroker::GetRole -- A role for basic SELECT operations on the data
 This class provides methods used to accomplish basic C<SELECT> operations on the database.
 It allows the retrieval of records using a simple C<WHERE> clause of the form 
 C<WHERE constraint_1 AND constraint_2 AND ... AND constraint_n>.
-Subparts of the where clause can only be ANDed (OR is not supported). Each subpart of the 
-C<WHERE> clause specifies that a field must be either equal to a given value, not equal to a 
-given value, NULL or NOT NULL. 
+Subparts of the C<WHERE> clause can only be combined with C<AND> (C<OR> is not supported). 
+Each subpart of the C<WHERE> clause specifies that a field must be either equal to a given 
+value, not equal to a given value, NULL or NOT NULL. 
 
 Classes using this role must implement methods C<getColumnNames()>, C<getTableName()> and C<db()>.
 
@@ -59,6 +59,7 @@ RETURNS:
      If the method is called with C<$isCount> set to true, then it will return
      a reference to an array containing a single hash reference, its unique key being 
      C<'COUNT(*)'> with the associated value set to the selected count.
+     
 =cut
 
 my $getRef = sub {
@@ -84,8 +85,12 @@ my $getRef = sub {
             # Update @where and @vals with the current constraint in %$columnValuesRef
             my $val = $columnValuesRef->{$k};
             my $valType = ref($val);
-            if($valType eq '')        { $self->addWhereEquals(  $columnValuesRef, $k, \@where, \@vals); }
-		    elsif($valType eq 'HASH') { $self->addWhereFunction($columnValuesRef, $k, \@where, \@vals); }
+            if ($valType eq '') { 
+				$self->addWhereEquals(  $columnValuesRef, $k, \@where, \@vals); 
+		    }
+		    elsif ($valType eq 'HASH') { 
+				$self->addWhereFunction($columnValuesRef, $k, \@where, \@vals); 
+		    }
 			else {
                 NeuroDB::objectBroker::ObjectBrokerException->throw(
                     errorMessage => sprintf(
@@ -130,11 +135,11 @@ INPUTS:
    - Reference on the hash of all field constraints.
    - Name of the field for which a string representation is sought.
    - Reference on the array of all constraints (in string form).
-   - Reference on the array of values each field in $columnValuesRef must be
+   - Reference on the array of values each field in C<$columnValuesRef> must be
      equal or not equal to.
       
 RETURNS: 
-   - Nothing (adds an element to @$whereRef).
+   - Nothing (adds an element to C<@$whereRef>).
 
 =cut
 
@@ -154,18 +159,18 @@ sub addWhereEquals {
 =head3 addWhereFunction($columnValuesRef, $k, $whereRef, $valsRef)
 
 Gets the string representation of a constraint that uses an SQL function or operator.
-Currently, only the operator C<NOT> (i.e. field NOT equal to a given value or NOT NULL) is 
+Currently, only the operator C<NOT> (i.e. field C<NOT> equal to a given value or C<NOT NULL>) is 
 supported.
 
 INPUTS:
    - Reference on the hash of all field constraints
    - Name of the field for which a string representation is sought.
    - Reference on the array of all constraints (in string form)
-   - Reference on the array of values each field in $columnValuesRef must be
+   - Reference on the array of values each field in C<$columnValuesRef> must be
      equal or not equal to.
       
 RETURNS: 
-   - Nothing. Updates arrays @$whereRef (and @$valsRef if necessary).
+   - Nothing. Updates arrays C<@$whereRef> (and C<@$valsRef> if necessary).
 
 =cut
 
@@ -207,11 +212,11 @@ INPUTS:
    - Reference on the hash of all field constraints
    - Name of the field for which a string representation is sought.
    - Reference on the array of all constraints (in string form)
-   - Reference on the array of values each field in $columnValuesRef must be
+   - Reference on the array of values each field in C<$columnValuesRef> must be
      equal or not equal to.
       
 RETURNS: 
-   - Nothing. Updates arrays @$whereRef (and @$valsRef if necessary).
+   - Nothing. Updates arrays C<@$whereRef> (and C<@$valsRef> if necessary).
 
 =cut
 sub addWhereNotEquals {

--- a/uploadNeuroDB/NeuroDB/objectBroker/GetRole.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/GetRole.pm
@@ -1,0 +1,297 @@
+package NeuroDB::objectBroker::GetRole;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::objectBroker::GetRole -- A role for basic SELECT operations on the database
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+This class provides methods used to accomplish basic C<SELECT> operations on the database.
+It allows the retrieval of records using a simple C<WHERE> clause of the form 
+C<WHERE constraint_1 AND constraint_2 AND ... AND constraint_n>.
+Subparts of the where clause can only be ANDed (OR is not supported). Each subpart of the 
+C<WHERE> clause specifies that a field must be either equal to a given value, not equal to a 
+given value, NULL or NOT NULL. 
+
+Classes using this role must implement methods C<getColumnNames()>, C<getTableName()> and C<db()>.
+
+=head2 Methods
+
+=cut
+
+use Moose::Role;
+
+requires 'getColumnNames';
+requires 'getTableName';
+requires 'db';
+
+use NeuroDB::objectBroker::ObjectBrokerException;
+
+use TryCatch;
+
+=pod
+
+=head3 get($isCount, $columnValuesRef)
+
+Fetches the records in the table whose name is returned by method C<getTableName()> that satisfy
+specific constraints. 
+
+Note that this method is private.
+
+INPUTS:
+   - boolean indicating if only a count of the records found is needed
+     or the full record properties.
+   - reference to a hash array that contains the column values that the records
+     should have in order to be part of the result set (key: column name, value: column
+     value).
+      
+RETURNS: 
+   - a reference to an array of hash references. Every hash contains the values
+     for a given row returned by the method call: the key/value pairs contain
+     the name of a column (see C<@MRI_SCAN_TYPE_FIELDS>) and the value it 
+     holds, respectively. As an example, suppose array C<$r> contains the result of a
+     given call to this function. One would fetch the C<Scan_type> of the 2nd record 
+     returned using C<< $r->[1]->{'Scan_type'} >>.
+     If the method is called with C<$isCount> set to true, then it will return
+     a reference to an array containing a single hash reference, its unique key being 
+     C<'COUNT(*)'> with the associated value set to the selected count.
+=cut
+
+my $getRef = sub {
+	my($self, $isCount, $columnValuesRef) = @_;
+
+    my @where;
+    my @vals;
+    
+    if (%$columnValuesRef) {
+        foreach my $k (keys %$columnValuesRef) {
+			# Field must be in array of known column names. Throw an exception
+			# otherwise
+            if(!grep($k eq $_, $self->getColumnNames())) {
+                NeuroDB::objectBroker::ObjectBrokerException->throw(
+                    errorMessage => sprintf(
+                        "Get records from table %s failed: unknown field %s",
+                        $self->getTableName(),
+                        $k
+                    )
+                );
+            }
+            
+            # Update @where and @vals with the current constraint in %$columnValuesRef
+            my $val = $columnValuesRef->{$k};
+            my $valType = ref($val);
+            if($valType eq '')        { $self->addWhereEquals(  $columnValuesRef, $k, \@where, \@vals); }
+		    elsif($valType eq 'HASH') { $self->addWhereFunction($columnValuesRef, $k, \@where, \@vals); }
+			else {
+                NeuroDB::objectBroker::ObjectBrokerException->throw(
+                    errorMessage => sprintf(
+                        "Unsupported value type for get call on table %s: %s",
+                        $self->getTableName(),
+                        $valType
+                    )
+                );
+	        }
+        }
+	}
+
+    my $select = $isCount ? 'COUNT(*)' : join(',', $self->getColumnNames());
+
+    # Get the query in string form
+    my $query = sprintf("SELECT %s FROM %s", $select, $self->getTableName());
+    $query .= sprintf(' WHERE %s', join(' AND ', @where)) if @where;
+
+    # Run the query and return the result
+    try {
+        return $self->db->pselect($query, @vals);
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to get records from table %s. Reason:\n%s",
+                $self->getTableName(),
+                $e
+            )
+        );
+    }
+};
+
+=pod
+
+=head3 addWhereEquals($columnValuesRef, $k, $whereRef, $valsRef)
+
+Gets the string representation of a constraint of the form C<field=value> and adds it
+to the current set of C<WHERE> clauses. Note that constraints specifying that a field 
+must be NULL will be properly translated to C<field IS NULL> (not C<field=NULL>).
+
+INPUTS:
+   - Reference on the hash of all field constraints.
+   - Name of the field for which a string representation is sought.
+   - Reference on the array of all constraints (in string form).
+   - Reference on the array of values each field in $columnValuesRef must be
+     equal or not equal to.
+      
+RETURNS: 
+   - Nothing (adds an element to @$whereRef).
+
+=cut
+
+sub addWhereEquals {
+	my($self, $columnValuesRef, $k, $whereRef, $valsRef) = @_;
+	
+	if(defined $columnValuesRef->{$k}) {
+        push(@$whereRef, "$k=?");
+	    push(@$valsRef, $columnValuesRef->{$k});
+	} else {
+        push(@$whereRef, "$k IS NULL");
+    }
+}
+
+=pod
+
+=head3 addWhereFunction($columnValuesRef, $k, $whereRef, $valsRef)
+
+Gets the string representation of a constraint that uses an SQL function or operator.
+Currently, only the operator C<NOT> (i.e. field NOT equal to a given value or NOT NULL) is 
+supported.
+
+INPUTS:
+   - Reference on the hash of all field constraints
+   - Name of the field for which a string representation is sought.
+   - Reference on the array of all constraints (in string form)
+   - Reference on the array of values each field in $columnValuesRef must be
+     equal or not equal to.
+      
+RETURNS: 
+   - Nothing. Updates arrays @$whereRef (and @$valsRef if necessary).
+
+=cut
+
+sub addWhereFunction {
+	my($self, $columnValuesRef, $k, $whereRef, $valsRef) = @_;
+
+    # Make sure hash array %{ $columnValueRef->{$k} } has exactly one key/value pair
+    if(keys %{ $columnValuesRef->{$k} } != 1) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to get records from table %s. Hash array for constraint "
+                    . "on column %s should contain exacly one key/value pair.",
+                $self->getTableName(),
+                $k
+            )
+        );
+	}
+	
+	# Make sure key of %{ $columnValuesRef->{$k} } is 'NOT'
+	my($fname, $args) = each %{ $columnValuesRef->{$k} };
+	if($fname eq'NOT') { $self->addWhereNotEquals($columnValuesRef, $k, $whereRef, $valsRef); }
+    else {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => "Failed to get records from table %s. Unsupported "
+                . "function $fname for constraint on column $k"
+        );
+    }	
+}
+
+=pod
+
+=head3 addWhereNotEquals($columnValuesRef, $k, $whereRef, $valsRef)
+
+Gets the string representation of a constraint of the form C<field != value> and adds it to
+the current set of C<WHERE> clauses. Note that constraints specifying that a field must not be NULL 
+will be properly translated to C<field IS NOT NULL> (not C<field!=NULL>).
+
+INPUTS:
+   - Reference on the hash of all field constraints
+   - Name of the field for which a string representation is sought.
+   - Reference on the array of all constraints (in string form)
+   - Reference on the array of values each field in $columnValuesRef must be
+     equal or not equal to.
+      
+RETURNS: 
+   - Nothing. Updates arrays @$whereRef (and @$valsRef if necessary).
+
+=cut
+sub addWhereNotEquals {
+	my($self, $columnValuesRef, $k, $whereRef, $valsRef) = @_;
+	
+	if(defined $columnValuesRef->{$k}->{'NOT'}) {
+        push(@$whereRef, "$k!=?");
+	    push(@$valsRef, $columnValuesRef->{$k}->{'NOT'});
+	} else {
+        push(@$whereRef, "$k IS NOT NULL");
+    }	
+}
+
+=pod
+
+=head3 get($columnValuesRef)
+
+Fetches the records in the table whose name is returned by method C<getTableName()> that satisfy
+specific constraints. 
+
+INPUTS:
+   - reference to a hash array that contains the constraints on the column values that the records
+     should have in order to be part of the result set. The keys are column names and
+     the values are the constraints on each column. Each constraint can be expressed as
+     a single value or a reference to a hash (this hash describes a constraint involving an
+     SQL function or operator other than '='). Examples of a valid set of constraints:
+      
+     {  
+       Field1 => 'Value1',
+       Field2 => { NOT => 3 },
+       Field3 => undef
+     }
+      
+RETURNS: 
+   - a reference to an array of hash references. Every hash contains the values
+     for a given row returned by the method call: the key/value pairs contain
+     the name of a column (as listed by C<getColumnNames()>) and the value it 
+     holds, respectively. As an example, suppose array C<$r> contains the result of a
+     given call to this function. One would fetch the C<Scan_type> of the 2nd record 
+     returned using C<< $r->[1]->{'Scan_type'} >>.
+=cut
+
+sub get {
+	my($self, $columnValuesRef) = @_;
+	
+	return $getRef->($self, 0, $columnValuesRef);
+}
+
+=pod
+
+=head3 getCount($columnValuesRef)
+
+Fetches the number of records in the table whose name is returned by method C<getTableName()> 
+that satisfy specific constraints. 
+
+INPUTS:
+   - reference to a hash array that contains the constraints on the column values that the records
+     should have in order to be part of the result set. The keys are column names and
+     the values are the constraints on each column. Each constraint can be expressed as
+     a single value or a reference to a hash (this hash describes a constraint involving an
+     SQL function or operator other than '='). Examples of a valid set of constraints:
+     
+     {  
+       Field1 => 'Value1',
+       Field2 => { NOT => 3 },
+       Field3 => undef
+     }
+      
+RETURNS: 
+   - the number of records found.
+
+=cut
+
+sub getCount {
+	my($self, $columnValuesRef) = @_;
+	
+	my $results = $getRef->($self, 1, $columnValuesRef);
+	return $results->[0]->{'COUNT(*)'};
+}
+
+
+
+1;

--- a/uploadNeuroDB/NeuroDB/objectBroker/InsertRole.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/InsertRole.pm
@@ -36,7 +36,7 @@ by C<getTableName()>.
 
 INPUTS:
    - reference to a hash array that contains the column values for the record to insert.
-     Each key must be a valid field (i.e that exsists in the array returned by C<getColumnNames()>
+     Each key must be a valid field (i.e that exists in the array returned by C<getColumnNames()>
      and each value is the value for the given field. Use C<undef> to set a field to C<NULL>.
       
 RETURNS: 

--- a/uploadNeuroDB/NeuroDB/objectBroker/InsertRole.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/InsertRole.pm
@@ -1,0 +1,90 @@
+package NeuroDB::objectBroker::InsertRole;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::objectBroker::InsertRole -- A role for basic C<INSERT> operations on the database.
+
+=head1 DESCRIPTION
+
+This class provides a generic method to insert a given record in the database.
+If an operation cannot be executed successfully, a C<NeuroDB::objectBroker::ObjectBrokerException>
+will be thrown. All classes that use this role must implement methods C<getTableName()>, C<getColumnNames()> and C<db()>.
+
+=head2 Methods
+
+=cut
+
+use Moose::Role;
+
+requires 'getColumnNames';
+requires 'getTableName';
+requires 'db';
+
+use NeuroDB::DatabaseException;
+use NeuroDB::objectBroker::ObjectBrokerException;
+
+use TryCatch;
+
+=pod
+
+=head3 insertOne($valuesRef)
+
+Inserts the record with the properties passed as argument in the table whose name is returned
+by C<getTableName()>.
+
+INPUTS:
+   - reference to a hash array that contains the column values for the record to insert.
+     Each key must be a valid field (i.e that exsists in the array returned by C<getColumnNames()>
+     and each value is the value for the given field. Use C<undef> to set a field to C<NULL>.
+      
+RETURNS: 
+   - the ID of the inserted record if the operation succeeded. A <NeuroDB::objectBroker::ObjectBrokerException>
+     will be thrown otherwise.
+
+=cut
+
+sub insertOne {
+    my($self, $valuesRef) = @_;
+
+    # Make sure %$valuesRef is not empty
+    if(!keys %$valuesRef) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Insertion of record in table %s failed: no values specified",
+                $self->getTableName()
+            )
+        );
+    }
+
+    # Make sure all keys of %$valuesRef exist in the array returned by
+    # getColumnNames()
+    foreach my $v (keys %$valuesRef) {
+        if(!grep($v eq $_, $self->getColumnNames())) {
+            NeuroDB::objectBroker::ObjectBrokerException->throw(
+                errorMessage => sprintf(
+                    "Insertion of record in table %s failed: invalid field %s",
+                    $self->getTableName(),
+                    $v
+               )
+            );
+        }
+    }
+
+    # Insert the record and return its ID
+    try {
+        my @results = $self->db->insertOne($self->getTableName(), $valuesRef);
+        return $results[0];
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to insert record in table %s:\n%s",
+                $self->getTableName(),
+                $e
+            )
+        );
+    }
+}
+
+1;

--- a/uploadNeuroDB/NeuroDB/objectBroker/MriScannerOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriScannerOB.pm
@@ -10,6 +10,9 @@ NeuroDB::objectBroker::MriScannerOB -- An object broker for mri_scanner records
 
   use NeuroDB::Database;
   use NeuroDB::objectBroker::MriScannerOB;
+  use NeuroDB::DatabaseException;
+  use NeuroDB::objectBroker::ObjectBrokerException;
+  
   use TryCatch;
 
   my $db = NeuroDB::Database->new(
@@ -40,8 +43,31 @@ NeuroDB::objectBroker::MriScannerOB -- An object broker for mri_scanner records
   my $mriScannerRef;
   try {
       $mriScannerRef = $mriScannerOB->get(
-          { CandID => 655660 }
+          { Software => 'my_software' }
       );
+      foreach(@$mriScannerRef) {
+          print "ID for scanner model $_->{'Model'} is $_->{'ID'}\n";
+      }
+      
+      # Fetch the scanner with a NULL manufacturer
+      $mriScannerRef = $mriScannerOB->get(
+          { Manufacturer => undef }
+      );
+      
+      # Fetch the scanners with a CandID != 999999
+      $mriScannerRef = $mriScannerOB->get(
+          { CandID => { NOT => 999999 } }
+      );
+      
+      # Create a new scanner with the given properties
+      mriScannerOB->insertOne({
+          ID            => 7,
+          Manufacturer  => 'SIEMENS',
+          Model         => 'Prisma_fit',
+          Serial_number => 67094,
+          Software      => 'syngo MR E11',
+          CandID        => 151581
+      });
   } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
       die sprintf(
           "Failed to retrieve mri_scanner records: %s",
@@ -70,20 +96,6 @@ use TryCatch;
 my $TABLE_NAME = "mri_scanner";
 
 my @COLUMN_NAMES = qw(ID Manufacturer Model Serial_number Software CandID);
-
-=pod
-
-=head3 new(db => $db) >> (constructor inherited from C<ObjectBroker>)
-
-Creates a new instance of this class. The only parameter to provide is the
-C<Database> object used to access the database.
-
-INPUT: the database object used to query the C<mri_scanner> table.
-
-RETURN: new instance of this class.
-
-=cut
-
 
 =pod
 

--- a/uploadNeuroDB/NeuroDB/objectBroker/MriScannerOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriScannerOB.pm
@@ -1,0 +1,120 @@
+package NeuroDB::objectBroker::MriScannerOB;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::objectBroker::MriScannerOB -- An object broker for mri_scanner records
+
+=head1 SYNOPSIS
+
+  use NeuroDB::Database;
+  use NeuroDB::objectBroker::MriScannerOB;
+  use TryCatch;
+
+  my $db = NeuroDB::Database->new(
+      userName     => 'user',
+      databaseName => 'my_db',
+      hostName     => 'my_hostname',
+      password     => 'pwd'
+  );
+
+  try {
+      $db->connect();
+  } catch(NeuroDB::DatabaseException $e) {
+      die sprintf(
+          "User %s failed to connect to %s on %s: %s (error code %d)\n",
+          'user',
+          'my_db',
+          'my_hostname',
+          $e->errorMessage,
+          $e->errorCode
+      );
+  }
+
+  .
+  .
+  .
+
+  my $mriScannerOB = NeuroDB::objectBroker::MriScannerOB->new(db => $db);
+  my $mriScannerRef;
+  try {
+      $mriScannerRef = $mriScannerOB->get(
+          { CandID => 655660 }
+      );
+  } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+      die sprintf(
+          "Failed to retrieve mri_scanner records: %s",
+          $e->errorMessage
+      );
+  }
+
+=head1 DESCRIPTION
+
+This class provides a set of methods to fetch records from the C<mri_scanner>
+table. If an operation cannot be executed successfully, a C<NeuroDB::objectBroker::ObjectBrokerException>
+will be thrown. See the documentation for C<GetRole> and C<InsertRole> for information on how to perform
+basic C<INSERT>/C<SELECT> operations using this object broker.
+
+=cut
+
+use Moose;
+
+extends 'NeuroDB::objectBroker::ObjectBroker';
+
+with 'NeuroDB::objectBroker::GetRole';
+with 'NeuroDB::objectBroker::InsertRole';
+
+use TryCatch;
+
+my $TABLE_NAME = "mri_scanner";
+
+my @COLUMN_NAMES = qw(ID Manufacturer Model Serial_number Software CandID);
+
+=pod
+
+=head3 new(db => $db) >> (constructor inherited from C<ObjectBroker>)
+
+Creates a new instance of this class. The only parameter to provide is the
+C<Database> object used to access the database.
+
+INPUT: the database object used to query the C<mri_scanner> table.
+
+RETURN: new instance of this class.
+
+=cut
+
+
+=pod
+
+=head3 getTableName()
+
+Gets the name of the database table with which this object broker interacts.
+
+INPUT: None
+
+RETURN: name of the database table with which this object broker interacts.
+
+=cut
+
+sub getTableName {
+	return $TABLE_NAME;
+}
+
+=pod 
+
+=head3 getColumnNames()
+
+Gets the column names for table mri_scanner.
+
+INPUT: None
+
+RETURN: Column names for table mri_scanner.
+
+=cut
+
+sub getColumnNames {
+	return @COLUMN_NAMES;
+}
+
+1;

--- a/uploadNeuroDB/NeuroDB/objectBroker/ObjectBroker.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/ObjectBroker.pm
@@ -1,0 +1,37 @@
+package NeuroDB::objectBroker::ObjectBroker;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::objectBroker::ObjectBroker -- Superclass for all object brokers.
+
+=head1 DESCRIPTION
+
+This class provides the set of methods common to all object brokers. Any object broker used 
+by the MRI pipeline or associated scripts should extend this class.
+
+=head2 Methods
+
+=cut
+
+use Moose;
+
+use NeuroDB::Database;
+
+=pod
+
+=head3 new(db => $db) >> (constructor)
+
+Create a new instance of this class. The only parameter to provide is the
+C<Database> object used to access the database.
+
+INPUT: the database object used to perform queries on the database tables.
+
+RETURN: new instance of this class.
+
+=cut
+
+has 'db' => (is  => 'rw', isa => 'NeuroDB::Database', required => 1);
+
+1;

--- a/uploadNeuroDB/NeuroDB/objectBroker/PSCOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/PSCOB.pm
@@ -9,7 +9,10 @@ NeuroDB::objectBroker::PSCOB -- An object broker for records stored in table C<p
 =head1 SYNOPSIS
 
   use NeuroDB::Database;
+  use NeuroDB::DatabaseException;
   use NeuroDB::objectBroker::PSCOB;
+  use NeuroDB::objectBroker::ObjectBrokerException;
+  
   use TryCatch;
 
   my $db = NeuroDB::Database->new(
@@ -40,7 +43,20 @@ NeuroDB::objectBroker::PSCOB -- An object broker for records stored in table C<p
   my $pscRef;
   try {
       $pscRef = $pscOB->get(
-          { Alias => 'DCC' }
+          { MRI_alias => 'my_alias' }
+      );
+      foreach (@$pscRef) {
+          printf "ID for PSC named $_->{'Name'} is $_->{'ID'}\n";
+      }
+
+      # Fetch the PSC with a NULL Alias
+      $pscRef = $pscOB->get(
+          { Alias => undef }
+      );
+      
+      # Fetch all PSCs except the DCC
+      $pscRef = $pscOB->get(
+          { Name => { NOT => 'Data Coordinating Center' } }
       );
   } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
       die sprintf(
@@ -53,8 +69,8 @@ NeuroDB::objectBroker::PSCOB -- An object broker for records stored in table C<p
 
 This class provides a set of methods to fetch records from the C<psc>
 table. If an operation cannot be executed successfully, a C<NeuroDB::objectBroker::ObjectBrokerException>
-will be thrown. See the documentation for C<GetRole> and C<InsertRole> for information on how to perform
-basic C<INSERT>/C<SELECT> operations using this object broker.
+will be thrown. See the documentation for C<GetRole> for information on how to perform
+basic C<SELECT> operations using this object broker.
 
 =head2 Methods
 
@@ -71,20 +87,6 @@ use TryCatch;
 my $TABLE_NAME = "psc";
 
 my @COLUMN_NAMES = qw(CenterID Name Alias MRI_alias);
-
-=pod
-
-=head3 new(db => $db) >> (constructor inherited from C<ObjectBroker>)
-
-Create a new instance of this class. The only parameter to provide is the
-C<Database> object used to access the database.
-
-INPUT: the database object used to query the C<psc> table.
-
-RETURN: new instance of this class.
-
-=cut
-
 
 =pod
 

--- a/uploadNeuroDB/NeuroDB/objectBroker/PSCOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/PSCOB.pm
@@ -1,0 +1,121 @@
+package NeuroDB::objectBroker::PSCOB;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::objectBroker::PSCOB -- An object broker for records stored in table C<psc>.
+
+=head1 SYNOPSIS
+
+  use NeuroDB::Database;
+  use NeuroDB::objectBroker::PSCOB;
+  use TryCatch;
+
+  my $db = NeuroDB::Database->new(
+      userName     => 'user',
+      databaseName => 'my_db',
+      hostName     => 'my_hostname',
+      password     => 'pwd'
+  );
+
+  try {
+      $db->connect();
+  } catch(NeuroDB::DatabaseException $e) {
+      die sprintf(
+          "User %s failed to connect to %s on %s: %s (error code %d)\n",
+          'user',
+          'my_db',
+          'my_hostname',
+          $e->errorMessage,
+          $e->errorCode
+      );
+  }
+
+  .
+  .
+  .
+
+  my $pscOB = NeuroDB::objectBroker::PSCOB->new(db => $db);
+  my $pscRef;
+  try {
+      $pscRef = $pscOB->get(
+          { Alias => 'DCC' }
+      );
+  } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+      die sprintf(
+          "Failed to retrieve psc records: %s",
+          $e->errorMessage
+      );
+  }
+
+=head1 DESCRIPTION
+
+This class provides a set of methods to fetch records from the C<psc>
+table. If an operation cannot be executed successfully, a C<NeuroDB::objectBroker::ObjectBrokerException>
+will be thrown. See the documentation for C<GetRole> and C<InsertRole> for information on how to perform
+basic C<INSERT>/C<SELECT> operations using this object broker.
+
+=head2 Methods
+
+=cut
+
+use Moose;
+
+extends 'NeuroDB::objectBroker::ObjectBroker';
+
+with 'NeuroDB::objectBroker::GetRole';
+
+use TryCatch;
+
+my $TABLE_NAME = "psc";
+
+my @COLUMN_NAMES = qw(CenterID Name Alias MRI_alias);
+
+=pod
+
+=head3 new(db => $db) >> (constructor inherited from C<ObjectBroker>)
+
+Create a new instance of this class. The only parameter to provide is the
+C<Database> object used to access the database.
+
+INPUT: the database object used to query the C<psc> table.
+
+RETURN: new instance of this class.
+
+=cut
+
+
+=pod
+
+=head3 getTableName()
+
+Gets the name of the database table with which this object broker interacts.
+
+INPUT: None
+
+RETURN: name of the database table with which this object broker interacts.
+
+=cut
+
+
+sub getTableName {
+	return $TABLE_NAME;
+}
+
+=pod 
+
+=head3 getColumnNames()
+
+Gets the column names for table psc.
+
+INPUT: None
+
+RETURN: Column names for table psc.
+
+=cut
+sub getColumnNames {
+	return @COLUMN_NAMES;
+}
+
+1;

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -501,7 +501,8 @@ if (defined($CandMismatchError)) {
 my ($sessionID) = NeuroDB::MRI::getSessionID(
         $subjectIDsref, 
         $tarchiveInfo{'DateAcquired'},
-        \$dbh, $subjectIDsref->{'subprojectID'}
+        \$dbh, $subjectIDsref->{'subprojectID'},
+        $db
    );
 
 ################################################################

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -212,7 +212,7 @@ if  ($file->getFileDatum('FileType') eq 'mnc')  {
     }elsif  ($lookupCenterName eq 'PatientID')      {
         $patientInfo    =   fetchMincHeader($filename,'patient:identification');
     }
-    ($center_name, $centerID)   =   NeuroDB::MRI::getPSC($patientInfo, \$dbh);
+    ($center_name, $centerID)   =   NeuroDB::MRI::getPSC($patientInfo, \$dbh, $db);
     my  $psc    =   $center_name;
     if  (!$psc)     { 
         print LOG "\nERROR: No center found for this candidate \n\n"; 

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -439,7 +439,7 @@ if (!defined($subjectIDsref->{'visitLabel'})) {
 my ($sessionID) =
     NeuroDB::MRI::getSessionID(
          $subjectIDsref, $tarchiveInfo{'DateAcquired'},
-         \$dbh, $subjectIDsref->{'subprojectID'}
+         \$dbh, $subjectIDsref->{'subprojectID'}, $db
     );
 
 ################################################################


### PR DESCRIPTION
This adds object brokers for tables `mri_scanner` and `psc`. In doing so, it uses two new Moose features: inheritance and roles. This allows simplification of the object broker classes. The existing object broker classes will eventually be converted using this new model in a future PR. 

How/what to test:
   - Thorough testing of the `minc_insertion.pl` , `tarchiveLoader` and `register_processed_data.pl` scripts. Try to build test cases that specifically validate the modified code.
   - Build a test script that creates one or both of the object brokers, perform various select/insert operations and make sure that they work. The synopsis of both object brokers can be helpful for that task.