### PR TITLE
Removing creation of site incoming directory from the install scripts

### DIFF
--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -92,14 +92,9 @@ echo "Creating the data directories"
 echo
 
 #####################################################################################
-###############incoming directory using sites########################################
+###############incoming directory ###################################################
 #####################################################################################
 sudo -S su $USER -c "mkdir -m 2770 -p /data/incoming/"
-echo "Creating incoming director(y/ies)"
- for s in $site; do 
-  sudo -S su $USER -c "mkdir -m 770 -p /data/incoming/$s/incoming"
- done
-echo
 
 ###################################################################################
 #######set environment variables under .bashrc#####################################

--- a/imaging_install_MacOSX.sh
+++ b/imaging_install_MacOSX.sh
@@ -54,14 +54,9 @@ echo "Creating the data directories"
   sudo -S su $USER -c "mkdir -m 770 -p $mridir/dicom-archive/.loris_mri"
 echo
 #####################################################################################
-###############incoming directory using sites########################################
+###############incoming directory ###################################################
 #####################################################################################
 sudo -S su $USER -c "mkdir -m 2770 -p /data/incoming/";
-echo "Creating incoming director(y/ies)"
- for s in $site; do 
-  sudo -S su $USER -c "mkdir -m 770 -p /data/incoming/$s/incoming";
- done;
-echo
 
 ###################################################################################
 #######set environment variables under .bashrc#####################################


### PR DESCRIPTION
Removal of the creation of `sites` directory in the `incoming` folder since they are not used anymore by the pipeline.

See also: Redmine https://redmine.cbrain.mcgill.ca/issues/14967