### PR TITLE
Added creation of bvec and bval files when creating NIfTI files

### DIFF
--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -346,6 +346,46 @@ INPUTS:
   - $fileref : file hash ref
   - $data\_dir: data directory (e.g. `/data/$PROJECT/data`)
 
+### create\_dwi\_nifti\_bval\_file($file\_ref, $bval\_file)
+
+Creates the NIfTI `.bval` file required for DWI acquisitions based on the
+returned value of `acquisition:bvalues`.
+
+INPUTS:
+  - $file\_ref : file hash ref
+  - $bval\_file: path to the `.bval` file to write into
+
+RETURNS:
+  - undef if no `acquisition:bvalues` were found (skipping the creation
+    of the `.bval` file since there is nothing to write into)
+  - 1 after the `.bval` file was created
+
+### create\_dwi\_nifti\_bvec\_file($file\_ref, $bvec\_file)
+
+Creates the NIfTI `.bvec` file required for DWI acquisitions based on the
+returned value of `acquisition:direction_x`, `acquisition:direction_y` and
+`acquisition:direction_z`.
+
+INPUTS:
+  - $file\_ref : file hash ref
+  - $bvec\_file: path to the `.bvec` file to write into
+
+RETURNS:
+  - undef if no `acquisition:direction_x`, `acquisition:direction_y` and
+    `acquisition:direction_z` were found (skipping the creation
+    of the `.bvec` file since there is nothing to write into)
+  - 1 after the `.bvec` file was created
+
+### write\_to\_file($file, $value, $mode)
+
+This method writes into a file `$file` values stored in `$value`. The mode
+in which the file should be open with is specified in `$mode`.
+
+INPUTS:
+  - $file : output file to write into
+  - $value: value that needs to be written in the file
+  - $mode : mode with which the file should be open with (`'\`'> or `'\`\\>'>)
+
 ### make\_minc\_pics($dbhr, $TarchiveSource, $profile, $minFileID, $debug, $verbose)
 
 Creates pics associated with MINC files.

--- a/docs/scripts_md/create_nifti_bval_bvec.md
+++ b/docs/scripts_md/create_nifti_bval_bvec.md
@@ -1,0 +1,27 @@
+# NAME
+
+create\_nifti\_bval\_bvec.pl -- a script that creates the missing bval and bvec
+files for DWI NIfTI acquisitions.
+
+# SYNOPSIS
+
+perl tools/create\_nifti\_bval\_bvec.pl `[options]`
+
+Available options are:
+
+\-profile: name of the config file in `../dicom-archive/.loris_mri`
+\-verbose: be verbose
+
+# DESCRIPTION
+
+This script will create the missing NIfTI bval and bvec files for DWI
+acquisitions.
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience

--- a/tools/create_nifti_bval_bvec.pl
+++ b/tools/create_nifti_bval_bvec.pl
@@ -1,0 +1,201 @@
+#! /usr/bin/perl
+
+=pod
+
+=head1 NAME
+
+create_nifti_bval_bvec.pl -- a script that creates the missing bval and bvec
+files for DWI NIfTI acquisitions.
+
+
+=head1 SYNOPSIS
+
+perl tools/create_nifti_bval_bvec.pl C<[options]>
+
+Available options are:
+
+-profile: name of the config file in C<../dicom-archive/.loris_mri>
+-verbose: be verbose
+
+
+=head1 DESCRIPTION
+
+This script will create the missing NIfTI bval and bvec files for DWI
+acquisitions.
+
+
+=head1 LICENSING
+
+License: GPLv3
+
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience
+
+=cut
+
+
+
+use strict;
+use warnings;
+use Getopt::Tabular;
+
+use NeuroDB::File;
+use NeuroDB::MRI;
+use NeuroDB::DBI;
+use NeuroDB::ExitCodes;
+
+
+
+
+### Set up Getopt::Tabular
+
+my $profile;
+my $verbose      = 0;
+my $profile_desc = "Name of the config file in ../dicom-archive/.loris_mri";
+
+my @opt_table = (
+    [ "-profile", "string",  1, \$profile, $profile_desc ],
+    [ "-verbose", "boolean", 1, \$verbose, "Be verbose"  ]
+);
+
+my $Help = <<HELP;
+******************************************************************************
+CREATE NIFTI BVAL BVEC DWI FILES
+******************************************************************************
+
+This will check if the configuration flag for NIfTI files creation is set to
+'yes' and will create .bvec and .bval files for the DWI acquisitions that
+need to accompany the NIfTI DWI files (bug in mnc2nii that do not create
+those files so we create them ourselves based on values present in the MINC
+header for acquisition:bvalues, acquisition:direction_x,
+acquisition:direction_y and acquisition:direction_z.
+
+Documentation: perldoc create_nifti_bval_bvec.pl
+
+HELP
+
+my $Usage = <<USAGE;
+Usage: $0 [options]
+       $0 -help to list options
+USAGE
+
+&Getopt::Tabular::SetHelp($Help, $Usage);
+&Getopt::Tabular::GetOptions(\@opt_table, \@ARGV)
+    || exit $NeuroDB::ExitCodes::GETOPT_FAILURE;
+
+
+
+## input error checking
+
+if (!$ENV{LORIS_CONFIG}) {
+    print STDERR "\n\tERROR: Environment variable 'LORIS_CONFIG' not set\n\n";
+    exit $NeuroDB::ExitCodes::INVALID_ENVIRONMENT_VAR;
+}
+
+if (!defined $profile || !-e "$ENV{LORIS_CONFIG}/.loris_mri/$profile") {
+    print $Help;
+    print STDERR "$Usage\n\tERROR: You must specify a valid and existing profile.\n\n";
+    exit $NeuroDB::ExitCodes::PROFILE_FAILURE;
+}
+
+{ package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
+
+if ( !@Settings::db ) {
+    print STDERR "\n\tERROR: You don't have a \@db setting in the file "
+        . "$ENV{LORIS_CONFIG}/.loris_mri/$profile \n\n";
+    exit $NeuroDB::ExitCodes::DB_SETTINGS_FAILURE;
+}
+
+
+
+## establish database connection
+
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+print "\n==> Successfully connected to the database \n" if $verbose;
+
+
+
+## get config settings
+
+my $data_dir   = NeuroDB::DBI::getConfigSetting(\$dbh, 'dataDirBasepath');
+my $create_nii = NeuroDB::DBI::getConfigSetting(\$dbh, 'create_nii');
+
+
+
+## exit if create_nii is set to No
+
+unless ($create_nii) {
+    print "\nConfig option 'create_nii' set to no. bvec/bval files will not be "
+          . "created as NIfTI files are not created by the imaging pipeline\n\n";
+    exit $NeuroDB::ExitCodes::SUCCESS;
+}
+
+
+
+## grep all FileIDs for which acquisition:bvalues are set
+
+print "\n==> Fetching all FileIDs with acquisition:bvalues. \n" if $verbose;
+
+( my $query = <<QUERY ) =~ s/\n/ /g;
+  SELECT
+    FileID
+  FROM
+    parameter_file
+    JOIN parameter_type USING (ParameterTypeID)
+  WHERE
+    parameter_type.Name=?
+QUERY
+
+my $sth = $dbh->prepare($query);
+$sth->execute('acquisition:bvalues');
+
+my @file_ids;
+while( my $fileID = $sth->fetchrow_array) {
+    push @file_ids, $fileID;
+}
+
+unless (@file_ids) {
+    print "\n No files were found with header 'acquisition:bvalues' so no need "
+          . "to create bval/bvec files \n";
+    exit $NeuroDB::ExitCodes::SUCCESS;
+}
+
+
+
+## loop through all FileIDs and create bvec/bval files
+foreach my $file_id (@file_ids) {
+
+    # load the file based on the FileID
+    my $file = NeuroDB::File->new(\$dbh);
+    $file->loadFile($file_id);
+
+    # determine paths for bval/bvec files
+    my $minc = $file->getFileDatum('File');
+    my ($bval_file, $bvec_file) = map { $minc }(0 .. 1);
+    $bval_file =~ s/mnc$/bval/g;
+    $bvec_file =~ s/mnc$/bvec/g;
+
+    # create complementary nifti files for DWI acquisitions
+    my $bval_success = NeuroDB::MRI::create_dwi_nifti_bval_file(
+        \$file, $data_dir . '/' . $bval_file
+    );
+    my $bvec_success = NeuroDB::MRI::create_dwi_nifti_bvec_file(
+        \$file, $data_dir . '/' . $bvec_file
+    );
+    if ($bval_success && $bvec_success) {
+        print "\n==> Succesfully created bval/bvec files for $minc \n";
+    }
+
+    # update parameter_file table with bvec/bval paths
+    $file->setParameter('check_bval_filename', $bval_file) if $bval_success;
+    $file->setParameter('check_bvec_filename', $bvec_file) if $bvec_success;
+}
+
+
+
+## disconnect from the database and exit the script with SUCCESS exit code
+$dbh->disconnect();
+exit $NeuroDB::ExitCodes::SUCCESS;

--- a/tools/create_nifti_bval_bvec.pl
+++ b/tools/create_nifti_bval_bvec.pl
@@ -71,7 +71,7 @@ This will check if the configuration flag for NIfTI files creation is set to
 need to accompany the NIfTI DWI files (bug in mnc2nii that do not create
 those files so we create them ourselves based on values present in the MINC
 header for acquisition:bvalues, acquisition:direction_x,
-acquisition:direction_y and acquisition:direction_z.
+acquisition:direction_y and acquisition:direction_z).
 
 Documentation: perldoc create_nifti_bval_bvec.pl
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1446,7 +1446,7 @@ sub create_dwi_nifti_bval_file {
     $bvals =~ s/\.$//;   # remove the last trailing '.' from the string
 
     # print bvals into bval_file
-    open(FILE, '>', $bval_file) or die "Could not open file $bval_file $!";
+    open(FILE, '>', $bval_file) or die "Could not open file $bval_file: $!\n";
     print FILE $bvals;
     close FILE;
 


### PR DESCRIPTION
For DWI files, the binary `mnc2nii` is not creating the `.bvec` and `.bval` files necessary to obtain the direction informations. Added support in the imaging pipeline so that those files can be created automatically within the function `make_nii` of the `MRI.pm` file.

### Behaviour of the script: 
  - if there are values in the MINC header `acquisition:bvalues` then create the `.bval` file using these values
  - if there are values in the MINC headers `acquisition:direction_x`, `acquisition:direction_y` and `acquisition:direction_z` then create the `.bvec` file using these values 

### Notes for existing projects

A script has been created in the `tools` directory to create the missing bval/bvec files for projects that have the 'create_nii' configuration set to 'Yes'. This script is called `create_nifti_bval_bvec.pl`.
 
![screen shot 2018-08-15 at 10 08 55 am](https://user-images.githubusercontent.com/1402456/44152339-45caa6f0-a073-11e8-96a7-61872a09a42d.png)


### Notes for people that want to create those files from a different script

Simply run `mnc2nii`, then call the `MRI.pm` functions `create_dwi_nifti_bval_file` and `create_dwi_nifti_bvec_file` to create the `.bval` and `.bvec` files. Args to the function are:
  - file hash ref (after loading the file via the `File.pm` library
  - full path to the `.bval` or `.bvec` file