### PR TITLE
Replace the "Gender" field with "Sex" in the candidate and tarchive tables 

### DIFF
--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -174,7 +174,7 @@ QUERY
       tarchive SET  
         DicomArchiveID = ?,       PatientName = ?,
         PatientID = ?,            PatientDoB = ?,
-        PatientGender = ?,        DateAcquired = ?,
+        PatientSex = ?,           DateAcquired = ?,
         ScannerManufacturer = ?,  ScannerModel = ?,
         ScannerSerialNumber = ?,  ScannerSoftwareVersion = ?,
         CenterName = ?,           AcquisitionCount = ?,

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -339,13 +339,13 @@ INPUTS:
 
 RETURNS: the new DICOM archive location
 
-### CreateMRICandidates($subjectIDsref, $gender, $tarchiveInfo, $User, $centerID, $upload\_id)
+### CreateMRICandidates($subjectIDsref, $sex, $tarchiveInfo, $User, $centerID, $upload\_id)
 
 Registers a new candidate in the `candidate` table.
 
 INPUTS:
   - $subjectIDsref: subject's ID information hash ref
-  - $gender       : gender of the candidate
+  - $sex          : sex of the candidate
   - $tarchiveInfo : tarchive information hash ref
   - $User         : user that is running the pipeline
   - $centerID     : center ID

--- a/docs/scripts_md/tarchive_validation.md
+++ b/docs/scripts_md/tarchive_validation.md
@@ -35,7 +35,7 @@ string (typically, the patient name or patient ID)
 \- Verification of the `ScannerID` of the DICOM study archive (optionally
 creates a new scanner entry in the database if necessary)
 
-\- Optionally, creation of candidates as needed and standardization of gender
+\- Optionally, creation of candidates as needed and standardization of sex
 information when creating the candidates (DICOM uses M/F, LORIS database uses
 Male/Female)
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -423,7 +423,7 @@ sub createTarchiveArray {
         $where = "ArchiveLocation LIKE '%".basename($tarchive)."'";
     }
     my $query = "SELECT PatientName, PatientID, PatientDoB, md5sumArchive,".
-                " DateAcquired, DicomArchiveID, PatientGender,".
+                " DateAcquired, DicomArchiveID, PatientSex,".
                 " ScannerManufacturer, ScannerModel, ScannerSerialNumber,".
                 " ScannerSoftwareVersion, neurodbCenterName, TarchiveID,".
                 " SourceLocation, ArchiveLocation FROM tarchive WHERE $where";
@@ -1449,13 +1449,13 @@ sub moveAndUpdateTarchive {
 
 =pod
 
-=head3 CreateMRICandidates($subjectIDsref, $gender, $tarchiveInfo, $User, $centerID, $upload_id)
+=head3 CreateMRICandidates($subjectIDsref, $sex, $tarchiveInfo, $User, $centerID, $upload_id)
 
 Registers a new candidate in the C<candidate> table.
 
 INPUTS:
   - $subjectIDsref: subject's ID information hash ref
-  - $gender       : gender of the candidate
+  - $sex          : sex of the candidate
   - $tarchiveInfo : tarchive information hash ref
   - $User         : user that is running the pipeline
   - $centerID     : center ID
@@ -1465,17 +1465,17 @@ INPUTS:
 
 sub CreateMRICandidates {
     ############################################################
-    ### Standardize gender (DICOM uses M/F, DB uses Male/Female)
+    ### Standardize sex (DICOM uses M/F, DB uses Male/Female)
     ############################################################
     my $this = shift;
     my $query = '';
-    my ($subjectIDsref,$gender,$tarchiveInfo,$User,$centerID, $upload_id) = @_;
+    my ($subjectIDsref,$sex,$tarchiveInfo,$User,$centerID, $upload_id) = @_;
     my ($message);
 
-    if ($tarchiveInfo->{'PatientGender'} eq 'F') {
-            $gender = "Female";
-    } elsif ($tarchiveInfo->{'PatientGender'} eq 'M') {
-        $gender = "Male";
+    if ($tarchiveInfo->{'PatientSex'} eq 'F') {
+            $sex = "Female";
+    } elsif ($tarchiveInfo->{'PatientSex'} eq 'M') {
+        $sex = "Male";
     }
 
     ################################################################
@@ -1494,13 +1494,13 @@ sub CreateMRICandidates {
                 NeuroDB::MRI::createNewCandID($this->{dbhr});
             }
             $query = "INSERT INTO candidate ".
-                     "(CandID, PSCID, DoB, Gender,CenterID, Date_active,".
+                     "(CandID, PSCID, DoB, Sex,CenterID, Date_active,".
                      " Date_registered, UserID,Entity_type) ".
                      "VALUES(" . 
                      ${$this->{'dbhr'}}->quote($subjectIDsref->{'CandID'}).",".
                      ${$this->{'dbhr'}}->quote($subjectIDsref->{'PSCID'}).",".
                      ${$this->{'dbhr'}}->quote($tarchiveInfo->{'PatientDoB'}) ."," .
-                     ${$this->{'dbhr'}}->quote($gender).",". 
+                     ${$this->{'dbhr'}}->quote($sex).",".
                      ${$this->{'dbhr'}}->quote($centerID). 
                      ", NOW(), NOW(), '$User', 'Human')";
             

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -39,7 +39,7 @@ string (typically, the patient name or patient ID)
 - Verification of the C<ScannerID> of the DICOM study archive (optionally
 creates a new scanner entry in the database if necessary)
 
-- Optionally, creation of candidates as needed and standardization of gender
+- Optionally, creation of candidates as needed and standardization of sex
 information when creating the candidates (DICOM uses M/F, LORIS database uses
 Male/Female)
 
@@ -107,7 +107,7 @@ my $NewScanner  = 1;           # This should be the default unless you are a
 my $globArchiveLocation = 0;   # whether to use strict ArchiveLocation strings
                                # or to glob them (like '%Loc')
 my $template         = "TarLoad-$hour-$min-XXXXXX"; # for tempdir
-my ($gender, $tarchive,%tarchiveInfo);
+my ($sex, $tarchive,%tarchiveInfo);
 my $User             = `whoami`; 
 
 my @opt_table = (
@@ -151,7 +151,7 @@ The program does the following validation
 
 - Verify/determine the ScannerID (optionally create a new one if necessary)
 
-- Optionally create candidates as needed Standardize gender (DICOM uses M/F, 
+- Optionally create candidates as needed Standardize sex (DICOM uses M/F,
   DB uses Male/Female)
 
 - Check the CandID/PSCID Match It's possible that the CandID exists, but 
@@ -346,12 +346,12 @@ my $subjectIDsref = $utility->determineSubjectID(
 
 ################################################################
 ################################################################
-## Optionally create candidates as needed Standardize gender ###
+## Optionally create candidates as needed Standardize sex    ###
 ## (DICOM uses M/F, DB uses Male/Female) #######################
 ################################################################
 ################################################################
 $utility->CreateMRICandidates(
-    $subjectIDsref, $gender, \%tarchiveInfo, $User, $centerID, $upload_id
+    $subjectIDsref, $sex, \%tarchiveInfo, $User, $centerID, $upload_id
 );
 
 ################################################################


### PR DESCRIPTION
### Description
This pull request goes with the LORIS changes to the renaming of the following fields:
- `tarchive` table: `PatientGender` renamed to `PatientSex`
- `candidate` table: `Gender` renamed to `Sex`

### How to test this PR
- make sure to source the patch from the LORIS PR that changes the field names
- try inserting a scan that will create a candidate and insert into the tarchive table

### See also
PR on the LORIS side: https://github.com/aces/Loris/pull/3897/files