### PR TITLE
Adding regex check for phantom validation

### DIFF
--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -266,8 +266,12 @@ sub IsCandidateInfoValid {
             ############## and the file is of type DICOM###########
             #######################################################
                     if ($row[4] eq 'N') {
-                        if ( !$this->PatientNameMatch($_) ) {
-                                $files_with_unmatched_patient_name++;
+                        if ( !$this->PatientNameMatch($_, $this->{'pname'}) ) {
+                            $files_with_unmatched_patient_name++;
+                        }
+                    } elsif ($row[4] eq 'Y') {
+                        if ( !$this->PatientNameMatch($_, "phantom")) {
+                            $files_with_unmatched_patient_name++;
                         }
                     }
                 }
@@ -433,13 +437,15 @@ sub runTarchiveLoader {
 
 =pod
 
-=head3 PatientNameMatch($dicom_file)
+=head3 PatientNameMatch($dicom_file, $expected_pname_regex)
 
 This method extracts the patient name field from the DICOM file header using
 C<dcmdump> and compares it with the patient name information stored in the
 C<mri_upload> table.
 
-INPUT: full path to the DICOM file
+INPUTS:
+  - $dicom_file          : full path to the DICOM file
+  - $expected_pname_regex: expected patient name regex to find in the DICOM file
 
 RETURNS: 1 on success, 0 on failure
 
@@ -447,7 +453,7 @@ RETURNS: 1 on success, 0 on failure
 
 sub PatientNameMatch {
     my $this         = shift;
-    my ($dicom_file) = @_;
+    my ($dicom_file, $expected_pname_regex) = @_;
 
     my $lookupCenterNameUsing = NeuroDB::DBI::getConfigSetting(
         $this->{'dbhr'},'lookupCenterNameUsing'
@@ -478,11 +484,11 @@ sub PatientNameMatch {
         $this->spool($message, 'Y', $notify_notsummary);
         exit $NeuroDB::ExitCodes::DICOM_PNAME_EXTRACTION_FAILURE;
     }
-    my ($l,$pname,$t) = split /\[(.*?)\]/, $patient_name_string;
-    if ($pname !~ /^$this->{'pname'}/) {
+    my ($l,$dicom_pname,$t) = split /\[(.*?)\]/, $patient_name_string;
+    if ($dicom_pname !~ /^$expected_pname_regex/) {
         my $message = "\nThe $lookupCenterNameUsing read "
                       . "from the DICOM header does not start with "
-                      . $this->{'pname'}
+                      . $expected_pname_regex
                       . " from the mri_upload table\n";
     	$this->spool($message, 'Y', $notify_notsummary);
         return 0; ##return false


### PR DESCRIPTION
Currently, in the `IsCandidateInfoValid()` function of the `ImagingUpload.pm` library, we only checked the patient name in the DICOM file for `PSCID_CandID_VisitLabel`. For the phantom, no checks were performed. Since the convention of phantom naming always contains the name "phantom" in all LORIS instances, this PR adds a check for phantom scans to make sure the patient name in the DICOM file contains the string "phantom".

## How to test this PR

- try inserting a candidate scan with the code from that PR
- try inserting a phantom scan with the code from that PR
