### PR TITLE
Change hyphen separated ranges in mri_protocol to MIN/MAX columns: Redmine 14022 

### DIFF
--- a/docs/02-Install.md
+++ b/docs/02-Install.md
@@ -37,18 +37,46 @@ Alternatively, LORIS provides a PHP script called `populate_visit_windows.php`
 in its `tools/` directory that can be used.
 
 
-4. **`mri_scan_type`** and **`mri_protocol`** tables
+4. **`mri_scan_type`**, **`mri_protocol`** and **`mri_protocol_checks`** tables
 
-Ensure your `mri_scan_type` and `mri_protocol` tables contain an entry for 
-each type of scan in the study protocol.
-The `mri_protocol` table is used to identify incoming scans based on their 
-series description **OR** scan parameter values (TE, TR, slice thickness, etc). 
-By default, this table is populated with entries for t1, t2, fMRI and DTI, and 
-the columns defining expected scan parameters (*e.g.* `TE_Range`) are defined 
-very broadly.  
-The `Scan_type` column values are defined in the `mri_scan_type` table 
-(*e.g.* 44=t1). Do not include commas, hyphens, spaces or periods in your 
-`mri_scan_type.Scan_type` column values.
+> - `mri_scan_type`: this table is a lookup table that stores the name of
+the acquisition (*e.g.* t1, t2, flair...). Do not include commas, hyphens,
+spaces or periods in your `mri_scan_type.Scan_type` column values.The ID
+present in this table will be used in the `mri_protocol` and
+`mri_protocol_checks` tables described below.
+
+> - `mri_protocol`: this table is used to identify incoming scans based
+on their series description **OR** scan parameter values (TE, TR,
+slice thickness, etc). By default, this table is populated with entries for t1,
+t2, fMRI and DTI, and the columns defining expected scan parameters
+(*e.g.* `TE_min`, `TE_max`) are defined very broadly.
+
+> - `mri_protocol_checks`: this table allows further checking on the acquisition
+once the scan type has been identified in order to flag certain scans based on
+additional parameters found in the header. For example, let's say a scan has been
+identified with the `mri_protocol` table to be a `t1`. Additional headers could
+be checked in order to flag with a caveat or exclude the scan based on the value
+of that header.
+
+**Behaviour of the `*Min` and `*Max` columns of the `mri_protocol` and
+`mri_protocol_checks` tables:**
+
+> - if for a given parameter (*e.g.* TR) a `*Min` **AND** a `*Max` value have
+been specified, then it will check if the parameter of the scan falls into the
+range \[Min-Max].
+
+> - if for a given parameter, a `*Min` is provided but not a `*Max` then the
+imaging pipeline will check if the parameter of the scan is higher than
+the `*Min` value specified in the table.
+
+> - if for a given parameter, a `*Max` is provided but not a `*Min` then the
+imaging pipeline will check if the parameter of the scan is lower than
+the `*Max` value specified in the table.
+
+> - if for a given parameter, both `*Min` and `*Max` are set to `NULL`, then
+there will be no constraint on that header.
+
+
 
 5. **`Config`** table
 

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -140,16 +140,6 @@ INPUTS:
   - $time           : time dimension of the scan
   - $seriesUID      : `SeriesUID` of the scan
 
-### debug\_inrange($val, $range)
-
-Will evaluate whether the scalar `$value` is in the specified `$range`.
-
-INPUTS:
-  - $val  : scalar value to evaluate
-  - $range: scalar range string
-
-RETURNS: 1 if in range, 0 if not in range
-
 ### scan\_type\_id\_to\_text($typeID, $db)
 
 Determines the type of the scan identified by its scan type ID.
@@ -173,7 +163,7 @@ RETURNS: ID of the scan type
 ### in\_range($value, $range\_string)
 
 Determines whether numerical value falls within the range described by range
-string. Range string is a single range unit which follows the syntax 
+string. Range string is a single range unit which follows the syntax
 "X" or "X-Y".
 
 INPUTS:
@@ -193,20 +183,6 @@ INPUTS:
   - $nb\_decimals: the number of first decimals
 
 RETURNS: 1 if the numbers are relatively equal, 0 otherwise
-
-### range\_to\_sql($field, $range\_string)
-
-Generates a valid SQL WHERE expression to test `$field` against
-`$range_string` using the same `$range_string` syntax as `&in_range()`.
-It returns a scalar range SQL string appropriate to use as a WHERE condition
-(`SELECT ... WHERE range_to_sql(...)`).
-
-INPUTS:
-  - $field       : scalar field
-  - $range\_string: scalar range string that follows the same format as in
-                    `&in_range()`
-
-RETURNS: scalar range SQL string
 
 ### register\_db($file\_ref)
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -704,11 +704,19 @@ Determines whether numerical value falls within the range described by range
 string. Range string is a single range unit which follows the syntax
 "X" or "X-Y".
 
+Note that if C<$value> is not defined, it means the value is not defined in the
+header, therefore we do not want to restrict on that header and the function
+returns 1.
+
+Note that if C<$range_string>="-", it means that the value in the database are
+NULL for both the MIN and MAX columns, therefore we do not want to restrict the
+range for this field and the function will return 1.
+
 INPUTS:
   - $value       : numerical value to evaluate
   - $range_string: the range to use
 
-RETURNS: 1 if the value is in range, 0 otherwise
+RETURNS: 1 if the value is in range or the range is undef, 0 otherwise
 
 =cut
 
@@ -717,8 +725,11 @@ sub in_range
     my ($value, $range_string) = @_;
     chomp($value);
 
-    return 0 unless $range_string;
-    return 0 unless defined($value);
+    # return 1 if the range_string = "-" as it means that max & min values were undef
+    # when calling the in_range function and we should not restrict on that field
+    return 1 if $range_string eq "-";
+    # return 1 if the value is empty as it means we should not restrict on that field
+    return 1 unless defined($value);
 
     # grep the min and max values of the range
     my @range = split(/-/, $range_string);

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -525,17 +525,17 @@ sub identify_scan_db {
             }
 
 	    } else {
-         	if ( &in_range($tr, "$tr_min-$tr_max")
-                 && &in_range($te, "$te_min-$te_max")
-                 && &in_range($tr, "$ti_min-$ti_max")
-                 && &in_range($tr, "$xspace_min-$xspace_max")
-                 && &in_range($tr, "$yspace_min-$yspace_max")
-                 && &in_range($tr, "$zspace_min-$zspace_max")
-                 && &in_range($tr, "$xstep_min-$xstep_max")
-                 && &in_range($tr, "$ystep_min-$ystep_max")
-                 && &in_range($tr, "$zstep_min-$zstep_max")
-                 && &in_range($tr, "$time_min-$time_max")
-                 && &in_range($slice_thickness, "$slice_thick_min-$slice_thick_max")
+         	if ( &in_range($tr,              "$tr_min-$tr_max"                  )
+              && &in_range($te,              "$te_min-$te_max"                  )
+              && &in_range($ti,              "$ti_min-$ti_max"                  )
+              && &in_range($xspace,          "$xspace_min-$xspace_max"          )
+              && &in_range($yspace,          "$yspace_min-$yspace_max"          )
+              && &in_range($zspace,          "$zspace_min-$zspace_max"          )
+              && &in_range($xstep,           "$xstep_min-$xstep_max"            )
+              && &in_range($ystep,           "$ystep_min-$ystep_max"            )
+              && &in_range($zstep,           "$zstep_min-$zstep_max"            )
+              && &in_range($time,            "$time_min-$time_max"              )
+              && &in_range($slice_thickness, "$slice_thick_min-$slice_thick_max")
             ) {
                     return &scan_type_id_to_text($rowref->{'Scan_type'}, $db);
             }

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -460,8 +460,7 @@ sub identify_scan_db {
     my $ScannerID = @$resultsRef> 0 ? $resultsRef->[0]->{'ID'} : 0;
     
     # get the list of protocols for a site their scanner and subproject
-    $query = "SELECT Scan_type, ScannerID, Center_name, TR_range, TE_range, TI_range, slice_thickness_range, xspace_range, yspace_range, zspace_range,
-              xstep_range, ystep_range, zstep_range, time_range, series_description_regex
+    $query = "SELECT *
               FROM mri_protocol
               WHERE
              (Center_name='$psc' AND ScannerID='$ScannerID')
@@ -476,44 +475,68 @@ sub identify_scan_db {
     my $rowref;
 
     while($rowref = $sth->fetchrow_hashref()) {
-        my $sd_regex = $rowref->{'series_description_regex'};
+        my $sd_regex          = $rowref->{'series_description_regex'};
+        my $tr_min     = $rowref->{'TR_min'};
+        my $tr_max     = $rowref->{'TR_max'};
+        my $te_min     = $rowref->{'TE_min'};
+        my $te_max     = $rowref->{'TE_max'};
+        my $ti_min     = $rowref->{'TI_min'};
+        my $ti_max     = $rowref->{'TI_max'};
+        my $xspace_min = $rowref->{'xspace_min'};
+        my $xspace_max = $rowref->{'xspace_max'};
+        my $yspace_min = $rowref->{'yspace_min'};
+        my $yspace_max = $rowref->{'yspace_max'};
+        my $zspace_min = $rowref->{'zspace_min'};
+        my $zspace_max = $rowref->{'zspace_max'};
+        my $xstep_min  = $rowref->{'xstep_min'};
+        my $xstep_max  = $rowref->{'xstep_max'};
+        my $ystep_min  = $rowref->{'ystep_min'};
+        my $ystep_max  = $rowref->{'ystep_max'};
+        my $zstep_min  = $rowref->{'zstep_min'};
+        my $zstep_max  = $rowref->{'zstep_max'};
+        my $time_min   = $rowref->{'time_min'};
+        my $time_max   = $rowref->{'time_max'};
+        my $slice_thick_min = $rowref->{'slice_thickness_min'};
+        my $slice_thick_max = $rowref->{'slice_thickness_max'};
+
         if(0) {
             print "\tChecking ".&scan_type_id_to_text($rowref->{'Scan_type'}, $db)." ($rowref->{'Scan_type'}) ($series_description =~ $sd_regex)\n";
             print "\t";
-            if($sd_regex && ($series_description =~ /$sd_regex/i)) {print "series_description\t";}
-            print &in_range($tr, $rowref->{'TR_range'}) ? "TR\t" : '';
-            print &in_range($te, $rowref->{'TE_range'}) ? "TE\t" : '';
-            print &in_range($ti, $rowref->{'TI_range'}) ? "TI\t" : '';
-            print &in_range($xspace, $rowref->{'xspace_range'}) ? "xspace\t" : '';
-            print &in_range($yspace, $rowref->{'yspace_range'}) ? "yspace\t" : '';
-            print &in_range($zspace, $rowref->{'zspace_range'}) ? "zspace\t" : '';
-            print &in_range($slice_thickness, $rowref->{'slice_thickness_range'}) ? "ST\t" : '';
-            print &in_range($xstep, $rowref->{'xstep_range'}) ? "xstep\t" : '';
-            print &in_range($ystep, $rowref->{'ystep_range'}) ? "ystep\t" : '';
-            print &in_range($zstep, $rowref->{'zstep_range'}) ? "zstep\t" : '';
-            print &in_range($time, $rowref->{'time_range'}) ? "time\t" : '';
+            if($sd_regex && ($series_description =~ /$sd_regex/i)) {
+                print "series_description\t";
+            }
+            print &in_range($tr,     "$tr_min-$tr_max")         ? "TR\t"     : '';
+            print &in_range($te,     "$te_min-$te_max")         ? "TE\t"     : '';
+            print &in_range($ti,     "$ti_min-$ti_max")         ? "TI\t"     : '';
+            print &in_range($xspace, "$xspace_min-$xspace_max") ? "xspace\t" : '';
+            print &in_range($yspace, "$yspace_min-$yspace_max") ? "yspace\t" : '';
+            print &in_range($zspace, "$zspace_min-$zspace_max") ? "zspace\t" : '';
+            print &in_range($xstep,  "$xstep_min-$xstep_max")   ? "xstep\t"  : '';
+            print &in_range($ystep,  "$ystep_min-$ystep_max")   ? "ystep\t"  : '';
+            print &in_range($zstep,  "$zstep_min-$zstep_max")   ? "zstep\t"  : '';
+            print &in_range($time,   "$time_min-$time_max")     ? "time\t"   : '';
+            print &in_range($slice_thickness, "$slice_thick_min-$slice_thick_max") ? "ST\t" : '';
             print "\n";
         }
-        
-	if ($sd_regex) {
+
+	    if ($sd_regex) {
             if ($series_description =~ /$sd_regex/i) {
                 return &scan_type_id_to_text($rowref->{'Scan_type'}, $db);
             }
-	}
-	else {
-         	if ((!$rowref->{'TR_range'} || &in_range($tr, $rowref->{'TR_range'}))
-                && (!$rowref->{'TE_range'} || &in_range($te, $rowref->{'TE_range'}))
-                && (!$rowref->{'TI_range'} || &in_range($ti, $rowref->{'TI_range'}))
-                && (!$rowref->{'slice_thickness_range'} || &in_range($slice_thickness, $rowref->{'slice_thickness_range'}))
 
-                && (!$rowref->{'xspace_range'} || &in_range($xspace, $rowref->{'xspace_range'}))
-                && (!$rowref->{'yspace_range'} || &in_range($yspace, $rowref->{'yspace_range'}))
-                && (!$rowref->{'zspace_range'} || &in_range($zspace, $rowref->{'zspace_range'}))
-
-                && (!$rowref->{'xstep_range'} || &in_range($xstep, $rowref->{'xstep_range'}))
-                && (!$rowref->{'ystep_range'} || &in_range($ystep, $rowref->{'ystep_range'}))
-                && (!$rowref->{'zstep_range'} || &in_range($zstep, $rowref->{'zstep_range'}))
-                && (!$rowref->{'time_range'} || &in_range($time, $rowref->{'time_range'}))) {
+	    } else {
+         	if ( &in_range($tr, "$tr_min-$tr_max")
+                 && &in_range($te, "$te_min-$te_max")
+                 && &in_range($tr, "$ti_min-$ti_max")
+                 && &in_range($tr, "$xspace_min-$xspace_max")
+                 && &in_range($tr, "$yspace_min-$yspace_max")
+                 && &in_range($tr, "$zspace_min-$zspace_max")
+                 && &in_range($tr, "$xstep_min-$xstep_max")
+                 && &in_range($tr, "$ystep_min-$ystep_max")
+                 && &in_range($tr, "$zstep_min-$zstep_max")
+                 && &in_range($tr, "$time_min-$time_max")
+                 && &in_range($slice_thickness, "$slice_thick_min-$slice_thick_max")
+            ) {
                     return &scan_type_id_to_text($rowref->{'Scan_type'}, $db);
             }
         }
@@ -600,34 +623,6 @@ QUERY
 
 =pod
 
-=head3 debug_inrange($val, $range)
-
-Will evaluate whether the scalar C<$value> is in the specified C<$range>.
-
-INPUTS:
-  - $val  : scalar value to evaluate
-  - $range: scalar range string
-
-RETURNS: 1 if in range, 0 if not in range
-
-=cut
-
-sub debug_inrange {
-    my $val = shift;
-    my $range = shift;
-
-    if(&in_range($val, $range)) {
-        print "$val IN $range\n";
-        return 1;
-    } else {
-        print "$val NOT IN $range\n";
-        return 0;
-    }
-}
-
-
-=pod
-
 =head3 scan_type_id_to_text($typeID, $db)
 
 Determines the type of the scan identified by its scan type ID.
@@ -706,7 +701,7 @@ sub scan_type_text_to_id {
 =head3 in_range($value, $range_string)
 
 Determines whether numerical value falls within the range described by range
-string. Range string is a single range unit which follows the syntax 
+string. Range string is a single range unit which follows the syntax
 "X" or "X-Y".
 
 INPUTS:
@@ -725,15 +720,28 @@ sub in_range
     return 0 unless $range_string;
     return 0 unless defined($value);
 
-    chomp($range_string);
-    if($range_string=~/^[0-9.]+$/) { ## single value element
-        return 1 if &floats_are_equal($value, $range_string, $FLOAT_EQUALS_NB_DECIMALS);
-    } else { ## range_string X-Y
-        $range_string =~ /([0-9.]+)-([0-9.]+)/;
-        return 1 if ($1 <= $value && $value <= $2) 
-            || &floats_are_equal($value, $1, $FLOAT_EQUALS_NB_DECIMALS) 
-            || &floats_are_equal($value, $2, $FLOAT_EQUALS_NB_DECIMALS);
-    }
+    # grep the min and max values of the range
+    my @range = split(/-/, $range_string);
+    my $min   = $range[0];
+    my $max   = $range[1];
+
+    # returns 1 if both $min and $max are undefined as in infinity range
+    return 1 if (!defined $min && !defined $max);
+
+    # returns 1 if min & max are defined and value is within the range [min-max]
+    return 1 if (defined $min && defined $max)
+        && ( ($min <= $value && $value <= $max)
+             || &floats_are_equal($value, $min, $FLOAT_EQUALS_NB_DECIMALS)
+             || &floats_are_equal($value, $max, $FLOAT_EQUALS_NB_DECIMALS)
+        );
+
+    # returns 1 if only min is defined and value is <= to $min
+    return 1 if (defined $min and !defined $max)
+        && ($min <= $value || &floats_are_equal($value, $min, $FLOAT_EQUALS_NB_DECIMALS));
+
+    # returns 1 if only max is defined and value is >= to $max
+    return 1 if (defined $max and !defined $min)
+            && ($value <= $max || &floats_are_equal($value, $max, $FLOAT_EQUALS_NB_DECIMALS));
 
     ## if we've gotten this far, we're out of range.
     return 0;
@@ -759,53 +767,6 @@ sub floats_are_equal {
     my($f1, $f2, $nb_decimals) = @_;
 
     return sprintf("%.${nb_decimals}g", $f1) eq sprintf("%.${nb_decimals}g", $f2);
-}
-
-
-=pod
-
-=head3 range_to_sql($field, $range_string)
-
-Generates a valid SQL WHERE expression to test C<$field> against
-C<$range_string> using the same C<$range_string> syntax as C<&in_range()>.
-It returns a scalar range SQL string appropriate to use as a WHERE condition
-(C<SELECT ... WHERE range_to_sql(...)>).
-
-INPUTS:
-  - $field       : scalar field
-  - $range_string: scalar range string that follows the same format as in
-                    C<&in_range()>
-
-RETURNS: scalar range SQL string
-
-=cut
-
-sub range_to_sql {
-    my ($field, $range_string) = @_;
-    chomp($field);
-
-    # make sure there are no semi-colons in $field
-    return '1' if $field=~/;/;
-
-    # make sure string doesn't contain anything invalid
-    return '1' unless $range_string=~/^[0-9,.-]+$/;
-
-    my @ranges = split(/,/, $range_string);
-    my $range = '';
-    my $output = '';
-
-    foreach $range (@ranges) {
-        if($range=~/-/) { # it's a range
-            my @ends = split(/-/, $range);
-            $output .= ' OR ' unless $output eq '';
-            $output .= "($ends[0]<=$field AND $field<=$ends[1])";
-        } else { # it's a single value
-            $output .= ' OR ' unless $output eq '';
-            $output .= "$field=$range";
-        }
-    }
-
-    return $output;
 }
 
 


### PR DESCRIPTION
Rebased Mouna's PR and added support for the MIN/MAX values in the `mri_protocol_checks` table.

The `mri_protocol` and `mri_protocol_checks` tables have been normalized to replace all `%_range` fields by `%_min` and `%_max` values (see aces/Loris#3973). 

## How to set up the `mri_protocol` and `mri_protocol_checks` tables

- if for a given parameter (*e.g.* TR) a `*Min` **AND** a `*Max` value have
been specified, then it will check if the parameter of the scan falls into the
range \[Min-Max].

- if for a given parameter, a `*Min` is provided but not a `*Max` then the
imaging pipeline will check if the parameter of the scan falls is higher than
the `*Min` value specifie in the table.

- if for a given parameter, a `*Max` is provided but not a `*Min` then the
imaging pipeline will check if the parameter of the scan falls is lower than
the `*Max` value specified in the table.

> - if for a given parameter, both `*Min` and `*Max` are set to `NULL`, then
there will be no constraint on that header.

## Notes for existing projects

Make sure to run the script `tools/normalize_mri_protocol_range_data.php` of the LORIS repo to properly convert your `mri_protocol` and `mri_protocol_checks` tables.

See also: aces/Loris#3973

## How to test

Make sure to test the different possibilities mentioned above on the "How to set up the `mri_protocol` and `mri_protocol_checks` tables" section for the `mri_protocol` and `mri_protocol_checks` table and that it behaves as expected. 
