### PR TITLE
Rename candidate CenterID to RegistrationCenterID

### DIFF
--- a/tools/example_scripts/deletemincsqlwrapper.pl
+++ b/tools/example_scripts/deletemincsqlwrapper.pl
@@ -107,7 +107,7 @@ my $queryF = <<SQL;
   LEFT JOIN parameter_type AS pt using (ParameterTypeID)
   LEFT JOIN files_qcstatus AS q using (FileID)
   LEFT JOIN session AS s ON (f.SessionID=s.ID)
-  LEFT JOIN psc AS c ON (c.CenterID=s.CenterID)
+  LEFT JOIN psc AS c ON (c.RegistrationCenterID=s.CenterID)
   LEFT JOIN mri_scan_type AS m ON (m.ID=f.AcquisitionProtocolID)
   LEFT JOIN tarchive AS t ON f.TarchiveSource=t.TarchiveID
   WHERE pt.Name = 'acquisition:slice_thickness'

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -271,7 +271,8 @@ sub getSessionID {
                 # fixme add some debug messages if this is to be kept
                 print "Set newVisitNo = $newVisitNo and centerID = $centerID\n";
             } else {
-                $query = "SELECT CenterID FROM candidate WHERE CandID=".$dbh->quote($subjectIDref->{'CandID'});
+                $query = "SELECT RegistrationCenterID AS CenterID FROM candidate "
+                         . "WHERE CandID=" . $dbh->quote($subjectIDref->{'CandID'});
                 $sth = $dbh->prepare($query);
                 $sth->execute();
                 if($sth->rows > 0) {
@@ -1074,7 +1075,12 @@ sub registerScanner {
     # create a new candidate for the scanner if it does not exist.
     if(!defined($candID)) {
 	    $candID = createNewCandID($dbhr);
-	    $query = "INSERT INTO candidate (CandID, PSCID, CenterID, Date_active, Date_registered, UserID, Entity_type) VALUES ($candID, 'scanner', $centerID, NOW(), NOW(), 'NeuroDB::MRI', 'Scanner')";
+	    $query = "INSERT INTO candidate "
+                 . "(CandID,          PSCID,  RegistrationCenterID, Date_active,  "
+                 . " Date_registered, UserID, Entity_type                       ) "
+                 . "VALUES "
+                 . "($candID, 'scanner',      $centerID,  NOW(),   "
+                 . " NOW(),   'NeuroDB::MRI', 'Scanner'          ) ";
 	    $dbh->do($query);
     }	
     

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1503,8 +1503,8 @@ sub CreateMRICandidates {
                 NeuroDB::MRI::createNewCandID($this->{dbhr});
             }
             $query = "INSERT INTO candidate ".
-                     "(CandID, PSCID, DoB, Sex,CenterID, Date_active,".
-                     " Date_registered, UserID,Entity_type) ".
+                     "(CandID, PSCID, DoB, Sex, RegistrationCenterID, ".
+                     "Date_active, Date_registered, UserID, Entity_type) ".
                      "VALUES(" . 
                      ${$this->{'dbhr'}}->quote($subjectIDsref->{'CandID'}).",".
                      ${$this->{'dbhr'}}->quote($subjectIDsref->{'PSCID'}).",".


### PR DESCRIPTION
### Brief summary of changes

This PR rename the CenterID field column of the candidate table to RegistrationCenterID, which will correspond to the CenterID at which the candidate was first registered. This should never be changed for a given candidate. 

### Associated LORIS PR:

https://github.com/aces/Loris/pull/4078

### This resolves issue...

- [x] Github https://github.com/aces/Loris/issues/4057

### To test this change...

- [ ] Source the patch in the LORIS PR to update your `candidate` table with the new field name https://github.com/aces/Loris/pull/4078/files#diff-c786698cac6c4494eb91bd8e36f608b9
- [ ] Make sure the insertion pipeline runs as expected and that the changes made to the queries work as expected with the new field name