### PR TITLE
Cleanup multiple ways of getting header info from MINC

### DIFF
--- a/DTIPrep/DTI/DTI.pm
+++ b/DTIPrep/DTI/DTI.pm
@@ -829,13 +829,15 @@ sub insertFieldList {
     my  ($raw_dti, $processed_minc, $minc_field) = @_;
 
     # fetches list of arguments starting with $minc_field (i.e. 'patient:'; 'study:' ...)
-    my  ($arguments) = &NeuroDB::MRI::fetch_header_info($raw_dti, $minc_field);
+    my  ($arguments) = &NeuroDB::MRI::fetch_header_info(
+        $raw_dti, $minc_field, 0, 1
+    );
 
     # fetches list of values with arguments starting with $minc_field. Don't remove semi_colon (last option of fetch_header_info).
     my  ($values) = &NeuroDB::MRI::fetch_header_info($raw_dti, $minc_field, 1);
 
-    my  ($arguments_list, $arguments_list_size) =   get_header_list('=', $arguments);
-    my  ($values_list, $values_list_size)       =   get_header_list(';', $values);
+    my  ($arguments_list, $arguments_list_size) = get_header_list('\cI\cI', $arguments);
+    my  ($values_list, $values_list_size)       = get_header_list(';',      $values);
 
     my  @insert_failure;
     if  ($arguments_list_size   ==  $values_list_size)  {

--- a/DTIPrep/DTIPrepRegister.pl
+++ b/DTIPrep/DTIPrepRegister.pl
@@ -534,14 +534,12 @@ sub register_minc {
         $src_tool       =   $toolName;
         $src_pipeline   =   $pipelineName;
         # insert pipelineName into the mincheader if not already in.
-        ($pipelineName_insert)  = &DTI::modify_header('processing:pipeline', 
-                                                      $src_pipeline, 
-                                                      $minc,
-                                                      '$3, $4, $5, $6');
-        ($toolName_insert)      = &DTI::modify_header('processing:tool', 
-                                                      $src_tool, 
-                                                      $minc,
-                                                      '$3, $4, $5, $6');
+        ($pipelineName_insert) = &DTI::modify_header(
+            'processing:pipeline', $src_pipeline, $minc
+        );
+        ($toolName_insert) = &DTI::modify_header(
+            'processing:tool', $src_tool, $minc
+        );
         return undef    if ((!$toolName_insert) && (!$pipelineName_insert));
     }
     
@@ -562,14 +560,13 @@ sub register_minc {
                                                      $scanType);
 
     # Insert into the mincheader processed directory of the minc to register
-    my $procdir             = dirname($minc);
-    my ($procdir_insert)    = &DTI::modify_header('processing:processed_dir', 
-                                                  $procdir,
-                                                  $minc,
-                                                  '$3, $4, $5, $6');
+    my $procdir          = dirname($minc);
+    my ($procdir_insert) = &DTI::modify_header(
+        'processing:processed_dir', $procdir, $minc
+    );
 
     # Insert nrrd file into minc file if $registered_nrrd is defined
-    my ($nrrd_insert)       = &DTI::modify_header('processing:nrrd_file', $registered_nrrd, $minc, '$3, $4, $5, $6')  if ($registered_nrrd);
+    my ($nrrd_insert) = &DTI::modify_header('processing:nrrd_file', $registered_nrrd, $minc) if ($registered_nrrd);
     
     # Determine coordinate '}->{'pace
     my ($coordinateSpace);
@@ -1153,10 +1150,9 @@ sub getPipelineDate {
         
         if ($file=~/\.mnc/) {
             # insert pipelineDate into mincheader if not already in the mincheader. 
-            ($date_insert)  = &DTI::modify_header('processing:processing_date', 
-                                                  $pipelineDate, 
-                                                  $file,
-                                                  '$3, $4, $5, $6');
+            ($date_insert) = &DTI::modify_header(
+                'processing:processing_date', $pipelineDate, $file
+            );
         }
     
     } else  {
@@ -1200,14 +1196,12 @@ sub insertReports {
     return undef    unless (($minc) && ($registeredXMLFile) && ($registeredQCReportFile));
 
     # Insert files into the mincheader
-    my ($Txtreport_insert)  = &DTI::modify_header('processing:DTIPrepTxtReport',
-                                                  $registeredQCReportFile,     
-                                                  $minc,
-                                                  '$3, $4, $5, $6');
-    my ($XMLreport_insert)  = &DTI::modify_header('processing:DTIPrepXmlReport',
-                                                  $registeredXMLFile, 
-                                                  $minc,
-                                                  '$3, $4, $5, $6');
+    my ($Txtreport_insert) = &DTI::modify_header(
+        'processing:DTIPrepTxtReport', $registeredQCReportFile, $minc
+    );
+    my ($XMLreport_insert) = &DTI::modify_header(
+        'processing:DTIPrepXmlReport', $registeredXMLFile, $minc
+    );
 
     return ($Txtreport_insert, $XMLreport_insert);
 }
@@ -1237,20 +1231,18 @@ sub insertPipelineSummary   {
     my ($summary)   =   &DTI::getRejectedDirections($data_dir, $XMLReport);
     
     # insert slice wise excluded gradients in mincheader
-    my $rm_slicewise        = $summary->{'EXCLUDED'}{'slice'}{'txt'};
-    my $count_slice         = $summary->{'EXCLUDED'}{'slice'}{'nb'};
-    my ($insert_slice)      = &DTI::modify_header('processing:slicewise_rejected',
-                                                  $rm_slicewise,
-                                                  $minc,
-                                                  '$3, $4, $5, $6');
+    my $rm_slicewise   = $summary->{'EXCLUDED'}{'slice'}{'txt'};
+    my $count_slice    = $summary->{'EXCLUDED'}{'slice'}{'nb'};
+    my ($insert_slice) = &DTI::modify_header(
+        'processing:slicewise_rejected', $rm_slicewise, $minc
+    );
 
     # insert interlace wise excluded gradients in mincheader
-    my $rm_interlace        = $summary->{'EXCLUDED'}{'interlace'}{'txt'};
-    my $count_interlace     = $summary->{'EXCLUDED'}{'interlace'}{'nb'};
-    my ($insert_inter)      = &DTI::modify_header('processing:interlace_rejected',
-                                                  $rm_interlace,
-                                                  $minc, 
-                                                  '$3, $4, $5, $6');
+    my $rm_interlace    = $summary->{'EXCLUDED'}{'interlace'}{'txt'};
+    my $count_interlace = $summary->{'EXCLUDED'}{'interlace'}{'nb'};
+    my ($insert_inter)  = &DTI::modify_header(
+        'processing:interlace_rejected', $rm_interlace, $minc
+    );
 
     # insert total count (and intergradient count except if scanType is DTIPrepNoReg
     my $count_intergradient = $summary->{'EXCLUDED'}{'intergrad'}{'nb'};
@@ -1261,19 +1253,17 @@ sub insertPipelineSummary   {
         $total  = $count_total - $count_intergradient;
     } else {
         # insert intergradient wise excluded gradients in mincheader
-        $rm_intergradient   = $summary->{'EXCLUDED'}{'intergrad'}{'txt'};
-        ($insert_gradient)  = &DTI::modify_header('processing:intergradient_rejected',
-                                                  $rm_intergradient,
-                                                  $minc,
-                                                  '$3, $4, $5, $6');
+        $rm_intergradient  = $summary->{'EXCLUDED'}{'intergrad'}{'txt'};
+        ($insert_gradient) = &DTI::modify_header(
+            'processing:intergradient_rejected', $rm_intergradient, $minc
+        );
         # total is equal to count_total
         $total  = $count_total;
     }
     # compute total number of excluded gradients and insert it in mincheader
-    my ($total_insert)     = &DTI::modify_header('processing:total_rejected', 
-                                                 $total, 
-                                                 $minc,
-                                                 '$3, $4, $5, $6');
+    my ($total_insert) = &DTI::modify_header(
+        'processing:total_rejected', $total, $minc
+    );
 
     # If all insertions went well, return 1, otherwise return undef
     if (($total_insert) && ($insert_slice) && ($insert_inter) 

--- a/docs/scripts_md/DTI.md
+++ b/docs/scripts_md/DTI.md
@@ -324,18 +324,6 @@ INPUTS:
 
 RETURNS: 1 if argument was inserted in the MINC header, undef otherwise
 
-### fetch\_header\_info($field, $minc, $awk, $keep\_semicolon)
-
-Function that fetches header information in MINC file.
-
-INPUTS:
-  - $field: field to look for in MINC header
-  - $minc : MINC file
-  - $awk  : awk info to check if argument inserted in MINC header
-  - $keep\_semicolon: if set, keep ";" at the end of extracted value
-
-RETURNS: value of the field found in the MINC header
-
 ### get\_header\_list($splitter, $fields)
 
 Gets the list of arguments and values to insert into the MINC header

--- a/docs/scripts_md/DTI.md
+++ b/docs/scripts_md/DTI.md
@@ -311,7 +311,7 @@ INPUTS:
 
 RETURNS: 1 on success, undef on failure
 
-### modify\_header($argument, $value, $minc, $awk)
+### modify\_header($argument, $value, $minc)
 
 Function that runs `minc_modify_header` and inserts MINC header information if
 not already inserted.
@@ -320,7 +320,6 @@ INPUTS:
   - $argument: argument to be inserted in MINC header
   - $value   : value of the argument to be inserted in MINC header
   - $minc    : MINC file
-  - $awk     : awk info to check if the argument was inserted in MINC header
 
 RETURNS: 1 if argument was inserted in the MINC header, undef otherwise
 

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -386,6 +386,18 @@ INPUTS:
 
 RETURNS: the `CandID` or 0 if the `PSCID` does not exist
 
+### fetch\_minc\_header\_info($minc, $field, $awk, $keep\_semicolon)
+
+Function that fetches header information in MINC file.
+
+INPUTS:
+  - $minc : MINC file
+  - $field: field name to look for in MINC header (or 'all' to grep all headers)
+  - $awk  : awk info to check if argument inserted in MINC header
+  - $keep\_semicolon: if set, keep ";" at the end of extracted value
+
+RETURNS: value of the field found in the MINC header
+
 # TO DO
 
 Fix comments written as #fixme in the code.

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -386,14 +386,13 @@ INPUTS:
 
 RETURNS: the `CandID` or 0 if the `PSCID` does not exist
 
-### fetch\_minc\_header\_info($minc, $field, $awk, $keep\_semicolon)
+### fetch\_minc\_header\_info($minc, $field, $keep\_semicolon)
 
 Function that fetches header information in MINC file.
 
 INPUTS:
   - $minc : MINC file
   - $field: field name to look for in MINC header (or 'all' to grep all headers)
-  - $awk  : awk info to check if argument inserted in MINC header
   - $keep\_semicolon: if set, keep ";" at the end of extracted value
 
 RETURNS: value of the field found in the MINC header

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -386,16 +386,17 @@ INPUTS:
 
 RETURNS: the `CandID` or 0 if the `PSCID` does not exist
 
-### fetch\_minc\_header\_info($minc, $field, $keep\_semicolon)
+### fetch\_minc\_header\_info($minc, $field, $keep\_semicolon, $get\_arg\_name)
 
 Function that fetches header information in MINC file.
 
 INPUTS:
   - $minc : MINC file
-  - $field: field name to look for in MINC header (or 'all' to grep all headers)
-  - $keep\_semicolon: if set, keep ";" at the end of extracted value
+  - $field: string to look for in MINC header (or 'all' to grep all headers)
+  - $keep\_semicolon: if set, keeps ";" at the end of extracted value
+  - $get\_arg\_name  : if set, returns the MINC header field name
 
-RETURNS: value of the field found in the MINC header
+RETURNS: value (or header name) of the field found in the MINC header
 
 # TO DO
 

--- a/docs/scripts_md/register_processed_data.md
+++ b/docs/scripts_md/register_processed_data.md
@@ -80,16 +80,6 @@ INPUTS:
 
 RETURNS: acquisition protocol ID
 
-### fetchMincHeader($file, $field)
-
-This function parses the MINC header and looks for a specific field value.
-
-INPUTS:
-  - $file : MINC file
-  - $field: MINC header field values
-
-RETURNS: MINC header value
-
 ### copy\_file($filename, $subjectIDsref, $scan\_type, $fileref)
 
 Moves files to `assembly` folder.

--- a/tools/MakeNiiFilesBIDSCompliant.pl
+++ b/tools/MakeNiiFilesBIDSCompliant.pl
@@ -537,7 +537,7 @@ QUERY
                 print "Adding now $headerName header to $headerFile\n" if $verbose;
 
                 $headerVal = NeuroDB::MRI::fetch_header_info(
-                    $mincFileName, $headerNameMINC, '$3, $4, $5, $6'
+                    $mincFileName, $headerNameMINC
                 );
                 # Some headers need to be explicitely converted to floats in Perl
                 # so json_encode does not add the double quotation around them
@@ -584,7 +584,7 @@ QUERY
                 $headerNameMINC = 'dicom_0x0019:el_0x1029';
                 $extraHeader    = "SliceTiming";
                 $headerVal      =  &NeuroDB::MRI::fetch_header_info(
-                    $mincFileName, $headerNameMINC, '$3, $4, $5, $6'
+                    $mincFileName, $headerNameMINC
                 );
                 # Some earlier dcm2mnc converters created SliceTiming with values
                 # such as 0b, -91b, -5b, etc... so those MINC headers with `b`

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -325,7 +325,7 @@ sub loadFileFromDisk {
     }
     
     # get the set of attributes
-    my $header = `mincheader -data "$file"`;
+    my $header = &NeuroDB::MRI::fetch_header_info($file, 'all');
     my @attributes = split(/;\n/s, $header);
     foreach my $attribute (@attributes) {
         if($attribute =~ /\s*(\w*:\w+) = (.*)$/s) {

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1540,6 +1540,42 @@ sub my_trim {
 	return $str;
 }
 
+=pod
+
+=head3 fetch_minc_header_info($minc, $field, $awk, $keep_semicolon)
+
+Function that fetches header information in MINC file.
+
+INPUTS:
+  - $minc : MINC file
+  - $field: field name to look for in MINC header (or 'all' to grep all headers)
+  - $awk  : awk info to check if argument inserted in MINC header
+  - $keep_semicolon: if set, keep ";" at the end of extracted value
+
+RETURNS: value of the field found in the MINC header
+
+=cut
+
+sub fetch_header_info {
+    my ($minc, $field, $awk, $keep_semicolon) = @_;
+    my $value;
+    if ($field eq 'all') {
+        # run mincheader and return all the content of the command
+        $value = `mincheader -data "$minc"`;
+    }
+    else {
+        # fetch a particular header value, remove extra spaces and optionally
+        # the semicolon
+        my $val = `mincheader $minc | grep $field | awk '{print $awk}' | tr '\n' ' '`;
+        $value = $val if $val !~ /^\s*"*\s*"*\s*$/;
+        return undef unless ($value); # return undef if no value found
+        $value =~ s/"//g;     # remove "
+        $value =~ s/^\s+//;   # remove leading spaces
+        $value =~ s/\s+$//;   # remove trailing spaces
+        $value =~ s/;// unless ($keep_semicolon);  # remove ";" unless $keep_semicolon is defined
+    }
+    return $value;
+}
 
 1;
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1542,14 +1542,13 @@ sub my_trim {
 
 =pod
 
-=head3 fetch_minc_header_info($minc, $field, $awk, $keep_semicolon)
+=head3 fetch_minc_header_info($minc, $field, $keep_semicolon)
 
 Function that fetches header information in MINC file.
 
 INPUTS:
   - $minc : MINC file
   - $field: field name to look for in MINC header (or 'all' to grep all headers)
-  - $awk  : awk info to check if argument inserted in MINC header
   - $keep_semicolon: if set, keep ";" at the end of extracted value
 
 RETURNS: value of the field found in the MINC header
@@ -1557,23 +1556,22 @@ RETURNS: value of the field found in the MINC header
 =cut
 
 sub fetch_header_info {
-    my ($minc, $field, $awk, $keep_semicolon) = @_;
+    my ($minc, $field, $keep_semicolon) = @_;
+
     my $value;
     if ($field eq 'all') {
         # run mincheader and return all the content of the command
         $value = `mincheader -data "$minc"`;
-    }
-    else {
+    } else {
         # fetch a particular header value, remove extra spaces and optionally
         # the semicolon
-        my $val = `mincheader $minc | grep $field | awk '{print $awk}' | tr '\n' ' '`;
-        $value = $val if $val !~ /^\s*"*\s*"*\s*$/;
-        return undef unless ($value); # return undef if no value found
-        $value =~ s/"//g;     # remove "
-        $value =~ s/^\s+//;   # remove leading spaces
-        $value =~ s/\s+$//;   # remove trailing spaces
-        $value =~ s/;// unless ($keep_semicolon);  # remove ";" unless $keep_semicolon is defined
+        my $val = `mincheader -data "$minc" | grep "$field" | cut -d= -f2 | tr '\n' ' '`;
+        $value = my_trim($val) if $val !~ /^\s*"*\s*"*\s*$/;
+        return undef unless ($value);  # return undef if no value found
+        $value =~ s/"//g;  # remove "
+        $value =~ s/;// unless ($keep_semicolon);  # remove ";"
     }
+
     return $value;
 }
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1542,21 +1542,23 @@ sub my_trim {
 
 =pod
 
-=head3 fetch_minc_header_info($minc, $field, $keep_semicolon)
+=head3 fetch_minc_header_info($minc, $field, $keep_semicolon, $get_arg_name)
 
 Function that fetches header information in MINC file.
 
 INPUTS:
   - $minc : MINC file
-  - $field: field name to look for in MINC header (or 'all' to grep all headers)
-  - $keep_semicolon: if set, keep ";" at the end of extracted value
+  - $field: string to look for in MINC header (or 'all' to grep all headers)
+  - $keep_semicolon: if set, keeps ";" at the end of extracted value
+  - $get_arg_name  : if set, returns the MINC header field name
 
-RETURNS: value of the field found in the MINC header
+
+RETURNS: value (or header name) of the field found in the MINC header
 
 =cut
 
 sub fetch_header_info {
-    my ($minc, $field, $keep_semicolon) = @_;
+    my ($minc, $field, $keep_semicolon, $header_part) = @_;
 
     my $value;
     if ($field eq 'all') {
@@ -1565,8 +1567,9 @@ sub fetch_header_info {
     } else {
         # fetch a particular header value, remove extra spaces and optionally
         # the semicolon
-        my $val = `mincheader -data "$minc" | grep "$field" | cut -d= -f2 | tr '\n' ' '`;
-        $value = my_trim($val) if $val !~ /^\s*"*\s*"*\s*$/;
+        my $cut_opt = $header_part ? "-f1" : "-f2";
+        my $val = `mincheader -data "$minc" | grep "$field" | cut -d= $cut_opt | tr '\n' ' '`;
+        $value  = my_trim($val) if $val !~ /^\s*"*\s*"*\s*$/;
         return undef unless ($value);  # return undef if no value found
         $value =~ s/"//g;  # remove "
         $value =~ s/;// unless ($keep_semicolon);  # remove ";"

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -206,11 +206,15 @@ if  ($file->getFileDatum('FileType') eq 'mnc')  {
     my  $lookupCenterName       =   NeuroDB::DBI::getConfigSetting(
                                     \$dbh,'lookupCenterNameUsing'
                                     );
-    my  $patientInfo;
-    if      ($lookupCenterName eq 'PatientName')    {
-        $patientInfo    =   fetchMincHeader($filename,'patient:full_name');
-    }elsif  ($lookupCenterName eq 'PatientID')      {
-        $patientInfo    =   fetchMincHeader($filename,'patient:identification');
+    my $patientInfo;
+    if ($lookupCenterName eq 'PatientName') {
+        $patientInfo = &NeuroDB::MRI::fetch_header_info(
+            $filename, 'patient:full_name', '$3, $4, $5, $6'
+        );
+    }elsif ($lookupCenterName eq 'PatientID') {
+        $patientInfo = &NeuroDB::MRI::fetch_header_info(
+            $filename, 'patient:identification', '$3, $4, $5, $6'
+        );
     }
     ($center_name, $centerID)   =   NeuroDB::MRI::getPSC($patientInfo, \$dbh, $db);
     my  $psc    =   $center_name;
@@ -229,11 +233,19 @@ my $scannerID;
 
 if  ($file->getFileDatum('FileType') eq 'mnc')  {
     my  %scannerInfo;
-    $scannerInfo{'ScannerManufacturer'}     =   fetchMincHeader($filename,'study:manufacturer');
-    $scannerInfo{'ScannerModel'}            =   fetchMincHeader($filename,'study:device_model');
-    $scannerInfo{'ScannerSerialNumber'}     =   fetchMincHeader($filename,'study:serial_no');
-    $scannerInfo{'ScannerSoftwareVersion'}  =   fetchMincHeader($filename,'study:software_version');
-    $scannerID = NeuroDB::MRI::findScannerID(
+    $scannerInfo{'ScannerManufacturer'} = &NeuroDB::MRI::fetch_header_info(
+        $filename, 'study:manufacturer', '$3, $4, $5, $6'
+    );
+    $scannerInfo{'ScannerModel'} = &NeuroDB::MRI::fetch_header_info(
+        $filename, 'study:device_model', '$3, $4, $5, $6'
+    );
+    $scannerInfo{'ScannerSerialNumber'} = &NeuroDB::MRI::fetch_header_info(
+        $filename, 'study:serial_no', '$3, $4, $5, $6'
+    );
+    $scannerInfo{'ScannerSoftwareVersion'} = &NeuroDB::MRI::fetch_header_info(
+        $filename, 'study:software_version', '$3, $4, $5, $6'
+    );
+    $scannerID  =   NeuroDB::MRI::findScannerID(
         $scannerInfo{'ScannerManufacturer'}, $scannerInfo{'ScannerModel'},
         $scannerInfo{'ScannerSerialNumber'}, $scannerInfo{'ScannerSoftwareVersion'},
         $centerID,                           \$dbh,
@@ -458,34 +470,6 @@ sub getAcqProtID    {
 
     return  ($acqProtID);
 }
-
-
-=pod
-
-=head3 fetchMincHeader($file, $field)
-
-This function parses the MINC header and looks for a specific field value.
-
-INPUTS:
-  - $file : MINC file
-  - $field: MINC header field values
-
-RETURNS: MINC header value
-
-=cut
-
-sub fetchMincHeader {
-    my  ($file,$field)  =   @_;
-
-    my  $value  =   `mincheader $file | grep '$field' | awk '{print \$3, \$4, \$5, \$6}' | tr '\n' ' '`;
-
-    $value=~s/"//g;    #remove "
-    $value=~s/^\s+//; #remove leading spaces
-    $value=~s/\s+$//; #remove trailing spaces
-    $value=~s/;//;    #remove ;
-
-    return  $value;
-}    
 
 
 =pod

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -209,11 +209,11 @@ if  ($file->getFileDatum('FileType') eq 'mnc')  {
     my $patientInfo;
     if ($lookupCenterName eq 'PatientName') {
         $patientInfo = &NeuroDB::MRI::fetch_header_info(
-            $filename, 'patient:full_name', '$3, $4, $5, $6'
+            $filename, 'patient:full_name'
         );
     }elsif ($lookupCenterName eq 'PatientID') {
         $patientInfo = &NeuroDB::MRI::fetch_header_info(
-            $filename, 'patient:identification', '$3, $4, $5, $6'
+            $filename, 'patient:identification'
         );
     }
     ($center_name, $centerID)   =   NeuroDB::MRI::getPSC($patientInfo, \$dbh, $db);
@@ -234,16 +234,16 @@ my $scannerID;
 if  ($file->getFileDatum('FileType') eq 'mnc')  {
     my  %scannerInfo;
     $scannerInfo{'ScannerManufacturer'} = &NeuroDB::MRI::fetch_header_info(
-        $filename, 'study:manufacturer', '$3, $4, $5, $6'
+        $filename, 'study:manufacturer'
     );
     $scannerInfo{'ScannerModel'} = &NeuroDB::MRI::fetch_header_info(
-        $filename, 'study:device_model', '$3, $4, $5, $6'
+        $filename, 'study:device_model'
     );
     $scannerInfo{'ScannerSerialNumber'} = &NeuroDB::MRI::fetch_header_info(
-        $filename, 'study:serial_no', '$3, $4, $5, $6'
+        $filename, 'study:serial_no'
     );
     $scannerInfo{'ScannerSoftwareVersion'} = &NeuroDB::MRI::fetch_header_info(
-        $filename, 'study:software_version', '$3, $4, $5, $6'
+        $filename, 'study:software_version'
     );
     $scannerID  =   NeuroDB::MRI::findScannerID(
         $scannerInfo{'ScannerManufacturer'}, $scannerInfo{'ScannerModel'},


### PR DESCRIPTION
This PR cleans up the multiple functions to grep MINC header information and merges them into a single function in `MRI.pm`.

See also: https://redmine.cbrain.mcgill.ca/issues/15106

To test:
- [ ] test tarchiveLoader
- [x] test DTIPrep pipeline (to be noted, the DTIPrep_pipeline breaks when there are NIfTI files and MINC files for the t1, see issue #352, a separate PR will be issued to minor to fix this)
- [x] test register_processed_data.pl (to be noted, register_processed_data.pl is broken on major due to the call to the object broker MriScannerOB with not the proper database connection, see issue #353, a separate PR will be issued to major to fix this)
