### PR TITLE
Fix DTIPrep pipeline when create NIfTI is set to yes

### DIFF
--- a/DTIPrep/DTI/DTI.pm
+++ b/DTIPrep/DTI/DTI.pm
@@ -162,14 +162,14 @@ RETURNS:
 sub getAnatFile {
     my ($nativedir, $t1_scan_type)  = @_;
 
-    # Fetch files in native directory that matched t1_scan_type
-    my $anat_list   = DTI::getFilesList($nativedir, $t1_scan_type);
+    # Fetch files in native directory that matched t1_scan_type and MINC file type
+    my $anat_list = DTI::getFilesList($nativedir, "\_$t1_scan_type\_.*mnc\$");
 
     # Return undef if no anat found, first anat otherwise
     if (@$anat_list == 0) { 
         return undef; 
     } else { 
-        my $anat    = @$anat_list[0];
+        my $anat = @$anat_list[0];
         return $anat;
     }
 }

--- a/DTIPrep/DTI/DTI.pm
+++ b/DTIPrep/DTI/DTI.pm
@@ -166,12 +166,7 @@ sub getAnatFile {
     my $anat_list = DTI::getFilesList($nativedir, "\_$t1_scan_type\_.*mnc\$");
 
     # Return undef if no anat found, first anat otherwise
-    if (@$anat_list == 0) { 
-        return undef; 
-    } else { 
-        my $anat = @$anat_list[0];
-        return $anat;
-    }
+    return @$anat_list ? @$anat_list[0] : undef;
 }
 
 

--- a/DTIPrep/DTI/DTI.pm
+++ b/DTIPrep/DTI/DTI.pm
@@ -163,7 +163,7 @@ sub getAnatFile {
     my ($nativedir, $t1_scan_type)  = @_;
 
     # Fetch files in native directory that matched t1_scan_type and MINC file type
-    my $anat_list = DTI::getFilesList($nativedir, "\_$t1_scan_type\_.*mnc\$");
+    my $anat_list = DTI::getFilesList($nativedir, "\_$t1_scan_type\_[^_]+\.mnc\$");
 
     # Return undef if no anat found, first anat otherwise
     return @$anat_list ? @$anat_list[0] : undef;


### PR DESCRIPTION
### Description

When a project uses NIfTI files creation, the DTIPrep pipeline breaks when searching for a t1 in the native subdirectory as it returns the NIfTI file instead of the MINC file. This fixes the issue and returns only the MINC file.

### This fixes...

-[x] issue #352 