### PR TITLE
Fixed error message when loading MRI.pm

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1206,8 +1206,8 @@ sub getPSC {
 
     my $subjectIDsref = Settings::getSubjectIDs(
                             $patientName,
-                            null,
-                            null,
+                            undef,
+                            undef,
                             $dbhr
                         );
     my $PSCID = $subjectIDsref->{'PSCID'};


### PR DESCRIPTION
### Description

When loading the NeuroDB::MRI library in a script, we get the following error message:
```
Unquoted string "null" may clash with future reserved word at /data/qpn/bin/mri/uploadNeuroDB/NeuroDB/MRI.pm line 1141.
 at /data/qpn/bin/mri/uploadNeuroDB/NeuroDB/MRI.pm line 1141.
	require NeuroDB/MRI.pm called at register_processed_data.pl line 67
	main::BEGIN() called at /data/qpn/bin/mri/uploadNeuroDB/NeuroDB/MRI.pm line 1141
	eval {...} called at /data/qpn/bin/mri/uploadNeuroDB/NeuroDB/MRI.pm line 1141
Unquoted string "null" may clash with future reserved word at /data/qpn/bin/mri/uploadNeuroDB/NeuroDB/MRI.pm line 1142.
 at /data/qpn/bin/mri/uploadNeuroDB/NeuroDB/MRI.pm line 1142.
	require NeuroDB/MRI.pm called at register_processed_data.pl line 67
	main::BEGIN() called at /data/qpn/bin/mri/uploadNeuroDB/NeuroDB/MRI.pm line 1142
	eval {...} called at /data/qpn/bin/mri/uploadNeuroDB/NeuroDB/MRI.pm line 1142
```

This fixes the error message on minor.

### This fixes...

- [x] issue #356 