### PR TITLE
Move getSNRModalities() out of the profile file (prod file)

### DIFF
--- a/dicom-archive/profileTemplate
+++ b/dicom-archive/profileTemplate
@@ -30,17 +30,6 @@
 # -----------------------------------------------------------------------------------------------
 =cut
 
-### This gets the modalities that SNR is to be computed on
-## Filename base usually contains the modality
-## So compute SNR on the 3-D modalities; most commonly t1, t2, flair, and pd
-sub getSNRModalities {
-    my $base = shift;
-    if ($base =~ /t1/i or $base =~ /t2/i or $base =~ /flair/i or $base =~ /pd/i) {
-        return 1;
-    }
-    return 0;
-}
-
 # extracts the subject and timepoint identifiers from the patient name 
 # assumes identifers are stored as <PSCID>_<DCCID>_<visit> in PatientName field, where <visit> is 3 digits.
 sub getSubjectIDs {

--- a/docs/02-Install.md
+++ b/docs/02-Install.md
@@ -204,11 +204,6 @@ scripts (in the `python` directory). It accesses data stored in the
 if($acquisitionProtocol eq 't1' or $acquisitionProtocol eq 't2' or $acquisitionProtocol eq 'dti' or $acquisitionProtocol eq 'bold' or $acquisitionProtocol =~ /fmri/) { return 1; }
 ```
 
-- `getSNRModalities()`
-    
-    Routine to instruct the pipeline which 3D modalities to include when 
-    computing the signal-to-noise-ratio (SNR) on MINC images.
-
 - `getSubjectIDs()`
 
     Routine to parse candidate’s PSCID, CandID, Center (determined from the PSCID), and visit 

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -33,7 +33,7 @@ utilities
                               $subjectIDsref
                             );
 
-    $utility->computeSNR($TarchiveID, $ArchLoc, $profile);
+    $utility->computeSNR($TarchiveID, $ArchLoc);
     $utility->orderModalitiesByAcq($TarchiveID, $ArchLoc);
 
 # DESCRIPTION
@@ -401,15 +401,14 @@ INPUT: subject's ID information hash ref
 RETURNS: the candidate mismatch error, or undef if the candidate is validated
 or a phantom
 
-### computeSNR($tarchiveID, $upload\_id, $profile)
+### computeSNR($tarchiveID, $upload\_id)
 
-Computes the SNR on the modalities specified in the `getSNRModalities()`
-routine of the `$profile` file.
+Computes the SNR on the modalities specified in the Config module under the
+section Imaging Pipeline in the field called 'compute\_snr\_modalities'.
 
 INPUTS:
   - $tarchiveID: DICOM archive ID
   - $upload\_id : upload ID of the study
-  - $profile   : configuration file (usually prod)
 
 ### orderModalitiesByAcq($tarchiveID, $upload\_id)
 

--- a/tools/BackPopulateSNRAndAcquisitionOrder.pl
+++ b/tools/BackPopulateSNRAndAcquisitionOrder.pl
@@ -176,7 +176,7 @@ if($sth->rows > 0) {
         );
 		print "Currently updating the SNR for applicable files in parameter_file table ".
             "for tarchiveID $TarchiveID at location $ArchLoc\n";    
-        $utility->computeSNR($TarchiveID, $upload_id, $profile);
+        $utility->computeSNR($TarchiveID, $upload_id);
 		print "Currently updating the Acquisition Order per modality in files table\n";    
         $utility->orderModalitiesByAcq($TarchiveID, $upload_id);
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1774,13 +1774,13 @@ QUERY
     $minc_file_arr->execute($tarchiveID);
 
     while (my $row = $minc_file_arr->fetchrow_hashref()) {
-        my $filename     = $row->{'file'};
+        my $filename     = $row->{'File'};
         my $fileID       = $row->{'FileID'};
-        my $fileScanType = $row->{'AcquisitionProtocolID'};
+        my $fileScanType = $row->{'Scan_type'};
         my $base         = basename($filename);
         my $fullpath     = "$data_dir/$filename";
         my $message;
-        if ( grep(/$fileScanType/, $modalities) ) {
+        if ( grep(/$fileScanType/, @{$modalities}) ) {
             my $cmd = "noise_estimate --snr $fullpath";
             my $SNR = `$cmd`;
             $SNR =~ s/\n//g;
@@ -1800,7 +1800,7 @@ QUERY
             $message = "The SNR can not be computed for $base as the imaging "
                        . "modality is not supported by the SNR computation. The "
                        . "supported modalities for your projects are "
-                       . join(',', $modalities);
+                       . join(',', $modalities) . ".\n";
             $this->{LOG}->print($message);
             $this->spool($message, 'N', $upload_id, $notify_detailed);
         }

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1780,7 +1780,7 @@ QUERY
         my $base         = basename($filename);
         my $fullpath     = "$data_dir/$filename";
         my $message;
-        if ( grep($_ eq $fileScanType, @{$modalities}) ) {
+        if ( grep($_ eq $fileScanType, @$modalities) ) {
             my $cmd = "noise_estimate --snr $fullpath";
             my $SNR = `$cmd`;
             $SNR =~ s/\n//g;
@@ -1800,7 +1800,7 @@ QUERY
             $message = "The SNR can not be computed for $base as the imaging "
                        . "modality is not supported by the SNR computation. The "
                        . "supported modalities for your projects are "
-                       . join(',', $modalities) . ".\n";
+                       . join(', ', @$modalities) . ".\n";
             $this->{LOG}->print($message);
             $this->spool($message, 'N', $upload_id, $notify_detailed);
         }

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1780,7 +1780,7 @@ QUERY
         my $base         = basename($filename);
         my $fullpath     = "$data_dir/$filename";
         my $message;
-        if ( grep(/$fileScanType/, @{$modalities}) ) {
+        if ( grep($_ eq $fileScanType, @{$modalities}) ) {
             my $cmd = "noise_estimate --snr $fullpath";
             my $SNR = `$cmd`;
             $SNR =~ s/\n//g;

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -579,7 +579,7 @@ foreach my $minc (@minc_files) {
 ################################################################
 ############### Compute SNR on 3D modalities ###################
 ################################################################
-$utility->computeSNR($tarchiveInfo{TarchiveID}, $upload_id, $profile);
+$utility->computeSNR($tarchiveInfo{TarchiveID}, $upload_id);
 ################################################################
 ####### Add order of acquisition for similar modalities ########
 ####### within the same session based on series number #########


### PR DESCRIPTION
### Description

Moves the function `getSNRModalities()` out of the profile file. The list of modalities to compute SNR on will now be stored in the Config module of LORIS under the Imaging Pipeline Section as shown in the screenshot below:
![screen shot 2018-11-28 at 3 50 12 pm](https://user-images.githubusercontent.com/1402456/49181416-50383300-f325-11e8-85be-39becaecb8fb.png)

 The function `computeSNR()` of `MRIProcessingUtility.pm` has been updated to grep that information from the Config module now instead of the profile file.

SQL for this changes are in https://github.com/aces/Loris/pull/4159

### This resolves...

- [x] Redmine: https://redmine.cbrain.mcgill.ca/issues/15721

### Caveat for existing projects:

Make sure you have run the patch from this LORIS PR (https://github.com/aces/Loris/pull/4159; link to be updated to final URL of the patch at the time of release documentation) and that you have updated the Config module with the modalities listed in the function `getSNRModalities` of your profile file.

From now on, the insertion scripts will rely on the values stored in the Config module instead of the profile file and the function `getSNRModalities` can be removed from your profile file.

### To test this

- [ ] Source the patch from the LORIS PR https://github.com/aces/Loris/pull/4159
- [ ] Run the tarchiveLoader and make sure it computes the SNR only for the modalities mentioned in the Config module
- [ ] Run the tool `BackPopulateSNRAndAcquisitionOrder.pl` on one `TarchiveID` for which you have previously removed the SNR values from `parameter_file` and make sure it computes the SNR as expected