### PR TITLE
Additional check to verify avoid duplication of imaging files (using SeriesUID/EchoTime)

### DIFF
--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -74,7 +74,7 @@ INPUTS:
 
 RETURNS: next visit label found for the candidate
 
-### getFileNamesfromSeriesUID($seriesuid, @alltarfiles)
+### getDICOMFileNamesfromSeriesUID($seriesuid, @alltarfiles)
 
 Will extract from the `tarchive_files` table a list of DICOM files
 matching a given `SeriesUID`.
@@ -446,6 +446,20 @@ Ensures no column in the `mri_protocol` nor the `mri_protocol_checks`
 tables has comma-separated values.
 
 RETURNS: 1 on success, 0 on failure
+
+### is\_file\_unique($file, $upload\_id)
+
+Queries the `files` and `parameter_file` tables to make sure that no imaging
+datasets with the same `SeriesUID` and `EchoTime` or the same `MD5sum` hash
+can be found in the database already. If there is a match, it will return a
+message with the information about why the file is not unique. If there is no
+match, then it will return undef.
+
+INPUTS:
+  - $file     : the file object from the `NeuroDB::File` package
+  - $upload\_id: the `UploadID` associated to the file
+
+RETURNS: a message with the reason why the file is not unique or undef
 
 # TO DO
 

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -532,17 +532,19 @@ my ($sessionID, $requiresStaging) =
         \$dbh, $subjectIDsref->{'subprojectID'}
    );
 
+
 ################################################################
 ############ Compute the md5 hash ##############################
 ################################################################
-my $unique = $utility->computeMd5Hash( $file, $upload_id );
-if (!$unique) { 
-    $message = "\n--> WARNING: This file has already been uploaded!\n";  
-    print STDERR $message if $verbose;
-    print LOG $message; 
-    $notifier->spool('tarchive validation', $message, 0,
-                    'minc_insertion.pl', $upload_id, 'Y', 
-                    $notify_notsummary);
+my $not_unique_message = $utility->is_file_unique( $file, $upload_id );
+if ($not_unique_message) {
+    print STDERR $not_unique_message if $verbose;
+    print LOG $not_unique_message;
+    $notifier->spool(
+        'tarchive validation', $not_unique_message, 0,
+        'minc_insertion.pl',   $upload_id,          'Y',
+        $notify_notsummary
+    );
     exit $NeuroDB::ExitCodes::FILE_NOT_UNIQUE;
 } 
 


### PR DESCRIPTION
### Description

Example case: A file named `project_123456_V01_t1_001.mnc` with SeriesUID='1.2.3' and EchoTime='30' has been inserted into the files table. The study site relabel that scan session to V02 instead of V01 and reupload the DICOMs. When running the insertion scripts on those new DICOM, the file would be named `project_123456_V02_t1_001.mnc` and would have a different MD5sum than `project_123456_V01_t1_001.mnc` as the PatientName field has been modified prior to upload. Therefore, the current insertion script will insert a duplicate of a scan that was already in the database since the SeriesUID and EchoTime of this new file remains '1.2.3' and '30'.

This PR fixes the issue that a file could be reinserted in the `files` table if the MD5sum changed. It will now check that no file can be found in the `files` table with the combination SeriesUID/EchoTime (which is unique for each imaging file) in addition to the MD5sum check and exit `minc_insertion.pl` if there was a match found.

Note: in the case of Fieldmap or multi echo acquisitions, a given SeriesUID could be found in multiple files after conversion to MINC. This is why we are using the combination SeriesUID/EchoTime to verify that an imaging file is unique. To date, no exception was found to this rule.

### This resolves...

- [x] Redmine https://redmine.cbrain.mcgill.ca/issues/5498

### To test this

- [ ] with the code from aces/minor, reupload a scan that was already uploaded in the past but with a different PatientName and notice that all acquisitions are reinserted into the `files` table creating duplicates
- [ ] check out this branch and reupload the scan with a different PatientName and notice that no duplicates will be created this time and the LOG will say:
```
ERROR: there is already a file registered in the files table with SeriesUID='1.2.3' and EchoTime='30'.
The already registered file is 'assembly/123456/V01/mri/native/project_123456_V01_t1_001.mnc'
```