### PR TITLE
Header (0020,0032) now only checked when -slicepos is passed on the command line

### DIFF
--- a/dicom-archive/get_dicom_info.pl
+++ b/dicom-archive/get_dicom_info.pl
@@ -136,7 +136,8 @@ foreach my $filename (@input_list) {
     my(@position) = 
 	# ImagePositionPatient (0x0020, 0x0032)
         &convert_coordinates(&split_dicom_list(&trim($dicom->value('0020', '0032'))));
-    if (scalar(@position) != 3) {
+    my $computeSlicePos = grep($_->[1] eq 'slicepos', @Variables);
+    if (scalar(@position) != 3 && $computeSlicePos) {
        warn "Warning: The file: $filename is not DICOM!\n";
        push my @croft, $filename;
        next;
@@ -153,7 +154,7 @@ foreach my $filename (@input_list) {
     my(@normal) = 
        &vector_cross_product(\@column, \@row);
     my @slc_dircos = &get_dircos(@normal);
-    my $slicepos = &vector_dot_product(\@position, \@slc_dircos);
+    my $slicepos = &vector_dot_product(\@position, \@slc_dircos) if $computeSlicePos;
 
     # Print out variable labels
     if(!$PrintedLabels && $PrintLabels) {

--- a/dicom-archive/get_dicom_info.pl
+++ b/dicom-archive/get_dicom_info.pl
@@ -138,7 +138,8 @@ foreach my $filename (@input_list) {
         &convert_coordinates(&split_dicom_list(&trim($dicom->value('0020', '0032'))));
     my $computeSlicePos = grep($_->[1] eq 'slicepos', @Variables);
     if (scalar(@position) != 3 && $computeSlicePos) {
-       warn "Warning: The file: $filename is not DICOM!\n";
+       warn "Warning: DICOM header (0020,0032) not found in $filename: "
+           . "slice position cannot be computed. Skipping file.\n";
        push my @croft, $filename;
        next;
    }


### PR DESCRIPTION
This PR modifies the behaviour of script `get_dicom_info.pl`: DICOM files passed as arguments to this script are now reported as not being DICOM only if they __don't__ have header `(0020,0032)` __and__ `-slicepos` was passed on the command line.

`dcmodify -e` can be useful during testing if one wants to remove header `(0020,0032)` from an existing DICOM file.

This fixes [issue #364](https://github.com/aces/Loris-MRI/issues/364)