### PR TITLE
Addition of a LORIS tool to deface  structural images and register the defaced images back into LORIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Download the pre-compiled package for your operating system.  Install required d
 
   where `$mincToolsDirectory` is the path where the MINC toolkit is installed (e.g. `/opt/minc/` OR `/opt/minc/$mincToolsVersion/` for more recent installs)
 
+For the defacing scripts, you will also need to download the pre-compiled `bic-mni-models` and `beast` data and model packages for you operation system.
+
+   ```bash
+   sudo dpkg -i bic-mni-models-0.1.1-20120421.deb
+   sudo dpkg -i beast-library-1.1.0-20121212.deb
+   ```
+
 #### 4. Run installer to set up directories, configure environment, install Perl libraries and DICOM toolkit:
 
    ```bash 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Download the pre-compiled package for your operating system.  Install required d
 For the defacing scripts, you will also need to download the pre-compiled `bic-mni-models` and `beast` data and model packages for you operation system.
 
    ```bash
-   sudo dpkg -i bic-mni-models-0.1.1-20120421.deb
-   sudo dpkg -i beast-library-1.1.0-20121212.deb
+   sudo dpkg -i bic-mni-models-<version>.deb
+   sudo dpkg -i beast-library-<version>.deb
    ```
 
 #### 4. Run installer to set up directories, configure environment, install Perl libraries and DICOM toolkit:

--- a/docs/scripts_md/run_defacing_script.md
+++ b/docs/scripts_md/run_defacing_script.md
@@ -1,0 +1,136 @@
+# NAME
+
+run\_defacing.pl -- a script that creates defaced images for anatomical
+acquisitions specified in the Config module of LORIS.
+
+# SYNOPSIS
+
+perl tools/run\_defacing\_script.pl `[options]`
+
+Available options are:
+
+\-profile     : name of the config file in `../dicom-archive/.loris_mri`
+\-tarchive\_ids: comma-separated list of MySQL TarchiveIDs
+\-verbose     : be verbose
+
+# DESCRIPTION
+
+This script will create defaced images for anatomical acquisitions that are
+specified in the Config module of LORIS.
+
+# METHODS
+
+### grep\_FileIDs\_to\_deface($session\_id\_arr, $modalities\_to\_deface\_arr)
+
+Queries the database for the list of acquisitions' FileID to be used to run the
+defacing algorithm based on the provided list of SessionID and Scan\_type to
+restrict the search.
+
+INPUTS:
+  - $session\_id\_arr          : array of SessionIDs to use when grepping FileIDs
+  - $modalities\_to\_deface\_arr: array of Scan\_type to use when grepping FileIDs
+
+RETURNS: hash of matching FileIDs to be used to run the defacing algorithm
+         organized in a hash as follows:
+            {0123}                      # sessionID key
+              {flair}                   # flair scan type key
+                {$FileID} = $File\_path  # key = FileID; value = MINC file path
+              {t1}                      # t1 scan type key
+                {$FileID} = $File\_path  # key = FileID 1; value = MINC file 1 path
+                {$FileID} = $File\_path  # key = FileID 2; value = MINC file 2 path
+
+### grep\_candID\_visit\_from\_SessionID($session\_id)
+
+Greps the candidate's `CandID` and the visit label corresponding to the
+`SessionID` given as input.
+
+INPUT: the session ID to use to look for `CandID` and visit label
+
+RETURNS: the candidate's `CandID` and the session visit label
+
+### check\_if\_deface\_files\_already\_in\_db($session\_files, $session\_id)
+
+Checks whether there are already defaced images present in the database for
+the session.
+
+INPUTS:
+  - $session\_files: list of files to deface
+  - $session\_id   : the session ID to use to look for defaced images in `files`
+
+RETURNS: 1 if there are defaced images found, 0 otherwise
+
+### grep\_t1\_ref\_file($session\_files, $ref\_t1\_scan\_type)
+
+Grep the first t1w image from `$session_files` to use it as a reference image for
+`deface_minipipe.pl`.
+
+INPUTS:
+  - $session\_files   : list of files to deface
+  - $ref\_t1\_scan\_type: LORIS scan type of the t1w file to use as a reference
+                       for `deface_minipipe.pl`
+
+RETURNS: hash with information for the reference t1w image
+
+### determine\_output\_dir\_and\_basename($root\_dir, $candID, $visit, $ref\_file)
+
+Determine the output directory path and basename to be used by `deface_minipipe.pl`.
+
+INPUTS:
+  - $root\_dir: root directory (usually a temporary directory where defaced outputs
+               will be created)
+  - $candID  : candidate's `CandID`
+  - $visit   : candidate's visit label
+  - $ref\_file: hash with information about the reference t1 file to use to deface
+
+RETURNS:
+  - $output\_basedir : output base `CandID/VisitLabel` directory where defaced images
+                      will be created
+  - $output\_basename: basename to be used to create the `_deface_grid_0.mnc` file
+
+### deface\_session($ref\_file, $session\_files, $output\_basename)
+
+Function that will run `deface_minipipe.pl` on all anatomical images of the session
+and will return all defaced outputs in a hash.
+
+INPUTS:
+  - $ref\_file       : hash with info about the reference t1w file used to deface
+  - $session\_files  : list of other files than the reference t1w file to deface
+  - $output\_basename: output basename to be used by `deface_minipipe.pl`
+
+RETURNS: hash of defaced images with relevant information necessary to register them
+
+### fetch\_defaced\_files($ref\_file, $session\_files, $output\_basename)
+
+Function that will determine the name of the defaced outputs and check that the
+defaced outputs indeed exists in the file system. If all files are found in the
+filesystem, it will return a hash with all information necessary for registration
+of the defaced image.
+
+INPUTS:
+  - $ref\_file       : hash with info about the reference t1w file used to deface
+  - $session\_files  : list of other files than the reference t1w file to deface
+  - $output\_basename: output basename to be used by `deface_minipipe.pl`
+
+RETURNS: hash of defaced images with relevant information necessary to register them
+
+### register\_defaced\_files($defaced\_images)
+
+Registers the defaced images using `register_processed_data.pl`.
+
+INPUT: hash with the defaced images storing their input FileID and scan type
+
+### create\_defaced\_scan\_type($scan\_type)
+
+Function that inserts a new scan type in `mri_scan_type` if the scan type does not
+already exists in `mri_scan_type`.
+
+INPUT: the scan type to look for or insert in the `mri_scan_type` table
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience

--- a/docs/scripts_md/run_defacing_script.md
+++ b/docs/scripts_md/run_defacing_script.md
@@ -5,13 +5,15 @@ acquisitions specified in the Config module of LORIS.
 
 # SYNOPSIS
 
-perl tools/run\_defacing\_script.pl `[options]`
+`perl tools/run_defacing_script.pl [options]`
 
 Available options are:
 
-\-profile     : name of the config file in `../dicom-archive/.loris_mri`
-\-tarchive\_ids: comma-separated list of MySQL TarchiveIDs
-\-verbose     : be verbose
+`-profile`     : name of the config file in `../dicom-archive/.loris_mri`
+
+`-tarchive_ids`: comma-separated list of MySQL `TarchiveID`s
+
+`-verbose`     : be verbose
 
 # DESCRIPTION
 
@@ -32,12 +34,13 @@ INPUTS:
 
 RETURNS: hash of matching FileIDs to be used to run the defacing algorithm
          organized in a hash as follows:
-            {0123}                      # sessionID key
-              {flair}                   # flair scan type key
-                {$FileID} = $File\_path  # key = FileID; value = MINC file path
-              {t1}                      # t1 scan type key
-                {$FileID} = $File\_path  # key = FileID 1; value = MINC file 1 path
-                {$FileID} = $File\_path  # key = FileID 2; value = MINC file 2 path
+
+    {0123}                          # sessionID key
+        {flair}                     # flair scan type key
+            {$FileID} = $File_path  # key = FileID; value = MINC file path
+        {t1}                        # t1 scan type key
+            {$FileID} = $File_path  # key = FileID 1; value = MINC file 1 path
+            {$FileID} = $File_path  # key = FileID 2; value = MINC file 2 path
 
 ### grep\_candID\_visit\_from\_SessionID($session\_id)
 

--- a/environment
+++ b/environment
@@ -12,3 +12,6 @@ source /data/%PROJECT%/bin/mri/python_virtualenvs/loris-mri-python/bin/activate
 source %MINC_TOOLKIT_DIR%/minc-toolkit-config.sh
 umask 0002
 
+# for the defacing scripts
+export BEASTLIB=%MINC_TOOLKIT_DIR%/../share/beast-library-1.1
+export MNI_MODELS=%MINC_TOOLKIT_DIR%/../share/icbm152_model_09c

--- a/tools/run_defacing_script.pl
+++ b/tools/run_defacing_script.pl
@@ -41,12 +41,7 @@ use File::Temp 'tempdir';
 use NeuroDB::DBI;
 use NeuroDB::ExitCodes;
 
-#-----------------------------------------------#
-# Triggers the deletion of the tmp extract dir  #
-# if something like CTRL-C is pressed during    #
-# execution of the script                       #
-#-----------------------------------------------#
-use sigtrap 'handler' => \&rmTmpDefaceDir, 'normal-signals';
+
 
 # These are hardcoded as examples of how to deal with special modalities:
 # - MP2RAGE inversion scans produces a distortion and a normalized image, only the
@@ -75,10 +70,12 @@ my %SPECIAL_ACQUISITIONS = (
 );
 
 
+
+
 my $profile;
 my $session_ids;
-my $verbose        = 0;
-my $profile_desc   = "Name of the config file in ../dicom-archive/.loris_mri";
+my $verbose          = 0;
+my $profile_desc     = "Name of the config file in ../dicom-archive/.loris_mri";
 my $session_ids_desc = "Comma-separated list of SessionIDs on which to run the "
                        . "defacing algorithm (if not set, will deface images for "
                        . "all SessionIDs present in the database)";
@@ -183,12 +180,13 @@ unless ($mni_models && $beastlib && $tmp_dir_var) {
 
 ## create the tmp directory where the outputs of the deface pipeline will be
 # temporarily stored (before insertion in the database)
-#my $tmp_dir = &tempdir('deface-XXXXXXXX', TMPDIR => 1, CLEANUP => 1);
-my $tmp_dir = '/data/not_backed_up/deface-MbPAr_e8';
-# TODO set cleanup to 1 once done programming
+
+my $tmp_dir = &tempdir('deface-XXXXXXXX', TMPDIR => 1, CLEANUP => 1);
+
 
 
 ## get today's date
+
 my ($sec, $min, $hour, $mday, $mon, $year, $wday, $yday, $isdst) = localtime();
 my $today = sprintf( "%4d-%02d-%02d", $year + 1900, $mon + 1, $mday );
 
@@ -203,6 +201,7 @@ my %files_hash  = grep_FileIDs_to_deface(\@session_ids, $to_deface);
 
 
 ## Loop through SessionIDs
+
 foreach my $session_id (keys %files_hash) {
     # extract the hash of the list of files to deface for that session ID
     my %session_files = %{ $files_hash{$session_id} };
@@ -372,6 +371,20 @@ sub grep_candID_visit_from_SessionID {
 }
 
 
+=pod
+
+=head3 check_if_deface_files_already_in_db($session_files, $session_id)
+
+Checks whether there are already defaced images present in the database for
+the session.
+
+INPUTS:
+  - $session_files: list of files to deface
+  - $session_id   : the session ID to use to look for defaced images in C<files>
+
+RETURNS: 1 if there are defaced images found, 0 otherwise
+
+=cut
 
 sub check_if_deface_files_already_in_db {
     my ($session_files, $session_id) = @_;

--- a/tools/run_defacing_script.pl
+++ b/tools/run_defacing_script.pl
@@ -165,7 +165,7 @@ unless ($ref_scan_type && $to_deface) {
     print STDERR "\n==> ERROR: you need to configure both the "
                  . "reference_scan_type_for_defacing & modalities_to_deface config "
                  . "settings in the imaging pipeline section of the Config module.\n"
-                 . "If these configurations are not present, make sure you have run "
+                 . "If these configurations are not present, ensure you have run "
                  . "all the patches coming with the LORIS release you are using.\n";
     exit $NeuroDB::ExitCodes::SELECT_FAILURE;
 }
@@ -178,7 +178,7 @@ my ($tmp_dir_var, $mni_models, $beastlib) = @ENV{'TMPDIR', 'MNI_MODELS', 'BEASTL
 unless ($mni_models && $beastlib && $tmp_dir_var) {
     print STDERR "\n==> ERROR: the environment variables 'TMPDIR', 'MNI_MODELS' and "
                  . "'BEASTLIB' are required to be set for the defacing script to "
-                 . "run. Please make sure you updated your environment file with "
+                 . "run. Please ensure you updated your environment file with "
                  . "the proper variables and that you source your environment file "
                  . "before running this script.\n";
     exit $NeuroDB::ExitCodes::INVALID_ENVIRONMENT_VAR;
@@ -206,7 +206,7 @@ print "\n==> Fetching all FileIDs to deface.\n" if $verbose;
 my @session_ids = defined $session_ids ? split(",", $session_ids) : ();
 
 unless ($to_deface) {
-    print "\nNo modalities were set to be defaced in the Config module. Make sure"
+    print "\nNo modalities were set to be defaced in the Config module. Ensure"
           . " to select modalities to deface in the Config module under the imaging"
           . " pipeline section (setting called modalities_to_deface. \n\n";
     exit $NeuroDB::ExitCodes::SUCCESS;
@@ -600,7 +600,7 @@ sub fetch_defaced_files {
         }
     }
 
-    # make sure all the files can be found on the filesystem
+    # ensure all the files can be found on the filesystem
     foreach my $file (keys %defaced_images) {
         return undef unless (-e $file);
     }

--- a/tools/run_defacing_script.pl
+++ b/tools/run_defacing_script.pl
@@ -10,13 +10,15 @@ acquisitions specified in the Config module of LORIS.
 
 =head1 SYNOPSIS
 
-perl tools/run_defacing_script.pl C<[options]>
+C<perl tools/run_defacing_script.pl [options]>
 
 Available options are:
 
--profile     : name of the config file in C<../dicom-archive/.loris_mri>
--tarchive_ids: comma-separated list of MySQL TarchiveIDs
--verbose     : be verbose
+C<-profile>     : name of the config file in C<../dicom-archive/.loris_mri>
+
+C<-tarchive_ids>: comma-separated list of MySQL C<TarchiveID>s
+
+C<-verbose>     : be verbose
 
 
 =head1 DESCRIPTION
@@ -275,12 +277,15 @@ INPUTS:
 
 RETURNS: hash of matching FileIDs to be used to run the defacing algorithm
          organized in a hash as follows:
-            {0123}                      # sessionID key
-              {flair}                   # flair scan type key
-                {$FileID} = $File_path  # key = FileID; value = MINC file path
-              {t1}                      # t1 scan type key
-                {$FileID} = $File_path  # key = FileID 1; value = MINC file 1 path
-                {$FileID} = $File_path  # key = FileID 2; value = MINC file 2 path
+
+
+    {0123}                          # sessionID key
+        {flair}                     # flair scan type key
+            {$FileID} = $File_path  # key = FileID; value = MINC file path
+        {t1}                        # t1 scan type key
+            {$FileID} = $File_path  # key = FileID 1; value = MINC file 1 path
+            {$FileID} = $File_path  # key = FileID 2; value = MINC file 2 path
+
 
 =cut
 

--- a/tools/run_defacing_script.pl
+++ b/tools/run_defacing_script.pl
@@ -1,0 +1,320 @@
+#! /usr/bin/perl
+
+=pod
+
+=head1 NAME
+
+run_defacing.pl -- a script that creates defaced images for anatomical
+acquisitions specified in the Config module of LORIS.
+
+
+=head1 SYNOPSIS
+
+perl tools/run_defacing_script.pl C<[options]>
+
+Available options are:
+
+-profile     : name of the config file in C<../dicom-archive/.loris_mri>
+-tarchive_ids: comma-separated list of MySQL TarchiveIDs
+-verbose     : be verbose
+
+
+=head1 DESCRIPTION
+
+This script will create defaced images for anatomical acquisitions that are
+specified in the Config module of LORIS.
+
+
+=head1 LICENSING
+
+License: GPLv3
+
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience
+
+=cut
+
+
+use strict;
+use warnings;
+use Getopt::Tabular;
+use File::Basename;
+use File::Path 'make_path';
+
+use NeuroDB::DBI;
+use NeuroDB::ExitCodes;
+
+my $profile;
+my $session_ids;
+my $verbose        = 0;
+my $profile_desc   = "Name of the config file in ../dicom-archive/.loris_mri";
+my $session_ids_desc = "Comma-separated list of SessionIDs on which to run the "
+                       . "defacing algorithm (if not set, will deface images for "
+                       . "all SessionIDs present in the database)";
+
+my @opt_table = (
+    [ "-profile",    "string",  1, \$profile,     $profile_desc      ],
+    [ "-sessionIDs", "string",  1, \$session_ids, $session_ids_desc ],
+    [ "-verbose",    "boolean", 1, \$verbose,     "Be verbose"       ]
+);
+
+my $Help = <<HELP;
+**********************************************************************************
+DEFACE ANATOMICAL SCANS BASED ON SCAN TYPES TO DEFACE IN THE CONFIGURATION MODULE
+**********************************************************************************
+
+This script will run the defacing algorithm on anatomical scan types listed in the
+compute_defaced_images of the imaging pipeline section of the configuration module.
+
+If a list of SessionIDs is provided using the option -sessionIDs, then the defacing
+algorithm will be run restricted to MINC files belonging to those SessionIDs.
+
+If -sessionIDs is not set, the defacing algorithm will be run on MINC files
+belonging to all SessionIDs present in the database.
+
+Documentation: perldoc run_defacing_script.pl
+
+HELP
+
+my $Usage = <<USAGE;
+Usage: $0 [options]
+       $0 -help to list options
+USAGE
+
+&Getopt::Tabular::SetHelp($Help, $Usage);
+&Getopt::Tabular::GetOptions(\@opt_table, \@ARGV)
+    || exit $NeuroDB::ExitCodes::GETOPT_FAILURE;
+
+
+
+## input error checking
+
+if (!$ENV{LORIS_CONFIG}) {
+    print STDERR "\n\tERROR: Environment variable 'LORIS_CONFIG' not set\n\n";
+    exit $NeuroDB::ExitCodes::INVALID_ENVIRONMENT_VAR;
+}
+
+if (!defined $profile || !-e "$ENV{LORIS_CONFIG}/.loris_mri/$profile") {
+    print $Help;
+    print STDERR "$Usage\n\tERROR: You must specify a valid and existing profile.\n\n";
+    exit $NeuroDB::ExitCodes::PROFILE_FAILURE;
+}
+
+{ package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
+
+if ( !@Settings::db ) {
+    print STDERR "\n\tERROR: You don't have a \@db setting in the file "
+                 . "$ENV{LORIS_CONFIG}/.loris_mri/$profile \n\n";
+    exit $NeuroDB::ExitCodes::DB_SETTINGS_FAILURE;
+}
+
+
+
+## establish database connection
+
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+print "\n==> Successfully connected to the database \n" if $verbose;
+
+
+
+## get config settings
+
+my $ref_scan_type = &NeuroDB::DBI::getConfigSetting(\$dbh, 'reference_scan_type_for_defacing');
+my $to_deface     = &NeuroDB::DBI::getConfigSetting(\$dbh, 'modalities_to_deface'            );
+my $data_dir      = &NeuroDB::DBI::getConfigSetting(\$dbh, 'dataDirBasepath'                 );
+$data_dir         =~ s/\/$//;  # remove trailing /
+unless ($ref_scan_type && $to_deface) {
+    print STDERR "\n==> ERROR: you need to configure both the "
+                 . "reference_scan_type_for_defacing & modalities_to_deface config "
+                 . "settings in the imaging pipeline section of the Config module.\n"
+                 . "If these configurations are not present, make sure you have run "
+                 . "all the patches coming with the LORIS release you are using.\n";
+    exit $NeuroDB::ExitCodes::SELECT_FAILURE;
+}
+
+
+
+## get environment variables
+
+my $tmp_dir    = $ENV{'TMPDIR'};
+my $mni_models = $ENV{'MNI_MODELS'};
+my $beastlib   = $ENV{'BEASTLIB'};
+unless ($mni_models && $beastlib && $tmp_dir) {
+    print STDERR "\n==> ERROR: the environment variables 'TMPDIR', 'MNI_MODELS' and "
+                 . "'BEASTLIB' are required to be set for the defacing script to "
+                 . "run. Please make sure you updated your environment file with "
+                 . "the proper variables and that you source your environment file "
+                 . "before running this script.\n";
+    exit $NeuroDB::ExitCodes::INVALID_ENVIRONMENT_VAR;
+}
+
+
+
+## grep the list of MINC files that will need to be defaced
+
+print "\n==> Fetching all FileIDs to deface.\n" if $verbose;
+my @session_ids = defined $session_ids ? split(",", $session_ids) : ();
+my %files_hash = grep_FileIDs_to_deface(\@session_ids, $to_deface);
+
+
+
+## Loop through SessionIDs
+foreach my $session_id (keys %files_hash) {
+    # extract the hash of the list of files to deface for that session ID
+    my %session_files = %{ $files_hash{$session_id} };
+
+    # grep the CandID and VisitLabel for the dataset
+    my ($candID, $visit) = grep_candID_visit_from_SessionID($session_id);
+
+    # grep the t1 file of reference for the defacing (first FileID for t1 scan type)
+    my $ref_file = grep_t1_ref_file(\%session_files, $ref_scan_type);
+
+    # determine where the result of the deface command will go
+    my ($output_basedir, $output_basename) = determine_output_dir_and_basename(
+        $tmp_dir, $candID, $visit, $ref_file, $ref_scan_type
+    );
+
+    # run the deface command
+    create_the_deface_command($ref_file, \%session_files, $output_basename);
+}
+
+
+exit $NeuroDB::ExitCodes::SUCCESS;
+
+
+=pod
+
+=head3 grep_FileIDs_to_deface($session_id_arr, $modalities_to_deface_arr)
+
+Queries the database for the list of acquisitions' FileID to be used to run the
+defacing algorithm based on the provided list of SessionID and Scan_type to
+restrict the search.
+
+INPUTS:
+  - $session_id_arr          : array of SessionIDs to use when grepping FileIDs
+  - $modalities_to_deface_arr: array of Scan_type to use when grepping FileIDs
+
+RETURNS: hash of matching FileIDs to be used to run the defacing algorithm
+         organized in a hash as follows:
+            {0123}                      # sessionID key
+              {flair}                   # flair scan type key
+                {$FileID} = $File_path  # key = FileID; value = MINC file path
+              {t1}                      # t1 scan type key
+                {$FileID} = $File_path  # key = FileID 1; value = MINC file 1 path
+                {$FileID} = $File_path  # key = FileID 2; value = MINC file 2 path
+=cut
+
+sub grep_FileIDs_to_deface {
+    my ($session_id_arr, $modalities_to_deface_arr) = @_;
+
+    # base query
+    my $query = "SELECT  SessionID, FileID, Scan_type, File "
+                . "FROM  files f "
+                . "JOIN  mri_scan_type mst ON (f.AcquisitionProtocolID = mst.ID)";
+
+    # add where close for the different scan types to deface
+    my @where = map { "mst.Scan_type = ?" } @$modalities_to_deface_arr;
+    $query   .= sprintf(" WHERE (%s) ", join(" OR ", @where));
+
+    # add where close for the session IDs specified to the script if -sessionIDs was set
+    if ($session_id_arr) {
+        @where  = map { "f.SessionID = ?" } @$session_id_arr;
+        $query .= sprintf(" AND (%s) ", join(" OR ", @where));
+    }
+
+    my $sth = $dbh->prepare($query);
+
+    # bind parameters
+    my $idx = 0;
+    foreach my $scan_type (@$modalities_to_deface_arr) {
+        # bind scan type parameters
+        $idx++;
+        $sth->bind_param($idx, $scan_type);
+    }
+    if ($session_id_arr) {
+        foreach my $session_id (@$session_id_arr) {
+            # bind sessionID parameters if -sessionIDs set when running the script
+            $idx++;
+            $sth->bind_param($idx, $session_id);
+        }
+    }
+
+    $sth->execute();
+
+    # grep the list of FileIDs on which to run defacing
+    my %file_id_hash;
+    while (my $row = $sth->fetchrow_hashref){
+        my $session_key   = $row->{'SessionID'};
+        my $scan_type_key = $row->{'Scan_type'};
+        my $file_id_value = $row->{'FileID'};
+        my $file_value    = $row->{'File'};
+        $file_id_hash{$session_key}{$scan_type_key}{$file_id_value} = $file_value;
+    }
+
+    return %file_id_hash
+}
+
+sub grep_candID_visit_from_SessionID {
+    my ($session_id) = @_;
+
+    my $query  = "SELECT CandID, Visit_label FROM session WHERE ID = ?";
+    my $result = $dbh->selectrow_hashref($query, undef, $session_id);
+
+    my $cand_id     = $result->{'CandID'     };
+    my $visit_label = $result->{'Visit_label'};
+
+    return $cand_id, $visit_label;
+}
+
+sub grep_t1_ref_file {
+    my ($session_files, $ref_t1_scan_type) = @_;
+
+    my %t1_files   = %{ $$session_files{$ref_t1_scan_type} };
+    my @t1_fileIDs = sort( grep( defined $t1_files{$_}, keys %t1_files ) );
+    my $ref_fileID = $t1_fileIDs[0];
+    my $ref_file   = $t1_files{$ref_fileID};
+    delete $$session_files{$ref_t1_scan_type}{$ref_fileID};
+
+    return $ref_file;
+}
+
+sub determine_output_dir_and_basename {
+    my ($root_dir, $candID, $visit, $ref_file, $ref_t1_scan_type) = @_;
+
+    # determine output base directory and create it if it does not exist yet
+    my $output_basedir  = "$root_dir/$candID/$visit/";
+    make_path($output_basedir) unless (-e $output_basedir);
+
+    # determine the output base name for the *_deface_grid_0.mnc output
+    my $output_basename = $output_basedir . basename($ref_file);
+    $output_basename    =~ s/_${ref_t1_scan_type}_\d\d\d\.mnc//i;
+
+    # return the output base directory and output basename
+    return $output_basedir, $output_basename;
+}
+
+sub create_the_deface_command {
+    my ($ref_file, $session_files, $output_basename) = @_;
+
+    # initialize the command with the t1 reference file
+    my $cmd = "deface_minipipe.pl $data_dir/$ref_file ";
+
+    # then add all other files that need to be defaced to the command
+    foreach my $scan_type (keys $session_files) {
+        my %files = %{ $$session_files{$scan_type} };
+        foreach my $fileID (keys %files) {
+            my $file_relative_path = $$session_files{$scan_type}{$fileID};
+            $cmd .= " $data_dir/$file_relative_path ";
+        }
+    }
+
+    # then finalize the command with the output basename and additional options
+    $cmd .= " $output_basename --keep-real-range --beastlib $beastlib "
+        . " --model mni_icbm152_t1_tal_nlin_sym_09c "
+        . " --model-dir $mni_models";
+
+    system($cmd);
+}

--- a/tools/run_defacing_script.pl
+++ b/tools/run_defacing_script.pl
@@ -44,15 +44,17 @@ use NeuroDB::ExitCodes;
 
 
 # These are hardcoded as examples of how to deal with special modalities:
+# - Siemens field-map modality produces a phase and two magnitude files. Only the
+#   magnitude images should be defaced (no face on the phase image).
 # - MP2RAGE inversion scans produces a distortion and a normalized image, only the
 #   normalized image should be defaced (no face on the distortion image).
 # - quantitative multi-echo T2star produces a phase and a magnitude image for each
 #   echo. In that case, only the magnitude files should be defaced (no face on the
 #   phase image so should not deface)
-# These 2 variables will be used when grepping the list of FileIDs to deface (in
-# function grep_FileIDs_to_deface
-## TODO document this better
+# The %SPECIAL_ACQUISITIONS_FILTER variable has been created to filter out the
+# correct FileIDs of the images that need to be defaced for those special modalities
 my %SPECIAL_ACQUISITIONS_FILTER = (
+    'fieldmap'      => 'ORIGINAL\\PRIMARY\\M\\ND',
     'MP2RAGEinv1'   => 'ORIGINAL\\\\\\\\PRIMARY\\\\\\\\M\\ND\\NORM',
     'MP2RAGEinv2'   => 'ORIGINAL\\\\\\\\PRIMARY\\\\\\\\M\\ND\\NORM',
     'qT2starEcho1'  => 'ORIGINAL\\\\\\\\PRIMARY\\\\\\\\M\\\\\\\\ND',
@@ -69,9 +71,13 @@ my %SPECIAL_ACQUISITIONS_FILTER = (
     'qT2starEcho12' => 'ORIGINAL\\\\\\\\PRIMARY\\\\\\\\M\\\\\\\\ND'
 );
 
-# These are hardcoded as examples of how to deal with multi-contrast acquisitions
-# such as multi-echo acquisitions or MP2RAGE
-my @MULTI_CONTRAST_ACQUISITIONS_BASE_NAMES = ( "MP2RAGE", "qT2star" );
+# The @MULTI_CONTRAST_ACQUISITIONS_BASE_NAMES variable will store the base names
+# of multi-contrast acquisitions such as MP2RAGE, qT2star or fieldmap. These will
+# allow to call the deface_minipipe.pl tool properly for multi-contrast
+# acquisition (a.k.a. fieldmap_file1,fieldmap_file2) which will tell the
+# deface_minipipe.pl script to not create 2 XFMs but instead reuse the XFM from
+# fieldmap_file1 to register fieldmap_file2
+my @MULTI_CONTRAST_ACQUISITIONS_BASE_NAMES = ( "fieldmap", "MP2RAGE", "qT2star" );
 
 
 

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -526,7 +526,7 @@ sub filterParameters {
     my $parametersRef = $this->getParameters();
 
     foreach my $key (keys %{$parametersRef}) {
-        if(($key ne 'header')
+        if(($key ne 'header') && (defined length($parametersRef->{$key}))
             && (length($parametersRef->{$key}) > MAX_DICOM_PARAMETER_LENGTH)) {
             $this->removeParameter($key);
         }

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1280,7 +1280,7 @@ sub compute_hash {
 	$ctx->add($file->getParameter('patient:birthdate'));          # Patient DOB
 	$ctx->add($file->getParameter('study_instance_uid'));         # StudyInstanceUID
 	$ctx->add($file->getParameter('series_description'));         # SeriesDescription
-    if ($file->getParameter('processing:intergradient_rejected')) {
+    if (defined $file->getParameter('processing:intergradient_rejected')) {
         $ctx->add($file->getParameter('processing:intergradient_rejected'));
     }
     # processing:intergradient_rejected minc field is the only field

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1280,7 +1280,9 @@ sub compute_hash {
 	$ctx->add($file->getParameter('patient:birthdate'));          # Patient DOB
 	$ctx->add($file->getParameter('study_instance_uid'));         # StudyInstanceUID
 	$ctx->add($file->getParameter('series_description'));         # SeriesDescription
-    $ctx->add($file->getParameter('processing:intergradient_rejected')); 
+    if ($file->getParameter('processing:intergradient_rejected')) {
+        $ctx->add($file->getParameter('processing:intergradient_rejected'));
+    }
     # processing:intergradient_rejected minc field is the only field
     # separating a noRegQCedDTI and a QCedDTI minc file.
     }

--- a/uploadNeuroDB/bin/deface_minipipe.pl
+++ b/uploadNeuroDB/bin/deface_minipipe.pl
@@ -183,6 +183,8 @@ foreach my $modality (keys %images_hash) {
       $images_hash{$modality}{Model} = $model_t2w;
     } elsif (basename($scan) =~ /pd/i) {
       $images_hash{$modality}{Model} = $model_pdw;
+    } else {
+      $images_hash{$modality}{Model} = $model_t1w;
     }
   }
 }

--- a/uploadNeuroDB/bin/deface_minipipe.pl
+++ b/uploadNeuroDB/bin/deface_minipipe.pl
@@ -13,8 +13,6 @@
 #              make no representations about the suitability of this
 #              software for any purpose.  It is provided "as is" without
 #              express or implied warranty.
-#@VERSION    : version modified by Cecile Madjar on November 2018 that will 
-#              be commited to the MINC tool kit in the near future
 ###############################################################################
 
 use strict;
@@ -25,14 +23,8 @@ use Getopt::Long;
 my $fake=0;
 my $verbose=0;
 my $clobber=0;
-my $amp=1.0;
-my $fwhm=10;
 my $me=basename($0);
 my $keep_tmp=0;
-my $mask;
-my $byte;
-my $edge_smooth;
-my $dual_echo=0;
 my $model_dir;
 my $model_name;
 my $nonlinear=0;
@@ -42,46 +34,38 @@ my $fwhm=6;
 
 my $no_int_norm=0;
 my $watermark=0;
-my $t1w_xfm;
-my $t2w_xfm;
-my $pdw_xfm;
+my @xfms;
 my $brain_mask;
 my $keep_real_range;
 my $beastlib;
 my $mri_3t;
 
 GetOptions (
-  "verbose"       => \$verbose,
-  "clobber"       => \$clobber,
-  "dual-echo"     => \$dual_echo,
-  "model-dir=s"   => \$model_dir,
-  "model=s"       => \$model_name,
-  "nonlinear"     => \$nonlinear,
-  'no-int-norm'   => \$no_int_norm,
-  'watermark'     => \$watermark,
-  't1w-xfm=s'     => \$t1w_xfm,
-  't2w-xfm=s'     => \$t2w_xfm,
-  'pdw-xfm=s'     => \$pdw_xfm,
-  'brain-mask=s'  => \$brain_mask,
-  'keep-tmp'      => \$keep_tmp,
+  "verbose"         => \$verbose,
+  "clobber"         => \$clobber,
+  "model-dir=s"     => \$model_dir,
+  "model=s"         => \$model_name,
+  "nonlinear"       => \$nonlinear,
+  'no-int-norm'     => \$no_int_norm,
+  'watermark'       => \$watermark,
+  'xfm=s'           => \@xfms,
+  'brain-mask=s'    => \$brain_mask,
+  'keep-tmp'        => \$keep_tmp,
   'keep-real-range' => \$keep_real_range,
-  'beastlib=s'    => \$beastlib,
-  '3t'            => \$mri_3t,
+  'beastlib=s'      => \$beastlib,
+  '3t'              => \$mri_3t,
 ); 
 
 die <<HELP
-Usage: $me <T1w> [modality2] [modality3] ... [modalityX] <output_base>
+Usage: $me <T1W_file> [modality2_file] [modality3echo1_file,modality3echo2_file] ... [modalityX_file] <output_base>
  --model-dir <model directory>
  --model     <model name>
  [--verbose
   --clobber
-  --dual-echo - assume dual echo T2/PD (T2 being provided to the script right before PD)
   --nonlinear  perform quick nonlinear registration to compensate for different head shape (i.e for small kids)
   --watermark watermark output files
   --no-int-norm - don't normalize output file to 0-4095 range, useful only for watermarking
-  --t1w-xfm <t1w.xfm>
-  --t2w-xfm <t2w.xfm>
-  --pdw-xfm <pdw.xfm>
+  --xfm <filebasename,file.xfm> - specify both the base name of the modality and the xfm file to convert this modality to stereotaxic space; can be called multiple times
   --keep-real-range - keep the real range of the data the same
   --beastlib <dir> - location of BEaST library, mandatory
   --3t for 3T scans
@@ -89,27 +73,97 @@ Usage: $me <T1w> [modality2] [modality3] ... [modalityX] <output_base>
 HELP
 if $#ARGV<1 || !$beastlib;
 
+
+## Grep the arguments
+
 my $output_base = pop @ARGV;             # base name to use for the grid file
-my $output_dir  = dirname($output_base); # this would be the final output directory
-my $t1w         = shift @ARGV;           # this stores the full path to the t1w file
-my @other_scans = @ARGV;      # array that stores full path to other files to deface
+my $output_dir  = dirname($output_base); # will be the final output directory
+my $t1w         = shift @ARGV;           # get the full path to the t1w file
+my @multi_echo_scans = grep(/,/, @ARGV); # grep the multi-contrast, mp2rage and
+                                         # other reiteration acquisitions
+                                         # (arguments with , included)
+my @other_scans = grep(! /,/, @ARGV);    # grep the non-multi-contrast, non mp2rage
+                                         #  or non-reiteration acquisitions
+                                         # (arguments without ,)
 
-my $out_grid = "${output_base}_deface_grid_0.mnc"; # full path to the final grid file
+# create the directory where the final outputs will be saved
+mkdir($output_dir) unless (-e $output_dir);
 
+
+
+## Determine defaced file names
+
+# determine the output grid file name
+my $out_grid = "${output_base}_deface_grid_0.mnc"; # full path to final grid file
 # determine final path to defaced t1w
 my $out_t1w         = "$output_dir/" . basename($t1w, '.mnc') . "_defaced.mnc";
-# determine final paths to the other defaced files
-my @out_other_scans = map { "$output_dir/" . basename($_, '.mnc') . "_defaced.mnc" } @other_scans;
-
-check_file($out_t1w) unless $clobber;
-for ( my $idx = 0; $idx < scalar @other_scans; $idx++ ) {
-  check_file($out_other_scans[$idx]) if !$clobber || $other_scans[$idx];
+# determine final paths for multi-echo acquisitions
+my %images_hash;
+foreach my $modality (@multi_echo_scans) {
+  my @files_in  = split(',', $modality);
+  my @files_out = map { "$output_dir/" . basename($_, '.mnc') . "_defaced.mnc" } @files_in;
+  $images_hash{$files_in[0]}{OriginalFiles} = \@files_in;
+  $images_hash{$files_in[0]}{DefacedFiles}  = \@files_out;
 }
+# determine final paths to the other defaced files
+foreach my $modality (@other_scans) {
+  my @file_in = ($modality);
+  my @file_out = map { "$output_dir/" . basename($_, '.mnc') . "_defaced.mnc" } @file_in;
+  $images_hash{$modality}{OriginalFiles} = \@file_in;
+  $images_hash{$modality}{DefacedFiles}  = \@file_out;
+}
+
+
+
+## Grep the XFM files from the command line if option -xfm set
+my $t1w_xfm;
+foreach my $option (@xfms) {
+  my @array = split(',', $option);
+  my $scan  = $array[0];
+  my $xfm   = $array[1];
+  if ($t1w =~ m/$scan/) {
+    # set the T1W XFM if the scan matches the T1W image provided as a reference
+    $t1w_xfm = $xfm;
+  } elsif ( grep($scan, keys %images_hash) ) {
+    # append the XFM for other modalities in the hash
+    my @key = grep(/$scan/, keys %images_hash);
+    $images_hash{$key[0]}{xfm} = $xfm;
+  } else {
+    print "\nError, the file basename specified with the argument -xfm does not"
+          . " appear in the list of modalities you provided with the script.\n";
+    exit;
+  }
+}
+
+
+
+## check that the defaced images are not already present. If present and no
+# -clobber option is set, the script will die.
+
+# check if defaced t1w file exists
+check_file($out_t1w) unless $clobber;
+# check if defaced multi-contrast acquisitions exist
+foreach my $modality (keys %images_hash) {
+  my @in_files  = $images_hash{$modality}{OriginalFiles};
+  my @out_files = $images_hash{$modality}{DefacedFiles};
+  for ( my $idx = 0; $idx < scalar @out_files; $idx++ ) {
+    check_file($out_files[$idx]) if !$clobber || $in_files[$idx];
+  }
+}
+
+
+
+## Create the temporary directory where intermediary processing outputs will be
 
 my $tmpdir = &tempdir( "$me-XXXXXXXX", TMPDIR => 1, CLEANUP => !$keep_tmp );
 
 my $compress = $ENV{MINC_COMPRESS};
 delete $ENV{MINC_COMPRESS} if $ENV{MINC_COMPRESS};
+
+
+
+## Determine the paths to the different models to be used for the different
+# modalities
 
 my $model_t1w  = "$model_dir/$model_name.mnc";
 my $model_t2w  = $model_t1w;
@@ -119,143 +173,170 @@ my $model_face = "$model_dir/${model_name}_face_mask.mnc";
 $model_t2w =~ s/t1/t2/;
 $model_pdw =~ s/t1/pd/;
 
-# determine which model to use for the other modalities stored in @other_scans
-# based on their filename
-my @models;
-foreach my $scan (@other_scans) {
-  push(@models, $model_t1w) if basename($scan) =~ /t1|mp2?rage/i;
-  push(@models, $model_t2w) if basename($scan) =~ /t2|flair/i;
-  push(@models, $model_pdw) if basename($scan) =~ /pd/;
+# determine which model to use for the multi-contrast modalities
+foreach my $modality (keys %images_hash) {
+  foreach my $scan (@{ $images_hash{$modality}{OriginalFiles} }) {
+    if (basename($scan) =~ /t1|mp2?rage/i) {
+      $images_hash{$modality}{Model} = $model_t1w;
+    } elsif (basename($scan) =~ /t2|flair/i) {
+      $images_hash{$modality}{Model} = $model_t2w;
+    } elsif (basename($scan) =~ /pd/i) {
+      $images_hash{$modality}{Model} = $model_pdw;
+    }
+  }
 }
 
-my $model_mask = "$model_dir/${model_name}_mask.mnc";
-#fix irregular sampling
+
+
+## Fix irregular sampling
+
 $t1w = fix_sampling($t1w);
-foreach my $scan (@other_scans) {
-  fix_sampling($scan);
+foreach my $modality (keys %images_hash) {
+  foreach my $scan (@{ $images_hash{$modality}{OriginalFiles} }) {
+    fix_sampling($scan);
+  }
 }
 
-# perform NU correct & clamp
-correct($t1w, $model_t1w, "$tmpdir/clp_t1w.mnc") unless $t1w_xfm && $brain_mask;
-for ( my $idx = 0; $idx < scalar @other_scans; $idx++ ) {
-  my $scan   = $other_scans[$idx];      # full path to the original scan
-  my $suffix = basename($scan, '.mnc'); # suffix used for NU corrected & clamped file
-  my $model  = $models[$idx];           # ICBM template to use
-  correct($scan, $model, "$tmpdir/clp_$suffix.mnc") unless $t1w_xfm && $brain_mask;
+
+
+
+## Perform NU correct & clamp
+
+my $clp_t1_file = "$tmpdir/clp_t1w.mnc";
+correct($t1w, $model_t1w, $clp_t1_file) unless $t1w_xfm && $brain_mask;
+foreach my $modality (keys %images_hash) {
+  foreach my $scan (@{ $images_hash{$modality}{OriginalFiles} }) {
+    my $suffix = basename($scan, '.mnc');
+    my $model  = $images_hash{$modality}{Model};
+    correct($scan, $model, "$tmpdir/clp_$suffix.mnc") unless $t1w_xfm && $brain_mask;
+  }
 }
 
-#stx registration
-my @other_xfms;
-unless($t1w_xfm && $brain_mask)
-{
-  unless($t1w_xfm)
-  {
-    do_cmd('bestlinreg.pl','-lsq9',"$tmpdir/clp_t1w.mnc",$model_t1w,"$tmpdir/t1w_stx.xfm") ;
-    $t1w_xfm="$tmpdir/t1w_stx.xfm";
+
+
+## Stereotaxic registration
+
+my $t1w_stx_xfm = "$tmpdir/t1w_stx.xfm";
+unless($t1w_xfm && $brain_mask) {
+  # create the t1w XFM if it was not provided to the script
+  unless ($t1w_xfm) {
+    do_cmd('bestlinreg.pl', '-lsq9', $clp_t1_file, $model_t1w, $t1w_stx_xfm);
+    $t1w_xfm = "$tmpdir/t1w_stx.xfm";
   }
 
-  #T2 to T1 registration
-  for ( my $idx = 0; $idx < scalar @other_scans; $idx++ ) {
-    my $scan   = $other_scans[$idx];      # full path to the original scan
-    my $suffix = basename($scan, '.mnc'); # suffix used for XFM file names
-    my $model  = $models[$idx];           # ICBM template to use
-    # if this is a t2w based image or another t1w based image, run mritoself to the
-    # with the first t1w clamped image as a reference
-    if ( ($model =~ /t2/i && !$t2w_xfm) || $model =~ /t1/i ) {
-      do_cmd('mritoself','-mi','-lsq6','-close','-nothreshold',
-          "$tmpdir/clp_$suffix.mnc","$tmpdir/clp_t1w.mnc",
-          "$tmpdir/${suffix}_t1.xfm");
+  # Other modality to T1 co-registration
+  foreach my $modality (keys %images_hash) {
+    my $suffix    = basename($modality, '.mnc');  # suffix to use for file names
+    my $xfm_stx   = "$tmpdir/${suffix}_stx.xfm";  # name of the XFM modality to stx
+    my $xfm_to_t1 = "$tmpdir/${suffix}_t1.xfm";   # name of the XFM modality to t1
+    my $clp_file  = "$tmpdir/clp_$suffix.mnc";    # name of the clp file
 
-      do_cmd('xfmconcat',"$tmpdir/${suffix}_t1.xfm",$t1w_xfm,"$tmpdir/${suffix}_stx.xfm");
-      push(@other_xfms, "$tmpdir/${suffix}_stx.xfm");
-    }
-    if ($model =~ /pd/i && !$pdw_xfm) {
-      if ($dual_echo) {
-        my $t2_suffix = basename($other_scans[$idx-1], 'mnc');
-        do_cmd('cp',"$tmpdir/${t2_suffix}_stx.xfm","$tmpdir/${suffix}_stx.xfm");
-      } else {
-        do_cmd('mritoself','-mi','-lsq6','-close','-nothreshold',
-            "$tmpdir/clp_$suffix","$tmpdir/clp_t1w.mnc",
-            "$tmpdir/${suffix}_t1.xfm");
-        do_cmd('xfmconcat',"$tmpdir/${suffix}_t1.xfm",$t1w_xfm,"$tmpdir/${suffix}_stx.xfm");
-      }
-      push(@other_xfms, "$tmpdir/${suffix}_stx.xfm");
+    unless ($images_hash{$modality}{xfm}) {
+      # do registration if no xfm files were provided
+      do_cmd('mritoself', '-mi', '-lsq6', '-close', '-nothreshold', $clp_file, $clp_t1_file, $xfm_to_t1);
+      do_cmd('xfmconcat', $xfm_to_t1, $t1w_xfm, $xfm_stx);
+      $images_hash{$modality}{xfm} = $xfm_stx;
     }
   }
 }
 
-unless($brain_mask)
-{
-  do_cmd('itk_resample',"$tmpdir/clp_t1w.mnc","$tmpdir/stx_t1w.mnc",'--transform',$t1w_xfm,'--like',$model_t1w);
+
+
+## Brain mask creation (if it does not already exist)
+
+unless($brain_mask) {
+  do_cmd('itk_resample', $clp_t1_file, "$tmpdir/stx_t1w.mnc", '--transform', $t1w_xfm, '--like', $model_t1w);
   #do_cmd('mincbet',"$tmpdir/stx_t1w.mnc","$tmpdir/stx_brain",'-m','-n');
   do_cmd('mincbeast', $beastlib, "$tmpdir/stx_t1w.mnc", "$tmpdir/stx_brain_mask.mnc",'-fill','-same_resolution','-median','-configuration',"$beastlib/default.2mm.conf");
-  $brain_mask="$tmpdir/stx_brain_mask.mnc";
+  $brain_mask = "$tmpdir/stx_brain_mask.mnc";
 }
 
-if( -e $out_grid && $clobber)
-{
-  do_cmd('rm','-f',$out_grid);
-}
 
-unless( -e $out_grid )
-{
-  if($nonlinear)
-  {
-    do_cmd('itk_resample',"$tmpdir/clp_t1w.mnc","$tmpdir/stx_t1w.mnc",'--transform',$t1w_xfm,'--like',$model_t1w) if( ! -e "$tmpdir/stx_t1w.mnc");
-    do_cmd('nlfit_s','-level',8,"$tmpdir/stx_t1w.mnc",$model_t1w,"$tmpdir/nl.xfm");
 
-    do_cmd('mincresample','-nearest',$model_face,'-transform',"$tmpdir/nl.xfm",'-use_input_sampling',"$tmpdir/face.mnc",'-invert_transformation');
-    $model_face="$tmpdir/face.mnc";
+## Grid creation
+
+# remove the grid file if one already exists in the temporary directory
+do_cmd('rm','-f', $out_grid) if (-e $out_grid && $clobber);
+
+unless( -e $out_grid ) {
+  if($nonlinear) {
+    do_cmd('itk_resample', $clp_t1_file, $t1w_stx_xfm, '--transform', $t1w_xfm, '--like', $model_t1w) if (! -e $t1w_stx_xfm);
+    do_cmd('nlfit_s', '-level', 8, $t1w_stx_xfm, $model_t1w, "$tmpdir/nl.xfm");
+
+    do_cmd('mincresample', '-nearest', $model_face, '-transform', "$tmpdir/nl.xfm", '-use_input_sampling', "$tmpdir/face.mnc", '-invert_transformation');
+    $model_face = "$tmpdir/face.mnc";
   }
   #do_cmd('mincreshape','-float',$model_face,"$tmpdir/face_float.mnc");
   # create a defacing grid in stx space
-  do_cmd('make_random_grid.pl', '--clobber',
-         '--mask', $model_face, $model_face, 
-         "$tmpdir/grid.mnc",'--amplitude', 
-          $amp, '--fwhm', $fwhm);
+  do_cmd('make_random_grid.pl', '--clobber', '--mask', $model_face, $model_face, "$tmpdir/grid.mnc", '--amplitude', $amp, '--fwhm', $fwhm);
 
-  do_cmd('itk_morph','--exp','D[2]',$brain_mask,"$tmpdir/brain.mnc",'--clobber');
-  do_cmd('itk_morph','--exp','D[1]',$model_face,"$tmpdir/face.mnc" ,'--clobber');
+  do_cmd('itk_morph', '--exp','D[2]', $brain_mask, "$tmpdir/brain.mnc", '--clobber');
+  do_cmd('itk_morph', '--exp','D[1]', $model_face, "$tmpdir/face.mnc" , '--clobber');
 
-  do_cmd('mincresample',"$tmpdir/brain.mnc","$tmpdir/brain2.mnc",'-like',"$tmpdir/face.mnc",'-nearest','-clobber');
-  do_cmd('minccalc','-expression','A[0]==1&&A[1]==0?1:0', "$tmpdir/face.mnc", "$tmpdir/brain2.mnc", "$tmpdir/face2.mnc",'-clobber');
-  do_cmd('rm','-f',"$tmpdir/brain.mnc","$tmpdir/brain2.mnc");
+  do_cmd('mincresample', "$tmpdir/brain.mnc", "$tmpdir/brain2.mnc", '-like', "$tmpdir/face.mnc", '-nearest', '-clobber');
+  do_cmd('minccalc', '-expression', 'A[0]==1&&A[1]==0?1:0', "$tmpdir/face.mnc", "$tmpdir/brain2.mnc", "$tmpdir/face2.mnc", '-clobber');
+  do_cmd('rm', '-f', "$tmpdir/brain.mnc", "$tmpdir/brain2.mnc");
 
   do_cmd('mincresample',"$tmpdir/face2.mnc","$tmpdir/face.mnc",'-like',"$tmpdir/grid.mnc",'-nearest','-clobber');
 
-  do_cmd('mincconcat', '-clobber', '-concat_dimension', 'vector_dimension', '-coordlist',"0,1,2", "$tmpdir/face.mnc","$tmpdir/face.mnc","$tmpdir/face.mnc", "$tmpdir/face2.mnc",'-clobber');
-  do_cmd('minccalc', '-expression', 'A[0]*A[1]',"$tmpdir/face2.mnc", "$tmpdir/grid.mnc" , "$tmpdir/face_grid.mnc",'-clobber','-float');
-  do_cmd('cp',"$tmpdir/face_grid.mnc",$out_grid);
+  do_cmd('mincconcat', '-clobber', '-concat_dimension', 'vector_dimension', '-coordlist', "0,1,2", "$tmpdir/face.mnc", "$tmpdir/face.mnc", "$tmpdir/face.mnc", "$tmpdir/face2.mnc", '-clobber');
+  do_cmd('minccalc', '-expression', 'A[0]*A[1]', "$tmpdir/face2.mnc", "$tmpdir/grid.mnc", "$tmpdir/face_grid.mnc", '-clobber', '-float');
+  do_cmd('cp', "$tmpdir/face_grid.mnc", $out_grid);
 }
 
+
+
+## Deface volumes
+
+# deface the T1W
 deface_volume($out_grid, $t1w_xfm, $t1w, "$tmpdir/deface_t1w.mnc");
-for ( my $idx = 0; $idx < scalar @other_scans; $idx++ ) {
-  my $scan   = $other_scans[$idx]; # full path to the original scan
-  my $xfm    = $other_xfms[$idx];  # XFM file to use to deface the volume
-  $xfm       = $t2w_xfm if (!$xfm && $t2w_xfm && basename($scan) =~ /t2/i);
-  $xfm       = $pdw_xfm if (!$xfm && $pdw_xfm && basename($scan) =~ /pd/i);
-  my $tmpout = "$tmpdir/deface_" . basename($out_other_scans[$idx]);
-  deface_volume($out_grid, $xfm, $scan, $tmpout)
+
+# Deface the other modalities
+foreach my $modality (keys %images_hash) {
+  my $xfm_file  = $images_hash{$modality}{xfm};
+  my @in_files  = @{ $images_hash{$modality}{OriginalFiles} };
+  my @out_files = @{ $images_hash{$modality}{DefacedFiles} };
+
+  for ( my $idx = 0; $idx < scalar @out_files; $idx++ ) {
+    my $scan     = $in_files[$idx];
+    my $tmpout   = "$tmpdir/deface_" . basename($out_files[$idx]);
+    deface_volume($out_grid, $xfm_file, $scan, $tmpout);
+  }
 }
 
 
-$ENV{MINC_COMPRESS}=$compress if $compress;
 
-if($watermark)
-{
-  watermark("$tmpdir/deface_t1w.mnc",$out_t1w);
-  for ( my $idx = 0; $idx < scalar @other_scans; $idx++ ) {
-    my $final_out = $out_other_scans[$idx];  # full path to the final defaced file
-    my $tmp_out   = "$tmpdir/deface_" . basename($final_out);
-    watermark($tmp_out, $final_out);
+$ENV{MINC_COMPRESS} = $compress if $compress;
+
+
+
+## Create watermark output files
+
+if($watermark) {
+  watermark("$tmpdir/deface_t1w.mnc", $out_t1w);
+
+  foreach my $modality (keys %images_hash) {
+    my @out_files = @{ $images_hash{$modality}{DefacedFiles} };
+    for ( my $idx = 0; $idx < scalar @out_files; $idx++ ) {
+      my $final_out = $out_files[$idx];  # full path to the final defaced file
+      my $tmp_out   = "$tmpdir/deface_" . basename($final_out);
+      watermark($tmp_out, $final_out);
+    }
   }
+
 } else {
-  do_cmd('mincreshape',"$tmpdir/deface_t1w.mnc",$out_t1w,'-clobber');
-  for ( my $idx = 0; $idx < scalar @other_scans; $idx++ ) {
-    my $final_out = $out_other_scans[$idx];   # full path to the final defaced file
-    my $tmp_out   = "$tmpdir/deface_" . basename($final_out);
-    do_cmd('mincreshape', $tmp_out, $final_out, '-clobber');
+  do_cmd('mincreshape', "$tmpdir/deface_t1w.mnc", $out_t1w, '-clobber');
+
+  foreach my $modality (keys %images_hash) {
+    my @out_files = @{ $images_hash{$modality}{DefacedFiles} };
+
+    for ( my $idx = 0; $idx < scalar @out_files; $idx++ ) {
+      my $final_out = $out_files[$idx];   # full path to the final defaced file
+      my $tmp_out = "$tmpdir/deface_" . basename($final_out);
+      do_cmd('mincreshape', $tmp_out, $final_out, '-clobber');
+    }
   }
+
 }
 
 exit 0;

--- a/uploadNeuroDB/bin/deface_minipipe.pl
+++ b/uploadNeuroDB/bin/deface_minipipe.pl
@@ -87,7 +87,9 @@ my @other_scans = grep(! /,/, @ARGV);    # grep the non-multi-contrast, non mp2r
                                          # (arguments without ,)
 
 # create the directory where the final outputs will be saved
-mkdir($output_dir) unless (-e $output_dir);
+unless (-e $output_dir) {
+  mkdir($output_dir) or print "\nCould not create directory '$output_dir'. Error is: '$!'\n";
+}
 
 
 
@@ -96,7 +98,7 @@ mkdir($output_dir) unless (-e $output_dir);
 # determine the output grid file name
 my $out_grid = "${output_base}_deface_grid_0.mnc"; # full path to final grid file
 # determine final path to defaced t1w
-my $out_t1w         = "$output_dir/" . basename($t1w, '.mnc') . "_defaced.mnc";
+my $out_t1w = "$output_dir/" . basename($t1w, '.mnc') . "_defaced.mnc";
 # determine final paths for multi-echo acquisitions
 my %images_hash;
 foreach my $modality (@multi_echo_scans) {
@@ -119,8 +121,7 @@ foreach my $modality (@other_scans) {
 my $t1w_xfm;
 foreach my $option (@xfms) {
   my @array = split(',', $option);
-  my $scan  = $array[0];
-  my $xfm   = $array[1];
+  my ($scan, $xfm) = @array[0,1];
   if ($t1w =~ m/$scan/) {
     # set the T1W XFM if the scan matches the T1W image provided as a reference
     $t1w_xfm = $xfm;

--- a/uploadNeuroDB/bin/deface_minipipe.pl
+++ b/uploadNeuroDB/bin/deface_minipipe.pl
@@ -1,0 +1,477 @@
+#!/usr/bin/env perl
+
+############################# MNI Header #####################################
+#@NAME       :  deface_minipipe.pl
+#@DESCRIPTION:  defacing pipeline
+#@COPYRIGHT  :
+#              Vladimir S. Fonov  February, 2009
+#              Montreal Neurological Institute, McGill University.
+#              Permission to use, copy, modify, and distribute this
+#              software and its documentation for any purpose and without
+#              fee is hereby granted, provided that the above copyright
+#              notice appear in all copies.  The author and McGill University
+#              make no representations about the suitability of this
+#              software for any purpose.  It is provided "as is" without
+#              express or implied warranty.
+#@VERSION    : version modified by Cecile Madjar on November 2018 that will 
+#              be commited to the MINC tool kit in the near future
+###############################################################################
+
+use strict;
+use File::Basename;
+use File::Temp qw/ tempfile tempdir /;
+use Getopt::Long;
+
+my $fake=0;
+my $verbose=0;
+my $clobber=0;
+my $amp=1.0;
+my $fwhm=10;
+my $me=basename($0);
+my $keep_tmp=0;
+my $mask;
+my $byte;
+my $edge_smooth;
+my $dual_echo=0;
+my $model_dir;
+my $model_name;
+my $nonlinear=0;
+
+my $amp=12;
+my $fwhm=6;
+
+my $no_int_norm=0;
+my $watermark=0;
+my $t1w_xfm;
+my $t2w_xfm;
+my $pdw_xfm;
+my $brain_mask;
+my $keep_real_range;
+my $beastlib;
+my $mri_3t;
+
+GetOptions (
+  "verbose"       => \$verbose,
+  "clobber"       => \$clobber,
+  "dual-echo"     => \$dual_echo,
+  "model-dir=s"   => \$model_dir,
+  "model=s"       => \$model_name,
+  "nonlinear"     => \$nonlinear,
+  'no-int-norm'   => \$no_int_norm,
+  'watermark'     => \$watermark,
+  't1w-xfm=s'     => \$t1w_xfm,
+  't2w-xfm=s'     => \$t2w_xfm,
+  'pdw-xfm=s'     => \$pdw_xfm,
+  'brain-mask=s'  => \$brain_mask,
+  'keep-tmp'      => \$keep_tmp,
+  'keep-real-range' => \$keep_real_range,
+  'beastlib=s'    => \$beastlib,
+  '3t'            => \$mri_3t,
+); 
+
+die <<HELP
+Usage: $me <T1w> [modality2] [modality3] ... [modalityX] <output_base>
+ --model-dir <model directory>
+ --model     <model name>
+ [--verbose
+  --clobber
+  --dual-echo - assume dual echo T2/PD (T2 being provided to the script right before PD)
+  --nonlinear  perform quick nonlinear registration to compensate for different head shape (i.e for small kids)
+  --watermark watermark output files
+  --no-int-norm - don't normalize output file to 0-4095 range, useful only for watermarking
+  --t1w-xfm <t1w.xfm>
+  --t2w-xfm <t2w.xfm>
+  --pdw-xfm <pdw.xfm>
+  --keep-real-range - keep the real range of the data the same
+  --beastlib <dir> - location of BEaST library, mandatory
+  --3t for 3T scans
+  ]
+HELP
+if $#ARGV<1 || !$beastlib;
+
+my $output_base = pop @ARGV;             # base name to use for the grid file
+my $output_dir  = dirname($output_base); # this would be the final output directory
+my $t1w         = shift @ARGV;           # this stores the full path to the t1w file
+my @other_scans = @ARGV;      # array that stores full path to other files to deface
+
+my $out_grid = "${output_base}_deface_grid_0.mnc"; # full path to the final grid file
+
+# determine final path to defaced t1w
+my $out_t1w         = "$output_dir/" . basename($t1w, '.mnc') . "_defaced.mnc";
+# determine final paths to the other defaced files
+my @out_other_scans = map { "$output_dir/" . basename($_, '.mnc') . "_defaced.mnc" } @other_scans;
+
+check_file($out_t1w) unless $clobber;
+for ( my $idx = 0; $idx < scalar @other_scans; $idx++ ) {
+  check_file($out_other_scans[$idx]) if !$clobber || $other_scans[$idx];
+}
+
+my $tmpdir = &tempdir( "$me-XXXXXXXX", TMPDIR => 1, CLEANUP => !$keep_tmp );
+
+my $compress = $ENV{MINC_COMPRESS};
+delete $ENV{MINC_COMPRESS} if $ENV{MINC_COMPRESS};
+
+my $model_t1w  = "$model_dir/$model_name.mnc";
+my $model_t2w  = $model_t1w;
+my $model_pdw  = $model_t1w;
+my $model_face = "$model_dir/${model_name}_face_mask.mnc";
+
+$model_t2w =~ s/t1/t2/;
+$model_pdw =~ s/t1/pd/;
+
+# determine which model to use for the other modalities stored in @other_scans
+# based on their filename
+my @models;
+foreach my $scan (@other_scans) {
+  push(@models, $model_t1w) if basename($scan) =~ /t1|mp2?rage/i;
+  push(@models, $model_t2w) if basename($scan) =~ /t2|flair/i;
+  push(@models, $model_pdw) if basename($scan) =~ /pd/;
+}
+
+my $model_mask = "$model_dir/${model_name}_mask.mnc";
+#fix irregular sampling
+$t1w = fix_sampling($t1w);
+foreach my $scan (@other_scans) {
+  fix_sampling($scan);
+}
+
+# perform NU correct & clamp
+correct($t1w, $model_t1w, "$tmpdir/clp_t1w.mnc") unless $t1w_xfm && $brain_mask;
+for ( my $idx = 0; $idx < scalar @other_scans; $idx++ ) {
+  my $scan   = $other_scans[$idx];      # full path to the original scan
+  my $suffix = basename($scan, '.mnc'); # suffix used for NU corrected & clamped file
+  my $model  = $models[$idx];           # ICBM template to use
+  correct($scan, $model, "$tmpdir/clp_$suffix.mnc") unless $t1w_xfm && $brain_mask;
+}
+
+#stx registration
+my @other_xfms;
+unless($t1w_xfm && $brain_mask)
+{
+  unless($t1w_xfm)
+  {
+    do_cmd('bestlinreg.pl','-lsq9',"$tmpdir/clp_t1w.mnc",$model_t1w,"$tmpdir/t1w_stx.xfm") ;
+    $t1w_xfm="$tmpdir/t1w_stx.xfm";
+  }
+
+  #T2 to T1 registration
+  for ( my $idx = 0; $idx < scalar @other_scans; $idx++ ) {
+    my $scan   = $other_scans[$idx];      # full path to the original scan
+    my $suffix = basename($scan, '.mnc'); # suffix used for XFM file names
+    my $model  = $models[$idx];           # ICBM template to use
+    # if this is a t2w based image or another t1w based image, run mritoself to the
+    # with the first t1w clamped image as a reference
+    if ( ($model =~ /t2/i && !$t2w_xfm) || $model =~ /t1/i ) {
+      do_cmd('mritoself','-mi','-lsq6','-close','-nothreshold',
+          "$tmpdir/clp_$suffix.mnc","$tmpdir/clp_t1w.mnc",
+          "$tmpdir/${suffix}_t1.xfm");
+
+      do_cmd('xfmconcat',"$tmpdir/${suffix}_t1.xfm",$t1w_xfm,"$tmpdir/${suffix}_stx.xfm");
+      push(@other_xfms, "$tmpdir/${suffix}_stx.xfm");
+    }
+    if ($model =~ /pd/i && !$pdw_xfm) {
+      if ($dual_echo) {
+        my $t2_suffix = basename($other_scans[$idx-1], 'mnc');
+        do_cmd('cp',"$tmpdir/${t2_suffix}_stx.xfm","$tmpdir/${suffix}_stx.xfm");
+      } else {
+        do_cmd('mritoself','-mi','-lsq6','-close','-nothreshold',
+            "$tmpdir/clp_$suffix","$tmpdir/clp_t1w.mnc",
+            "$tmpdir/${suffix}_t1.xfm");
+        do_cmd('xfmconcat',"$tmpdir/${suffix}_t1.xfm",$t1w_xfm,"$tmpdir/${suffix}_stx.xfm");
+      }
+      push(@other_xfms, "$tmpdir/${suffix}_stx.xfm");
+    }
+  }
+}
+
+unless($brain_mask)
+{
+  do_cmd('itk_resample',"$tmpdir/clp_t1w.mnc","$tmpdir/stx_t1w.mnc",'--transform',$t1w_xfm,'--like',$model_t1w);
+  #do_cmd('mincbet',"$tmpdir/stx_t1w.mnc","$tmpdir/stx_brain",'-m','-n');
+  do_cmd('mincbeast', $beastlib, "$tmpdir/stx_t1w.mnc", "$tmpdir/stx_brain_mask.mnc",'-fill','-same_resolution','-median','-configuration',"$beastlib/default.2mm.conf");
+  $brain_mask="$tmpdir/stx_brain_mask.mnc";
+}
+
+if( -e $out_grid && $clobber)
+{
+  do_cmd('rm','-f',$out_grid);
+}
+
+unless( -e $out_grid )
+{
+  if($nonlinear)
+  {
+    do_cmd('itk_resample',"$tmpdir/clp_t1w.mnc","$tmpdir/stx_t1w.mnc",'--transform',$t1w_xfm,'--like',$model_t1w) if( ! -e "$tmpdir/stx_t1w.mnc");
+    do_cmd('nlfit_s','-level',8,"$tmpdir/stx_t1w.mnc",$model_t1w,"$tmpdir/nl.xfm");
+
+    do_cmd('mincresample','-nearest',$model_face,'-transform',"$tmpdir/nl.xfm",'-use_input_sampling',"$tmpdir/face.mnc",'-invert_transformation');
+    $model_face="$tmpdir/face.mnc";
+  }
+  #do_cmd('mincreshape','-float',$model_face,"$tmpdir/face_float.mnc");
+  # create a defacing grid in stx space
+  do_cmd('make_random_grid.pl', '--clobber',
+         '--mask', $model_face, $model_face, 
+         "$tmpdir/grid.mnc",'--amplitude', 
+          $amp, '--fwhm', $fwhm);
+
+  do_cmd('itk_morph','--exp','D[2]',$brain_mask,"$tmpdir/brain.mnc",'--clobber');
+  do_cmd('itk_morph','--exp','D[1]',$model_face,"$tmpdir/face.mnc" ,'--clobber');
+
+  do_cmd('mincresample',"$tmpdir/brain.mnc","$tmpdir/brain2.mnc",'-like',"$tmpdir/face.mnc",'-nearest','-clobber');
+  do_cmd('minccalc','-expression','A[0]==1&&A[1]==0?1:0', "$tmpdir/face.mnc", "$tmpdir/brain2.mnc", "$tmpdir/face2.mnc",'-clobber');
+  do_cmd('rm','-f',"$tmpdir/brain.mnc","$tmpdir/brain2.mnc");
+
+  do_cmd('mincresample',"$tmpdir/face2.mnc","$tmpdir/face.mnc",'-like',"$tmpdir/grid.mnc",'-nearest','-clobber');
+
+  do_cmd('mincconcat', '-clobber', '-concat_dimension', 'vector_dimension', '-coordlist',"0,1,2", "$tmpdir/face.mnc","$tmpdir/face.mnc","$tmpdir/face.mnc", "$tmpdir/face2.mnc",'-clobber');
+  do_cmd('minccalc', '-expression', 'A[0]*A[1]',"$tmpdir/face2.mnc", "$tmpdir/grid.mnc" , "$tmpdir/face_grid.mnc",'-clobber','-float');
+  do_cmd('cp',"$tmpdir/face_grid.mnc",$out_grid);
+}
+
+deface_volume($out_grid, $t1w_xfm, $t1w, "$tmpdir/deface_t1w.mnc");
+for ( my $idx = 0; $idx < scalar @other_scans; $idx++ ) {
+  my $scan   = $other_scans[$idx]; # full path to the original scan
+  my $xfm    = $other_xfms[$idx];  # XFM file to use to deface the volume
+  $xfm       = $t2w_xfm if (!$xfm && $t2w_xfm && basename($scan) =~ /t2/i);
+  $xfm       = $pdw_xfm if (!$xfm && $pdw_xfm && basename($scan) =~ /pd/i);
+  my $tmpout = "$tmpdir/deface_" . basename($out_other_scans[$idx]);
+  deface_volume($out_grid, $xfm, $scan, $tmpout)
+}
+
+
+$ENV{MINC_COMPRESS}=$compress if $compress;
+
+if($watermark)
+{
+  watermark("$tmpdir/deface_t1w.mnc",$out_t1w);
+  for ( my $idx = 0; $idx < scalar @other_scans; $idx++ ) {
+    my $final_out = $out_other_scans[$idx];  # full path to the final defaced file
+    my $tmp_out   = "$tmpdir/deface_" . basename($final_out);
+    watermark($tmp_out, $final_out);
+  }
+} else {
+  do_cmd('mincreshape',"$tmpdir/deface_t1w.mnc",$out_t1w,'-clobber');
+  for ( my $idx = 0; $idx < scalar @other_scans; $idx++ ) {
+    my $final_out = $out_other_scans[$idx];   # full path to the final defaced file
+    my $tmp_out   = "$tmpdir/deface_" . basename($final_out);
+    do_cmd('mincreshape', $tmp_out, $final_out, '-clobber');
+  }
+}
+
+exit 0;
+
+
+sub deface_volume {
+
+  my ($deface_grid,$xfm,$scan,$out)=@_;
+
+  do_cmd('xfminvert',$xfm,"$tmpdir/native.xfm",'-clobber');
+  do_cmd('uniformize_minc.pl',$scan,"$tmpdir/scan.mnc",'--step',2,'--resample','nearest','--clobber');
+  do_cmd('resample_grid',$deface_grid,"$tmpdir/native.xfm","$tmpdir/deface_grid_0.mnc",'--like',"$tmpdir/scan.mnc",'--clobber');
+
+  open XFM,">$tmpdir/deface.xfm" or die;
+  print XFM "MNI Transform File\nTransform_Type = Grid_Transform;\nDisplacement_Volume = deface_grid_0.mnc;\n";
+  close XFM;
+
+  #my ($lo,$hi)=split(/\n/,`mincstats -q -min -max $scan`);
+  my @arg=('mincresample','-nearest','-transform',"$tmpdir/deface.xfm",$scan,$out,'-clobber','-use_input_sampling');#,'-range',$lo,$hi
+  push @arg,'-keep_real_range' if $keep_real_range;
+  do_cmd(@arg);
+  do_cmd('rm','-f',"$tmpdir/native.xfm","$tmpdir/native_grid_0.mnc","$tmpdir/scan.mnc","$tmpdir/deface_grid_0.mnc","$tmpdir/deface.xfm","$tmpdir/deface_grid_0.mnc");
+
+}
+
+sub watermark {
+
+  my ($infile,$outfile)=@_;
+
+  my $posterior = "$model_dir/watermark_posterior.mnc";
+  my $inferior  = "$model_dir/watermark_inferior.mnc";
+  my $left      = "$model_dir/watermark_left.mnc";
+
+  my %info=minc_info($infile);
+
+  do_cmd('mincreshape','-dimorder','xspace,zspace,yspace',$infile,"$tmpdir/sample.mnc",'-clob');
+  reshape_like($posterior,"$tmpdir/sample.mnc","$tmpdir/posterior.mnc");
+  reshape_like($inferior ,"$tmpdir/sample.mnc","$tmpdir/inferior.mnc");
+  reshape_like($left     ,"$tmpdir/sample.mnc","$tmpdir/left.mnc");
+
+  my $avg=`mincstats -biModalT -q $infile`;
+  chomp($avg);
+  $avg=int(0.8*$avg);
+
+  do_cmd('mincmath','-nocheck_dimensions','-max',"$tmpdir/posterior.mnc","$tmpdir/inferior.mnc","$tmpdir/left.mnc","$tmpdir/tmp.mnc",'-clobber');
+  do_cmd('minccalc','-expression',"A[0]*$avg","$tmpdir/tmp.mnc","$tmpdir/combined.mnc",'-short');
+
+  do_cmd('mincmath','-clobber','-add',"$tmpdir/sample.mnc","$tmpdir/combined.mnc","$tmpdir/out.mnc",'-copy_header','-short','-nocheck_dimensions');
+
+  my @arg=('mincreshape','-dimorder',$info{dimnames},'-clobber',"$tmpdir/out.mnc",$outfile);
+  push @arg,'-valid_range',0,4095 unless $no_int_norm;
+  do_cmd(@arg);
+  
+  do_cmd('rm','-f',"$tmpdir/sample.mnc","$tmpdir/combined.mnc","$tmpdir/out.mnc","$tmpdir/posterior.mnc","$tmpdir/inferior.mnc","$tmpdir/left.mnc");
+}
+
+sub do_cmd {
+    print STDOUT "@_\n" if $verbose;
+    if(!$fake) {
+        system(@_) == 0 or die "DIED: @_\n";
+    }
+}
+sub check_file {
+  die("${_[0]} exists!\n") if -e $_[0];
+}
+
+sub minc_info {
+   my ($input)=@_;
+   my %info = (
+   'dimnames' => undef,
+   'xspace'   => undef,
+   'yspace'   => undef,
+   'zspace'   => undef,
+   'xstart' => undef,
+   'ystart' => undef,
+   'zstart' => undef,
+   'xstep' => undef,
+   'ystep' => undef,
+   'zstep' => undef,
+   );   
+   ($info{dimnames},
+    $info{xspace},$info{yspace},$info{zspace},
+    $info{xstart},$info{ystart},$info{zstart},
+    $info{xstep},$info{ystep},$info{zstep})= 
+    split(/\n/, `mincinfo -vardims image -dimlength xspace -dimlength yspace -dimlength zspace -attvalue xspace:start -attvalue yspace:start -attvalue zspace:start -attvalue xspace:step -attvalue yspace:step -attvalue zspace:step $input`);
+    for (values %info) 
+    {  
+      
+      if( /space/ ) 
+      { 
+        s/\s/,/g; 
+      } else  {
+        $_*=1.0;
+      }
+    } #convert to floats
+  chop($info{dimnames}); #remove last comma
+  #print join(' ',%info);
+  return %info;
+}
+
+# makes a minc file with the same dimension order and step sign
+sub reshape_like {
+  my ($in,$sample,$out)=@_;
+  my %info=minc_info($sample);
+  
+  do_cmd('mincreshape',$in,"$tmpdir/tmp.mnc",
+    '-dimrange',"xspace=0,$info{xspace}",
+    '-dimrange',"yspace=0,$info{yspace}",
+    '-dimrange',"zspace=0,$info{zspace}",
+    '-dimorder',$info{dimnames},
+    '-clobber'
+  );
+         
+  do_cmd('mincreshape',"$tmpdir/tmp.mnc",$out,#"$tmpdir/tmp.mnc",
+    '-dimorder',$info{dimnames},
+    '-dimsize', 'xspace=-1',
+    '-dimsize', 'yspace=-1',
+    '-dimsize', 'zspace=-1', 
+    $info{xstep}>0?'+xdirection':'-xdirection',
+    $info{ystep}>0?'+ydirection':'-ydirection',
+    $info{zstep}>0?'+zdirection':'-zdirection',
+    '-clobber');
+}
+
+
+#resample like another minc file
+sub resample_like {
+  my ($in,$sample,$out)=@_;
+
+  my %info=minc_info($sample);
+  
+  if($info{xstep}<0)
+  {
+    $info{xstart}+=$info{xstep}*$info{xspace};
+    $info{xstep}= -$info{xstep};
+  }
+
+  if($info{ystep}<0)
+  {
+    $info{ystart}+=$info{ystep}*$info{yspace};
+    $info{ystep}= -$info{ystep};
+  }
+
+  if($info{zstep}<0)
+  {
+    $info{zstart}+=$info{zstep}*$info{zspace};
+    $info{zstep}= -$info{zstep};
+  }
+
+  $info{xlen}=$info{xstep}*$info{xspace};
+  $info{ylen}=$info{ystep}*$info{yspace};
+  $info{zlen}=$info{zstep}*$info{zspace};
+  
+  my @att=split(/\n/,`mincinfo -attvalue xspace:direction_cosines -attvalue yspace:direction_cosines -attvalue zspace:direction_cosines $sample`);
+  
+  my @cosx=split(/\s/,$att[0]);
+  my @cosy=split(/\s/,$att[1]);
+  my @cosz=split(/\s/,$att[2]);
+  
+  do_cmd('mincreshape',$in,"$tmpdir/tmp.mnc",'-clobber');
+  do_cmd('minc_modify_header',
+         '-dappend',"xspace:direction_cosines=$cosx[0]",
+         '-dappend',"xspace:direction_cosines=$cosx[1]",
+         '-dappend',"xspace:direction_cosines=$cosx[2]",
+
+         '-dappend',"yspace:direction_cosines=$cosy[0]",
+         '-dappend',"yspace:direction_cosines=$cosy[1]",
+         '-dappend',"yspace:direction_cosines=$cosy[2]",
+
+         '-dappend',"zspace:direction_cosines=$cosz[0]",
+         '-dappend',"zspace:direction_cosines=$cosz[1]",
+         '-dappend',"zspace:direction_cosines=$cosz[2]",
+
+         '-dinsert',"xspace:start=$info{xstart}",
+         '-dinsert',"yspace:start=$info{ystart}",
+         '-dinsert',"zspace:start=$info{zstart}",
+         
+         '-dinsert',"xspace:step=$info{xstep}",
+         '-dinsert',"yspace:step=$info{ystep}",
+         '-dinsert',"zspace:step=$info{zstep}",
+         "$tmpdir/tmp.mnc");
+  do_cmd('mincresample','-like',$sample,'-clobber','-nearest',"$tmpdir/tmp.mnc",$out);
+}
+
+sub correct {
+  my ($in,$model,$out)=@_;
+  if($mri_3t)
+  {
+    do_cmd("nu_correct", "-clobber", "-iter", 100, "-stop", 0.0001, "-fwhm", 0.1,$in, "$tmpdir/nuc.mnc",'-clobber');
+  } else {
+    do_cmd("nu_correct", "-clobber", "-iter", 100, "-stop", 0.0001, "-fwhm", 0.1,$in, "$tmpdir/nuc.mnc",'-clobber','-distance',50);
+  }
+  do_cmd('volume_pol',"$tmpdir/nuc.mnc",$model,'--order',1,'--expfile',"$tmpdir/pol.exp",'--clobber');
+  do_cmd('minccalc','-expfile',"$tmpdir/pol.exp","$tmpdir/nuc.mnc",$out,'-clobber');
+}
+
+sub fix_sampling {
+  my $in_minc=$_[0];
+  my $need_fixing=0;
+  my $spc;
+  foreach $spc(split(/\n/,`mincinfo -attvalue xspace:spacing -attvalue yspace:spacing -attvalue zspace:spacing  $in_minc`))
+  {
+    $need_fixing=1 if $spc=~/irregular/;
+  }
+  my $out=$in_minc;
+
+  if($need_fixing)
+  {
+    $out=$tmpdir.'/'.basename($in_minc,'.gz');
+    if($in_minc=~/.gz$/)
+    {
+      do_cmd("gunzip -c $in_minc >$out");
+    } else {
+      do_cmd('cp',$in_minc,$out);
+    }
+    do_cmd('minc_modify_header','-sinsert','xspace:spacing=regular__','-sinsert','zspace:spacing=regular__','-sinsert','yspace:spacing=regular__',$out)
+  }
+  return $out;
+}


### PR DESCRIPTION
### Description

This PR adds a new tool that will allow defacing of the structural images listed in the Config module under the imaging pipeline section in the new field called `modalities_to_deface` (See PR https://github.com/aces/Loris/pull/4232 on the LORIS side for the SQL patch).

Note that the script `deface_minipipe.pl` in `uploadNeuroDB/bin` has been taken out of the BIC EZminc GitHub repo (https://github.com/BIC-MNI/EZminc/tree/ITK4/scripts).

Screenshot of a defaced scan:
![defaced](https://user-images.githubusercontent.com/1402456/52799332-99a43e80-3047-11e9-87e6-5e1b150c5122.jpg)

### How to use the tool

1) Make sure to populate the configuration `modalities_to_deface` in the imaging pipeline section of the Configuration module with all scan types that you wish to deface (typically, T1W, T2W, T2*, FLAIR and other 3D structural images)

2) To run the tool, go to the `tools` directory and run:
```perl run_defacing_script.pl -profile <profile> [ -sessionIDs <list of sessionIDs> ]```
Note that if the `-sessionIDs` is not passed to the script, it will deface images from all sessions with the modalities to deface.

#### Special notes for multi-contrast acquisitions:

At the top of the script, 2 variables have been implemented and can be customized:

**1. `%SPECIAL_ACQUISITIONS_FILTER`:** 

For acquisitions such as fieldmaps, a phase and two magnitude files are available. We only want to deface the magnitude files as the phase file does not have a face and we don't want to alter the phase image. To differentiate between the phase and magnitude files, we need to use the `acquisition:image_type` MINC header for which the value will be:
- `ORIGINAL\\PRIMARY\\M\\ND` for the magnitude files 
- `ORIGINAL\\PRIMARY\\P\\ND` for the phase file

Therefore, to only deface the magnitude fieldmap images, we need to specify the value of `acquisition:image_type` in the constant variable `%SPECIAL_ACQUISITIONS_FILTER` at the top of the script like that:
```
my %SPECIAL_ACQUISITIONS_FILTER = (
    'fieldmap'      => 'ORIGINAL\\PRIMARY\\M\\ND'
);
```

In the script, this constant variable also shows examples for MP2RAGE and multi-echo acquisitions.

**2. `@MULTI_CONTRAST_ACQUISITIONS_BASE_NAMES`**

The `@MULTI_CONTRAST_ACQUISITIONS_BASE_NAMES` variable will store the base names of multi-contrast acquisitions such as `MP2RAGE`, `qT2star` or `fieldmap`. These will allow to call the `deface_minipipe.pl` tool properly for multi-contrast acquisition (a.k.a. `fieldmap_file1,fieldmap_file2`). Calling `deface_minipipe.pl` with images separated by `,` will tell the script not to create 2 XFMs (one for each fieldmap file) but instead reuse the XFM from  `fieldmap_file1` to register `fieldmap_file2`.

### Notes for existing projects

If you desire to use this new tool, make sure you have:
- downloaded and installed the `bic-mni-models` anatomical template library and the `beast` library from the MINC tools in `/opt/minc/` (https://bic-mni.github.io/#data-files-and-models)
- added the two following variables to your environment file so that the scripts can find the MNI models (replace %MINC_TOOLKIT_DIR% by the path to your MINC toolkit install):
```
# for the defacing scripts
export BEASTLIB=%MINC_TOOLKIT_DIR%/../share/beast-library-1.1
export MNI_MODELS=%MINC_TOOLKIT_DIR%/../share/icbm152_model_09c
```
- sourced the SQL patch from the https://github.com/aces/Loris/pull/4232 LORIS PR 
- adapted the constant variables (`%SPECIAL_ACQUISITIONS_FILTER`, `@MULTI_CONTRAST_ACQUISITIONS_BASE_NAMES`) at the top of the `tools/run_defacing_script.pl` script to your project's need.

Additional checks before running the script:
- make sure `which deface_minipipe.pl` is returning the following `$LORIS-MRI/uploadNeuroDB/bin/deface_minipipe.pl` script and not the one present in the MINC toolkit (`/opt/minc/$VERSION`) as LORIS-MRI is using the version of `deface_minipipe.pl` under development (which have not yet been released with the MINC tools). If `which deface_minipipe.pl` is not pointing to the correct script, you will need to update your `$PATH` bash variable to make sure `$LORIS-MRI/uploadNeuroDB/bin` is the first path mentioned in the variable.

### See also

- LORIS PR with SQL patch: https://github.com/aces/Loris/pull/4232
- Redmine ticket: https://redmine.cbrain.mcgill.ca/issues/10524