### PR TITLE
Use getpwuid instead of a call to whoami to get the userid throughout the MRI pipeline codebase.

### DIFF
--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -292,7 +292,7 @@ RETURNS: $upload_id : The upload ID
 sub insertIntoMRIUpload {
 
     my ( $dbhr, $patientname, $phantom, $fullpath ) = @_;
-    my $User = `whoami`;
+    my $User = getpwuid($>);
 
     my $query = "INSERT INTO mri_upload ".
                 "(UploadedBy, UploadDate, PatientName, ".

--- a/dicom-archive/updateMRI_Upload.pl
+++ b/dicom-archive/updateMRI_Upload.pl
@@ -100,7 +100,7 @@ my $tarchive = '';
 my $query = '';
 my $sth = undef;
 my $tarchiveID = 0;
-my $User             = `whoami`;
+my $User             = getpwuid($>);
 my $versionInfo = sprintf "%d revision %2d", q$Revision: 1.24 $
     =~ /: (\d+)\.(\d+)/;
 

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -270,7 +270,7 @@ my $exclude          = NeuroDB::DBI::getConfigSetting(
                         \$dbh, 'excluded_series_description'
                        );
 my $template         = "TarLoad-$hour-$min-XXXXXX"; # for tempdir
-my $User             = `whoami`;
+my $User             = getpwuid($>);
 
 # fixme there are better ways 
 my @progs = ("convert", "Mincinfo_wrapper", "mincpik", $converter);

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -106,7 +106,7 @@ my $globArchiveLocation = 0;   # whether to use strict ArchiveLocation strings
                                # or to glob them (like '%Loc')
 my $template         = "TarLoad-$hour-$min-XXXXXX"; # for tempdir
 my ($gender, $tarchive,%tarchiveInfo);
-my $User             = `whoami`; 
+my $User             = getpwuid($>); 
 
 my @opt_table = (
                  ["Basic options","section"],


### PR DESCRIPTION
Title says it all. This PR implements the right way to get the effective UID in a Perl process. To test, simply verify that the variable containing the user ID is set correctly in the modified scripts.

This fixes [Redmine ticket 14115](https://redmine.cbrain.mcgill.ca/issues/14115).