### PR TITLE
[Bug fix] Insert into parameter_type_category_rel table when creating new parameter_type

### DIFF
--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -229,8 +229,7 @@ class Physiological:
     def get_parameter_type_category_id(self):
         """
         Greps ParameterTypeCategoryID from parameter_type_category table.
-        If no ParameterTypeCategoryID were found, the script will create it in
-        parameter_type_category.
+        If no ParameterTypeCategoryID was found, it will return None.
 
         :return: ParameterTypeCategoryID
          :rtype: int
@@ -242,18 +241,11 @@ class Physiological:
                   'WHERE Name = %s ',
             args=('Electrophysiology Variables',)
         )
-        if category_result:
-            category_id = category_result[0]['ParameterTypeCategoryID']
-        else:
-            # if no results, create an entry in parameter_type_category
-            category_id = self.db.insert(
-                table_name   = 'parameter_type_category',
-                column_names = ('Name', 'Type'),
-                values       = ('Electrophysiology Variables', 'Metavars'),
-                get_last_id  = True
-            )
+        
+        if not category_result:
+            return None
 
-        return category_id
+        return category_result[0]['ParameterTypeCategoryID']
 
     def grep_electrode_from_physiological_file_id(self, physiological_file_id):
         """

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -215,7 +215,45 @@ class Physiological:
                 get_last_id  = True
             )
 
+            # link the parameter_type_id to a parameter type category
+            category_id = self.get_parameter_type_category_id()
+            self.db.insert(
+                table_name   = 'parameter_type_category_rel',
+                column_names = ('ParameterTypeCategoryID', 'ParameterTypeID'),
+                values       = (category_id, parameter_type_id),
+                get_last_id  = False
+            )
+
         return parameter_type_id
+
+    def get_parameter_type_category_id(self):
+        """
+        Greps ParameterTypeCategoryID from parameter_type_category table.
+        If no ParameterTypeCategoryID were found, the script will create it in
+        parameter_type_category.
+
+        :return: ParameterTypeCategoryID
+         :rtype: int
+        """
+
+        category_result = self.db.pselect(
+            query='SELECT ParameterTypeCategoryID '
+                  'FROM parameter_type_category '
+                  'WHERE Name = %s ',
+            args=('Electrophysiology Variables',)
+        )
+        if category_result:
+            category_id = category_result[0]['ParameterTypeCategoryID']
+        else:
+            # if no results, create an entry in parameter_type_category
+            category_id = self.db.insert(
+                table_name   = 'parameter_type_category',
+                column_names = ('Name', 'Type'),
+                values       = ('Electrophysiology Variables', 'Metavars'),
+                get_last_id  = True
+            )
+
+        return category_id
 
     def grep_electrode_from_physiological_file_id(self, physiological_file_id):
         """

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -479,7 +479,7 @@ sub getParameterTypeID {
         $query = "INSERT INTO parameter_type (Name, Type, Description, SourceFrom, Queryable) VALUES (".$dbh->quote($paramType).", 'text', ".$dbh->quote("$paramType magically created by NeuroDB::File").", 'parameter_file', 0)";
         $dbh->do($query);
 
-        # grep the inserted ParameterTypeID and update parameter_category_rel
+        # link the inserted ParameterTypeID to a parameter type category
         my $param_type_id = $dbh->{'mysql_insertid'};
         $query = "INSERT INTO parameter_type_category_rel "
                  . " (ParameterTypeID, ParameterTypeCategoryID) "

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -478,7 +478,18 @@ sub getParameterTypeID {
         my ($user) = getpwuid($UID);
         $query = "INSERT INTO parameter_type (Name, Type, Description, SourceFrom, Queryable) VALUES (".$dbh->quote($paramType).", 'text', ".$dbh->quote("$paramType magically created by NeuroDB::File").", 'parameter_file', 0)";
         $dbh->do($query);
-        return $dbh->{'mysql_insertid'};
+
+        # grep the inserted ParameterTypeID and update parameter_category_rel
+        my $param_type_id = $dbh->{'mysql_insertid'};
+        $query = "INSERT INTO parameter_type_category_rel "
+                 . " (ParameterTypeID, ParameterTypeCategoryID) "
+                 . " SELECT ?, ParameterTypeCategoryID "
+                    . " FROM parameter_type_category "
+                    . " WHERE Name='MRI Variables'";
+        $sth = $dbh->prepare($query);
+        $sth->execute($param_type_id);
+
+        return $param_type_id;
     }
 }
 	


### PR DESCRIPTION
### Description

This fixes an issue raised in https://github.com/aces/Loris/pull/3695#discussion_r242642123 where entries into the `parameter_type` table created by the imaging script were not linked to a parameter type category via `parameter_type_category_rel`. The code in this PR fixes this issue.


The imaging part if corrected in the `File.pm` file and the electrophysiology part is corrected in `physiological.py` library. 

### Resolves

- [x] issue raised in @davidblader publication module PR (https://github.com/aces/Loris/pull/3695#discussion_r242642123)

### Caveat for Existing Projects

Make sure to source the SQL patch in the following LORIS PR https://github.com/aces/Loris/pull/4263 to fix existing projects' table.

