### PR TITLE
[Bug fix] fix get_dicom_info.pl so that it skips the scanner reports

### DIFF
--- a/dicom-archive/get_dicom_info.pl
+++ b/dicom-archive/get_dicom_info.pl
@@ -93,6 +93,7 @@ use FindBin;
 use Getopt::Tabular qw(GetOptions);
 use lib "$FindBin::Bin";
 use DICOM::DICOM;
+use NeuroDB::MRI;
 use NeuroDB::ExitCodes;
 
 my $Help;
@@ -128,11 +129,13 @@ if(@Variables <= 0)
     die "Please specify one or more fields to display\n";
 }
 
-foreach my $filename (@input_list) {
+my ($dicom_files, $non_dicom_files) = NeuroDB::MRI::isDicom(@input_list);
+
+foreach my $filename (@$dicom_files) {
     my $dicom = DICOM->new();
     $dicom->fill($filename);
 
-    next if ($dicom->value('0008','103E') eq 'PhoenixZIPReport');
+    next unless ($dicom->value('7fe0','0010'));
 
     # Get slice position and orientation (row and column vectors)
     my(@position) = 

--- a/dicom-archive/get_dicom_info.pl
+++ b/dicom-archive/get_dicom_info.pl
@@ -132,6 +132,8 @@ foreach my $filename (@input_list) {
     my $dicom = DICOM->new();
     $dicom->fill($filename);
 
+    next if ($dicom->value('0008','103E') eq 'PhoenixZIPReport');
+
     # Get slice position and orientation (row and column vectors)
     my(@position) = 
 	# ImagePositionPatient (0x0020, 0x0032)

--- a/dicom-archive/get_dicom_info.pl
+++ b/dicom-archive/get_dicom_info.pl
@@ -129,13 +129,13 @@ if(@Variables <= 0)
     die "Please specify one or more fields to display\n";
 }
 
-my ($dicom_files, $non_dicom_files) = NeuroDB::MRI::isDicom(@input_list);
+my $isImage_hash = NeuroDB::MRI::isDicomImage(@input_list);
+my @image_files  = grep { $$isImage_hash{$_} == 1 } keys $isImage_hash;
 
-foreach my $filename (@$dicom_files) {
+
+foreach my $filename (@image_files) {
     my $dicom = DICOM->new();
     $dicom->fill($filename);
-
-    next unless ($dicom->value('7fe0','0010'));
 
     # Get slice position and orientation (row and column vectors)
     my(@position) = 

--- a/docs/scripts_md/ImagingUpload.md
+++ b/docs/scripts_md/ImagingUpload.md
@@ -94,14 +94,6 @@ INPUTS:
 
 RETURNS: 1 on success, 0 on failure
 
-### isDicom($dicom\_file)
-
-This method checks whether the file given as an argument is of type DICOM.
-
-INPUT: full path to the DICOM file
-
-RETURNS: 1 if file is of type DICOM, 0 if file is not of type DICOM
-
 ### runCommandWithExitCode($command)
 
 This method will run any linux command given as an argument using the

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -406,15 +406,18 @@ INPUTS:
 
 RETURNS: the `CandID` or 0 if the `PSCID` does not exist
 
-### isDicom(@files\_list)
+### isDicomImage(@files\_list)
 
-This method checks whether the list of files given as an argument is of type DICOM.
+This method checks whether the files given as an argument are DICOM images or not.
+It will return a hash with the file path as keys and true or false as values (the
+value will be set to true if the file is a DICOM image, otherwise it will be set to
+false).
 
 INPUT: array with full path to the DICOM files
 
 RETURNS:
-  - @dicom\_files    : array with the list of DICOM medical imaging data files
-  - @non\_dicom\_files: array with the list of non-DICOM files
+  - %isDicomImage: hash with file path as keys and true or false as values (true
+                   if the file is a DICOM image file, false otherwise)
 
 # TO DO
 

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -406,6 +406,16 @@ INPUTS:
 
 RETURNS: the `CandID` or 0 if the `PSCID` does not exist
 
+### isDicom(@files\_list)
+
+This method checks whether the list of files given as an argument is of type DICOM.
+
+INPUT: array with full path to the DICOM files
+
+RETURNS:
+  - @dicom\_files    : array with the list of DICOM medical imaging data files
+  - @non\_dicom\_files: array with the list of non-DICOM files
+
 # TO DO
 
 Fix comments written as #fixme in the code.

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -53,6 +53,7 @@ use NeuroDB::FileDecompress;
 use NeuroDB::Notify;
 use NeuroDB::ExitCodes;
 use NeuroDB::DBI;
+use NeuroDB::MRI;
 use File::Temp qw/ tempdir /;
 
 
@@ -151,9 +152,7 @@ sub IsCandidateInfoValid {
     ############################################################
     #########################Initialization#####################
     ############################################################
-    my $files_not_dicom                   = 0;
     my $files_with_unmatched_patient_name = 0;
-    my $is_candinfovalid                  = 0;
     my @row                               = ();
 
     ############################################################
@@ -243,61 +242,35 @@ sub IsCandidateInfoValid {
         return 0;
     }
 
-    foreach (@file_list) {
-        ########################################################
-        #1) Exlcude files starting with . (and ._ as a result)##
-        #including the .DS_Store file###########################
-        #2) Check to see if the file is of type DICOM###########
-        #3) Check to see if the header matches the patient-name#
-        ########################################################
-        if ( (basename($_) =~ /^\./)) {
-            $cmd = "rm " . ($_);
-            print "\n $cmd \n";
-            system($cmd);
-        }
-        else {
-            if ( ( $_ ne '.' ) && ( $_ ne '..' )) {
-                if ( !$this->isDicom($_) ) {
-                    $files_not_dicom++;
-                }
-    	        else {
-            #######################################################
-            #Validate the Patient-Name, only if it's not a phantom#
-            ############## and the file is of type DICOM###########
-            #######################################################
-                    if ($row[4] eq 'N') {
-                        # make sure the regex used for PatientNameMatch starts
-                        # with $this->{'pname'}
-                        if (!$this->PatientNameMatch($_, "^$this->{'pname'}")) {
-                            $files_with_unmatched_patient_name++;
-                        }
-                    } elsif ($row[4] eq 'Y') {
-                        # make sure the regex used for PatientNameMatch
-                        # includes "phantom" string
-                        my $lego_phantom_regex = NeuroDB::DBI::getConfigSetting(
-                            $this->{dbhr}, 'LegoPhantomRegex'
-                        );
-                        my $living_phantom_regex = NeuroDB::DBI::getConfigSetting(
-                            $this->{dbhr}, 'LivingPhantomRegex'
-                        );
-                        my $phantom_regex =
-                            "($lego_phantom_regex)|($living_phantom_regex)";
-                        if (!$this->PatientNameMatch($_, $phantom_regex)) {
-                            $files_with_unmatched_patient_name++;
-                        }
-                    }
-                }
-            }
-        }
-    }
+    my ($dicom_files, $non_dicom_files) = NeuroDB::MRI::isDicom(@file_list);
 
-    if ( $files_not_dicom > 0 ) {
+    # return 0 if found at least one non-DICOM file
+    my $files_not_dicom = scalar @$non_dicom_files;
+    if ($files_not_dicom > 0 ) {
         $message = "\nERROR: There are $files_not_dicom file(s) which"
-          . " are not of type DICOM \n";
+            . " are not of type DICOM \n";
         $this->spool($message, 'Y', $notify_notsummary);
         return 0;
     }
 
+    # check that the patient name was set properly in the DICOM files
+    my $lego_phantom_regex = NeuroDB::DBI::getConfigSetting(
+        $this->{dbhr}, 'LegoPhantomRegex'
+    );
+    my $living_phantom_regex = NeuroDB::DBI::getConfigSetting(
+        $this->{dbhr}, 'LivingPhantomRegex'
+    );
+    my $phantom_regex = "($lego_phantom_regex)|($living_phantom_regex)";
+    my $patient_name  = $this->{'pname'};
+    foreach my $file (@$dicom_files) {
+        if ($row[4] eq 'N' && !$this->PatientNameMatch($file, "^$patient_name")) {
+            $files_with_unmatched_patient_name++;
+        } elsif ($row[4] eq 'Y' && !$this->PatientNameMatch($file, $phantom_regex)) {
+            $files_with_unmatched_patient_name++;
+        }
+    }
+
+    # return 0 if found at least one DICOM file without the proper patient name
     if ( $files_with_unmatched_patient_name > 0 ) {
         $message =
             "\nERROR: There are $files_with_unmatched_patient_name file(s)"
@@ -507,31 +480,6 @@ sub PatientNameMatch {
     }
     return 1;     ##return true
 
-}
-
-
-=pod
-
-=head3 isDicom($dicom_file)
-
-This method checks whether the file given as an argument is of type DICOM.
-
-INPUT: full path to the DICOM file
-
-RETURNS: 1 if file is of type DICOM, 0 if file is not of type DICOM
-
-=cut
-
-sub isDicom {
-    my $this         = shift;
-    my ($dicom_file) = @_;
-    my $cmd    = "file $dicom_file";
-    my $file_type    = `$cmd`;
-    if ( !( $file_type =~ /DICOM medical imaging data$/ ) ) {
-        print "\n $dicom_file is not of type DICOM \n";
-        return 0;
-    }
-    return 1;
 }
 
 =pod

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1612,23 +1612,23 @@ sub my_trim {
 
 =head3 isDicomImage(@files_list)
 
-This method checks whether the files given as an argument are of type DICOM. All
-DICOM image files will be returned in the array @image_files. Non-DICOM image or
-DICOM scanner reports that are not images will be returned in the array
-@non_image_files.
+This method checks whether the files given as an argument are DICOM images or not.
+It will return a hash with the file path as keys and true or false as values (the
+value will be set to true if the file is a DICOM image, otherwise it will be set to
+false).
 
 INPUT: array with full path to the DICOM files
 
 RETURNS:
-  - @image_files    : array with the list of DICOM medical imaging data images
-  - @non_image_files: array with the list of non-DICOM images
+  - %isDicomImage: hash with file path as keys and true or false as values (true
+                   if the file is a DICOM image file, false otherwise)
 
 =cut
 
 sub isDicomImage {
     my (@files_list) = @_;
 
-    my $cmd = "file " . join(' ', @files_list);
+    my $cmd = "ls @files_list | xargs file";
     my @file_types = `$cmd`;
 
     my %isDicomImage;

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1607,6 +1607,38 @@ sub my_trim {
 }
 
 
+=pod
+
+=head3 isDicom(@files_list)
+
+This method checks whether the list of files given as an argument is of type DICOM.
+
+INPUT: array with full path to the DICOM files
+
+RETURNS:
+  - @dicom_files    : array with the list of DICOM medical imaging data files
+  - @non_dicom_files: array with the list of non-DICOM files
+
+=cut
+
+sub isDicom {
+    my (@files_list) = @_;
+
+    my $cmd = "file " . join(' ', @files_list);
+    my @file_types = `$cmd`;
+
+    my @dicom_files;
+    my @non_dicom_files;
+    foreach my $line (@file_types) {
+        my ($file, $type) = split(':', $line);
+        push @dicom_files, $file     if ($type =~ /DICOM medical imaging data$/);
+        push @non_dicom_files, $file if (!$type =~ /DICOM medical imaging data$/);
+    }
+
+    return \@dicom_files, \@non_dicom_files;
+}
+
+
 1;
 
 __END__

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1210,9 +1210,13 @@ sub dicom_to_minc {
     } elsif ($exclude) {
         $excluded_regex = $exclude;
     }
-    $d2m_cmd = "find $study_dir -type f | $get_dicom_info -studyuid -series".
-               " -echo -image -file -attvalue 0018 0024 -series_descr ".
-               " -stdin | sort -n -k1 -k2 -k7 -k3 -k6 -k4 ";
+    $d2m_cmd = "find $study_dir -type f " .
+               " | xargs file {} \; " .
+               " | grep 'DICOM medical imaging data' " .
+               " | cut -d: -f1 " .
+               " | $get_dicom_info -studyuid -series -echo -image -file " .
+               " -attvalue 0018 0024 -series_descr -stdin" .
+               " | sort -n -k1 -k2 -k7 -k3 -k6 -k4 ";
     $d2m_cmd .= ' | grep -iv -P "\t(' . $excluded_regex . ')\s*$"' if ($excluded_regex);
     $d2m_cmd .= " | cut -f 5 | ";
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1211,9 +1211,6 @@ sub dicom_to_minc {
         $excluded_regex = $exclude;
     }
     $d2m_cmd = "find $study_dir -type f " .
-               " | xargs file {} \; " .
-               " | grep 'DICOM medical imaging data' " .
-               " | cut -d: -f1 " .
                " | $get_dicom_info -studyuid -series -echo -image -file " .
                " -attvalue 0018 0024 -series_descr -stdin" .
                " | sort -n -k1 -k2 -k7 -k3 -k6 -k4 ";


### PR DESCRIPTION
### Description

The `dcm2mnc` conversion is currently failing on datasets that contains Siemens reports. This PR adds a check in `get_dicom_info.pl` so that the script skips the scanner report.

Also added a check so that only DICOM medical imaging data files are passed to `get_dicom_info.pl` when converting data to MINC files.



