### PR TITLE
Updated documentation of get_dicom_files.pl.

### DIFF
--- a/docs/scripts_md/get_dicom_files.md
+++ b/docs/scripts_md/get_dicom_files.md
@@ -25,7 +25,9 @@ Available options are:
 \-d       : extract the files in directory `<dir_argument>/get_dicom_files.pl.<UNIX_process_number>`
            For example with `-d /data/tmp`, the DICOM files will be extracted in 
            `/data/tmp/get_dicom_files.pl.67888` (assuming 67888 is the process number). 
-           By default, dir\_argument is set to the value of the environment variable `TMPDIR`.
+           By default, dir\_argument is set to the value of the environment variable `TMPDIR`. Note 
+           that the directory argument has to exist and be writeable, otherwise the script will issue
+           an error and abort.
 
 \-o       : basename of the final `tar.gz` file to produce, in the current directory (defaults to 
            `dicoms.tar.gz`).

--- a/tools/get_dicom_files.pl
+++ b/tools/get_dicom_files.pl
@@ -30,7 +30,9 @@ Available options are:
 -d       : extract the files in directory C<< <dir_argument>/get_dicom_files.pl.<UNIX_process_number> >>
            For example with C<-d /data/tmp>, the DICOM files will be extracted in 
            C</data/tmp/get_dicom_files.pl.67888> (assuming 67888 is the process number). 
-           By default, dir_argument is set to the value of the environment variable C<TMPDIR>.
+           By default, dir_argument is set to the value of the environment variable C<TMPDIR>. Note 
+           that the directory argument has to exist and be writeable, otherwise the script will issue
+           an error and abort.
           
 -o       : basename of the final C<tar.gz> file to produce, in the current directory (defaults to 
            C<dicoms.tar.gz>).


### PR DESCRIPTION
Tiny change to the documentation: mentioned that the directory argument to `-d` has to exist or an error is raised.