### PR TITLE
[EEG install] fix README.md dependencies for EEG pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ See [aces/Loris](https://github.com/aces/loris) README.md for further informatio
 sudo apt-get install python3 
 sudo apt-get install python3-dev
 sudo apt-get install python3-pip
+sudo apt-get install libmysqlclient-dev
 sudo pip3 install virtualenv
 ```
 


### PR DESCRIPTION
This PR fixes an issue with the install process of the EEG pipeline documented in the README.md. Added `sudo apt-get install libmysqlclient-dev` as a dependency.
