### PR TITLE
[EEG bug fixes] Fixing a few bugs discovered when inserting a new BIDS EEG dataset

### DIFF
--- a/python/lib/candidate.py
+++ b/python/lib/candidate.py
@@ -1,6 +1,7 @@
 """This class gather functions for candidate handling."""
 
 import random
+from dateutil.parser import parse
 import lib.exitcode
 
 
@@ -76,10 +77,9 @@ class Candidate:
         for row in participants_info:
             if not row['participant_id'] == self.psc_id:
                 continue
+            self.grep_bids_dob(row)
             if 'sex' in row:
                 self.map_sex(row['sex'])
-            if 'dob' in row:
-                self.dob = row['dob']
             if 'age' in row:
                 self.age = row['age']
             if 'site' in row:
@@ -118,7 +118,7 @@ class Candidate:
             insert_col = insert_col + ('Gender',)
             insert_val = insert_val + (self.sex,)
         if self.dob:
-            insert_col = insert_col + ('DoB')
+            insert_col = insert_col + ('DoB',)
             insert_val = insert_val + (self.dob,)
 
         db.insert(
@@ -158,11 +158,19 @@ class Candidate:
          :type sex: str
         """
 
-        if sex.lower in ('m', 'male'):
+        if sex.lower() in ('m', 'male'):
             self.sex = 'Male'
 
-        if sex.lower in ('f', 'female'):
+        if sex.lower() in ('f', 'female'):
             self.sex = 'Female'
+
+    def grep_bids_dob(self, subject_info):
+
+        dob_names = ['date_of_birth', 'birth_date', 'dob']
+        for name in dob_names:
+            if name in subject_info:
+                dob   = parse(subject_info[name])
+                self.dob = dob.strftime('%Y-%m-%d')
 
     @staticmethod
     def generate_cand_id(db):

--- a/python/lib/candidate.py
+++ b/python/lib/candidate.py
@@ -165,6 +165,14 @@ class Candidate:
             self.sex = 'Female'
 
     def grep_bids_dob(self, subject_info):
+        """
+        Greps the date of birth from the BIDS structure and add it to self.dob which
+        will be inserted into the DoB field of the candidate table
+
+        :param subject_info: dictionary with all information present in the BIDS
+                             participants.tsv file for a given candidate
+         :type subject_info: dict
+        """
 
         dob_names = ['date_of_birth', 'birth_date', 'dob']
         for name in dob_names:

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -404,7 +404,7 @@ class Physiological:
             optional_fields = (
                 'description',        'sampling_frequency', 'low_cutoff',
                 'high_cutoff',        'manual',             'notch',
-                'status_description', 'unit',               'reference'
+                'status_description', 'units',              'reference'
             )
             for field in optional_fields:
                 if field not in row.keys():
@@ -436,7 +436,7 @@ class Physiological:
                 row['manual'],
                 row['notch'],
                 row['status_description'],
-                row['unit'],
+                row['units'],
                 row['reference'],
                 channel_file
             )


### PR DESCRIPTION
### Description

A new BIDS EEG dataset was provided and tested against the current insertion pipeline and a few little bugs needed to be fixed:
- `Gender` was not populated in the `candidate` table
- Date of birth was not properly parse and populated in the `candidate` table
- The `Unit` field of `physiological_channel` was not populated when a unit was provided in the BIDS structure (typo in the BIDS field name) 

### Notes

**This should be part of release 20.2 since it is the release that some of our collaborator will be using to insert EEG data and those bugs were found when testing their dataset**