### PR TITLE
[Bug fix] Fix get dicom info bug for long list of DICOM files

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1637,7 +1637,7 @@ sub isDicomImage {
     my $tmp_file = $ENV{'TMPDIR'} . "/tmp_list";
     open(my $fh, '>', $tmp_file) or die "Could not open file '$tmp_file' $!";
     foreach my $file (@files_list) {
-        print $fh "$file\n";
+        printf $fh "%s\n", quotemeta($file);
     }
     close($fh);
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1628,8 +1628,16 @@ RETURNS:
 sub isDicomImage {
     my (@files_list) = @_;
 
-    my $cmd = "ls @files_list | xargs file";
+    my $tmp_file = $ENV{'TMPDIR'} . "/tmp_list";
+    open(my $fh, '>', $tmp_file) or die "Could not open file '$tmp_file' $!";
+    foreach my $file (@files_list) {
+        print $fh "$file\n";
+    }
+    close($fh);
+
+    my $cmd = "cat $tmp_file | xargs file";
     my @file_types = `$cmd`;
+    unlink $tmp_file;
 
     my %isDicomImage;
     foreach my $line (@file_types) {

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1628,6 +1628,12 @@ RETURNS:
 sub isDicomImage {
     my (@files_list) = @_;
 
+    # For now, the files list need to be written in a temporary file so that the
+    # command does not fail on large amount of files. If doing directly
+    # `ls @files_list | xargs file` then the argument list is too long at it does
+    # not return one file per line but many files in one line. Writing in a
+    # temporary file on which we run the command `cat` seems to be the only option
+    # that works at the moment...
     my $tmp_file = $ENV{'TMPDIR'} . "/tmp_list";
     open(my $fh, '>', $tmp_file) or die "Could not open file '$tmp_file' $!";
     foreach my $file (@files_list) {


### PR DESCRIPTION
### Description

This PR fixes a bug introduced in the code when modifying `get_dicom_info.pl` behaviour and the logic of determining if a DICOM file is indeed of type DICOM medical imaging file. The linux command `ls @files_list | xargs file` failed on larger DICOM datasets due to the amount of DICOM files given as an argument in a single line. To fix this, the list of files is now written in a temporary file on which the command `cat` is called, listing one file per line instead:
`cat $tmp_file | xargs files`

### To test this

Run a large DICOM study through the imaging pipeline (before the PR, it would have failed, after the PR it works). Note that in my case, the DICOM study contained only 1290 files.