### PR TITLE
Replace Gender by Sex in bids insertion scripts

### DIFF
--- a/python/lib/candidate.py
+++ b/python/lib/candidate.py
@@ -115,7 +115,7 @@ class Candidate:
         insert_val = (self.psc_id, str(self.cand_id), str(self.center_id))
 
         if self.sex:
-            insert_col = insert_col + ('Gender',)
+            insert_col = insert_col + ('Sex',)
             insert_val = insert_val + (self.sex,)
         if self.dob:
             insert_col = insert_col + ('DoB',)

--- a/python/lib/database.py
+++ b/python/lib/database.py
@@ -26,7 +26,7 @@ class Database:
 
         # to select data corresponding to specific parameters
         results = db.pselect(
-            "SELECT CandID FROM candidate WHERE Active = %s AND Gender = %s",
+            "SELECT CandID FROM candidate WHERE Active = %s AND Sex = %s",
             ('Y', 'Male')
         )
 


### PR DESCRIPTION
### Description

This PR fixes the BIDS import script and rename the `candidate` table field `Gender` to `Sex` as this field was renamed in major and the BIDS import scripts were part of the latest minor release (20.2.0). 

Note that the code changes on the MRI side was already done to account for the change of field name in the database (see #336).

### This fixes

[x] issue #380 
