### PR TITLE
Fixes the tarchive_validation.pl script when not dates are available in DICOMs

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -324,7 +324,7 @@ sub extractAndParseTarchive {
         $this->extract_tarchive($tarchive, $upload_id, $seriesuid);
     my $ExtractSuffix  = basename($tarchive, ".tar");
     # get rid of the tarchive Prefix 
-    $ExtractSuffix =~ s/DCM_(\d){4}-(\d){2}-(\d){2}_//;
+    $ExtractSuffix =~ s/DCM_(\d{4}-\d{2}-\d{2})?_//;
     my $info       = "head -n 12 $this->{TmpDir}/${ExtractSuffix}.meta";
     my $header     = `$info`;
     my $message = "\n$header\n";


### PR DESCRIPTION
### Description

If no dates are available in the DICOM dataset (a.k.a. for open science), the DICOM archives are called `DCM__Imaging...` and the `tarchive_validation.pl` script fails as it expects the format to be `DCM_date_Imaging...`. This PR fixes the regular expression so that the date is optional when parsing the file.

### This fixes

- a bug found when testing the pipeline on fully deidentified dataset. No tickets associated with it.