### PR TITLE
Modified Mincinfo_wrapper call to work when no date information is available

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1277,7 +1277,7 @@ sub get_mincs {
     my @files_list;
     foreach my $file (@files) {
         next unless $file =~ /\.mnc(\.gz)?$/;
-        my $cmd= "Mincinfo_wrapper -quiet -tab -file -date $this->{TmpDir}/$file";
+        my $cmd= "Mincinfo_wrapper -quiet -tab -file -attvalue acquisition:acquisition_id $this->{TmpDir}/$file";
         push @files_list, `$cmd`;
     }
     open SORTER, "|sort -nk2 | cut -f1 > $this->{TmpDir}/sortlist";


### PR DESCRIPTION
### Description

In the context of open science, no dates are available with the dataset. Currently, the call to `Mincinfo_wrapper` in the function `get_mincs` of `MRIProcessingUtility.pm` includes the `-date` option and then sorts on the date.

However, sorting the files based on the date does not really sort the files since they are all acquired on the same date for most of them. 

If we wish to sort the files based on their order of acquisition, we should instead call `Mincinfo_wrapper` with the option `-attvalue acquisition:acquisition_id` which returns the series number which is more informative on the order of acquisition.

### This fixes

- an issue with the pipeline when testing on datasets without dates for open science. No ticket created for that.