### PR TITLE
Skips moving the tarchive to a year subfolder when no dates are present in the DICOMs

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1398,6 +1398,10 @@ sub moveAndUpdateTarchive {
     my $tarchivePath = NeuroDB::DBI::getConfigSetting(
                         $this->{dbhr},'tarchiveLibraryDir'
                         );
+    # return the current tarchive location if no dates are available
+    return $tarchive_location unless ($tarchiveInfo->{'DateAcquired'});
+
+    # move the tarchive in a year subfolder
     $newTarchiveLocation = $tarchivePath ."/".
     substr($tarchiveInfo->{'DateAcquired'}, 0, 4);
     ############################################################


### PR DESCRIPTION
### Description

In the context of open science, no dates are available with the dataset therefore, the DICOM archives cannot be moved to a year subfolder when running `tarchiveLoader`. In this PR, if no acquisition date is available, the DICOM archive will remain in the `tarchive` directory and will not be moved to a subdirectory. If the acquisition date is present in the DICOM, then the behaviour remains the same.

### This fixes

- an issue with the pipeline when testing on datasets without dates for open science. No ticket created for that.