### PR TITLE
Fixed the pipeline for when there is no date in the DICOM files

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -380,8 +380,7 @@ sub determineSubjectID {
             $subjectIDsref->{'CandID'},
             $subjectIDsref->{'PSCID'},
             $subjectIDsref->{'visitLabel'},
-            (defined $tarchiveInfo->{'DateAcquired'}
-                ? $tarchiveInfo->{'DateAcquired'} : 'UNKNOWN')
+            $tarchiveInfo->{'DateAcquired'} // 'UNKNOWN'
         );
 	$this->{LOG}->print($message);
         $this->spool($message, 'N', $upload_id, $notify_detailed);

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -638,8 +638,7 @@ if ($valid_study) {
         $subjectIDsref->{'CandID'},
         $subjectIDsref->{'PSCID'},
         $subjectIDsref->{'visitLabel'},
-        (defined $tarchiveInfo{'DateAcquired'}
-            ? $tarchiveInfo{'DateAcquired'} : 'UNKNOWN')
+        $tarchiveInfo{'DateAcquired'} // 'UNKNOWN'
     );
     $notifier->spool('mri new study', $message, 0,
 		    'tarchiveLoader', $upload_id, 'N', 
@@ -670,8 +669,7 @@ if ($valid_study) {
     $message = sprintf(
         "\n %s acquired %s was deemed invalid\n\n%s\n",
         $tarchive,
-        (defined $tarchiveInfo{'DateAcquired'}
-            ? $tarchiveInfo{'DateAcquired'} : 'UNKNOWN'),
+        $tarchiveInfo{'DateAcquired'} // 'UNKNOWN',
         $study_dir
     );
     $notifier->spool('mri invalid study', $message, 0,

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -633,12 +633,14 @@ if ($valid_study) {
     ############################################################
     # spool a new study message ################################
     ############################################################
-    $message =             
-	    "\n" . $subjectIDsref->{'CandID'} . 
-            " " . $subjectIDsref->{'PSCID'} .
-            " " . $subjectIDsref->{'visitLabel'} .
-            "\tacquired ". $tarchiveInfo{'DateAcquired'} .
-	    "\n";
+    $message = sprintf(
+        "\n CandID: %s, PSCID: %s, Visit: %s, Acquisition Date: %s\n",
+        $subjectIDsref->{'CandID'},
+        $subjectIDsref->{'PSCID'},
+        $subjectIDsref->{'visitLabel'},
+        (defined $tarchiveInfo{'DateAcquired'}
+            ? $tarchiveInfo{'DateAcquired'} : 'UNKNOWN')
+    );
     $notifier->spool('mri new study', $message, 0,
 		    'tarchiveLoader', $upload_id, 'N', 
 		    $notify_detailed);
@@ -665,11 +667,13 @@ if ($valid_study) {
     ## spool a failure message This has been changed to tarchive
     ## instead of using patientName ############################
     ############################################################
-    $message = 
-	    "\n" . $tarchive. " acquired ". 
-            $tarchiveInfo{'DateAcquired'} .
-            " was deemed invalid\n\n". $study_dir .
-	    "\n";
+    $message = sprintf(
+        "\n %s acquired %s was deemed invalid\n\n%s\n",
+        $tarchive,
+        (defined $tarchiveInfo{'DateAcquired'}
+            ? $tarchiveInfo{'DateAcquired'} : 'UNKNOWN'),
+        $study_dir
+    );
     $notifier->spool('mri invalid study', $message, 0,
 		    'tarchiveLoader', $upload_id, 'Y', 
 		    $notify_notsummary);
@@ -678,19 +682,14 @@ if ($valid_study) {
 ################################################################
 # make final logfile name without overwriting phantom logs #####
 ################################################################
-my $final_logfile = $center_name."_".$tarchiveInfo{'DateAcquired'}.
-                    '_'.$subjectIDsref->{'CandID'};
-if ($subjectIDsref->{'isPhantom'}) { 
-    $final_logfile = $subjectIDsref->{'PSCID'}."_".
-    $tarchiveInfo{'DateAcquired'}.'_'.$subjectIDsref->{'CandID'}; 
-}
-
-################################################################
-### tarchiveLocation ###########################################
-### if something went wrong and there is no acq date and CandID 
-################################################################
-unless($tarchiveInfo{'DateAcquired'} && $subjectIDsref->{'CandID'}) { 
-    $final_logfile .= '_'.$temp[$#temp]; 
+my $final_logfile = $center_name;
+unless ($tarchiveInfo{'DateAcquired'} && $subjectIDsref->{'CandID'}) {
+    ### if something went wrong and there is no acq date or CandID
+    $final_logfile .= '_'.$temp[$#temp];
+} else {
+    $final_logfile .= $subjectIDsref->{'PSCID'} if $subjectIDsref->{'isPhantom'};
+    $final_logfile .= $tarchiveInfo{'DateAcquired'};
+    $final_logfile .= $subjectIDsref->{'CandID'};
 }
 $final_logfile .= '.log.gz';
 


### PR DESCRIPTION
### Description

In the context of open science, no dates are available with the dataset therefore, the following needed to be fixed:
- the DICOM archives cannot be moved to a year subfolder when running `tarchiveLoader`. If no acquisition date is available, the DICOM archive will remain in the `tarchive` directory and will not be moved to a subdirectory. If the acquisition date is present in the DICOM, then the behaviour remains the same.
- the call to `Mincinfo_wrapper` in the function `get_mincs` of `MRIProcessingUtility.pm` includes the `-date` option and then sorts based on the date. However, sorting the files based on the date does not really sort the files since they are all acquired on the same date for most of them. Therefore, if we wish to sort the files based on their order of acquisition, we should instead call `Mincinfo_wrapper` with the option `-attvalue acquisition:acquisition_id` which returns the series number which is more informative on the order of acquisition. 
- If no dates are available in the DICOM dataset (a.k.a. for open science), the DICOM archives are called `DCM__Imaging...` and the `tarchive_validation.pl` script fails as it expects the format to be `DCM_date_Imaging...`. This PR fixes the regular expression so that the date is optional when parsing the file.
- several warnings when attempting to concatenate the date with a string also needed to be fixed for when there is no dates in the dataset

### This fixes

all issues found when testing the pipeline on a fully deidentified dataset (including the removal of the acquisition dates). 

Closing #392, #393 and #394 since they are all solved in this PR and one could not test the pipeline when removing the acquisition date from the DICOM dataset fully otherwise.