### PR TITLE
Remove default -clobber option when calling dicomTar.pl

### DIFF
--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -410,7 +410,7 @@ QUERY
 =head3 is_study_unique($dbh, $update, $Archivemd5)
 
 Verifies if the DICOM study is already registered in the C<tarchive> table
-using the StudyUID field of the DICOM files. If the study is already present in the
+using the C<StudyUID> field of the DICOM files. If the study is already present in the
 C<tarchive> tables but C<-clobber> was not when running C<dicomTar.pl> or that we are
 using C<dicomSummary.pl>, it will return the appropriate error message.
 

--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -411,8 +411,8 @@ QUERY
 
 Verifies that the DICOM study is already registered in the C<tarchive> tables
 using the StudyUID field of the DICOM files. If the study is already present in the
-C<tarchive> tables but C<-clobber> was not when running <dicomTar.pl> or that we are
-using <dicomSummary.pl>, it will return the appropriate error message.
+C<tarchive> tables but C<-clobber> was not when running C<dicomTar.pl> or that we are
+using C<dicomSummary.pl>, it will return the appropriate error message.
 
 INPUTS:
   - $dbh       : database handle

--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -130,40 +130,16 @@ sub database {
     # whether the query worked fine
     my $success = undef;
     # check if this StudyUID is already in your database
-    (my $query = <<QUERY) =~ s/\n/ /gm;
-      SELECT 
-        DicomArchiveID, 
-        CreateInfo, 
-        LastUpdate,     
-        CreatingUser, 
-        md5sumArchive 
-      FROM 
-        tarchive 
-      WHERE 
-        DicomArchiveID=?
-QUERY
-    my $sth = $dbh->prepare($query);
-    $sth->execute($self->{studyuid});
-    
-    # if there is an entry get create info
-    if($sth->rows > 0) {
-	my @row = $sth->fetchrow_array();
-	if($update == 0) {
-	    print "\n\nPROBLEM:\n The user \'$row[3]\' has already inserted this study. \n The unique study ID is $row[0]\n";
-	    print " This is the information retained from the first time the study was inserted:\n $row[1]\n\n";
-	    print " Last update of record :\n $row[2]\n\n";
-	    exit $NeuroDB::ExitCodes::FILE_NOT_UNIQUE;
-	}
-	# do not allow to run diccomSummary with database option if the study has already been archived
-	elsif (!$Archivemd5 && $row[3] ne "") { 
-	    print "\n\n PROBLEM: This study has already been archived. You can only re-archive it using dicomTar!\n";
-	    print " This is the information retained from the first time the study has been archived:\n $row[1]\n\n";
-	    exit $NeuroDB::ExitCodes::FILE_NOT_UNIQUE;
+    my ($unique_study, $message) = $self->is_study_unique($dbh, $update);
+    if (!$unique_study && !$update) {
+        # if the study is not unique and update is not set it means the script
+        # should stop running and display the error message
+        print $message;
+        exit $NeuroDB::ExitCodes::FILE_NOT_UNIQUE;
     }
-	
-    } else {
-	$update = 0;
-    }
+    # the tarchive is unique so set update to false since it will need an insert
+    $update = 0 if $unique_study;
+
 
     # INSERT or UPDATE 
     # get acquisition metadata
@@ -197,13 +173,13 @@ QUERY
 
     # If we are in auto launch mode
     if(length($creating_user) == 0) {
-        ($query = <<QUERY) =~ s/\n/ /gm;
+        (my $query = <<QUERY) =~ s/\n/ /gm;
           SELECT UploadedBy
           FROM mri_upload
           WHERE DecompressedLocation = ?
 QUERY
         # Lookup in the mri_upload table
-        $sth     = $dbh->prepare($query);
+        my $sth     = $dbh->prepare($query);
         my @args = ($self->{dcmdir});
         $success = $sth->execute(@args);
         print "Failed running query: $query\n\n\n" unless $success;
@@ -255,6 +231,7 @@ QUERY
         push(@values, @new_vals);
     }
 
+    my $query;
     if (!$update) { 
         ($query = <<QUERY) =~ s/\n/ /gm;
           INSERT INTO 
@@ -273,7 +250,7 @@ QUERY
         push(@values, $self->{studyuid});
     }
     
-    $sth     = $dbh->prepare($query);
+    my $sth  = $dbh->prepare($query);
     $success = $sth->execute(@values);
 #FIXME
 print "Failed running query: $query\n\n\n" unless $success;
@@ -283,7 +260,7 @@ print "Failed running query: $query\n\n\n" unless $success;
     if(!$update) {
         $tarchiveID = $dbh->{'mysql_insertid'};
     } else {
-        (my $query = <<QUERY) =~ s/\n/ /gm;
+        ($query = <<QUERY) =~ s/\n/ /gm;
           SELECT 
             TarchiveID 
           FROM 
@@ -292,7 +269,7 @@ print "Failed running query: $query\n\n\n" unless $success;
             DicomArchiveID = ? 
             AND SourceLocation= ?
 QUERY
-        my $sth = $dbh->prepare($query);
+        $sth = $dbh->prepare($query);
         $sth->execute($self->{studyuid}, $self->{dcmdir});
         my @row = $sth->fetchrow_array();
         $tarchiveID = $row[0];
@@ -320,7 +297,7 @@ QUERY
     }
 
     # now create the tarchive_series records
-    (my $query = <<QUERY) =~ s/\n/ /gm;
+    ($query = <<QUERY) =~ s/\n/ /gm;
       INSERT INTO 
         tarchive_series 
           (
@@ -426,6 +403,60 @@ QUERY
         $insert_file->execute(@values);
     }
     return $success; # if query worked this will return 1;
+}
+
+sub is_study_unique {
+    my ($self, $dbh, $update, $Archivemd5) = @_;
+
+    # check if this StudyUID is already in your database
+    (my $query = <<QUERY) =~ s/\n/ /gm;
+      SELECT
+        DicomArchiveID,
+        CreateInfo,
+        LastUpdate,
+        CreatingUser,
+        md5sumArchive
+      FROM
+        tarchive
+      WHERE
+        DicomArchiveID=?
+QUERY
+    my $sth = $dbh->prepare($query);
+    $sth->execute($self->{studyuid});
+
+    # if there is an entry get create info
+    my ($message, $unique_study);
+    if($sth->rows > 0) {
+        $unique_study = 0;
+        my @row = $sth->fetchrow_array();
+        if ($update == 0) {
+            $message = <<MESSAGE;
+
+PROBLEM:
+The user '$row[3]' has already inserted this study.
+The unique study ID is '$row[0]'.
+This is the information retained from the first time the study was inserted:
+$row[1]
+
+Last update of record:
+$row[2]
+
+MESSAGE
+        } elsif (!$Archivemd5 && $row[3] ne "") {
+            # do not allow to run dicomSummary with database option if the study has already been archived
+            $message = <<MESSAGE;
+
+PROBLEM: This study has already been archived. You can only re-archive it using dicomTar!
+This is the information retained from the first time the study has been archived:
+$row[1]
+
+MESSAGE
+        }
+    } else {
+        $unique_study = 1;
+    }
+
+    return $unique_study, $message;
 }
 
 

--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -134,7 +134,7 @@ sub database {
     if (!$unique_study && !$update) {
         # if the study is not unique and update is not set it means the script
         # should stop running and display the error message
-        print $message;
+        print STDERR $message;
         exit $NeuroDB::ExitCodes::FILE_NOT_UNIQUE;
     }
     # the tarchive is unique so set update to false since it will need an insert
@@ -409,7 +409,7 @@ QUERY
 
 =head3 is_study_unique($dbh, $update, $Archivemd5)
 
-Verifies that the DICOM study is already registered in the C<tarchive> tables
+Verifies if the DICOM study is already registered in the C<tarchive> table
 using the StudyUID field of the DICOM files. If the study is already present in the
 C<tarchive> tables but C<-clobber> was not when running C<dicomTar.pl> or that we are
 using C<dicomSummary.pl>, it will return the appropriate error message.

--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -130,7 +130,7 @@ sub database {
     # whether the query worked fine
     my $success = undef;
     # check if this StudyUID is already in your database
-    my ($unique_study, $message) = $self->is_study_unique($dbh, $update);
+    my ($unique_study, $message) = $self->is_study_unique($dbh, $update, $Archivemd5);
     if (!$unique_study && !$update) {
         # if the study is not unique and update is not set it means the script
         # should stop running and display the error message
@@ -404,6 +404,27 @@ QUERY
     }
     return $success; # if query worked this will return 1;
 }
+
+=pod
+
+=head3 is_study_unique($dbh, $update, $Archivemd5)
+
+Verifies that the DICOM study is already registered in the C<tarchive> tables
+using the StudyUID field of the DICOM files. If the study is already present in the
+C<tarchive> tables but C<-clobber> was not when running <dicomTar.pl> or that we are
+using <dicomSummary.pl>, it will return the appropriate error message.
+
+INPUTS:
+  - $dbh       : database handle
+  - $update    : set to 1 to update C<tarchive> entry, 0 otherwise
+  - $Archivemd5: DICOM archive MD5 sum
+
+RETURNS:
+  - $unique_study: set to 0 if the study was found in the database, 1 otherwise
+  - $message     : error message or undef if no error found
+
+
+=cut
 
 sub is_study_unique {
     my ($self, $dbh, $update, $Archivemd5) = @_;

--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -220,7 +220,7 @@ if ($dbase) {
     # if there is a message returned, it means the script should stop running
     # and display the error message as the study is not unique
     if (!$unique_study && !$clobber) {
-        print $message;
+        print STDERR $message;
         exit $NeuroDB::ExitCodes::FILE_NOT_UNIQUE;
     }
     $dbh->disconnect();

--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -216,7 +216,7 @@ my $sumTypeVersion  = $summary->{sumTypeVersion};
 # check if the study is already uploaded in the tarchive tables
 if ($dbase) {
     $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
-    my ($unique_study, $message) = $summary->is_study_unique($dbh, $clobber);
+    my ($unique_study, $message) = $summary->is_study_unique($dbh, $clobber, undef);
     # if there is a message returned, it means the script should stop running
     # and display the error message as the study is not unique
     if (!$unique_study && !$clobber) {

--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -26,7 +26,10 @@ Available options are:
 -mri_upload_update      : Update the C<mri_upload> table by inserting the
                           correct C<tarchiveID>
 
--clobber                : Specify the name of the config file which resides in
+-clobber                : Use this option only if you want to replace the
+                          resulting tarball!
+
+-profile                : Specify the name of the config file which resides in
                           C<.loris_mri> in the current directory
 
 -centerName             : Specify the symbolic center name to be stored
@@ -209,6 +212,19 @@ my $sumTypeVersion = $summary->{'sumTypeVersion'};
 my $studyUnique = $summary->{'studyuid'};
 my $creator         = $summary->{user};
 my $sumTypeVersion  = $summary->{sumTypeVersion}; 
+
+# check if the study is already uploaded in the tarchive tables
+if ($dbase) {
+    $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+    my ($unique_study, $message) = $summary->is_study_unique($dbh, $clobber);
+    # if there is a message returned, it means the script should stop running
+    # and display the error message as the study is not unique
+    if (!$unique_study && !$clobber) {
+        print $message;
+        exit $NeuroDB::ExitCodes::FILE_NOT_UNIQUE;
+    }
+    $dbh->disconnect();
+}
 
 my $byDate;
 # Determine how to name the archive... by acquisition date or by today's date.

--- a/docs/scripts_md/DCMSUM.md
+++ b/docs/scripts_md/DCMSUM.md
@@ -37,6 +37,22 @@ INPUTS:
 
 RETURNS: 1 on success
 
+### is\_study\_unique($dbh, $update, $Archivemd5)
+
+Verifies that the DICOM study is already registered in the `tarchive` tables
+using the StudyUID field of the DICOM files. If the study is already present in the
+`tarchive` tables but `-clobber` was not when running &lt;dicomTar.pl> or that we are
+using &lt;dicomSummary.pl>, it will return the appropriate error message.
+
+INPUTS:
+  - $dbh       : database handle
+  - $update    : set to 1 to update `tarchive` entry, 0 otherwise
+  - $Archivemd5: DICOM archive MD5 sum
+
+RETURNS:
+  - $unique\_study: set to 0 if the study was found in the database, 1 otherwise
+  - $message     : error message or undef if no error found
+
 ### read\_file($file)
 
 Reads the content of a file (typically .meta file in the DICOM archive).

--- a/docs/scripts_md/DCMSUM.md
+++ b/docs/scripts_md/DCMSUM.md
@@ -40,7 +40,7 @@ RETURNS: 1 on success
 ### is\_study\_unique($dbh, $update, $Archivemd5)
 
 Verifies if the DICOM study is already registered in the `tarchive` table
-using the StudyUID field of the DICOM files. If the study is already present in the
+using the `StudyUID` field of the DICOM files. If the study is already present in the
 `tarchive` tables but `-clobber` was not when running `dicomTar.pl` or that we are
 using `dicomSummary.pl`, it will return the appropriate error message.
 

--- a/docs/scripts_md/DCMSUM.md
+++ b/docs/scripts_md/DCMSUM.md
@@ -41,8 +41,8 @@ RETURNS: 1 on success
 
 Verifies that the DICOM study is already registered in the `tarchive` tables
 using the StudyUID field of the DICOM files. If the study is already present in the
-`tarchive` tables but `-clobber` was not when running &lt;dicomTar.pl> or that we are
-using &lt;dicomSummary.pl>, it will return the appropriate error message.
+`tarchive` tables but `-clobber` was not when running `dicomTar.pl` or that we are
+using `dicomSummary.pl`, it will return the appropriate error message.
 
 INPUTS:
   - $dbh       : database handle

--- a/docs/scripts_md/DCMSUM.md
+++ b/docs/scripts_md/DCMSUM.md
@@ -39,7 +39,7 @@ RETURNS: 1 on success
 
 ### is\_study\_unique($dbh, $update, $Archivemd5)
 
-Verifies that the DICOM study is already registered in the `tarchive` tables
+Verifies if the DICOM study is already registered in the `tarchive` table
 using the StudyUID field of the DICOM files. If the study is already present in the
 `tarchive` tables but `-clobber` was not when running `dicomTar.pl` or that we are
 using `dicomSummary.pl`, it will return the appropriate error message.

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -306,7 +306,7 @@ sub IsCandidateInfoValid {
 =head3 runDicomTar()
 
 This method executes the following actions:
- - Runs C<dicomTar.pl> with C<-clobber -database -profile prod> options
+ - Runs C<dicomTar.pl> with C<-database -profile prod> options
  - Extracts the C<TarchiveID> of the DICOM archive created by C<dicomTar.pl>
  - Updates the C<mri_upload> table if C<dicomTar.pl> ran successfully
 
@@ -329,7 +329,7 @@ sub runDicomTar {
       $bin_dirPath . "/" . "dicom-archive" . "/" . "dicomTar.pl";
     my $command =
         $dicomtar . " " . $this->{'uploaded_temp_folder'} 
-      . " $tarchive_location -clobber -database -profile prod";
+      . " $tarchive_location -database -profile prod";
     if ($this->{verbose}) {
         $command .= " -verbose";
     }

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -322,7 +322,6 @@ sub runDicomTar {
     my $tarchive_location = NeuroDB::DBI::getConfigSetting(
                             $this->{dbhr},'tarchiveLibraryDir'
                             );
-    my $bin_dirPath = NeuroDB::DBI::getConfigSetting($this->{dbhr},'MRICodePath');
     my $command = sprintf(
         "dicomTar.pl %s %s -database -profile %s",
         quotemeta($this->{'uploaded_temp_folder'}),

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -322,17 +322,14 @@ sub runDicomTar {
     my $tarchive_location = NeuroDB::DBI::getConfigSetting(
                             $this->{dbhr},'tarchiveLibraryDir'
                             );
-    my $bin_dirPath = NeuroDB::DBI::getConfigSetting(
-                        $this->{dbhr},'MRICodePath'
-                        );
-    my $dicomtar = 
-      $bin_dirPath . "/" . "dicom-archive" . "/" . "dicomTar.pl";
-    my $command =
-        $dicomtar . " " . $this->{'uploaded_temp_folder'} 
-      . " $tarchive_location -database -profile prod";
-    if ($this->{verbose}) {
-        $command .= " -verbose";
-    }
+    my $bin_dirPath = NeuroDB::DBI::getConfigSetting($this->{dbhr},'MRICodePath');
+    my $command = sprintf(
+        "dicomTar.pl %s %s -database -profile %s",
+        quotemeta($this->{'uploaded_temp_folder'}),
+        quotemeta($tarchive_location),
+        'prod'
+    );
+    $command .= " -verbose" if $this->{verbose};
     my $output = $this->runCommandWithExitCode($command);
 
     if ( $output == 0 ) {


### PR DESCRIPTION
### Description

This removes the default `-clobber`  behaviour when calling `dicomTar.pl` in `ImagingUpload.pm` to avoid creating many issues in the database as raised in [this presentation](https://docs.google.com/presentation/d/1BpAvGcduTESUcDNrSyZOiz8sszbweJ7H_slKZfM-6so/edit#slide=id.g4e9a10fecf_0_151.).

In addition, a check has been added at the top of the script to stop `dicomTar.pl` if the study has already been uploaded and the option `-clobber` has not been used.

### This fixes

- [x] #385 