### PR TITLE
Use UploadID to update mri_upload instead of TarchiveID

### DIFF
--- a/batch_uploads_tarchive
+++ b/batch_uploads_tarchive
@@ -143,19 +143,34 @@ my $counter = 0;
 ## foreach series, batch magic
 foreach my $input (@inputs)
 {
+    chomp($input);
+    my @linearray = split(' ', $input);
+    my $tarchive  = $linearray[0];
+    $tarchive     =~ s/\t/ /;
+    $tarchive     =~ s/$tarchiveLibraryDir//;
+    my $upload_id = $linearray[1];
+
+    if (!$tarchive || !$upload_id) {
+        print STDERR "\nERROR: need to provide the ArchiveLocation and its "
+                     . "associated UploadID separated by a space.\n\n";
+        exit $NeuroDB::ExitCodes::MISSING_ARG;
+    }
+
     $counter++;
     $stdout = $stdoutbase.$counter;
     $stderr = $stderrbase.$counter;
 
-    #$stdout = '/dev/null';
-    #$stderr = '/dev/null';
-
-    ## this is where the subprocesses are created...  should basically run processor script with study directory as argument.
+    ## this is where the subprocesses are created...
+    ## should basically run processor script with study directory as argument.
     ## processor will do all the real magic
 
-    $input =~ s/\t/ /;
-    $input =~ s/$tarchiveLibraryDir//;
-    my $command = "tarchiveLoader -globLocation -profile prod $tarchiveLibraryDir/$input";
+    my $tarchive_path = "$tarchiveLibraryDir/$tarchive";
+    my $command = sprintf(
+        "tarchiveLoader -globLocation -profile %s -uploadID %s %s",
+        'prod',
+        quotemeta($upload_id),
+        quotemeta($tarchive_path)
+    );
     ##if qsub is enabled use it
     if ($is_qsub) {
 	     open QSUB, "| qsub -V -e $stderr -o $stdout -N process_tarchive_${counter}";

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -220,14 +220,14 @@ sub IsCandidateInfoValid {
             $archived_file_path = ($tarchivePath . "/" . $archived_file_path);
         }
 
-        my $command =
-            $bin_dirPath
-            . "/uploadNeuroDB/tarchiveLoader"
-            . " -globLocation -profile prod $archived_file_path";
-
-        if ($this->{verbose}){
-            $command .= " -verbose";
-        }
+        my $command = sprintf(
+            "%s/uploadNeuroDB/tarchiveLoader -globLocation -profile %s %s -uploadID %s",
+            quotemeta($bin_dirPath),
+            'prod',
+            quotemeta($archived_file_path),
+            quotemeta($this->{upload_id})
+        );
+        $command .= " -verbose" if $this->{verbose};
 
         $message =
             "\nThe Scan for the uploadID "
@@ -407,19 +407,19 @@ RETURNS: 1 on success, 0 on failure
 =cut
 
 sub runTarchiveLoader {
-    my $this               = shift;
+    my $this = shift;
     my $archived_file_path = $this->getTarchiveFileLocation();
     my $bin_dirPath = NeuroDB::DBI::getConfigSetting(
                         $this->{dbhr},'MRICodePath'
                         );
-    my $command =
-        $bin_dirPath
-      . "/uploadNeuroDB/tarchiveLoader"
-      . " -globLocation -profile prod $archived_file_path";
-
-    if ($this->{verbose}){
-        $command .= " -verbose";
-    }
+    my $command = sprintf(
+        "%s/uploadNeuroDB/tarchiveLoader -globLocation -profile %s %s -uploadID %s",
+        quotemeta($bin_dirPath),
+        'prod',
+        quotemeta($archived_file_path),
+        quotemeta($this->{upload_id})
+    );
+    $command .= " -verbose" if $this->{verbose};
     my $output = $this->runCommandWithExitCode($command);
     if ( $output == 0 ) {
         return 1;

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -14,6 +14,8 @@ Available options are:
 
 -profile     : name of the config file in C<../dicom-archive/.loris_mri>
 
+-uploadID    : The upload ID from which this MINC was created
+
 -reckless    : uploads data to database even if study protocol
                is not defined or violated
 
@@ -97,8 +99,7 @@ my $date = sprintf(
            );
 my $debug       = 0;  
 my $message     = '';
-my $tarchive_srcloc = '';
-my $upload_id   = undef;
+my $upload_id;
 my $verbose     = 0;           # default, overwritten if scripts are run with -verbose
 my $notify_detailed   = 'Y';   # notification_spool message flag for messages to be displayed 
                                # with DETAILED OPTION in the front-end/imaging_uploader 
@@ -132,6 +133,9 @@ my @opt_table = (
                  ["-profile","string",1, \$profile, "name of config file". 
                  " in ../dicom-archive/.loris_mri"],
 
+                 ["-uploadID", "string", 1, \$upload_id, "The upload ID " .
+                  "from which this MINC was created"],
+
                  ["Advanced options","section"],
 
                  ["-reckless", "boolean", 1, \$reckless,"Upload data to". 
@@ -146,9 +150,6 @@ my @opt_table = (
 
                  ["-tarchivePath","string",1, \$tarchive, "The absolute path". 
                   " to tarchive-file"],
-
-                 ["-uploadID", "string", 1, \$upload_id, "The upload ID " .
-                  "from which this MINC was created"],
 
                  ["-globLocation", "boolean", 1, \$globArchiveLocation,
                   "Loosen the validity check of the tarchive allowing for the". 
@@ -304,82 +305,17 @@ my $notifier = NeuroDB::Notify->new(\$dbh);
 #################### Check is_valid column #####################
 ################################################################
 my ( $is_valid, $ArchiveLocation );
-if ($tarchive) {
-    # if the tarchive path is given as an argument, find the associated UploadID
-    # and check if IsTarchiveValidated is set to 1.
-    $ArchiveLocation = $tarchive;
-    $ArchiveLocation    =~ s/$tarchiveLibraryDir\/?//g;
-
-    my $where = "WHERE t.ArchiveLocation='$tarchive'";
-    if ($globArchiveLocation) {
-        $where = "WHERE t.ArchiveLocation LIKE '%/" . quotemeta(basename($tarchive)) . "' "
-            .    "OR t.ArchiveLocation = '" . quotemeta(basename($tarchive)) . "'";
-    }
-    my $query = "SELECT m.IsTarchiveValidated FROM mri_upload m " .
-        "JOIN tarchive t on (t.TarchiveID = m.TarchiveID) $where ";
-    print $query . "\n" if $debug;
-    $is_valid = $dbh->selectrow_array($query);
-
-    if(!defined $is_valid) {
-        my $errorMessage = $globArchiveLocation
-            ? "No mri_upload with the same archive location basename as '$tarchive'\n"
-            : "No mri_upload with archive location '$tarchive'\n";
-        $utility->writeErrorLog(
-                $errorMessage, $NeuroDB::ExitCodes::INVALID_ARG, $logfile
-        );
-        $notifier->spool('tarchive validation', $errorMessage, 0,
-                         'minc_insertion.pl', $upload_id, 'Y', 
-                         $notify_notsummary);
-        exit $NeuroDB::ExitCodes::INVALID_ARG;
-    } 
-    
-    ## Setup  for the notification_spool table ##
-    # get the tarchive_srcloc from $tarchive
-    $query = "SELECT SourceLocation" .
-        " FROM tarchive t $where";
-    my $sth = $dbh->prepare($query);
-    $sth->execute();
-    $tarchive_srcloc = $sth->fetchrow_array;
-    
-    if(!defined $tarchive_srcloc) {
-        my $errorMessage = $globArchiveLocation
-            ? "No tarchive with the same source location basename as '$tarchive'\n"
-            : "No tarchive with source location '$tarchive'\n";
-            
-        $utility->writeErrorLog(
-                $errorMessage, $NeuroDB::ExitCodes::INVALID_ARG, $logfile
-        );
-        $notifier->spool('tarchive validation', $errorMessage, 0,
-                         'minc_insertion.pl', $upload_id, 'Y', 
-                         $notify_notsummary);
-        exit $NeuroDB::ExitCodes::INVALID_ARG;
-    } 
-
-    # get the $upload_id from $tarchive_srcloc
-    $query =
-        "SELECT UploadID FROM mri_upload "
-            . "WHERE DecompressedLocation =?";
-    $sth = $dbh->prepare($query);
-    $sth->execute($tarchive_srcloc);
-    $upload_id = $sth->fetchrow_array;
-    ## end of setup IDs for notification_spool table
-
-    # load the DICOM archive information from the tarchive table in studyInfo object
-    %studyInfo = $utility->createTarchiveArray(
-        $ArchiveLocation, $globArchiveLocation
-    );
-
-} elsif ($upload_id) {
+if ($upload_id) {
     # if the uploadID is passed as an argument, verify that the tarchive was
     # validated
     (my $query = <<QUERY) =~ s/\n/ /gm;
     SELECT
-      m.IsTarchiveValidated,
-      t.ArchiveLocation
+      IsTarchiveValidated,
+      ArchiveLocation
     FROM
-      mri_upload m JOIN tarchive t ON (t.TarchiveID = m.TarchiveID)
+      mri_upload JOIN tarchive USING (TarchiveID)
     WHERE
-      m.UploadID = ?
+      UploadID = ?
 QUERY
     print $query . "\n" if $debug;
     my $sth = $dbh->prepare($query);
@@ -389,6 +325,54 @@ QUERY
     $ArchiveLocation = $array[1];
 
     # create the studyInfo object
+    %studyInfo = $utility->createTarchiveArray(
+        $ArchiveLocation, $globArchiveLocation
+    );
+
+} elsif ($tarchive) {
+    # if only the tarchive path is given as an argument, find the associated UploadID
+    # and check if IsTarchiveValidated is set to 1.
+    $ArchiveLocation = $tarchive;
+    $ArchiveLocation    =~ s/$tarchiveLibraryDir\/?//g;
+
+    my $where = "WHERE ArchiveLocation='$tarchive'";
+    if ($globArchiveLocation) {
+        $where = "WHERE ArchiveLocation LIKE '%/" . quotemeta(basename($tarchive)) . "' "
+                 . "OR ArchiveLocation = '" . quotemeta(basename($tarchive)) . "'";
+    }
+    my $query = "SELECT IsTarchiveValidated, UploadID, SourceLocation "
+                . "FROM mri_upload "
+                . "JOIN tarchive USING (TarchiveID) $where ";
+    my $sth   = $dbh->prepare($query);
+    print $query . "\n" if $debug;
+
+    $sth->execute();
+    my $errorMessage;
+    if ($sth->rows == 0) {
+        $errorMessage = $globArchiveLocation
+            ? "No mri_upload with the same archive location basename as '$tarchive'\n"
+            : "No mri_upload with archive location '$tarchive'\n";
+        $utility->writeErrorLog(
+            $errorMessage, $NeuroDB::ExitCodes::INVALID_ARG, $logfile
+        );
+        print STDERR $errorMessage;
+        exit $NeuroDB::ExitCodes::INVALID_ARG;
+    } elsif ($sth->rows > 1) {
+        $errorMessage = "\nERROR: found more than one UploadID associated with "
+                        . "this ArchiveLocation ($tarchive). Please specify the "
+                        . "UploadID to use using the -uploadID option.\n\n";
+        $utility->writeErrorLog(
+            $errorMessage, $NeuroDB::ExitCodes::INVALID_ARG, $logfile
+        );
+        print STDERR $errorMessage;
+        exit $NeuroDB::ExitCodes::INVALID_ARG;
+    } else {
+        my %row          = $sth->fetchrow_hashref();
+        $is_valid        = $row{isTarchiveValidated};
+        $upload_id       = $row{UploadID};
+    }
+
+    # load the DICOM archive information from the tarchive table in studyInfo object
     %studyInfo = $utility->createTarchiveArray(
         $ArchiveLocation, $globArchiveLocation
     );

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -523,10 +523,8 @@ foreach my $minc (@minc_files) {
     ###########################################################
     ############# Call the minc_insertion script ##############
     ###########################################################
-
     $script = sprintf(
-        "minc_insertion.pl -tarchivePath %s -mincPath %s -profile %s -uploadID %s",
-        quotemeta($tarchive),
+        "minc_insertion.pl -mincPath %s -profile %s -uploadID %s",
         quotemeta($minc),
         quotemeta($profile),
         quotemeta($upload_id)
@@ -569,7 +567,7 @@ if ($valid_study) {
     ### And number_of_mincInserted #############################
     ############################################################
 
-    my $query = "SELECT number_of_mincInserted FROM mri_upload WHERE Upload=?";
+    my $query = "SELECT number_of_mincInserted FROM mri_upload WHERE UploadID=?";
     print $query . "\n" if $debug;
 
     my $sth = $dbh->prepare($query);
@@ -579,7 +577,7 @@ if ($valid_study) {
 
     $query = "UPDATE mri_upload "
              . " SET number_of_mincInserted=?, number_of_mincCreated=? "
-             . " WHERE Upload=?";
+             . " WHERE UploadID=?";
     print $query . "\n" if $debug;
 
     my $mri_upload_update = $dbh->prepare($query);

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -581,7 +581,7 @@ if ($valid_study) {
     print $query . "\n" if $debug;
 
     my $mri_upload_update = $dbh->prepare($query);
-    $mri_upload_update->execute($newCount, $mcount, $tarchiveInfo{TarchiveID});
+    $mri_upload_update->execute($newCount, $mcount, $upload_id);
  
     ############################################################
     ############# Create minc-pics #############################

--- a/uploadNeuroDB/tarchiveLoader
+++ b/uploadNeuroDB/tarchiveLoader
@@ -24,6 +24,8 @@ Available options are:
 
 -profile                 : Name of the config file in C<../dicom-archive/.loris_mri>
 
+-uploadID                : UploadID associated to this upload
+
 -force                   : Force the script to run even if the validation
                            has failed
 
@@ -34,9 +36,9 @@ Available options are:
                            for the possibility that the tarchive was moved to
                            a different directory
 
--newScanner                 : By default a new scanner will be registered if the
-                              data you upload requires it. You can risk turning
-                              it off
+-newScanner              : By default a new scanner will be registered if the
+                           data you upload requires it. You can risk turning
+                           it off
 
 -keeptmp                 : Keep temporary directory. Make sense if have
                            infinite space on your server
@@ -104,8 +106,7 @@ my $date        = sprintf(
                   );
 my $debug       = 0;  
 my $message     = '';
-my $tarchive_srcloc = '';
-my $upload_id   = undef;
+my $upload_id;
 my $verbose     = 0;           # default, overwritten if the scripts are run
                                # with -verbose
 my $notify_detailed   = 'Y';   # notification_spool message flag for messages to
@@ -139,6 +140,8 @@ my @opt_table = (
                  ["-profile     ","string",1, \$profile,
                   "Name of config file in ../dicom-archive/.loris_mri"
                  ],
+                 ["-uploadID", "string", 1, \$upload_id, "UploadID associated to ".
+                 "this upload."],
                  ["-force", "boolean", 1, \$force,"Force the script to run ".
                  "even if the validation has failed."],
                  ["Advanced options","section"],
@@ -212,6 +215,11 @@ if ( !$profile ) {
     print $Help;
     print STDERR "$Usage\n\tERROR: missing -profile argument\n\n";
     exit $NeuroDB::ExitCodes::PROFILE_FAILURE;
+}
+if ( !$upload_id ) {
+    print $Help;
+    print STDERR "$Usage\n\tERROR: missing -uploadID argument\n\n";
+    exit $NeuroDB::ExitCodes::MISSING_ARG;
 }
 { package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
 if ( !@Settings::db ) {
@@ -349,15 +357,15 @@ my %tarchiveInfo = $utility->createTarchiveArray(
 ################################################################
 ################## Call the validation script ##################
 ################################################################
-my $script = "tarchive_validation.pl $tarchive -profile $profile";
+my $script = sprintf(
+    "tarchive_validation.pl %s -profile %s -uploadID %s",
+    quotemeta($tarchive),
+    quotemeta($profile),
+    quotemeta($upload_id)
+);
+$script .= " -globLocation " if ($globArchiveLocation);
+$script .= " -verbose " if ($verbose);
 
-if ($globArchiveLocation) {
-    $script .= " -globLocation";
-}
-
-if ($verbose) {
-    $script .= " -verbose";
-}
 ################################################################
 ###### Note: system call returns the process ID ################
 ###### To the actual exit value, shift right by ################
@@ -365,19 +373,6 @@ if ($verbose) {
 ################################################################
 my $output = system($script); 
 $output = $output >> 8;
-
-################################################################
-### get the UploadID to log in the notification spool table ####
-################################################################
-# first get the tarchive SourceLocation from $tarchiveInfo 
-$tarchive_srcloc = $tarchiveInfo{'SourceLocation'};
-# then get the upload_id from tarchive_srcloc
-my $query =
-        "SELECT UploadID FROM mri_upload "
-        . "WHERE DecompressedLocation =?";
-my $sth = $dbh->prepare($query);
-$sth->execute($tarchive_srcloc);
-$upload_id = $sth->fetchrow_array;
 
 ################################################################
 #############Exit if the is_valid is false and $force is not####
@@ -529,49 +524,29 @@ foreach my $minc (@minc_files) {
     ############# Call the minc_insertion script ##############
     ###########################################################
 
-    $script = "minc_insertion.pl -tarchivePath $tarchive ".
-              "-mincPath $minc -profile $profile";
-
-    if ($force) {
-        $script .= " -force";
-    }
-
-    if ($globArchiveLocation) {
-        $script .= " -globLocation";
-    }
- 
-    if ($verbose) {
-        $script .= " -verbose";
-    }
-
+    $script = sprintf(
+        "minc_insertion.pl -tarchivePath %s -mincPath %s -profile %s -uploadID %s",
+        quotemeta($tarchive),
+        quotemeta($minc),
+        quotemeta($profile),
+        quotemeta($upload_id)
+    );
+    $script .= " -force"                    if $force;
+    $script .= " -globLocation"             if $globArchiveLocation;
+    $script .= " -verbose"                  if $verbose;
+    $script .= " -bypass_extra_file_checks" if $bypass_extra_file_checks;
     if ($acquisitionProtocol) {
-        $script .= " -acquisition_protocol " . $acquisitionProtocol;
+        $script .= " -acquisition_protocol " . quotemeta($acquisitionProtocol);
     }
 
-    if ($bypass_extra_file_checks) {
-        $script .= " -bypass_extra_file_checks";
-    }
-
-    # Should be kept last
-    if ($debug) {
-        print $script . "\n";
-    }
-    ###########################################################
-    ## Note: system call returns the process ID ###############
-    ## To get the actual exit value, shift right by eight as ##
-    ## done below #############################################
-    ###########################################################
-
-    $output = system($script);
-    $output = $output >> 8;
-    ###########################################################
-    #### if the return code of the script is 0 ################
-    #### mark the study as valid because this means at least ##
-    #### one volume will be inserted into the DB ##############
-    ###########################################################
+    print $script . "\n" if $debug;
+    $output = system($script); # system call returns the process ID
+    $output = $output >> 8;    # to get actual exit value, need to shift right by 8
     if ($output==0) {
-       $minc_inserted++;
-       $valid_study = 1;
+        # if the script's return code = 0, mark the study as valid as at least
+        # one MINC file was inserted into the DB
+        $minc_inserted++;
+        $valid_study = 1;
     }
 
 } # end foreach $minc
@@ -593,31 +568,22 @@ if ($valid_study) {
     ### Update the number_of_mincCreated #######################
     ### And number_of_mincInserted #############################
     ############################################################
-    my $where = "WHERE TarchiveID=?";
 
-    $query =
-        "SELECT number_of_mincInserted FROM mri_upload ";
-    $query = $query . $where;
-    if ($debug) {
-        print $query . "\n";
-    }
+    my $query = "SELECT number_of_mincInserted FROM mri_upload WHERE Upload=?";
+    print $query . "\n" if $debug;
 
     my $sth = $dbh->prepare($query);
-    $sth->execute($tarchiveInfo{TarchiveID});
+    $sth->execute($upload_id);
     my $oldCount = $sth->fetchrow_hashref->{'number_of_mincInserted'};
     my $newCount = $minc_inserted + ($oldCount ? $oldCount : 0);
 
-    $query = "UPDATE mri_upload SET number_of_mincInserted=?, ".
-                 "number_of_mincCreated=? ";
-    $query = $query . $where;
-    if ($debug) {
-        print $query . "\n";
-    }
+    $query = "UPDATE mri_upload "
+             . " SET number_of_mincInserted=?, number_of_mincCreated=? "
+             . " WHERE Upload=?";
+    print $query . "\n" if $debug;
 
     my $mri_upload_update = $dbh->prepare($query);
-    $mri_upload_update->execute(
-               $newCount,$mcount,$tarchiveInfo{TarchiveID}
-    );
+    $mri_upload_update->execute($newCount, $mcount, $tarchiveInfo{TarchiveID});
  
     ############################################################
     ############# Create minc-pics #############################
@@ -642,23 +608,19 @@ if ($valid_study) {
     $notifier->spool('mri new study', $message, 0,
 		    'tarchiveLoader', $upload_id, 'N', 
 		    $notify_detailed);
+
     ############################################################
     #### link the tarchive and mri_upload table  with session ##
     ############################################################
-     $where = "WHERE t.TarchiveID=?";
-     $query = "UPDATE tarchive t ".
-            "JOIN mri_upload m ON (m.tarchiveID=t.tarchiveID) ".
-            "SET t.SessionID =?, m.sessionID=? ";
-     $query = $query . $where;
-     if ($debug) {
-        print $query . "\n";
-     }
-     my $session_update = $dbh->prepare($query);
-     $session_update->execute(
-              $sessionID,
-              $sessionID,
-              $tarchiveInfo{'TarchiveID'}
-     );
+    $query = "UPDATE tarchive SET SessionID=? WHERE TarchiveID=?";
+    $sth   = $dbh->prepare($query);
+    print $query . "\n" if $debug;
+    $sth->execute($sessionID, $tarchiveInfo{'TarchiveID'});
+
+    $query = "UPDATE mri_upload SET SessionID=? WHERE UploadID=?";
+    $sth   = $dbh->prepare($query);
+    print $query . "\n" if $debug;
+    $sth->execute($sessionID, $upload_id);
 
 } else {
     ############################################################
@@ -757,12 +719,10 @@ if (!$valid_study) {
 ###############################################################
 ### Set Processed to 1 in mri_upload table#####################
 ###############################################################
-my $where = "WHERE TarchiveID=?";
-$query = "UPDATE mri_upload SET InsertionComplete=1 ";
-$query = $query . $where;
+my $query = "UPDATE mri_upload SET InsertionComplete=1 WHERE UploadID=?";
 
 my $mri_upload_update = $dbh->prepare($query);
-$mri_upload_update->execute($tarchiveInfo{TarchiveID});
+$mri_upload_update->execute($upload_id);
 
 exit $NeuroDB::ExitCodes::SUCCESS;
 

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -15,6 +15,8 @@ Available options are:
 
 -profile     : name of the config file in C<../dicom-archive/.loris-mri>
 
+-uploadID    : UploadID associated to the DICOM archive to validate
+
 -reckless    : upload data to the database even if the study protocol
                is not defined or if it is violated
 
@@ -98,6 +100,7 @@ my $message     = '';
 my $verbose     = 0;           # default, overwritten if scripts are run with -verbose
 my $profile     = undef;       # this should never be set unless you are in a
                                # stable production environment
+my $upload_id;                 # uploadID associated with the tarchive to validate
 my $reckless    = 0;           # this is only for playing and testing. Don't
                                # set it to 1!!!
 my $NewScanner  = 1;           # This should be the default unless you are a
@@ -112,7 +115,8 @@ my @opt_table = (
                  ["Basic options","section"],
                  ["-profile","string",1, \$profile,
                   "name of config file in ../dicom-archive/.loris_mri"],
-                 ["Advanced options","section"],
+                 ["-uploadID", "string", 1, \$upload_id, "UploadID associated to ".
+                  "the DICOM archive to validate."],
                  ["-reckless", "boolean", 1, \$reckless,
                   "Upload data to database even if study protocol is not".
                   " defined or violated."],
@@ -250,58 +254,6 @@ $ArchiveLocation       =~ s/$tarchiveLibraryDir\/?//g;
                     $globArchiveLocation
                 );
 
-# grep the upload_id from the tarchive's source location
-my $upload_id = NeuroDB::MRIProcessingUtility::getUploadIDUsingTarchiveSrcLoc(
-    $tarchiveInfo{SourceLocation}
-);
-
-################################################################
-############### Get the tarchive-id ############################
-################################################################
-$where = "WHERE TarchiveID=?";
-$query = "SELECT COUNT(*) FROM mri_upload $where ";
-$sth = $dbh->prepare($query);
-$sth->execute($tarchiveInfo{TarchiveID});
-my $tarchiveid_count = $sth->fetchrow_array;
-
-################################################################
-### Insert into the mri_upload table correct values ############
-### only if the $tarchive_id doesn't exist 
-################################################################
-
-if ($tarchiveid_count==0)  {
-    ############################################################	
-    ##if the scan is already inserted into the mri_upload ######
-    ###update it################################################
-    ############################################################
-    $where = "WHERE DecompressedLocation=?";
-    $query = "SELECT COUNT(*) FROM mri_upload $where ";
-    $sth = $dbh->prepare($query);
-    $sth->execute($tarchiveInfo{SourceLocation});
-    my $source_location = $sth->fetchrow_array;
-    if ($source_location !=0) {
-    	$where = "WHERE DecompressedLocation=?";
-	$query = "UPDATE mri_upload SET TarchiveID=? ";
-	$query = $query . $where;
-	my $mri_upload_update = $dbh->prepare($query);
-	$mri_upload_update->execute($tarchiveInfo{'SourceLocation'},
-				    $tarchiveInfo{TarchiveID}
-				   );
-    } else {
-       #########################################################
-       ##otherwise insert it####################################
-       #########################################################
-       $query = "INSERT INTO mri_upload (UploadedBy, ".
-                "UploadDate,TarchiveID, DecompressedLocation)" .
-                " VALUES (?,now(),?,?)";
-       my $mri_upload_inserts = $dbh->prepare($query);
-       $mri_upload_inserts->execute(
-           $User,
-           $tarchiveInfo{TarchiveID},
-           $tarchiveInfo{'SourceLocation'}
-       );
-    }
-}
 ################################################################
 #### Verify the archive using the checksum from database #######
 ################################################################
@@ -312,8 +264,7 @@ $utility->validateArchive($tarchive, \%tarchiveInfo, $upload_id);
 ### Verify PSC information using whatever field ################ 
 ### contains site string #######################################
 ################################################################
-my ($center_name, $centerID) =
-    $utility->determinePSC(\%tarchiveInfo, 1, $upload_id);
+my ($center_name, $centerID) = $utility->determinePSC(\%tarchiveInfo, 1, $upload_id);
 
 ################################################################
 ################################################################
@@ -322,8 +273,8 @@ my ($center_name, $centerID) =
 ################################################################
 ################################################################
 my $scannerID = $utility->determineScannerID(
-        \%tarchiveInfo, 1, $centerID, $NewScanner, $upload_id
-                );
+    \%tarchiveInfo, 1, $centerID, $NewScanner, $upload_id
+);
 
 ################################################################
 ################################################################
@@ -331,7 +282,7 @@ my $scannerID = $utility->determineScannerID(
 ################################################################
 ################################################################
 my $subjectIDsref = $utility->determineSubjectID(
-        $scannerID, \%tarchiveInfo, 1, $upload_id
+    $scannerID, \%tarchiveInfo, 1, $upload_id
 );
 
 ################################################################
@@ -381,11 +332,9 @@ if ( defined( &Settings::dicomFilter )) {
 ################################################################
 ##Update the IsTarchiveValidated flag in the mri_upload table ##
 ################################################################
-$where = "WHERE TarchiveID=?";
-$query = "UPDATE mri_upload SET IsTarchiveValidated='1' ";
-$query = $query . $where;
+$query = "UPDATE mri_upload SET IsTarchiveValidated='1' WHERE UploadID=?";
 my $mri_upload_update = $dbh->prepare($query);
-$mri_upload_update->execute($tarchiveInfo{TarchiveID});
+$mri_upload_update->execute($upload_id);
 
 
 exit $NeuroDB::ExitCodes::SUCCESS;


### PR DESCRIPTION
### Description

Modifies the update and select queries on `mri_upload` to use the `UploadID` instead of the `TarchiveID` to avoid updating multiple entries in the `mri_upload` table when more than one `UploadID` refers to the same `TarchiveID`.

### This fixes

- [x] #383 