### PR TITLE
Convert slice timing to seconds when creating the BIDS MRI structure

### DIFF
--- a/tools/MakeNiiFilesBIDSCompliant.pl
+++ b/tools/MakeNiiFilesBIDSCompliant.pl
@@ -596,7 +596,7 @@ QUERY
                     print "    SliceTiming is " .  $headerVal . "\n";
                 }
                 else {
-                    $headerVal = [ map {1 * $_} split(",", $headerVal) ];
+                    $headerVal = [ map {$_ / 1000} split(",", $headerVal) ];
                     print "    SliceTiming $headerVal was added \n" if $verbose;
                 }
                 $header_hash{$extraHeader} = $headerVal;


### PR DESCRIPTION
### Description

The MRI BIDS dataset created using the tool `MakeNiiFilesBIDSCompliant.pl ` fails the BIDS validator due to the SliceTiming field being export in milliseconds instead of seconds. This PR converts the BIDS SliceTiming field into seconds so that it can pass the BIDS validator.

### This fixes

- [x] #377 
