### PR TITLE
Removed imagePath, mincPath and data from imaging_install.sh 

### DIFF
--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -219,8 +219,5 @@ mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPD
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='$email' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='mail_user')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/bin/mri/dicom-archive/get_dicom_info.pl' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='get_dicom_info')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/tarchive/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='tarchiveLibraryDir')"
-mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='imagePath') AND Value = '/data/%PROJECTNAME%/data/'"
-mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='data') AND Value = '/data/%PROJECTNAME%/data/'"
-mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='mincPath') AND Value = '/data/%PROJECTNAME%/data/'"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/bin/mri/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='MRICodePath') AND Value = '/data/%PROJECTNAME%/bin/mri/'"
 echo

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -215,7 +215,37 @@ class Physiological:
                 get_last_id  = True
             )
 
+            # link the parameter_type_id to a parameter type category
+            category_id = self.get_parameter_type_category_id()
+            self.db.insert(
+                table_name   = 'parameter_type_category_rel',
+                column_names = ('ParameterTypeCategoryID', 'ParameterTypeID'),
+                values       = (category_id, parameter_type_id),
+                get_last_id  = False
+            )
+
         return parameter_type_id
+
+    def get_parameter_type_category_id(self):
+        """
+        Greps ParameterTypeCategoryID from parameter_type_category table.
+        If no ParameterTypeCategoryID was found, it will return None.
+
+        :return: ParameterTypeCategoryID
+         :rtype: int
+        """
+
+        category_result = self.db.pselect(
+            query='SELECT ParameterTypeCategoryID '
+                  'FROM parameter_type_category '
+                  'WHERE Name = %s ',
+            args=('Electrophysiology Variables',)
+        )
+        
+        if not category_result:
+            return None
+
+        return category_result[0]['ParameterTypeCategoryID']
 
     def grep_electrode_from_physiological_file_id(self, physiological_file_id):
         """

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -478,7 +478,18 @@ sub getParameterTypeID {
         my ($user) = getpwuid($UID);
         $query = "INSERT INTO parameter_type (Name, Type, Description, SourceFrom, Queryable) VALUES (".$dbh->quote($paramType).", 'text', ".$dbh->quote("$paramType magically created by NeuroDB::File").", 'parameter_file', 0)";
         $dbh->do($query);
-        return $dbh->{'mysql_insertid'};
+
+        # link the inserted ParameterTypeID to a parameter type category
+        my $param_type_id = $dbh->{'mysql_insertid'};
+        $query = "INSERT INTO parameter_type_category_rel "
+                 . " (ParameterTypeID, ParameterTypeCategoryID) "
+                 . " SELECT ?, ParameterTypeCategoryID "
+                    . " FROM parameter_type_category "
+                    . " WHERE Name='MRI Variables'";
+        $sth = $dbh->prepare($query);
+        $sth->execute($param_type_id);
+
+        return $param_type_id;
     }
 }
 	


### PR DESCRIPTION
### Description

This PR cleans up all the different paths that are referring to the same path (a.k.a. `/data/%PROJECT%/data/`). This gets rid of the Config settings `mincPath`, `imagePath` and `data` and updates the code accordingly.

The code changes on the LORISI front can be found in https://github.com/aces/Loris/pull/4314

### This fixes

- [x] Github #367 and https://github.com/aces/Loris/issues/4197 

### Caveat for existing projects

Make sure that your Config setting `dataDirBasepath` is configured to the proper data path (typically `/data/%PROJECT%/data`)