### PR TITLE
Added a batch script to run the defacing in parallel on multiple CPUs using QSUB

### DIFF
--- a/docs/scripts_md/batch_run_defacing_script.md
+++ b/docs/scripts_md/batch_run_defacing_script.md
@@ -4,7 +4,7 @@ batch\_run\_defacing\_script.pl -- Run the defacing algorithm on multiple sessio
 
 # SYNOPSIS
 
-perldoc batch\_run\_defacing\_script.pl \[-profile file\] < SessionIDs\_list.txt
+perldoc batch\_run\_defacing\_script.pl \[-profile file\] < list\_of\_session\_IDs.txt
 
 Available options are:
 

--- a/docs/scripts_md/batch_run_defacing_script.md
+++ b/docs/scripts_md/batch_run_defacing_script.md
@@ -1,0 +1,32 @@
+# NAME
+
+batch\_run\_defacing\_script.pl -- Run the defacing algorithm on multiple session IDs in parallel using QSUB
+
+# SYNOPSIS
+
+perldoc batch\_run\_defacing\_script.pl \[-profile file\] < SessionIDs\_list.txt
+
+Available options are:
+
+\-profile: name of config file in ../dicom-archive/.loris\_mri (typically called prod)
+
+# DESCRIPTION
+
+This script runs the defacing pipeline on multiple sessions. The list of
+session IDs are provided through a text file (e.g. `list_of_session_IDs.txt`
+with one sessionID per line).
+
+An example of what a `list_of_session_IDs.txt` might contain for 3 session IDs
+to be defaced:
+
+    123
+    124
+    125
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/batch_run_defacing_script.md
+++ b/docs/scripts_md/batch_run_defacing_script.md
@@ -4,7 +4,7 @@ batch\_run\_defacing\_script.pl -- Run the defacing algorithm on multiple sessio
 
 # SYNOPSIS
 
-perldoc batch\_run\_defacing\_script.pl \[-profile file\] < list\_of\_session\_IDs.txt
+perl batch\_run\_defacing\_script.pl \[-profile file\] < list\_of\_session\_IDs.txt
 
 Available options are:
 

--- a/tools/batch_run_defacing_script.pl
+++ b/tools/batch_run_defacing_script.pl
@@ -8,7 +8,7 @@ batch_run_defacing_script.pl -- Run the defacing algorithm on multiple session I
 
 =head1 SYNOPSIS
 
-perldoc batch_run_defacing_script.pl [-profile file] < SessionIDs_list.txt
+perldoc batch_run_defacing_script.pl [-profile file] < list_of_session_IDs.txt
 
 Available options are:
 

--- a/tools/batch_run_defacing_script.pl
+++ b/tools/batch_run_defacing_script.pl
@@ -1,0 +1,179 @@
+#!/usr/bin/perl -w
+
+=pod
+
+=head1 NAME
+
+batch_run_defacing_script.pl -- Run the defacing algorithm on multiple session IDs in parallel using QSUB
+
+=head1 SYNOPSIS
+
+perldoc batch_run_defacing_script.pl [-profile file] < SessionIDs_list.txt
+
+Available options are:
+
+-profile: name of config file in ../dicom-archive/.loris_mri (typically called prod)
+
+=head1 DESCRIPTION
+
+This script runs the defacing pipeline on multiple sessions. The list of
+session IDs are provided through a text file (e.g. C<list_of_session_IDs.txt>
+with one sessionID per line).
+
+An example of what a C<list_of_session_IDs.txt> might contain for 3 session IDs
+to be defaced:
+
+ 123
+ 124
+ 125
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut
+
+
+
+use strict;
+use warnings;
+no warnings 'once';
+use Getopt::Tabular;
+use NeuroDB::DBI;
+use NeuroDB::ExitCodes;
+
+
+
+#############################################################
+## Create the GetOpt table
+#############################################################
+
+my $profile;
+
+my @opt_table = (
+    [ '-profile', 'string', 1, \$profile, 'name of config file in ../dicom-archive/.loris_mri' ]
+);
+
+my $Help = <<HELP;
+*******************************************************************************
+Run run_defacing_script.pl in batch mode
+*******************************************************************************
+
+This script runs the defacing pipeline on multiple sessions. The list of 
+session IDs are provided through a text file (e.g. C<list_of_session_IDs.txt> 
+with one sessionID per line).
+
+An example of what a C<list_of_session_IDs.txt> might contain for 3 session IDs
+to be defaced:
+
+ 123
+ 124
+ 125
+
+Documentation: perldoc batch_run_defacing_script.pl
+
+HELP
+
+my $Usage = <<USAGE;
+usage: ./batch_run_defacing_script.pl -profile prod < list_of_session_IDs.txt > log_batch_defacing.txt 2>&1 [options]
+       $0 -help to list options
+USAGE
+
+&Getopt::Tabular::SetHelp( $Help, $Usage );
+&Getopt::Tabular::GetOptions( \@opt_table, \@ARGV ) || exit $NeuroDB::ExitCodes::GETOPT_FAILURE;
+
+
+
+
+#################################################################
+## Input error checking
+#################################################################
+
+if (!$ENV{LORIS_CONFIG}) {
+    print STDERR "\n\tERROR: Environment variable 'LORIS_CONFIG' not set\n\n";
+    exit $NeuroDB::ExitCodes::INVALID_ENVIRONMENT_VAR; 
+}
+
+if ( !defined $profile || !-e "$ENV{LORIS_CONFIG}/.loris_mri/$profile") {
+    print $Help;
+    print STDERR "$Usage\n\tERROR: You must specify a valid and existing profile.\n\n";
+    exit $NeuroDB::ExitCodes::PROFILE_FAILURE;
+}
+
+{ package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
+if ( !@Settings::db ) {
+    print STDERR "\n\tERROR: You don't have a \@db setting in the file "
+                 . "$ENV{LORIS_CONFIG}/.loris_mri/$profile \n\n";
+    exit $NeuroDB::ExitCodes::DB_SETTINGS_FAILURE;
+}
+
+
+
+
+
+#################################################################
+## Establish database connection and grep the database config
+#################################################################
+
+# connect to the database
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+
+# grep the database config settings
+my $data_dir  = &NeuroDB::DBI::getConfigSetting(\$dbh, 'dataDirBasepath');
+my $bin_dir   = &NeuroDB::DBI::getConfigSetting(\$dbh, 'MRICodePath'    );
+my $is_qsub   = &NeuroDB::DBI::getConfigSetting(\$dbh, 'is_qsub'        );
+my $mail_user = &NeuroDB::DBI::getConfigSetting(\$dbh, 'mail_user'      );
+
+# remove trailing / from the data directory
+$data_dir =~ s/\/$//g;
+
+
+
+
+
+#################################################################
+## Read STDIN into an array listing all SessionIDs
+#################################################################
+
+my @session_ids_list = <STDIN>;
+
+
+
+
+
+
+#################################################################
+## Loop through all session IDs to batch magic
+#################################################################
+
+my $counter    = 0;
+my $stdoutbase = "$data_dir/batch_output/defacingstdout.log"; 
+my $stderrbase = "$data_dir/batch_output/defacingstderr.log";
+
+foreach my $session_id (@session_ids_list) {
+
+    $counter++;
+    my $stdout = $stdoutbase.$counter;
+    my $stderr = $stderrbase.$counter;
+
+    my $command = "run_defacing_script.pl -profile $profile -sessionIDs $session_id";
+
+    if ($is_qsub) {
+        open QSUB, " | qsub -V -S /bin/sh -e $stderr -o $stdout -N process_defacing_${counter}";
+        print QSUB $command;
+        close QSUB;
+    } else {
+        system($command);
+    }
+} 
+
+
+exit $NeuroDB::ExitCodes::SUCCESS;
+
+
+
+

--- a/tools/batch_run_defacing_script.pl
+++ b/tools/batch_run_defacing_script.pl
@@ -8,7 +8,7 @@ batch_run_defacing_script.pl -- Run the defacing algorithm on multiple session I
 
 =head1 SYNOPSIS
 
-perldoc batch_run_defacing_script.pl [-profile file] < list_of_session_IDs.txt
+perl batch_run_defacing_script.pl [-profile file] < list_of_session_IDs.txt
 
 Available options are:
 
@@ -79,7 +79,7 @@ Documentation: perldoc batch_run_defacing_script.pl
 HELP
 
 my $Usage = <<USAGE;
-usage: ./batch_run_defacing_script.pl -profile prod < list_of_session_IDs.txt > log_batch_defacing.txt 2>&1 [options]
+usage: ./batch_run_defacing_script.pl -profile prod < list_of_session_IDs.txt [options]
        $0 -help to list options
 USAGE
 

--- a/tools/mass_perldoc_md_creation.pl
+++ b/tools/mass_perldoc_md_creation.pl
@@ -65,6 +65,7 @@ my @script_list = (
     'dicom-archive/get_dicom_info.pl',
     'dicom-archive/updateMRI_Upload.pl',
     'tools/BackPopulateSNRAndAcquisitionOrder.pl',
+    'tools/batch_run_defacing_script.pl',
     'tools/create_nifti_bval_bvec.pl',
     'tools/cleanupTarchives.pl',
     'tools/cleanup_paths_of_violation_tables.pl',


### PR DESCRIPTION
### Description

Added a tool script in order to be able to run the defacing pipeline in parallel on multiple CPUs using QSUB.

This script runs the defacing pipeline on multiple sessions. The list of session IDs are provided through a text file (e.g. C<list_of_session_IDs.txt> with one sessionID per line).

An example of what a C<list_of_session_IDs.txt> might contain for 3 session IDs to be defaced:
```
123
124
125
```

### This resolves

- no issue reported but this script was particularly useful in speeding the mass defacing on an open dataset so making it available to the LORIS-MRI community :)