### PR TITLE
Add a tool to produce 3D rendering of the face for visual QC of the defaced images

### DIFF
--- a/docs/scripts_md/batch_run_pipeline_qc_face_script.md
+++ b/docs/scripts_md/batch_run_pipeline_qc_face_script.md
@@ -14,13 +14,12 @@ Available options are:
 
 # DESCRIPTION
 
-This script runs the creation of 3D rendering QC images on multiple MINC files.
+This script creates the 3D rendering QC images on multiple MINC files.
 The list of MINC files to use to generate those 3D JPEG images are provided
-through a text file (e.g. `list_of_files.txt` with one file path per line.
+through a text file (e.g. `list_of_files.txt` with one file path per line).
 
 An example of what a `list_of_files.txt` might contain for 3 files to use to
-create a 3D JPEG rendering of a scan:
-to be defaced:
+create a 3D JPEG rendering of a scan to be defaced:
  /data/project/data/assembly/123456/V01/mri/processed/MINC\_deface/project\_123456\_V01\_t1w\_001\_t1w-defaced\_001.mnc
  /data/project/data/assembly/123456/V01/mri/processed/MINC\_deface/project\_123456\_V01\_t1w\_002\_t1w-defaced\_001.mnc
  /data/project/data/assembly/123456/V01/mri/processed/MINC\_deface/project\_123456\_V01\_t2w\_001\_t2w-defaced\_001.mnc

--- a/docs/scripts_md/batch_run_pipeline_qc_face_script.md
+++ b/docs/scripts_md/batch_run_pipeline_qc_face_script.md
@@ -1,0 +1,34 @@
+# NAME
+
+batch\_run\_pipeline\_qc\_face\_script.pl -- Run `pipeline_qc_deface.pl` in batch mode
+
+# SYNOPSIS
+
+perl batch\_run\_pipeline\_qc\_face\_script.pl \[-profile file\] \[-out\_basedir directory\] < list\_of\_files.txt
+
+Available options are:
+
+\-profile: name of config file in ../dicom-archive/.loris\_mri (typically called prod)
+
+\-out\_basedir: path to the output base directory where the jpg will be created
+
+# DESCRIPTION
+
+This script runs the creation of 3D rendering QC images on multiple MINC files.
+The list of MINC files to use to generate those 3D JPEG images are provided
+through a text file (e.g. `list_of_files.txt` with one file path per line.
+
+An example of what a `list_of_files.txt` might contain for 3 files to use to
+create a 3D JPEG rendering of a scan:
+to be defaced:
+ /data/project/data/assembly/123456/V01/mri/processed/MINC\_deface/project\_123456\_V01\_t1w\_001\_t1w-defaced\_001.mnc
+ /data/project/data/assembly/123456/V01/mri/processed/MINC\_deface/project\_123456\_V01\_t1w\_002\_t1w-defaced\_001.mnc
+ /data/project/data/assembly/123456/V01/mri/processed/MINC\_deface/project\_123456\_V01\_t2w\_001\_t2w-defaced\_001.mnc
+
+# LICENSING
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/tools/batch_run_pipeline_qc_face_script.pl
+++ b/tools/batch_run_pipeline_qc_face_script.pl
@@ -1,0 +1,189 @@
+#!/usr/bin/perl -w
+
+=pod
+
+=head1 NAME
+
+batch_run_pipeline_qc_face_script.pl -- Run C<pipeline_qc_deface.pl> in batch mode
+
+=head1 SYNOPSIS
+
+perl batch_run_pipeline_qc_face_script.pl [-profile file] [-out_basedir directory] < list_of_files.txt
+
+Available options are:
+
+-profile: name of config file in ../dicom-archive/.loris_mri (typically called prod)
+
+-out_basedir: path to the output base directory where the jpg will be created
+
+=head1 DESCRIPTION
+
+This script runs the creation of 3D rendering QC images on multiple MINC files.
+The list of MINC files to use to generate those 3D JPEG images are provided
+through a text file (e.g. C<list_of_files.txt> with one file path per line.
+
+An example of what a C<list_of_files.txt> might contain for 3 files to use to
+create a 3D JPEG rendering of a scan:
+to be defaced:
+ /data/project/data/assembly/123456/V01/mri/processed/MINC_deface/project_123456_V01_t1w_001_t1w-defaced_001.mnc
+ /data/project/data/assembly/123456/V01/mri/processed/MINC_deface/project_123456_V01_t1w_002_t1w-defaced_001.mnc
+ /data/project/data/assembly/123456/V01/mri/processed/MINC_deface/project_123456_V01_t2w_001_t2w-defaced_001.mnc
+
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut
+
+
+use strict;
+use warnings;
+no warnings 'once';
+use Getopt::Tabular;
+use File::Basename;
+use NeuroDB::DBI;
+use NeuroDB::ExitCodes;
+
+
+
+
+#############################################################
+## Create the GetOpt table
+#############################################################
+
+my $profile;
+my $out_basedir;
+
+my @opt_table = (
+    [ '-profile',     'string', 1, \$profile,     'name of config file in ../dicom-archive/.loris_mri'              ],
+    [ '-out_basedir', 'string', 1, \$out_basedir, 'path to the output base directory where the jpg will be created' ] 
+);
+
+my $Help = <<HELP;
+*******************************************************************************
+Run pipeline_qc_face.pl in batch mode
+*******************************************************************************
+
+This script runs the creation of 3D rendering QC images on multiple MINC files. 
+The list of MINC files to use to generate those 3D JPEG images are provided 
+through a text file (e.g. C<list_of_files.txt> with one file path per line.
+
+An example of what a C<list_of_files.txt> might contain for 3 files to use to 
+create a 3D JPEG rendering of a scan:
+to be defaced:
+
+ /data/project/data/assembly/123456/V01/mri/processed/MINC_deface/project_123456_V01_t1w_001_t1w-defaced_001.mnc
+ /data/project/data/assembly/123456/V01/mri/processed/MINC_deface/project_123456_V01_t1w_002_t1w-defaced_001.mnc
+ /data/project/data/assembly/123456/V01/mri/processed/MINC_deface/project_123456_V01_t2w_001_t2w-defaced_001.mnc
+
+Documentation: perldoc batch_run_pipeline_qc_face_script.pl
+
+HELP
+
+my $Usage = <<USAGE;
+usage: ./batch_run_pipeline_qc_deface_script.pl -profile prod  < list_of_files.txt [options]
+       $0 -help to list options
+USAGE
+
+&Getopt::Tabular::SetHelp( $Help, $Usage );
+&Getopt::Tabular::GetOptions( \@opt_table, \@ARGV ) || exit $NeuroDB::ExitCodes::GETOPT_FAILURE;
+
+
+
+
+#################################################################
+## Input error checking
+#################################################################
+
+if (!$ENV{LORIS_CONFIG}) {
+    print STDERR "\n\tERROR: Environment variable 'LORIS_CONFIG' not set\n\n";
+    exit $NeuroDB::ExitCodes::INVALID_ENVIRONMENT_VAR; 
+}
+
+if ( !defined $profile || !-e "$ENV{LORIS_CONFIG}/.loris_mri/$profile") {
+    print $Help;
+    print STDERR "$Usage\n\tERROR: You must specify a valid and existing profile.\n\n";
+    exit $NeuroDB::ExitCodes::PROFILE_FAILURE;
+}
+
+{ package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
+if ( !@Settings::db ) {
+    print STDERR "\n\tERROR: You don't have a \@db setting in the file "
+                 . "$ENV{LORIS_CONFIG}/.loris_mri/$profile \n\n";
+    exit $NeuroDB::ExitCodes::DB_SETTINGS_FAILURE;
+}
+
+if (!defined $out_basedir || !-e $out_basedir) {
+    print $Help;
+    print STDERR "$Usage\n\tERROR: You must specify a valid and existing out_basedir.\n\n";
+    exit $NeuroDB::ExitCodes::MISSING_ARG;
+}
+
+
+
+#################################################################
+## Establish database connection and grep the database config
+#################################################################
+
+# connect to the database
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+
+# grep the database config settings
+my $data_dir  = &NeuroDB::DBI::getConfigSetting(\$dbh, 'dataDirBasepath');
+my $bin_dir   = &NeuroDB::DBI::getConfigSetting(\$dbh, 'MRICodePath'    );
+my $is_qsub   = &NeuroDB::DBI::getConfigSetting(\$dbh, 'is_qsub'        );
+my $mail_user = &NeuroDB::DBI::getConfigSetting(\$dbh, 'mail_user'      );
+
+# remove trailing / from the data directory
+$data_dir =~ s/\/$//g;
+
+
+
+
+#################################################################
+## Read STDIN into an array listing all SessionIDs
+#################################################################
+
+my @files_list = <STDIN>;
+
+
+
+
+#################################################################
+## Loop through all files to batch magic
+#################################################################
+
+my $counter    = 0;
+my $stdoutbase = "$data_dir/batch_output/defaceqcstdout.log"; 
+my $stderrbase = "$data_dir/batch_output/defaceqcstderr.log";
+
+foreach my $file_in (@files_list) {
+    chomp ($file_in);
+
+    $counter++;
+    my $stdout   = $stdoutbase.$counter;
+    my $stderr   = $stderrbase.$counter;
+    my $file_out = $out_basedir . "/" . basename($file_in, ".mnc") . ".jpg";
+
+    my $command = "pipeline_qc_face.pl $file_in $file_out";
+
+    if ($is_qsub) {
+            open QSUB, " | qsub -V -S /bin/sh -e $stderr -o $stdout -N process_qc_deface_${counter}";
+        print QSUB $command;
+        close QSUB;
+    } else {
+        system($command);
+    }
+} 
+
+
+exit $NeuroDB::ExitCodes::SUCCESS;
+
+
+
+

--- a/tools/batch_run_pipeline_qc_face_script.pl
+++ b/tools/batch_run_pipeline_qc_face_script.pl
@@ -18,7 +18,7 @@ Available options are:
 
 =head1 DESCRIPTION
 
-This script runs the creation of 3D rendering QC images on multiple MINC files.
+This script creates the 3D rendering QC images on multiple MINC files.
 The list of MINC files to use to generate those 3D JPEG images are provided
 through a text file (e.g. C<list_of_files.txt> with one file path per line.
 
@@ -69,7 +69,7 @@ my $Help = <<HELP;
 Run pipeline_qc_face.pl in batch mode
 *******************************************************************************
 
-This script runs the creation of 3D rendering QC images on multiple MINC files. 
+This script creates the 3D rendering QC images on multiple MINC files. 
 The list of MINC files to use to generate those 3D JPEG images are provided 
 through a text file (e.g. C<list_of_files.txt> with one file path per line.
 
@@ -106,7 +106,7 @@ if (!$ENV{LORIS_CONFIG}) {
 }
 
 if ( !defined $profile || !-e "$ENV{LORIS_CONFIG}/.loris_mri/$profile") {
-    print $Help;
+    print STDERR $Help;
     print STDERR "$Usage\n\tERROR: You must specify a valid and existing profile.\n\n";
     exit $NeuroDB::ExitCodes::PROFILE_FAILURE;
 }
@@ -119,7 +119,7 @@ if ( !@Settings::db ) {
 }
 
 if (!defined $out_basedir || !-e $out_basedir) {
-    print $Help;
+    print STDERR $Help;
     print STDERR "$Usage\n\tERROR: You must specify a valid and existing out_basedir.\n\n";
     exit $NeuroDB::ExitCodes::MISSING_ARG;
 }
@@ -170,10 +170,14 @@ foreach my $file_in (@files_list) {
     my $stderr   = $stderrbase.$counter;
     my $file_out = $out_basedir . "/" . basename($file_in, ".mnc") . ".jpg";
 
-    my $command = "pipeline_qc_face.pl $file_in $file_out";
+    my $command = sprintf(
+        "pipeline_qc_face.pl %s %s",
+        quotemeta($file_in),
+        quotemeta($file_out)
+    );
 
     if ($is_qsub) {
-            open QSUB, " | qsub -V -S /bin/sh -e $stderr -o $stdout -N process_qc_deface_${counter}";
+        open QSUB, " | qsub -V -S /bin/sh -e " . quotemeta($stderr) . " -o " . quotemeta($stdout) . " -N process_qc_deface_${counter}";
         print QSUB $command;
         close QSUB;
     } else {

--- a/tools/batch_run_pipeline_qc_face_script.pl
+++ b/tools/batch_run_pipeline_qc_face_script.pl
@@ -20,11 +20,10 @@ Available options are:
 
 This script creates the 3D rendering QC images on multiple MINC files.
 The list of MINC files to use to generate those 3D JPEG images are provided
-through a text file (e.g. C<list_of_files.txt> with one file path per line.
+through a text file (e.g. C<list_of_files.txt> with one file path per line).
 
 An example of what a C<list_of_files.txt> might contain for 3 files to use to
-create a 3D JPEG rendering of a scan:
-to be defaced:
+create a 3D JPEG rendering of a scan to be defaced:
  /data/project/data/assembly/123456/V01/mri/processed/MINC_deface/project_123456_V01_t1w_001_t1w-defaced_001.mnc
  /data/project/data/assembly/123456/V01/mri/processed/MINC_deface/project_123456_V01_t1w_002_t1w-defaced_001.mnc
  /data/project/data/assembly/123456/V01/mri/processed/MINC_deface/project_123456_V01_t2w_001_t2w-defaced_001.mnc
@@ -74,8 +73,7 @@ The list of MINC files to use to generate those 3D JPEG images are provided
 through a text file (e.g. C<list_of_files.txt> with one file path per line.
 
 An example of what a C<list_of_files.txt> might contain for 3 files to use to 
-create a 3D JPEG rendering of a scan:
-to be defaced:
+create a 3D JPEG rendering of a scan to be defaced:
 
  /data/project/data/assembly/123456/V01/mri/processed/MINC_deface/project_123456_V01_t1w_001_t1w-defaced_001.mnc
  /data/project/data/assembly/123456/V01/mri/processed/MINC_deface/project_123456_V01_t1w_002_t1w-defaced_001.mnc
@@ -86,7 +84,7 @@ Documentation: perldoc batch_run_pipeline_qc_face_script.pl
 HELP
 
 my $Usage = <<USAGE;
-usage: ./batch_run_pipeline_qc_deface_script.pl -profile prod  < list_of_files.txt [options]
+usage: ./batch_run_pipeline_qc_deface_script.pl -profile prod -out_basedir /PATH/FOR/JPEG < list_of_files.txt 
        $0 -help to list options
 USAGE
 

--- a/tools/mass_perldoc_md_creation.pl
+++ b/tools/mass_perldoc_md_creation.pl
@@ -66,6 +66,7 @@ my @script_list = (
     'dicom-archive/updateMRI_Upload.pl',
     'tools/BackPopulateSNRAndAcquisitionOrder.pl',
     'tools/batch_run_defacing_script.pl',
+    'tools/batch_run_pipeline_qc_face_script.pl',
     'tools/create_nifti_bval_bvec.pl',
     'tools/cleanupTarchives.pl',
     'tools/cleanup_paths_of_violation_tables.pl',

--- a/uploadNeuroDB/bin/pipeline_qc_face.pl
+++ b/uploadNeuroDB/bin/pipeline_qc_face.pl
@@ -30,10 +30,10 @@ my $keep_tmp=0;
 my $stx_xfm;
 
 GetOptions(
-	   'verbose' => \$verbose,
-	   'fake'    => \$fake,
-	   'clobber' => \$clobber,
-       'stx=s'   => \$stx_xfm
+    'verbose' => \$verbose,
+    'fake'    => \$fake,
+    'clobber' => \$clobber,
+    'stx=s'   => \$stx_xfm
 );
 
 die "Program usage: ${me} <native> <output> [--stx <xfm>]\n" unless $#ARGV == 1 ;

--- a/uploadNeuroDB/bin/pipeline_qc_face.pl
+++ b/uploadNeuroDB/bin/pipeline_qc_face.pl
@@ -1,0 +1,89 @@
+#!/usr/bin/env perl
+
+############################# MNI Header #####################################
+#@NAME       :  pipeline_qc_face.pl
+#@DESCRIPTION:  Create a QC image showing face of the subject
+#@COPYRIGHT  :
+#              Vladimir S. Fonov  Dec, 2009
+#              Montreal Neurological Institute, McGill University.
+#              Permission to use, copy, modify, and distribute this
+#              software and its documentation for any purpose and without
+#              fee is hereby granted, provided that the above copyright
+#              notice appear in all copies.  The author and McGill University
+#              make no representations about the suitability of this
+#              software for any purpose.  It is provided "as is" without
+#              express or implied warranty.
+###############################################################################
+
+use strict;
+use File::Basename;
+use File::Temp qw/ tempfile tempdir /;
+use File::Path;
+use Getopt::Long;       
+use pipeline_functions;
+
+my $me = basename($0);
+my $verbose = 0;
+my $fake = 0;
+my $clobber = 0;
+my $keep_tmp=0;
+my $stx_xfm;
+
+GetOptions(
+	   'verbose' => \$verbose,
+	   'fake'    => \$fake,
+	   'clobber' => \$clobber,
+     'stx=s'   => \$stx_xfm
+	   );
+
+die "Program usage: ${me} <native> <output> [--stx <xfm>]\n" if $#ARGV < 1 ;
+
+my ($in,$out) = @ARGV;
+my @files_to_add_to_db;
+
+check_file($out) unless $clobber;
+   
+my $tmpdir = &tempdir( "$me-XXXXXXXX", TMPDIR => 1, CLEANUP => !$keep_tmp );
+
+if($stx_xfm)
+{
+  do_cmd('make_face.pl',$in,"$tmpdir/face_1.miff",'--threshold',0.8,'--rotate',-10,'--stx',$stx_xfm);
+  do_cmd('make_face.pl',$in,"$tmpdir/face_2.miff",'--threshold',0.8,'--stx',$stx_xfm);
+  do_cmd('make_face.pl',$in,"$tmpdir/face_3.miff",'--threshold',0.8,'--rotate',10,'--stx',$stx_xfm);
+} else {
+  do_cmd('make_face.pl',$in,"$tmpdir/face_1.miff",'--threshold',0.8,'--rotate',-10);
+  do_cmd('make_face.pl',$in,"$tmpdir/face_2.miff",'--threshold',0.8);
+  do_cmd('make_face.pl',$in,"$tmpdir/face_3.miff",'--threshold',0.8,'--rotate',10);
+}
+
+my $geo=`identify -format "%wx%h" $tmpdir/face_2.miff`;
+chomp($geo);
+#my @args = ('convert', '-box', 'white', 
+#	       '-font', '7x13bold', 
+	       #'-fill', 'white',
+#	       '-draw', "text 2,15 \"$imagelabel\"");
+
+#do_cmd(@args,$tmp_out, $out);
+do_cmd('montage','-geometry',$geo,"$tmpdir/face_1.miff","$tmpdir/face_2.miff","$tmpdir/face_3.miff",$out);
+
+
+@files_to_add_to_db = (@files_to_add_to_db, $out);
+print("Files created:@files_to_add_to_db\n");
+
+    
+####################################################################
+# do_cmd( arg1,argv2,.... )
+#
+# execute given command
+#
+#####################################################################
+sub do_cmd { 
+    print STDOUT "@_\n" if $verbose;
+    if(!$fake){
+      system(@_) == 0 or die "DIED: @_\n";
+    }
+}
+
+sub check_file {
+  die("${_[0]} exists!\n") if -e $_[0];
+}

--- a/uploadNeuroDB/bin/pipeline_qc_face.pl
+++ b/uploadNeuroDB/bin/pipeline_qc_face.pl
@@ -33,10 +33,10 @@ GetOptions(
 	   'verbose' => \$verbose,
 	   'fake'    => \$fake,
 	   'clobber' => \$clobber,
-     'stx=s'   => \$stx_xfm
-	   );
+       'stx=s'   => \$stx_xfm
+);
 
-die "Program usage: ${me} <native> <output> [--stx <xfm>]\n" if $#ARGV < 1 ;
+die "Program usage: ${me} <native> <output> [--stx <xfm>]\n" unless $#ARGV == 1 ;
 
 my ($in,$out) = @ARGV;
 my @files_to_add_to_db;
@@ -58,12 +58,6 @@ if($stx_xfm)
 
 my $geo=`identify -format "%wx%h" $tmpdir/face_2.miff`;
 chomp($geo);
-#my @args = ('convert', '-box', 'white', 
-#	       '-font', '7x13bold', 
-	       #'-fill', 'white',
-#	       '-draw', "text 2,15 \"$imagelabel\"");
-
-#do_cmd(@args,$tmp_out, $out);
 do_cmd('montage','-geometry',$geo,"$tmpdir/face_1.miff","$tmpdir/face_2.miff","$tmpdir/face_3.miff",$out);
 
 


### PR DESCRIPTION
### Description

This PR includes a modified version of the MINC tool `pipeline_qc_face.pl` to work with the LORIS-MRI pipelines in `uploadNeuroDB/bin` and a tool script that allows running `pipeline_qc_face.pl` in parallel on multiple CPUs.

Those new tools will create a 3D rendering of the face to ensure that the defacing went properly. They will produce jpeg files in a directory specified using the `-out_basedir` option of `batch_run_pipeline_qc_face_script.pl` that can be looked at to make sur the face was properly scrubbed. 

### This resolves

- no issue reported but this script was particularly useful in creating the QC images for open science :)