### PR TITLE
Adding the image_type to the mri_protocol when identifying for imaging protocol

### DIFF
--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -139,7 +139,7 @@ RETURNS: textual name of scan type from the `mri_scan_type` table
 
 ### insert\_violated\_scans($dbhr, $series\_desc, $minc\_location, $patient\_name, $candid, $pscid, $visit, $tr, $te, $ti, $slice\_thickness, $xstep, $ystep, $zstep, $xspace, $yspace, $zspace, $time, $seriesUID)
 
-Inserts scans that do not correspond to any of the defined protocol from the 
+Inserts scans that do not correspond to any of the defined protocol from the
 `mri_protocol` table into the `mri_protocol_violated_scans` table of the
 database.
 
@@ -163,6 +163,8 @@ INPUTS:
   - $zspace         : `z-space` of the image
   - $time           : time dimension of the scan
   - $seriesUID      : `SeriesUID` of the scan
+  - $tarchiveID     : `TarchiveID` of the DICOM archive from which this file is derived
+  - $image\_type     : the `image_type` header value of the image
 
 ### debug\_inrange($val, $range)
 
@@ -197,7 +199,7 @@ RETURNS: ID of the scan type
 ### in\_range($value, $range\_string)
 
 Determines whether numerical value falls within the range described by range
-string. Range string is a single range unit which follows the syntax 
+string. Range string is a single range unit which follows the syntax
 "X" or "X-Y".
 
 INPUTS:
@@ -292,9 +294,9 @@ RETURNS: `CandID` (int)
 
 ### getPSC($patientName, $dbhr)
 
-Looks for the site alias using the `session` table `CenterID` as 
+Looks for the site alias using the `session` table `CenterID` as
 a first resource, for the cases where it is created using the front-end,
-otherwise, find the site alias in whatever field (usually `patient_name` 
+otherwise, find the site alias in whatever field (usually `patient_name`
 or `patient_id`) is provided, and return the `MRI_alias` and `CenterID`.
 
 INPUTS:
@@ -418,6 +420,15 @@ INPUT: array with full path to the DICOM files
 RETURNS:
   - %isDicomImage: hash with file path as keys and true or false as values (true
                    if the file is a DICOM image file, false otherwise)
+
+### get\_trashbin\_file\_rel\_path($file)
+
+Determines and returns the relative path of a file moved to trashbin at the end of
+the insertion pipeline.
+
+INPUT: path to a given file
+
+RETURNS: the relative path of the file moved to the trashbin directory
 
 # TO DO
 


### PR DESCRIPTION
### Description

This PR contains the code changes needed to add the `image_type` check in the `mri_protocol` and `mri_protocol_violated_scans`. 

This `image_type` header field is a key variable as this is the only MINC header that allows to differentiate between a fieldmap phase difference from a fieldmap magnitude file which have different purposes when it comes to analyses and the insertion pipeline should be able to recognize one from the other. This is also the case for MP2RAGE modalities and other modern imaging modalities, hence the need to add that field in the mri_protocol table.

Example:
- image_type for fieldmap phase difference image: `ORIGINAL\\PRIMARY\\P\\ND` (P for phase)
- image_type for fieldmap magnitude image: `ORIGINAL\\PRIMARY\\M\\ND` (M for magnitude)

Note that because of the multiple `\` in that field, in order to insert the correct value, the `\`s need to be escaped. Example: 
`INSERT INTO mri_protocol SET image_type='ORIGINAL\\\\PRIMARY\\\\P\\\\ND', ...`

The SQL required for this PR can be found in the following PR on the LORIS side: https://github.com/aces/Loris/pull/4448

### This resolves issue...

- no issue reported but this script was particularly useful when inserting more modern imaging modalities into LORIS so making it available to the community :)

### Caveat for existing projects

Make sure to run the SQL patches from in order to add the `image_type` field to the `mri_protocol` and the `mri_protocol_violated_scans` tables. See https://github.com/aces/Loris/pull/4448 for the patches