### PR TITLE
fix batch_uploads_imageuploader that inserted duplicated uploads

### DIFF
--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -169,7 +169,6 @@ while(my $line = <STDIN>)
 {
     chomp $line;
     my @linearray = split(" " , $line);
-    push (@resultsarray, @linearray);
     @fullpath = $linearray[0];
     @phantom = $linearray[1];
     @patientname = $linearray[2];
@@ -180,7 +179,7 @@ while(my $line = <STDIN>)
 close STDIN;
 
 ## foreach series, batch magic
-foreach my $input (@resultsarray)
+foreach my $input (@fullpath)
 {
     $counter++;
     $stdout = $stdoutbase.$counter;

--- a/batch_uploads_imageuploader
+++ b/batch_uploads_imageuploader
@@ -57,9 +57,6 @@ use NeuroDB::ExitCodes;
 
 my $profile   = '';
 my $upload_id = undef; 
-my $fullpath = undef; 
-my $phantom = undef; 
-my $patientname = undef; 
 my ($debug, $verbose) = (0,1);
 my $stdout = '';
 my $stderr = '';
@@ -153,13 +150,8 @@ while($_ = $ARGV[0], /^-/) {
 
 
 ## read input from STDIN, store into array @inputs (`find ....... | this_script`)
-my @linearray = ();
-my @resultsarray = ();
-my @patientname = ();
 my @patientnamearray = ();
-my @fullpath = ();
 my @fullpatharray = ();
-my @phantom = ();
 my @phantomarray = ();
 my @submitted = ();
 
@@ -168,18 +160,16 @@ my $counter = 0;
 while(my $line = <STDIN>)
 {
     chomp $line;
+
     my @linearray = split(" " , $line);
-    @fullpath = $linearray[0];
-    @phantom = $linearray[1];
-    @patientname = $linearray[2];
-    push (@patientnamearray, @patientname);
-    push (@fullpatharray, @fullpath);
-    push (@phantomarray, @phantom);
+    push (@fullpatharray,    $linearray[0]);
+    push (@phantomarray,     $linearray[1]);
+    push (@patientnamearray, $linearray[2]);
 }
 close STDIN;
 
 ## foreach series, batch magic
-foreach my $input (@fullpath)
+foreach my $input (@fullpatharray)
 {
     $counter++;
     $stdout = $stdoutbase.$counter;
@@ -188,9 +178,9 @@ foreach my $input (@fullpath)
     #$stdout = '/dev/null';
     #$stderr = '/dev/null';
 
-    $fullpath = $fullpatharray[$counter-1];
-    $phantom = $phantomarray[$counter-1];
-    $patientname = $patientnamearray[$counter-1];
+    my $fullpath    = $fullpatharray[$counter-1];
+    my $phantom     = $phantomarray[$counter-1];
+    my $patientname = $patientnamearray[$counter-1];
 
     ## Ensure that 
     ## 1) the uploaded file is of type .tgz or .tar.gz or .zip


### PR DESCRIPTION
### Description

`batch_uploads_imageuploader` creates a duplicate entry in the `mri_upload` table when loading one upload:
```
+----------+-------------+---------------------+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------+-------------------+------------------------+-----------------------+------------+-----------+--------------------------+---------------------+-----------+------------------------------------------+-----------+
| UploadID | UploadedBy  | UploadDate          | UploadLocation                                                                        | DecompressedLocation                                                                 | InsertionComplete | number_of_mincInserted | number_of_mincCreated | TarchiveID | SessionID | IsCandidateInfoValidated | IsTarchiveValidated | Inserting | PatientName                              | IsPhantom |
+----------+-------------+---------------------+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------+-------------------+------------------------+-----------------------+------------+-----------+--------------------------+---------------------+-----------+------------------------------------------+-----------+
|      166 | cecile      | 2019-04-12 08:52:59 | /data/incoming/preventAD/MTL0078_857385_NAPEN00_20121204_104302249.tgz                | /data/not_backed_up/ImagingUpload-9-5-iq6JYs                                         |                 1 |                     13 |                    15 |    4002683 |      2895 |                        1 |                   1 |         0 | MTL0078_857385_NAPEN00                   | N         |
|      167 | cecile      | 2019-04-12 09:05:28 | /data/incoming/preventAD/MTL0078_857385_NAPEN00_20121204_104302249.tgz                |                                                                                      |                 0 |                   NULL |                  NULL |       NULL |      NULL |                     NULL |                   0 |      NULL | MTL0078_857385_NAPEN00                   | N         |
```

This PR fixes that bug in `batch_uploads_imageuploader`