### PR TITLE
Correct bug to call to registerScanner

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1018,7 +1018,7 @@ sub findScannerID {
     return 0 if !$register_new;
     
     # only register new scanners when told to do so !!!
-    $scanner_id = registerScanner($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr) unless $scanner_id;
+    my $scanner_id = registerScanner($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $db);
 
     return $scanner_id;
 }


### PR DESCRIPTION
The call to `registerScanner` in `MRI.pm` got screwed up when resolving conflicts between minor and major. This PR fixes the issue.