### PR TITLE
Remove deprecated function isValidMRIProtocol now that the mri_protocol contains MIN MAX values

### DIFF
--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -459,13 +459,6 @@ INPUTS:
   - $verb      : 'N' for few main messages,
                  'Y' for more messages (developers)
 
-### isValidMRIProtocol()
-
-Ensures no column in the `mri_protocol` nor the `mri_protocol_checks` 
-tables has comma-separated values.
-
-RETURNS: 1 on success, 0 on failure
-
 ### is\_file\_unique($file, $upload\_id)
 
 Queries the `files` and `parameter_file` tables to make sure that no imaging
@@ -487,9 +480,6 @@ Document the following functions:
   - registerProgs(@toregister)
 
 Remove the function get\_acqusitions($study\_dir, \\@acquisitions) that is not used
-
-Remove the function isValidMRIProtocol() once the database schema is configured 
-to prevent users from entering non-conform entries in the `mri_protocol` table
 
 Fix comments written as #fixme in the code
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -2048,50 +2048,6 @@ sub spool  {
            'MRIProcessingUtility.pm', $upload_id, $error, $verb);
 }
 
-=pod
-
-=head3 isValidMRIProtocol()
-
-Ensures no column in the C<mri_protocol> nor the C<mri_protocol_checks> 
-tables has comma-separated values.
-
-RETURNS: 1 on success, 0 on failure
-
-=cut
-
-sub isValidMRIProtocol  {
-    my $this = shift;
-
-    my $query = "SELECT COUNT(*) FROM mri_protocol 
-                WHERE TR_range LIKE '%,%'
-                OR TE_range LIKE '%,%'
-                OR TI_range LIKE '%,%'
-                OR slice_thickness_range LIKE '%,%'
-                OR xspace_range LIKE '%,%'
-                OR yspace_range LIKE '%,%'
-                OR zspace_range LIKE '%,%'
-                OR xstep_range LIKE '%,%'
-                OR ystep_range LIKE '%,%'
-                OR zstep_range LIKE '%,%'
-                OR time_range LIKE '%,%'";
-
-    my $sth = ${$this->{'dbhr'}}->prepare($query);
-    $sth->execute();
-    my $count_mri_protocol = $sth->fetchrow_array;
-
-    $query = "SELECT COUNT(*) FROM mri_protocol_checks 
-                WHERE ValidRange LIKE '%,%'";
-
-    $sth = ${$this->{'dbhr'}}->prepare($query);
-    $sth->execute();
-    my $count_mri_protocol_checks = $sth->fetchrow_array;
-
-    if ( $count_mri_protocol > 0 || $count_mri_protocol_checks > 0) {
-        return 0;  
-    } else {
-        return 1;
-    }
-}
 
 =pod
 
@@ -2159,9 +2115,6 @@ Document the following functions:
   - registerProgs(@toregister)
 
 Remove the function get_acqusitions($study_dir, \@acquisitions) that is not used
-
-Remove the function isValidMRIProtocol() once the database schema is configured 
-to prevent users from entering non-conform entries in the C<mri_protocol> table
 
 Fix comments written as #fixme in the code
 

--- a/uploadNeuroDB/tarchiveLoader.pl
+++ b/uploadNeuroDB/tarchiveLoader.pl
@@ -482,24 +482,6 @@ if ($mcount < 1) {
 }
 
 ################################################################
-################################################################
-# Make sure the mri_protocol table no longer has comma-separated
-########################## values ##############################
-################################################################
-my ($isMRIProtocolValid) = $utility->isValidMRIProtocol();
-
-if ( !($isMRIProtocolValid) ) {
-    my $message = "\nComma separated ranges or values in the mri_protocol "
-                  . "and mri_protocol_checks tables are no longer supported. "
-                  . "Please modify your tables accordingly. Exiting now. \n";
-    $notifier->spool('tarchive loader', $message, 0,
-		    'tarchiveLoader.pl', $upload_id, 'Y',
-		    $notify_notsummary);
-    print STDERR $message;
-    exit $NeuroDB::ExitCodes::PROJECT_CUSTOMIZATION_FAILURE;
-}
-
-################################################################
 #################### LOOP through MINCs ########################
 # At this step we actually have (multiple) MINC files so we loop
 # a valid study has at least one file that can be uploaded #####


### PR DESCRIPTION
This PR removes the function that was added in `MRIProcessingUtility.pm` when the `mri_protocol` table was modified to remove the `,` in the range columns. This function is not needed anymore now that the range columns have been split into `Min` `Max` columns.