### PR TITLE
Fixes a warning message of non-numeric value in comparison

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -972,7 +972,7 @@ sub update_mri_acquisition_dates {
     # set acquisition date to undef if the date is '0000-00-00', '' or 0
     #####################################################################
     if ( defined $acq_date
-            && ($acq_date eq '0000-00-00' || $acq_date eq '' || $acq_date == 0) ) {
+            && ($acq_date eq '0000-00-00' || $acq_date eq '' || $acq_date =~ /^0$/) ) {
         $acq_date = undef;
     }
 


### PR DESCRIPTION
The following warning message gets displayed when the pipeline run on a dataset with a valid acquisition date:
`Argument 2016-08-15 isn't numeric in numeric eq (==) at /data/demo/bin/mri/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm line 974.`

This PR resolves this warning message that got introduced by https://github.com/aces/Loris-MRI/pull/395.