### PR TITLE
Gets rid of the warning message Use of uninitialized value when computing SNR

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1889,7 +1889,7 @@ QUERY
             my $SNR_old = $file->getParameter('SNR');
             if ($SNR ne '') {
                 $file->setParameter('SNR', $SNR);
-                if (($SNR_old ne '') && ($SNR_old ne $SNR)) {
+                if (defined($SNR_old) && $SNR_old ne '' && $SNR_old ne $SNR) {
                     $message = "The SNR value was updated from $SNR_old to $SNR.\n";
                     $this->{LOG}->print($message);
                     $this->spool($message, 'N', $upload_id, $notify_detailed);


### PR DESCRIPTION
This PR resolves the warning message below that appeared when computing SNR on a dataset for the first time:
`Use of uninitialized value  in string ne at /data/demo/bin/mri/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm line 1892.`

