### PR TITLE
Reorder environment file for new installs

### DIFF
--- a/environment
+++ b/environment
@@ -3,7 +3,7 @@ source %MINC_TOOLKIT_DIR%/minc-toolkit-config.sh
 umask 0002
 
 # export PATH, PERL5LIB, TMPDIR and LORIS_CONFIG variables
-export PATH=/data/%PROJECT%/bin/mri:/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/uploadNeuroDB/bin:/data/%PROJECT%/bin/mri/dicom-archive:/data/%PROJECT%/bin/mri/python:/data/%PROJECT%/bin/mri/python/react-series-data-viewer:%MINC_TOOLKIT_DIR%/bin:$PATH
+export PATH=/data/%PROJECT%/bin/mri:/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/uploadNeuroDB/bin:/data/%PROJECT%/bin/mri/dicom-archive:/data/%PROJECT%/bin/mri/python:/data/%PROJECT%/bin/mri/tools:/data/%PROJECT%/bin/mri/python/react-series-data-viewer:%MINC_TOOLKIT_DIR%/bin:$PATH
 export PERL5LIB=/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/dicom-archive:$PERL5LIB
 export TMPDIR=/tmp
 export LORIS_CONFIG=/data/%PROJECT%/bin/mri/dicom-archive

--- a/environment
+++ b/environment
@@ -1,4 +1,9 @@
-export PATH=%MINC_TOOLKIT_DIR%/bin:/data/%PROJECT%/bin/mri:/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/uploadNeuroDB/bin:/data/%PROJECT%/bin/mri/dicom-archive:/data/%PROJECT%/bin/mri/python:/data/%PROJECT%/bin/mri/python/react-series-data-viewer:$PATH
+# to source the MINC toolkit
+source %MINC_TOOLKIT_DIR%/minc-toolkit-config.sh
+umask 0002
+
+# export PATH, PERL5LIB, TMPDIR and LORIS_CONFIG variables
+export PATH=/data/%PROJECT%/bin/mri:/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/uploadNeuroDB/bin:/data/%PROJECT%/bin/mri/dicom-archive:/data/%PROJECT%/bin/mri/python:/data/%PROJECT%/bin/mri/python/react-series-data-viewer:%MINC_TOOLKIT_DIR%/bin:$PATH
 export PERL5LIB=/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/dicom-archive:$PERL5LIB
 export TMPDIR=/tmp
 export LORIS_CONFIG=/data/%PROJECT%/bin/mri/dicom-archive
@@ -7,10 +12,6 @@ export LORIS_CONFIG=/data/%PROJECT%/bin/mri/dicom-archive
 export LORIS_MRI=/data/%PROJECT%/bin/mri
 export PYTHONPATH=$PYTHONPATH:/data/%PROJECT%/bin/mri/python:/data/%PROJECT%/bin/mri/python/react-series-data-viewer
 source /data/%PROJECT%/bin/mri/python_virtualenvs/loris-mri-python/bin/activate
-
-# to source the MINC toolkit
-source %MINC_TOOLKIT_DIR%/minc-toolkit-config.sh
-umask 0002
 
 # for the defacing scripts
 export BEASTLIB=%MINC_TOOLKIT_DIR%/../share/beast-library-1.1


### PR DESCRIPTION
The order in the environment file had to be changed in order for new projects to be able to use the `deface_minipipe.pl` from LORIS-MRI instead of the one from the MINC tools. 

For existing projects, instructions were given at the time of release [20.3.0](https://github.com/aces/Loris-MRI/releases/tag/v20.3.0) on how to modify their environment files in the section **Notes for existing projects**.