### PR TITLE
get_dicom_file fails when the series description contains a sed special character.

### DIFF
--- a/tools/get_dicom_files.pl
+++ b/tools/get_dicom_files.pl
@@ -301,13 +301,19 @@ foreach my $tarchiveRowRef (@{ $sth->fetchall_arrayref }) {
 
         my $outDir = "$tmpExtractDir/$id/$visitLabel/$dateAcquired/$outSubDir";
         
+        # Since we are using a path transform in the tar command, we have to escape
+        # sed's special characters
+        my $outDirForSed = $outDir;
+        $outDirForSed =~ s#\\#\\\\#g;
+        $outDirForSed =~ s#&#\\&#g;
+
         # --files-from: file containing the path of the files to extract
         # --transform: put all extracted files in $outDir
         # --absolute-path: since we are extracting in $outDir and since
         #                  $outDir is an absolute path, we need this option otherwise
         #                  tar will refuse to extract
         $cmd = sprintf(
-            "tar zxf %s/%s --files-from=%s --absolute-names --transform='s#^.*/#$outDir/#'",
+            "tar zxf %s/%s --files-from=%s --absolute-names --transform='s#^.*/#$outDirForSed/#'",
             quotemeta($tmpExtractDir),
             quotemeta($innerTar),
             quotemeta($fileList) 


### PR DESCRIPTION
get_dicom_script does not handle series descriptions that contain either a `&` or `\` well. Care must be taken when specifying the `--transform` option to `tar` with such series (see changes).

To test, one can "fake" a series description that contains one of the special characters and check that the script completes successfully. 

This fixes issue #433 