### PR TITLE
Add a note about the deletion script in the docs of LORIS-MRI

### DIFF
--- a/docs/04-Scripts.md
+++ b/docs/04-Scripts.md
@@ -165,7 +165,7 @@ In cases where a subject was scanned in two scanner sessions as part of the same
 
 As of release 21.0 of LORIS-MRI, a deletion script has been added to the tools 
 directory of the repository. This deletion script allows to delete completely an MRI 
-upload from the filesystem and database or partially remove some MINC files derived 
+upload from the filesystem and database or remove specific MINC files derived 
 from the MRI upload. Note that by default, all removed data will be backed up.
 
 Detailed information about the script can be found in: 

--- a/docs/04-Scripts.md
+++ b/docs/04-Scripts.md
@@ -164,8 +164,9 @@ In cases where a subject was scanned in two scanner sessions as part of the same
 ##4.4 - MRI upload deletion script
 
 As of release 21.0 of LORIS-MRI, a deletion script has been added to the tools 
-directory of the repository in order to delete completely an MRI upload from the 
-imaging tables.
+directory of the repository. This deletion script allows to delete completely an MRI 
+upload from the filesystem and database or partially remove some MINC files derived 
+from the MRI upload. Note that by default, all removed data will be backed up.
 
-Detailed information on how to run the script on an MRI upload can be found in: 
+Detailed information about the script can be found in: 
 https://github.com/aces/Loris-MRI/blob/21.0-dev/docs/scripts_md/delete_imaging_upload.md

--- a/docs/04-Scripts.md
+++ b/docs/04-Scripts.md
@@ -160,3 +160,12 @@ In cases where a subject was scanned in two scanner sessions as part of the same
   separate DICOM datasets. The insertion pipeline will automatically 
   associate and display both sets of images acquired in both scanner sessions 
   under the same `session` table record. 
+  
+##4.4 - MRI upload deletion script
+
+As of release 21.0 of LORIS-MRI, a deletion script has been added to the tools 
+directory of the repository in order to delete completely an MRI upload from the 
+imaging tables.
+
+Detailed information on how to run the script on an MRI upload can be found in: 
+https://github.com/aces/Loris-MRI/blob/21.0-dev/docs/scripts_md/delete_imaging_upload.md


### PR DESCRIPTION
Modified the documentation to add a section about the deletion script and to point to the MD file documentation on how to run the script.