### PR TITLE
[install script] Add the missing DBI.pm library to the CPAN install

### DIFF
--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -77,6 +77,10 @@ sudo -S cpan install Pod::Perldoc
 sudo -S cpan install Pod::Markdown
 sudo -S cpan install Pod::Usage
 sudo -S cpan install JSON
+sudo -S cpan install Moose
+sudo -S cpan install MooseX::Privacy
+sudo -S cpan install TryCatch
+sudo -S cpan install Throwable
 echo
 
 ################################################################################

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -67,6 +67,7 @@ echo "Installing the perl libraries...This will take a few minutes..."
 sudo -S cpan install Math::Round
 #echo $rootpass | sudo -S cpan install Bundle::CPAN
 sudo -S cpan install DBI
+sudo -S cpan install DBD::mysql
 sudo -S cpan install Getopt::Tabular
 sudo -S cpan install Time::JulianDay
 sudo -S cpan install Path::Class

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -66,6 +66,7 @@ echo "Installing the perl libraries...This will take a few minutes..."
 #echo $rootpass | sudo perl -MCPAN -e shell
 sudo -S cpan install Math::Round
 #echo $rootpass | sudo -S cpan install Bundle::CPAN
+sudo -S cpan install DBI
 sudo -S cpan install Getopt::Tabular
 sudo -S cpan install Time::JulianDay
 sudo -S cpan install Path::Class


### PR DESCRIPTION
The `DBI.pm` library is missing in the CPAN install instructions run by the install script. This PR adds it to the install script to correct this mistake.