### PR TITLE
[BIDS EEG import] Changed the field CenterID to be RegistrationCenterID when querying the candidate table

### DIFF
--- a/python/bids_import.py
+++ b/python/bids_import.py
@@ -180,7 +180,7 @@ def read_and_insert_bids(bids_dir, config_file, verbose, createcand, createvisit
             bids_reader, bids_id, db, createcand, loris_bids_root_dir, verbose
         )
         cand_id   = loris_cand_info['CandID']
-        center_id = loris_cand_info['CenterID']
+        center_id = loris_cand_info['RegistrationCenterID']
 
         # greps BIDS session's info for the candidate from LORIS (creates the
         # session if it does not exist yet in LORIS and the createvisit is set

--- a/python/lib/candidate.py
+++ b/python/lib/candidate.py
@@ -111,7 +111,7 @@ class Candidate:
                   " CandID = "   + str(self.cand_id) + \
                   " and Site = " + str(self.site))
 
-        insert_col = ('PSCID', 'CandID', 'CenterID')
+        insert_col = ('PSCID', 'CandID', 'RegistrationCenterID')
         insert_val = (self.psc_id, str(self.cand_id), str(self.center_id))
 
         if self.sex:


### PR DESCRIPTION
That change has been made on the perl scripts (#341) but apparently was not integrated into the python script for insertion of BIDS datasets. This fixes this.