### PR TITLE
[BIDS EEG import] Missed one renaming the CenterID field of the candidate table in one occurence in python scripts

### DIFF
--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -125,7 +125,7 @@ class Eeg:
         self.default_vl      = default_visit_label
         self.psc_id          = self.loris_cand_info['PSCID']
         self.cand_id         = self.loris_cand_info['CandID']
-        self.center_id       = self.loris_cand_info['CenterID']
+        self.center_id       = self.loris_cand_info['RegistrationCenterID']
         self.session_id      = self.get_loris_session_id()
 
         # grep the channels, electrodes, eeg and events files


### PR DESCRIPTION
This fixes one last occurence of CenterID that should have been renamed to RegistrationCenterID in #442.