### PR TITLE
[BIDS EEG] Fixing an if statement to check if `acq_time` is available in `sub-XX_scans.tsv`

### DIFF
--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -403,7 +403,7 @@ class Eeg:
         if scans_file:
             entries = utilities.read_tsv_file(scans_file)
             for entry in entries:
-                if os.path.basename(eeg_file) in entry['filename']:
+                if os.path.basename(eeg_file) in entry['filename'] and 'acq_time' in entry:
                     eeg_acq_time = entry['acq_time']
                     try:
                         eeg_acq_time = parse(eeg_acq_time)


### PR DESCRIPTION
This is fixing an if statement to check if `acq_time` is available in `sub-XX_scans.tsv` before using the value of that field into a variable.

Fixes error message when `acq_time` not present in that `.tsv` file:
```
  File "/data/qpn/bin/mri/python/lib/eeg.py", line 407, in fetch_and_insert_eeg_file
    eeg_acq_time = entry['acq_time']
KeyError: 'acq_time'
```