### PR TITLE
[BIDS EEG] Upgrade code so can be used with pybids 0.9.1

### DIFF
--- a/python/lib/bids.json
+++ b/python/lib/bids.json
@@ -72,18 +72,6 @@
         {
             "name": "extension",
             "pattern": "[._]*[a-zA-Z0-9]*?\\.([^/\\\\]+)$"
-        },
-        {
-            "name": "channels",
-            "pattern": "(.*\\_channels.tsv)$"
-        },
-        {
-            "name": "electrodes",
-            "pattern": "(.*\\_electrodes.tsv)$"
-        },
-        {
-            "name": "events",
-            "pattern": "(.*\\_events.tsv)$"
         }
     ],
 
@@ -93,11 +81,14 @@
         "sub-{subject}[/ses-{session}]/func/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}]_{suffix<bold>}.nii.gz",
         "sub-{subject}[/ses-{session}]/dwi/sub-{subject}[_ses-{session}][_acq-{acquisition}]_{suffix<dwi>}.{extension<bval|bvec|json|nii\\.gz|nii>|nii\\.gz}",
         "sub-{subject}[/ses-{session}]/fmap/sub-{subject}[_ses-{session}][_acq-{acquisition}][_dir-{direction}][_run-{run}]_{fmap<phasediff|magnitude[1-2]|phase[1-2]|fieldmap|epi>}.nii.gz",
-        "sub-{subject}[/ses-{session}]/[{datatype<func|meg|eeg>|func}/]sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<events>}.{extension<tsv>|tsv}",
+        "sub-{subject}[/ses-{session}]/[{datatype<func|meg>|func}/]sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<events>}.{extension<tsv>|tsv}",
         "sub-{subject}[/ses-{session}]/func/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<physio|stim>}.{extension<tsv\\.gz|json}",
         "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_meg.{extension|json}",
         "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_{suffix<channels>}.{extension<tsv>|tsv}",
         "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}]_{suffix<coordsystem>}.json",
-        "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}]_{suffix<photo>}.jpg"
+        "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}]_{suffix<photo>}.jpg",
+        "sub-{subject}[/ses-{session}]/eeg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_eeg_{suffix<channels>}.tsv",
+        "sub-{subject}[/ses-{session}]/eeg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_eeg_{suffix<electrodes>}.{extension<tsv>|tsv}",
+        "sub-{subject}[/ses-{session}]/eeg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_eeg_{suffix<events>}.{extension<tsv>|tsv}"
     ]
 }

--- a/python/lib/bids.json
+++ b/python/lib/bids.json
@@ -67,7 +67,7 @@
         },
         {
             "name": "datatype",
-            "pattern": "[/\\\\]+(func|anat|fmap|dwi|meg|eeg)[/\\\\]+s"
+            "pattern": "[/\\\\]+(func|anat|fmap|dwi|meg|eeg)[/\\\\]+"
         },
         {
             "name": "extension",
@@ -81,14 +81,11 @@
         "sub-{subject}[/ses-{session}]/func/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}]_{suffix<bold>}.nii.gz",
         "sub-{subject}[/ses-{session}]/dwi/sub-{subject}[_ses-{session}][_acq-{acquisition}]_{suffix<dwi>}.{extension<bval|bvec|json|nii\\.gz|nii>|nii\\.gz}",
         "sub-{subject}[/ses-{session}]/fmap/sub-{subject}[_ses-{session}][_acq-{acquisition}][_dir-{direction}][_run-{run}]_{fmap<phasediff|magnitude[1-2]|phase[1-2]|fieldmap|epi>}.nii.gz",
-        "sub-{subject}[/ses-{session}]/[{datatype<func|meg>|func}/]sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<events>}.{extension<tsv>|tsv}",
+        "sub-{subject}[/ses-{session}]/[{datatype<func|meg|eeg>|func}/]sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<events>}.{extension<tsv>|tsv}",
         "sub-{subject}[/ses-{session}]/func/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<physio|stim>}.{extension<tsv\\.gz|json}",
         "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_meg.{extension|json}",
         "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_{suffix<channels>}.{extension<tsv>|tsv}",
         "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}]_{suffix<coordsystem>}.json",
-        "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}]_{suffix<photo>}.jpg",
-        "sub-{subject}[/ses-{session}]/eeg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_eeg_{suffix<channels>}.tsv",
-        "sub-{subject}[/ses-{session}]/eeg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_eeg_{suffix<electrodes>}.{extension<tsv>|tsv}",
-        "sub-{subject}[/ses-{session}]/eeg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_eeg_{suffix<events>}.{extension<tsv>|tsv}"
+        "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}]_{suffix<photo>}.jpg"
     ]
 }

--- a/python/lib/bids.json
+++ b/python/lib/bids.json
@@ -1,61 +1,60 @@
 {
     "name": "bids",
-    "root": ".",
     "entities": [
         {
             "name": "subject",
-            "pattern": "[/\\\\]sub-([a-zA-Z0-9]+)",
-            "directory": "{{root}}/{subject}"
+            "pattern": "[/\\\\]+sub-([a-zA-Z0-9]+)",
+            "directory": "{subject}"
         },
         {
             "name": "session",
-            "pattern": "[_/\\\\]ses-([a-zA-Z0-9]+)",
+            "pattern": "[_/\\\\]+ses-([a-zA-Z0-9]+)",
             "mandatory": false,
-            "directory": "{{root}}/{subject}/{session}",
-            "missing_value": "ses-1"
+            "directory": "{subject}{session}"
         },
         {
             "name": "task",
-            "pattern": "[_/\\\\]task-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+task-([a-zA-Z0-9]+)"
         },
         {
             "name": "acquisition",
-            "pattern": "[_/\\\\]acq-([a-zA-Z0-9]+)"
-        },
-        {
-            "name": "acq",
-            "pattern": "[_/\\\\]acq-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+acq-([a-zA-Z0-9]+)"
         },
         {
             "name": "ce",
-            "pattern": "[_/\\\\]ce-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+ce-([a-zA-Z0-9]+)"
         },
         {
             "name": "reconstruction",
-            "pattern": "[_/\\\\]rec-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+rec-([a-zA-Z0-9]+)"
         },
         {
             "name": "dir",
-            "pattern": "[_/\\\\]dir-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+dir-([a-zA-Z0-9]+)"
         },
         {
             "name": "run",
-            "pattern": "[_/\\\\]run-0*(\\d+)"
+            "pattern": "[_/\\\\]+run-0*(\\d+)",
+            "dtype": "int"
         },
         {
-            "name": "mod",
-            "pattern": "[_/\\\\]mod-([a-zA-Z0-9]+)"
+            "name": "proc",
+            "pattern": "[_/\\\\]+proc-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "modality",
+            "pattern": "[_/\\\\]+mod-([a-zA-Z0-9]+)"
         },
         {
             "name": "echo",
-            "pattern": "[_/\\\\]echo-([0-9]+)\\_bold."
+            "pattern": "[_/\\\\]+echo-([0-9]+)\\_bold."
         },
         {
             "name": "recording",
-            "pattern": "[_/\\\\]recording-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+recording-([a-zA-Z0-9]+)"
         },
         {
-            "name": "type",
+            "name": "suffix",
             "pattern": "[._]*([a-zA-Z0-9]*?)\\.[^/\\\\]+$"
         },
         {
@@ -63,20 +62,16 @@
             "pattern": "(.*\\_scans.tsv)$"
         },
         {
-            "name": "bval",
-            "pattern": "(.*\\.bval)$"
-        },
-        {
-            "name": "bvec",
-            "pattern": "(.*\\.bvec)$"
-        },
-        {
             "name": "fmap",
             "pattern": "(phasediff|magnitude[1-2]|phase[1-2]|fieldmap|epi)\\.nii"
         },
         {
-            "name": "modality",
-            "pattern": "[/\\\\](func|anat|fmap|dwi|eeg)[/\\\\]"
+            "name": "datatype",
+            "pattern": "[/\\\\]+(func|anat|fmap|dwi|meg|eeg)[/\\\\]+s"
+        },
+        {
+            "name": "extension",
+            "pattern": "[._]*[a-zA-Z0-9]*?\\.([^/\\\\]+)$"
         },
         {
             "name": "channels",
@@ -91,12 +86,18 @@
             "pattern": "(.*\\_events.tsv)$"
         }
     ],
+
     "default_path_patterns": [
-        "sub-{subject}[/ses-{session}]/anat/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{contrast}][_rec-{reconstruction}]_{type}.nii.gz",
-        "sub-{subject}[/ses-{session}]/anat/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{contrast}][_rec-{reconstruction}][_mod-{modality}]_defacemask.nii.gz",
-        "sub-{subject}[/ses-{session}]/func/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}]_{type}.nii.gz",
-        "sub-{subject}[/ses-{session}]/dwi/sub-{subject}[_ses-{session}][_acq-{acquisition}]_{type}.nii.gz",
-        "sub-{subject}[/ses-{session}]/fmap/sub-{subject}[_ses-{session}][_acq-{acquisition}][_dir-{direction}][_run-{run}]_{type}.nii.gz",
-        "sub-{subject}[/ses-{session}]/func/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_physio.tsv"
+        "sub-{subject}[/ses-{session}]/anat/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{contrast}][_rec-{reconstruction}]_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio>}.nii.gz",
+        "sub-{subject}[/ses-{session}]/anat/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{contrast}][_rec-{reconstruction}][_mod-{modality}]_{suffix<defacemask>}.nii.gz",
+        "sub-{subject}[/ses-{session}]/func/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}]_{suffix<bold>}.nii.gz",
+        "sub-{subject}[/ses-{session}]/dwi/sub-{subject}[_ses-{session}][_acq-{acquisition}]_{suffix<dwi>}.{extension<bval|bvec|json|nii\\.gz|nii>|nii\\.gz}",
+        "sub-{subject}[/ses-{session}]/fmap/sub-{subject}[_ses-{session}][_acq-{acquisition}][_dir-{direction}][_run-{run}]_{fmap<phasediff|magnitude[1-2]|phase[1-2]|fieldmap|epi>}.nii.gz",
+        "sub-{subject}[/ses-{session}]/[{datatype<func|meg|eeg>|func}/]sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<events>}.{extension<tsv>|tsv}",
+        "sub-{subject}[/ses-{session}]/func/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<physio|stim>}.{extension<tsv\\.gz|json}",
+        "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_meg.{extension|json}",
+        "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_run-{run}][_proc-{proc}]_{suffix<channels>}.{extension<tsv>|tsv}",
+        "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}]_{suffix<coordsystem>}.json",
+        "sub-{subject}[/ses-{session}]/meg/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}]_{suffix<photo>}.jpg"
     ]
 }

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -91,10 +91,10 @@ class BidsReader:
 
         # grep the participant.tsv file and parse it
         participants_info = None
-        for file in self.bids_layout.get(type='participants'):
+        for file in self.bids_layout.get(suffix='participants', return_type='filename'):
             # note file[0] returns the path to participants.tsv
-            if 'participants.tsv' in file[0]:
-                participants_info = utilities.read_tsv_file(file[0])
+            if 'participants.tsv' in file:
+                participants_info = utilities.read_tsv_file(file)
             else:
                 continue
 
@@ -165,13 +165,11 @@ class BidsReader:
             if visit_list:
                 for visit in visit_list:
                     cand_session_dict['bids_ses_id'] = visit
-                    modalities = self.bids_layout.get_modalities(
-                        subject=subject, session=visit
-                    )
+                    modalities = self.bids_layout.get_datatype(subject=subject, session=visit)
                     cand_session_dict['modalities'] = modalities
             else:
                 cand_session_dict['bids_ses_id'] = None
-                modalities = self.bids_layout.get_modalities(subject=subject)
+                modalities = self.bids_layout.get_datatype(subject=subject)
                 cand_session_dict['modalities'] = modalities
 
             cand_session_modalities_list.append(cand_session_dict)

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -48,6 +48,7 @@ class BidsReader:
 
         # load dataset name and BIDS version
         dataset_json = bids_dir + "/dataset_description.json"
+        #TODO need to read the JSON file instead of using pybids here since those are no more supported in 0.9
         self.dataset_name = self.bids_layout.get_metadata(dataset_json)['Name']
         self.bids_version = self.bids_layout.get_metadata(dataset_json)['BIDSVersion']
 
@@ -72,11 +73,7 @@ class BidsReader:
         """
         bids_config = os.environ['LORIS_MRI'] + "/python/lib/bids.json"
         exclude_arr = ['/code/', '/sourcedata/', '/log/', '.git/']
-        bids_layout = BIDSLayout(
-            (self.bids_dir, bids_config),
-            root=self.bids_dir,
-            exclude=exclude_arr
-        )
+        bids_layout = BIDSLayout(root=self.bids_dir, config=bids_config, ignore=exclude_arr)
 
         return bids_layout
 

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -234,8 +234,7 @@ class BidsReader:
         """
 
         raw_file = None
-        for file in files_list:
-            filename = file[0]
+        for filename in files_list:
             if not derivative_pattern:
                 if 'derivatives' in filename:
                     # skip all files with 'derivatives' string in their path

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -6,6 +6,7 @@ import re
 import os
 import glob
 import sys
+import json
 
 import lib.exitcode
 import lib.utilities as utilities
@@ -48,9 +49,11 @@ class BidsReader:
 
         # load dataset name and BIDS version
         dataset_json = bids_dir + "/dataset_description.json"
-        #TODO need to read the JSON file instead of using pybids here since those are no more supported in 0.9
-        self.dataset_name = self.bids_layout.get_metadata(dataset_json)['Name']
-        self.bids_version = self.bids_layout.get_metadata(dataset_json)['BIDSVersion']
+        dataset_description = {}
+        with open(dataset_json) as json_file:
+            dataset_description = json.load(json_file)
+        self.dataset_name = dataset_description['Name']
+        self.bids_version = dataset_description['BIDSVersion']
 
         # load BIDS candidates information
         self.participants_info = self.load_candidates_from_bids()

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -136,8 +136,8 @@ class Eeg:
 
         # check if a tsv with acquisition dates or age is available for the subject
         self.scans_file = None
-        if self.bids_layout.get(type='scans', subject=self.psc_id):
-            self.scans_file = self.bids_layout.get(type='scans', subject=self.psc_id)[0][0]
+        if self.bids_layout.get(suffix='scans', subject=self.psc_id):
+            self.scans_file = self.bids_layout.get(suffix='scans', subject=self.psc_id)[0][0]
 
         # register the data into LORIS
         self.register_raw_data()
@@ -212,13 +212,13 @@ class Eeg:
                 subject  = self.bids_sub_id,
                 session  = self.bids_ses_id,
                 modality = self.bids_modality,
-                type     = bids_type
+                suffix   = bids_type
             )
         else:
             return self.bids_layout.get(
                 subject  = self.bids_sub_id,
                 modality = self.bids_modality,
-                type     = bids_type
+                suffix   = bids_type
             )
 
     def grep_bids_derivatives_eeg_files(self):
@@ -230,10 +230,10 @@ class Eeg:
         """
 
         bids_types = self.bids_layout.get(
-            subject=self.bids_sub_id,
-            modality=self.bids_modality,
-            target='type',
-            return_type='id'
+            subject     = self.bids_sub_id,
+            datatype    = self.bids_modality,
+            target      = 'suffix',
+            return_type = 'id'
         )
         # TODO check if want this part to be in the Config module instead of
         # TODO hardcoding it and risk that other random types are in the

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -136,8 +136,8 @@ class Eeg:
 
         # check if a tsv with acquisition dates or age is available for the subject
         self.scans_file = None
-        if self.bids_layout.get(suffix='scans', subject=self.psc_id):
-            self.scans_file = self.bids_layout.get(suffix='scans', subject=self.psc_id)[0][0]
+        if self.bids_layout.get(suffix='scans', subject=self.psc_id, return_type='filename'):
+            self.scans_file = self.bids_layout.get(suffix='scans', subject=self.psc_id, return_type='filename')[0]
 
         # register the data into LORIS
         self.register_raw_data()
@@ -209,16 +209,18 @@ class Eeg:
 
         if self.bids_ses_id:
             return self.bids_layout.get(
-                subject  = self.bids_sub_id,
-                session  = self.bids_ses_id,
-                modality = self.bids_modality,
-                suffix   = bids_type
+                subject     = self.bids_sub_id,
+                session     = self.bids_ses_id,
+                datatype    = self.bids_modality,
+                suffix      = bids_type,
+                return_type = 'filename'
             )
         else:
             return self.bids_layout.get(
-                subject  = self.bids_sub_id,
-                modality = self.bids_modality,
-                suffix   = bids_type
+                subject     = self.bids_sub_id,
+                datatype    = self.bids_modality,
+                suffix      = bids_type,
+                return_type = 'filename'
             )
 
     def grep_bids_derivatives_eeg_files(self):
@@ -355,9 +357,9 @@ class Eeg:
         # grep the raw files from eeg_files list
         eeg_file = BidsReader.grep_file(
             files_list         = files_list,
-            match_pattern      = ".(set$|edf$|vhdr$|cnt$|vsm$|bdf$)",
+            match_pattern      = ".(set$|edf$|vhdr$|vmrk$|eeg$|bdf$)",
             derivative_pattern = derivative_pattern
-        )  # TODO: revisit the eeg file formats once BIDS EEG is finalized
+        )
         json_file = BidsReader.grep_file(
             files_list         = files_list,
             match_pattern      = '.json$',


### PR DESCRIPTION
The release of pybids 0.7 was a major release for them with major change in their layout and it broke the python LORIS-MRI BIDS insertion scripts...

In this PR, the code of the BIDS insertion pipeline has been updated to use the latest stable release of pybids (a.k.a. 0.9.1).

This fixes #389.

## Caveat for existing project

Make sure to update your pybids package to 0.9.1:
```
pip uninstall pybids
pip install --upgrade pip
pip install pybids==0.9.1
```