### PR TITLE
Bulletproof the way the host's IP address is computed in dicomTar.pl.

### DIFF
--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -189,9 +189,13 @@ my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)=localtime(time);
 my $date            = sprintf("%4d-%02d-%02d %02d:%02d:%02d\n",
                     $year+1900,$mon+1,$mday,$hour,$min,$sec);
 my $today           = sprintf("%4d-%02d-%02d",$year+1900,$mon+1,$mday);
-my $hostname        = inet_ntoa(scalar(gethostbyname(hostname() || 'localhost')));
-                    #`hostname -f`;
-                    # # fixme specify -f for fully qualified if you need it.
+
+my $hostname;
+eval { $hostname = hostname() };
+$hostname = 'localhost' if $@ || !defined $hostname;
+$hostname = gethostbyname($hostname) // gethostbyname('localhost');
+$hostname = inet_ntoa($hostname);
+
 my $system          = `uname`;
 
 


### PR DESCRIPTION
As the title says. The calls to the various system funtions that are made (`hostname`, `gethostbyname`, `inet_ntoa`) can all either return `undef` or `croak` under rare circumstances. The code in dicomTar should always check the return value of these calls and never assume that they are always successful.

Tip to test: you can cut and paste the small chunk of code that computes the value of `$hostname` into a small program and run it on your VM. To have full control over what the system functions return, you can override them, like so:

```perl
*{hostname} = sub {
    croak "Hostname call failed";
};

*{gethostbyname} = sub {
    return undef;
};
```

Fix for https://redmine.cbrain.mcgill.ca/issues/13517