### PR TITLE
[Clean up] the full MINC header entry will not be imported into the parameter_file table anymore

### DIFF
--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -359,8 +359,6 @@ sub loadFileFromDisk {
 	 }
 	 close MI;
     
-    $this->setParameter('header', $header);
-
     return 1;
 }
 

--- a/uploadNeuroDB/NeuroDB/File.pm
+++ b/uploadNeuroDB/NeuroDB/File.pm
@@ -537,7 +537,7 @@ sub filterParameters {
     my $parametersRef = $this->getParameters();
 
     foreach my $key (keys %{$parametersRef}) {
-        if(($key ne 'header') && (defined length($parametersRef->{$key}))
+        if(defined length($parametersRef->{$key})
             && (length($parametersRef->{$key}) > MAX_DICOM_PARAMETER_LENGTH)) {
             $this->removeParameter($key);
         }


### PR DESCRIPTION
### Description

Until now, the whole header of a MINC file was dumped into a row of `parameter_file`, taking a lot of space in the database and the SQL dump created for that table.

During the imaging meeting of July 4th, a decision has been made to no longer store that row to gain some space in the database, hence, removing it from the imaging pipeline code.

This is linked to the LORIS PR https://github.com/aces/Loris/pull/4925

### This resolves

- [x] Github #388 

### How to test

Try inserting a MINC file into the database and make sure the `header` row is not present in the `parameter_file` table after insertion