### PR TITLE
Fixed incorrect use of MRIScannerOB in MRI.pm.

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -182,7 +182,7 @@ sub getScannerCandID {
     
     my $mriScannerOB = 
         NeuroDB::objectBroker::MriScannerOB->new(db => $db);
-    my $resultRef = $mriScannerOB->get(0, {ID => $scannerID});
+    my $resultRef = $mriScannerOB->get({ID => $scannerID});
     return @$resultRef ? $resultRef->[0]->{'CandID'} : undef;
 }
 


### PR DESCRIPTION
`MRI.pm` was still using the 2-argument version of `MRIScannerOB`'s `get` function, which is the old way of using this object broker. I switched it to the single argument (correct) version.

Fixes #460