### PR TITLE
[SQL] Removed insertion or updates in mri_acquisition_dates

### DIFF
--- a/docs/04-Scripts.md
+++ b/docs/04-Scripts.md
@@ -134,7 +134,6 @@ In general, to re-load an imaging dataset through the pipeline from the start
    dataset have been removed from the following database tables:
 
 - `parameter_file`
-- `mri_acquisition_dates`
 - `files` (best to delete from this table last)
 - `mri_upload`
 - `session` - not recommended - only if necessary, and only if no other data is
@@ -149,6 +148,9 @@ If any Quality Control flags or comments exist for these scans, you may also
   wish to delete specific records from `files_qcstatus` and the `mri_feedback_*`
   tables, before deleting from the `files` table.
 
+A script has been created in order to perform a safe deletion of an upload. Please,
+see section 4.4 for instructions on how to use the script.
+
 For backing up, re-labelling and re-loading MRI datasets with QC information,
   see [Beta Tutorial](https://github.com/aces/Loris/wiki/Reloading-MRI-data-for-mislabelled-session)
 
@@ -161,7 +163,7 @@ In cases where a subject was scanned in two scanner sessions as part of the same
   associate and display both sets of images acquired in both scanner sessions 
   under the same `session` table record. 
   
-##4.4 - MRI upload deletion script
+## 4.4 - MRI upload deletion script
 
 As of release 21.0 of LORIS-MRI, a deletion script has been added to the tools 
 directory of the repository. This deletion script allows to delete completely an MRI 

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -262,15 +262,6 @@ INPUTS:
   - $visit\_label : visit label associated with the scan
   - $file        : information about the scan
 
-### update\_mri\_acquisition\_dates($sessionID, $acq\_date)
-
-Updates the `mri_acquisition_dates` table by a new acquisition date
-`$acq_date`.
-
-INPUTS:
-  - $sessionID: session ID
-  - $acq\_date : acquisition date
-
 ### loadAndCreateObjectFile($minc, $upload\_id)
 
 Loads and creates the object file.

--- a/docs/scripts_md/minc_deletion.md
+++ b/docs/scripts_md/minc_deletion.md
@@ -26,8 +26,6 @@ This program deletes MINC files from LORIS by:
   - Deleting data from `files_qcstatus` and `feedback_mri_comments`
     database tables if the `-delqcdata` option is set. In most cases
     you would want to delete this when the images change
-  - Deleting `mri_acquisition_dates` entry if it is the last file
-    removed from that session.
 
 Users can use the argument `select` to view the record that could be removed
 from the database, or `confirm` to acknowledge that the data in the database

--- a/uploadNeuroDB/minc_deletion.pl
+++ b/uploadNeuroDB/minc_deletion.pl
@@ -31,8 +31,6 @@ This program deletes MINC files from LORIS by:
   - Deleting data from C<files_qcstatus> and C<feedback_mri_comments>
     database tables if the C<-delqcdata> option is set. In most cases
     you would want to delete this when the images change
-  - Deleting C<mri_acquisition_dates> entry if it is the last file
-    removed from that session.
 
 Users can use the argument C<select> to view the record that could be removed
 from the database, or C<confirm> to acknowledge that the data in the database
@@ -111,8 +109,6 @@ Deletes MINC files from LORIS by:
   - Deleting data from files_qcstatus & feedback_mri_comments
     database tables if the -delqcdata option is set. In most cases
     you would want to delete this when the images change
-  - Deleting mri_acquisition_dates entry if it is the last file
-    removed from that session.
 
 Users can use the argument "select" to view the record that could be removed
 from the database, or "confirm" to acknowledge that the data in the database
@@ -321,9 +317,6 @@ selORdel("parameter_file","Value");
 # selORdel("MRICandidateErrors","Reason");       # not applicable to /assembly
 # selORdel("mri_violations_log","LogID");        # "
 
-### Removal of entry in mri_acquisition_dates table ###
-### (if only one file exists and is being removed,  ###
-### the table entry needs to be removed)            ###
 print "\nTarchiveID: $tarchiveid\n";
 print "\nSessionID: $sessionid\n";
 
@@ -387,23 +380,6 @@ if ($sth->rows > 0) {
     print "\nfiles found in mri_violations_log\n";
 }
 
-
-# If no related files were found, delete the entry
-if (!$sessionfilesfound) {
-
-  my $query = $selORdel . "FROM mri_acquisition_dates where SessionID=?";
-  my $sth = $dbh->prepare($query);
-  $sth->execute($sessionid);
-
-  if ($selORdel eq "SELECT * ") {
-    while (my $pf = $sth->fetchrow_hashref()) {
-        print "\nAcquisitionDate: " . $pf->{'AcquisitionDate'};
-    }
-  } else {
-    print "\nmri_acquisition_dates has been deleted\n";
-  }
-
-}
 
 # If using SeriesUID, get number of matching files before deleting
 if ($field eq "SeriesUID") {


### PR DESCRIPTION
### Description

The associated PR https://github.com/aces/Loris/pull/4962 on the LORIS side removes the `mri_acquisition_dates` table from the database as this table does not necessarily store the correct acquisition date. Instead, replaced all the queries to look for the minimal date present in the `parameter_file` table which is more robust than what was stored in mri_acquisition_dates.

Note: the decision to remove this table was taken during an imaging meeting in 2017 and confirmed at an other imaging meeting in 2019.

#### Links to related tickets (Github, Redmine, ...)

https://redmine.cbrain.mcgill.ca/issues/6040