### PR TITLE
[dicomTar.pl] Exit when insertion or update fails

### DIFF
--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -295,14 +295,14 @@ print  $tarinfo if $verbose;
 
 # if -dbase has been given create an entry based on unique studyID
 # Create database entry checking for already existing entries...
-my $success;
+my ($success, $error);
 if ($dbase) {
     $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
     print "\nAdding archive info into database\n" if $verbose;
     my $update          = 1 if $clobber;
     my $ArchiveLocation = $finalTarget;
     $ArchiveLocation    =~ s/$targetlocation\/?//g;
-    $success            = $summary->database($dbh, $metaname, $update,
+    ($success, $error)    = $summary->database($dbh, $metaname, $update,
                             $tarTypeVersion, $tarinfo, $DICOMmd5sum,
                             $ARCHIVEmd5sum, $ArchiveLocation,
                             $neurodbCenterName);
@@ -317,7 +317,7 @@ if ($dbase) {
     if ($success) {
         print "\nDone adding archive info into database\n" if $verbose;
     } else {
-        print STDERR "\nThe database command failed\n";
+        print STDERR "\nThe database command failed\n $error";
         exit $NeuroDB::ExitCodes::INSERT_FAILURE;
     }
 }


### PR DESCRIPTION
### Description

`dicomTar.pl` continues executing insertion into the tarchive tables even if one insertion failed. In this PR, we catch the insertion failure and return the error so `dicomTar.pl` can be stopped and further insertions prevented.

Needed to modified the database function of `DCMSUM.pm` to return the error when an SQL insertion failed during the execution of `dicomTar.pl`.

Note: ideally, the returned error message would be inserted in the `notification_spool` table which should be a separate PR.

### This resolves

https://redmine.cbrain.mcgill.ca/issues/13841