### PR TITLE
Gzip NIfTI files to save disk space

### DIFF
--- a/tools/gzip_nifti_files.pl
+++ b/tools/gzip_nifti_files.pl
@@ -118,10 +118,12 @@ $db->connect();
 
 
 # ===========================================
-## Establish database connection
+## Get config setting using ConfigOB
 # ===========================================
 
-my $data_dir   = &NeuroDB::DBI::getConfigSetting(\$dbh, 'dataDirBasepath');
+my $configOB = NeuroDB::objectBroker::ConfigOB->new(db => $db);
+
+my $data_dir   = $configOB->getDataDirPath();
 $data_dir      =~ s#/$##;
 
 

--- a/tools/gzip_nifti_files.pl
+++ b/tools/gzip_nifti_files.pl
@@ -1,0 +1,219 @@
+#! /usr/bin/perl
+
+=pod
+
+=head1 NAME
+
+gzip_nifti_files.pl -- Gzip all NIfTI files found in the LORIS database system
+
+=head1 SYNOPSIS
+
+perl gzip_nifti_files.pl C<[options]>
+
+Available options are:
+
+-profile: name of the config file in C<../dicom-archive/.loris_mri>
+
+
+=head1 DESCRIPTION
+
+The program gzip all NIfTI files found in the LORIS database system. It will first
+grep the list of NIfTI files from the database (in the C<parameter_file> table).
+Then, the program will loop through the found NIfTI files and:
+
+- check that the file can be found on the filesystem (if not, it will issue a warning)
+
+- check that the NIfTI file is not already gzipped
+
+- create the gzipped NIfTI file
+
+- replace the entry in the C<parameter_file> table with the new gzipped NIfTI file path
+
+=head2 Methods
+
+=cut
+
+use strict;
+use warnings;
+
+use Getopt::Tabular;
+
+use NeuroDB::DBI;
+use NeuroDB::MRI;
+use NeuroDB::ExitCodes;
+
+use NeuroDB::Database;
+use NeuroDB::DatabaseException;
+
+use NeuroDB::objectBroker::ObjectBrokerException;
+use NeuroDB::objectBroker::ConfigOB;
+
+my $profile;
+
+my @opt_table = (
+    [ "-profile", "string", 1, \$profile,
+        "name of config file in ../dicom-archive/.loris_mri"
+    ]
+);
+
+my $Help = <<HELP;
+
+The program gzip all NIfTI files found in the LORIS database system.
+
+Documentation: perldoc gzip_nifti_files.pl
+
+HELP
+
+my $Usage = <<USAGE;
+
+Usage: $0 -help to list options
+
+USAGE
+
+&Getopt::Tabular::SetHelp($Help, $Usage);
+&Getopt::Tabular::GetOptions(\@opt_table, \@ARGV)
+    || exit $NeuroDB::ExitCodes::GETOPT_FAILURE;
+
+
+
+# ===========================================
+## Input option error checking
+# ===========================================
+
+if ( !$profile ) {
+    print $Help;
+    print STDERR "$Usage\n\tERROR: missing -profile argument\n\n";
+    exit $NeuroDB::ExitCodes::PROFILE_FAILURE;
+}
+
+{ package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
+
+if ( !@Settings::db ) {
+    print STDERR "\n\tERROR: You don't have a \@db setting in the file "
+        . "$ENV{LORIS_CONFIG}/.loris_mri/$profile \n\n";
+    exit $NeuroDB::ExitCodes::DB_SETTINGS_FAILURE;
+}
+
+
+
+
+# ===========================================
+## Establish database connection
+# ===========================================
+
+# old database connection
+my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
+print "\nSuccessfully connected to database \n";
+
+# new Moose database connection
+my $db  = NeuroDB::Database->new(
+    databaseName => $Settings::db[0],
+    userName     => $Settings::db[1],
+    password     => $Settings::db[2],
+    hostName     => $Settings::db[3]
+);
+$db->connect();
+
+
+
+
+# ===========================================
+## Establish database connection
+# ===========================================
+
+my $data_dir   = &NeuroDB::DBI::getConfigSetting(\$dbh, 'dataDirBasepath');
+$data_dir      =~ s#/$##;
+
+
+
+
+# ==================================================
+## Grep the list of NIfTI files from the database
+# ==================================================
+
+(my $query = <<QUERY) =~ s/\n/ /gm;
+    SELECT
+      pf.Value
+    FROM
+      parameter_file pf JOIN parameter_type pt USING (ParameterTypeID)
+    WHERE
+      pt.Name = ?
+QUERY
+my $arr_ref = $dbh->selectall_arrayref($query, { Slice => {} }, "check_nii_filename");
+
+
+
+
+# ==================================================
+## Loop through each NIfTI file and gzip them
+# ==================================================
+
+foreach my $row (@$arr_ref) {
+    my $nifti = $row->{Value};
+
+    # go to the next row if NIfTI file already gzipped
+    next if $nifti =~ m/.nii.gz$/;
+
+    # check that the file is found on the filesystem
+    my $nifti_full_path = "$data_dir/$nifti";
+    unless (-e $nifti_full_path) {
+        print "WARNING: could not find $nifti_full_path on the filesystem\n";
+        next;
+    }
+
+    # create the gzipped NIfTI file
+    my $gzip_nifti = &NeuroDB::MRI::gzip_file($nifti_full_path);
+    unless ($gzip_nifti) {
+        print "WARNING: Failure to create $gzip_nifti on the filesystem\n";
+        next;
+    }
+
+    # update the database table with the gzip NIfTI path
+    $gzip_nifti =~ s%$data_dir/%%g;
+    update_parameter_file_nifti_value($nifti, $gzip_nifti, \$dbh);
+}
+
+
+
+
+$db->disconnect();
+exit $NeuroDB::ExitCodes::SUCCESS;
+
+
+
+=pod
+
+=head3 update_parameter_file_nifti_value($nifti, $gzip_nifti, $dbh)
+
+Update the C<parameter_file> to store the new gzipped NIfTI file location instead of
+the uncompressed file path.
+
+INPUT:
+  - $nifti     : original path to the NIfTI file stored in the database
+  - $gzip_nifti: path to the gzipped NIfTI file to update in the database
+  - $dbh       : database handle
+
+=cut
+
+sub update_parameter_file_nifti_value {
+    my ($nifti, $gzip_nifti, $dbh) = @_;
+
+    my $update_query = "UPDATE parameter_file SET Value = ? WHERE Value = ?";
+
+    my $sth = $$dbh->prepare($update_query);
+    $sth->execute($gzip_nifti, $nifti);
+}
+
+__END__
+
+=pod
+
+=head1 LICENSING
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+
+=cut

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1313,23 +1313,52 @@ sub make_nii {
     my $file = $$fileref;
     my $minc  = $file->getFileDatum('File');
     my ($nifti, $bval_file, $bvec_file) = ($minc) x 3;
-    $nifti     =~ s/mnc$/nii/;
-    $bval_file =~ s/mnc$/bval/;
-    $bvec_file =~ s/mnc$/bvec/;
+    $nifti         =~ s/mnc$/nii/;
+    $bval_file     =~ s/mnc$/bval/;
+    $bvec_file     =~ s/mnc$/bvec/;
 
     #  mnc2nii command
-    my $m2n_cmd = "mnc2nii -nii -quiet $data_dir/$minc $data_dir/$nifti";
+    my $m2n_cmd  = "mnc2nii -nii -quiet $data_dir/$minc $data_dir/$nifti";
     system($m2n_cmd);
+
+    # gzip the NIfTI file
+    my $gzip_nifti = gzip_file("$data_dir/$nifti");
+    $gzip_nifti    =~ s%$data_dir/%%g;
 
     # create complementary nifti files for DWI acquisitions
     my $bval_success = create_dwi_nifti_bval_file($fileref, "$data_dir/$bval_file");
     my $bvec_success = create_dwi_nifti_bvec_file($fileref, "$data_dir/$bvec_file");
 
     # update mri table (parameter_file table)
-    $file->setParameter('check_nii_filename', $nifti);
+    $file->setParameter('check_nii_filename',  $gzip_nifti) if -e $gzip_nifti;
     $file->setParameter('check_bval_filename', $bval_file) if $bval_success;
     $file->setParameter('check_bvec_filename', $bvec_file) if $bvec_success;
 }
+
+
+=pod
+
+=head3 gzip_file($file)
+
+Gzip the file given as input and return the path of the gzipped file.
+
+INPUT: file to be gzipped
+
+RETURNS: path of the gzipped file (or undef if file not found)
+
+=cut
+
+sub gzip_file {
+    my ($file) = @_;
+
+    return undef unless (-e $file);
+
+    my $gzip_cmd = "gzip $file";
+    system($gzip_cmd);
+
+    (-e "$file.gz") ? return "$file.gz" : undef;
+}
+
 
 
 =pod


### PR DESCRIPTION
### Description

NIfTI files created by `mnc2nii` are uncompressed files taking a lot of disk space. However, most softwares using NIfTI files are supporting the compressed version of NIfTI (`.nii.gz`). 

In this PR, the created NIfTI files are automatically gzipped during the creation of NIfTI files and a tool script has been created to be able to gzip all NIfTI files already present in the database if one wants to gzip every single NIfTI files.

### This resolves

No issue opened but needed to save disk space on a LORIS project (before gzipping 2.3TB of disk space was used, after gzipping 714GB of space was used).

### How to test this

- [ ]  Run the insertion pipeline after having made sure that the `create_nii` config setting is set to 'Yes'
- [ ] If you already had NIfTI files on your test VM, run the tool `gzip_nifti_files.pl` with the `-profile prod` option and check that NIfTI files are being gzipped and updated in the database

Note: if a NIfTI file is not present on the filesystem for whichever reason, the tool script will issue a warning and go to the next NIfTI file.