### PR TITLE
[BIDS import] Included the import of MRI datasets organized as BIDS studies

### DIFF
--- a/docs/01-Introduction.md
+++ b/docs/01-Introduction.md
@@ -61,16 +61,22 @@ field of the Config module (under the Imaging Pipeline section). Note that what
 the series descriptions entered in that Config field need to be an exact match
 of the series description DICOM field.
 
-### 1.3 LORIS-MRI extension: Electrophysiology data insertion
+### 1.3 LORIS-MRI extension: BIDS data insertion
 
-The electrophysiology insertion scripts are all gathered under the Python 
-directory of the LORIS-MRI repository. It contains one main script called 
-`bids_import.py` that allow import of electrophysiological datasets that have
-been organized in a BIDS structure (see BIDS specification for [EEG][6] and 
-[MEG][7]). Those import scripts were written in `Python` in order to take 
-advantage of the already existing [PyBIDS library][8] that reads BIDS 
-structures.
+The following BIDS datasets can be imported into LORIS using insertion scripts that
+are gathered under the Python directory of the LORIS-MRI repository. It contains one 
+main script called `bids_import.py` that allow import of datasets that have been
+organized in a BIDS structure (see [BIDS specifications][6]). 
 
+Those import scripts were written in `Python` in order to take advantage of the 
+already existing [PyBIDS library][7] that reads BIDS structures.
+
+Currently, we support the insertion of:
+- MRI datasets organized in a BIDS structure
+- Electrophysiology datasets organized in a BIDS structure
+
+Note: electrophysiology datasets are imported in LORIS in a specific set of tables 
+illustrated in the image below.
 ![electrophysio_import](images/EEG_BIDS_diagram.png)
 
 
@@ -80,6 +86,5 @@ structures.
 [3]: https://en.wikibooks.org/wiki/MINC/Introduction 
 [4]: https://nifti.nimh.nih.gov/ 
 [5]: https://brainbrowser.cbrain.mcgill.ca/
-[6]: https://docs.google.com/document/d/1ArMZ9Y_quTKXC-jNXZksnedK2VHHoKP3HCeO5HPcgLE/edit#heading=h.4k1noo90gelw
-[7]: http://bids.neuroimaging.io/bids_spec.pdf
-[8]: https://github.com/INCF/pybids
+[6]: https://bids-specification.readthedocs.io/en/stable/
+[7]: https://github.com/INCF/pybids

--- a/docs/02-Install.md
+++ b/docs/02-Install.md
@@ -361,19 +361,22 @@ The graph below shows the different modules mentioned above with the
 ![pipeline_flow](images/overall_flow.png)
 
 
-### 2.4.2 BIDS insertion (Electrophysiology)
+### 2.4.2 BIDS insertion (Electrophysiology and Imaging)
 
-This pipeline was initially designed to import EEG datasets organized in a 
-BIDS structure into LORIS. With slight modifications and further 
-customization, it could handle other types of electrophysiology modalities.
+The pipeline to insert BIDS datasets into LORIS currently support the 
+following BIDS modalities/suffixes:
+  - Electroencephalography ('eeg')
+  - Magnetic Resonance Imaging ('anat', 'func', 'fmap', 'dwi') 
 
-Typically, electrophysiology data insertion into LORIS is performed via the 
-following steps:
+With slight modifications and further customization, it could handle other 
+types of electrophysiology or imaging modalities.
+
+Typically, BIDS data insertion into LORIS is performed via the following steps:
 
 1. Transfer the BIDS-format data to the LORIS server via commandline. Due to the 
 large size of electrophysiological/BIDS data, a suitable browser-based uploader is 
 not presently available.
 
-2. Run the BIDS import script to import the electrophysiology data into the 
-`physiological_*` tables of LORIS. More details about this import script can 
-be found in the [Scripts](04-Scripts.md) section.
+2. Run the BIDS import script to import the data into the `physiological_*` tables 
+for electrophysiology datasets and into the `file*` tables of LORIS. More details about this import script can 
+be found in the [PipelineLaunchOptions](05-PipelineLaunchOptions.md) section.

--- a/docs/02-Install.md
+++ b/docs/02-Install.md
@@ -364,7 +364,7 @@ The graph below shows the different modules mentioned above with the
 ### 2.4.2 BIDS insertion (Electrophysiology and Imaging)
 
 The pipeline to insert BIDS datasets into LORIS currently support the 
-following BIDS modalities/suffixes:
+following BIDS modalities/entities:
   - Electroencephalography ('eeg')
   - Magnetic Resonance Imaging ('anat', 'func', 'fmap', 'dwi') 
 

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -99,6 +99,10 @@ pip3 install pyblake2
 pip3 install mne
 pip3 install google
 pip3 install protobuf
+pip3 install matplotlib
+pip3 install nose
+pip3 install sklearn
+pip3 install nilearn
 # deactivate the virtualenv for now
 deactivate
 

--- a/python/bids_import.py
+++ b/python/bids_import.py
@@ -194,16 +194,14 @@ def read_and_insert_bids(bids_dir, config_file, verbose, createcand, createvisit
 
     # read list of modalities per session / candidate and register data
     for row in bids_reader.cand_session_modalities_list:
+        bids_session = row['bids_ses_id']
+        visit_label  = bids_session if bids_session else default_bids_vl
+        loris_bids_visit_rel_dir    = 'sub-' + row['bids_sub_id'] + '/' + 'ses-' + visit_label
         for modality in row['modalities']:
+            loris_bids_modality_rel_dir = loris_bids_visit_rel_dir + '/' + modality + '/'
+            lib.utilities.create_dir(loris_bids_root_dir + loris_bids_modality_rel_dir, verbose)
+
             if modality == 'eeg':
-                bids_session = row['bids_ses_id']
-                visit_label = bids_session if bids_session else default_bids_vl
-                loris_bids_eeg_rel_dir = "sub-" + row['bids_sub_id'] + "/" + \
-                                         "ses-" + visit_label + "/eeg/"
-                lib.utilities.create_dir(
-                    loris_bids_root_dir + loris_bids_eeg_rel_dir,
-                    verbose
-                )
                 Eeg(
                     bids_reader   = bids_reader,
                     bids_sub_id   = row['bids_sub_id'],
@@ -214,6 +212,20 @@ def read_and_insert_bids(bids_dir, config_file, verbose, createcand, createvisit
                     data_dir      = data_dir,
                     default_visit_label    = default_bids_vl,
                     loris_bids_eeg_rel_dir = loris_bids_eeg_rel_dir,
+                    loris_bids_root_dir    = loris_bids_root_dir
+                )
+
+            elif modality in ['anat', 'dwi', 'fmap', 'func']:
+                Mri(
+                    bids_reader   = bids_reader,
+                    bids_sub_id   = row['bids_sub_id'],
+                    bids_ses_id   = row['bids_ses_id'],
+                    bids_modality = modality,
+                    db            = db,
+                    verbose       = verbose,
+                    data_dir      = data_dir,
+                    default_visit_label    = default_bids_vl,
+                    loris_bids_eeg_rel_dir = loris_bids_mri_rel_dir,
                     loris_bids_root_dir    = loris_bids_root_dir
                 )
 

--- a/python/bids_import.py
+++ b/python/bids_import.py
@@ -12,6 +12,7 @@ from lib.candidate  import Candidate
 from lib.bidsreader import BidsReader
 from lib.session    import Session
 from lib.eeg        import Eeg
+from lib.mri        import Mri
 
 
 __license__ = "GPLv3"
@@ -153,7 +154,7 @@ def read_and_insert_bids(bids_dir, config_file, verbose, createcand, createvisit
     data_dir = data_dir if data_dir.endswith('/') else data_dir + "/"
 
     # load the BIDS directory
-    bids_reader = BidsReader(bids_dir)
+    bids_reader = BidsReader(bids_dir, verbose)
     if not bids_reader.participants_info          \
             or not bids_reader.cand_sessions_list \
             or not bids_reader.cand_session_modalities_list:
@@ -211,7 +212,7 @@ def read_and_insert_bids(bids_dir, config_file, verbose, createcand, createvisit
                     verbose       = verbose,
                     data_dir      = data_dir,
                     default_visit_label    = default_bids_vl,
-                    loris_bids_eeg_rel_dir = loris_bids_eeg_rel_dir,
+                    loris_bids_eeg_rel_dir = loris_bids_modality_rel_dir,
                     loris_bids_root_dir    = loris_bids_root_dir
                 )
 
@@ -225,7 +226,7 @@ def read_and_insert_bids(bids_dir, config_file, verbose, createcand, createvisit
                     verbose       = verbose,
                     data_dir      = data_dir,
                     default_visit_label    = default_bids_vl,
-                    loris_bids_eeg_rel_dir = loris_bids_mri_rel_dir,
+                    loris_bids_mri_rel_dir = loris_bids_modality_rel_dir,
                     loris_bids_root_dir    = loris_bids_root_dir
                 )
 

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -101,7 +101,7 @@ class Imaging:
             file_fields = file_fields + (key,)
             file_values = file_values + (value,)
         file_id = self.db.insert(
-            table_name='physiological_file',
+            table_name='files',
             column_names=file_fields,
             values=[file_values],
             get_last_id=True
@@ -129,7 +129,7 @@ class Imaging:
         # Gather column name & values to insert into parameter_file
         parameter_type_id = self.get_parameter_type_id(parameter_name)
         parameter_file_fields = ('FileID', 'ParameterTypeID', 'Value')
-        parameter_file_values = (file_id, parameter_type_id, value)
+        parameter_file_values = (file_id, parameter_type_id, str(value))
         self.db.insert(
             table_name='parameter_file',
             column_names=parameter_file_fields,
@@ -271,3 +271,44 @@ class Imaging:
 
         # return the result
         return results[0]['File'] if results else None
+
+    def map_BIDS_param_to_LORIS_param(self, file_parameters):
+
+        map_dict = {
+            'manufacturersModelName'      : 'manufacturer_model_name',
+            'DeviceSerialNumber'          : 'device_serial_number',
+            'SoftwareVersions'            : 'software_versions',
+            'MagneticFieldStrength'       : 'magnetic_field_strength',
+            'ReceiveCoilName'             : 'receiving_coil',
+            'ScanningSequence'            : 'scanning_sequence',
+            'SequenceVariant'             : 'sequence_variant',
+            'SequenceName'                : 'sequence_name',
+            'PhaseEncodingDirection'      : 'phase_encoding_direction',
+            'EchoTime'                    : 'echo_time',
+            'RepetitionTime'              : 'repetition_time',
+            'InversionTime'               : 'inversion_time',
+            'SliceThickness'              : 'slice_thickness',
+            'InstitutionName'             : 'institution_name',
+            'ImageType'                   : 'image_type',
+            'AcquisitionTime'             : 'acquisition_time',
+            'AcquisitionMatrixPE'         : 'acquisition_matrix',
+            'PercentPhaseFOV'             : 'percent_phase_field_of_view',
+            'ImageOrientationPatientDICOM': 'image_orientation_patient',
+            'MRAcquisitionType'           : 'mr_acquisition_type',
+            'AcquisitionNumber'           : 'acquisition_number',
+            'PatientPosition'             : 'patient_position',
+            'ImagingFrequency'            : 'imaging_frequency',
+            'SeriesNumber'                : 'series_number',
+            'PixelBandwidth'              : 'pixel_bandwidth',
+            'SeriesDescription'           : 'series_description',
+            'ProtocolName'                : 'protocol_name',
+            'SpacingBetweenSlices'        : 'spacing_between_slices',
+            'NumberOfAverages'            : 'number_of_averages',
+        }
+
+        # map BIDS parameters with the LORIS ones
+        for param in list(file_parameters):
+            if param in map_dict.keys():
+                file_parameters[map_dict[param]] = file_parameters[param]
+
+        return file_parameters

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -6,8 +6,12 @@ import re
 import os
 import subprocess
 import nilearn
+import numpy   as np
+import nibabel as nib
+
 from nilearn import plotting
 from nilearn import image
+
 
 __license__ = "GPLv3"
 
@@ -390,3 +394,42 @@ class Imaging:
         )
 
         return pic_rel_path
+
+    @staticmethod
+    def get_nifti_image_length_parameters(nifti_filepath):
+        """
+        Get the NIfTI image length dimensions (x, y, z and time for 4D dataset).
+
+        :param nifti_filepath: path to the NIfTI file
+         :type nifti_filepath: str
+
+        :return: tuple with the length of each dimension of the NIfTI file
+         :rtype: tuple
+        """
+
+        img = nib.load(nifti_filepath)
+
+        # get the voxel/time length array of the image
+        length = img.shape
+
+        return length
+
+    @staticmethod
+    def get_nifti_image_step_parameters(nifti_filepath):
+        """
+        Get the NIfTI image step information (xstep, ystep, zstep and number of volumes
+        for 4D dataset)
+
+        :param nifti_filepath: path to the NIfTI file
+         :type nifti_filepath: str
+
+        :return: tuple with the step information for the NIfTI file
+         :rtype: tuple
+        """
+
+        img = nib.load(nifti_filepath)
+
+        # get the voxel step/time step of the image
+        step = img.header.get_zooms()
+
+        return step

--- a/python/lib/mri.py
+++ b/python/lib/mri.py
@@ -321,14 +321,14 @@ class Mri:
             file_parameters['scans_tsv_file_bake2hash'] = scans_blake2
 
         # grep voxel step from the NIfTI file header
-        step_parameters = utilities.get_nifti_image_step_parameters(nifti_file.path)
+        step_parameters = imaging.get_nifti_image_step_parameters(nifti_file.path)
         file_parameters['xstep'] = step_parameters[0]
         file_parameters['ystep'] = step_parameters[1]
         file_parameters['zstep'] = step_parameters[2]
 
         # grep the time length from the NIfTI file header
         is_4d_dataset = False
-        length_parameters = utilities.get_nifti_image_length_parameters(nifti_file.path)
+        length_parameters = imaging.get_nifti_image_length_parameters(nifti_file.path)
         if len(length_parameters) == 4:
             file_parameters['time'] = length_parameters[3]
             is_4d_dataset = True

--- a/python/lib/mri.py
+++ b/python/lib/mri.py
@@ -353,13 +353,14 @@ class Mri:
         file_id   = result['FileID'] if result else None
         file_path = result['File']   if result else None
         if not file_id:
-            # grep the scan type ID from the mri_scan_type table
+            # grep the scan type ID from the mri_scan_type table (if it is not already in
+            # the table, it will add a row to the mri_scan_type table)
             scan_type_id = self.db.grep_id_from_lookup_table(
                 id_field_name       = 'ID',
                 table_name          = 'mri_scan_type',
                 where_field_name    = 'Scan_type',
                 where_value         = scan_type,
-                insert_if_not_found = False
+                insert_if_not_found = True
             )
 
             # copy the NIfTI file to the LORIS BIDS import directory

--- a/python/lib/mri.py
+++ b/python/lib/mri.py
@@ -1,0 +1,339 @@
+"""Deals with MRI BIDS datasets and register them into the database."""
+
+import os
+import json
+import getpass
+import string
+from pyblake2 import blake2b
+
+import lib.exitcode
+import lib.utilities as utilities
+from lib.database   import Database
+from lib.candidate  import Candidate
+from lib.session    import Session
+from lib.imaging    import Imaging
+from lib.bidsreader import BidsReader
+from lib.scanstsv   import ScansTSV
+
+
+__license__ = "GPLv3"
+
+
+class Mri:
+
+    def __init__(self, bids_reader, bids_sub_id, bids_ses_id, bids_modality, db,
+                 verbose, data_dir, default_visit_label,
+                 loris_bids_mri_rel_dir, loris_bids_root_dir):
+
+        # enumerate the different suffixes supported by BIDS per modality type
+        self.possible_suffix_per_modality = {
+            'anat' : [
+                       'T1w',   'T2w', 'T1rho', 'T1map', 'T2map',     'T2star',    'FLAIR',
+                       'FLASH', 'PD',  'PDmap', 'PDT2',  'inplaneT1', 'inplaneT2', 'angio'
+                     ],
+            'func' : [
+                       'bold', 'cbv', 'phase'
+                     ],
+            'dwi'  : [
+                       'dwi', 'sbref'
+                     ],
+            'fmap' : [
+                       'phasediff', 'magnitude1', 'magnitude2', 'phase1', 'phase2',
+                       'fieldmap', 'epi'
+                     ]
+        }
+
+        # load bids objects
+        self.bids_reader = bids_reader
+        self.bids_layout = bids_reader.bids_layout
+
+        # load the LORIS BIDS import root directory where the files will be copied
+        self.loris_bids_mri_rel_dir = loris_bids_mri_rel_dir
+        self.loris_bids_root_dir    = loris_bids_root_dir
+        self.data_dir               = data_dir
+
+        # load BIDS subject, visit and modality
+        self.bids_sub_id   = bids_sub_id
+        self.bids_ses_id   = bids_ses_id
+        self.bids_modality = bids_modality
+
+        # load database handler object and verbose bool
+        self.db      = db
+        self.verbose = verbose
+
+        # find corresponding CandID and SessionID in LORIS
+        self.loris_cand_info = self.get_loris_cand_info()
+        self.default_vl      = default_visit_label
+        self.psc_id          = self.loris_cand_info['PSCID']
+        self.cand_id         = self.loris_cand_info['CandID']
+        self.center_id       = self.loris_cand_info['RegistrationCenterID']
+        self.session_id      = self.get_loris_session_id()
+
+        # grep all the NIfTI files for the modality
+        self.nifti_files = self.grep_nifti_files()
+
+        # check if a tsv with acquisition dates or age is available for the subject
+        self.scans_file = None
+        if self.bids_layout.get(suffix='scans', subject=self.psc_id, return_type='filename'):
+            self.scans_file = \
+            self.bids_layout.get(suffix='scans', subject=self.psc_id, return_type='filename')[0]
+
+        # loop through NIfTI files and register them in the DB
+        for nifti_file in self.nifti_files:
+            self.register_nifti_file(nifti_file)
+
+
+    def get_loris_cand_info(self):
+        """
+        Gets the LORIS Candidate info for the BIDS subject.
+
+        :return: Candidate info of the subject found in the database
+         :rtype: list
+        """
+
+        candidate       = Candidate(verbose=self.verbose, psc_id=self.bids_sub_id)
+        loris_cand_info = candidate.get_candidate_info_from_loris(self.db)
+
+        return loris_cand_info
+
+    def get_loris_session_id(self):
+        """
+        Greps the LORIS session.ID corresponding to the BIDS visit. Note,
+        if no BIDS visit are set, will use the default visit label value set
+        in the config module
+
+        :return: the session's ID in LORIS
+         :rtype: int
+        """
+
+        # check if there are any visit label in BIDS structure, if not,
+        # will use the default visit label set in the config module
+        visit_label = self.bids_ses_id if self.bids_ses_id else self.default_vl
+
+        session = Session(
+            verbose     = self.verbose,
+            cand_id     = self.cand_id,
+            center_id   = self.center_id,
+            visit_label = visit_label
+        )
+        loris_vl_info = session.get_session_info_from_loris(self.db)
+
+        if not loris_vl_info:
+            message = "ERROR: visit label " + visit_label + "does not exist in " + \
+                      "the session table for candidate "  + self.cand_id         + \
+                      "\nPlease make sure the visit label is created in the "    + \
+                      "database or run bids_import.py with the -s option -s if " + \
+                      "you wish that the insertion pipeline creates the visit "  + \
+                      "label in the session table."
+            print(message)
+            exit(lib.exitcode.SELECT_FAILURE)
+
+        return loris_vl_info['ID']
+
+    def grep_nifti_files(self):
+        """
+        Returns the list of NIfTI files found for the modality.
+
+        :return: list of NIfTI files found for the modality
+         :rtype: list
+        """
+
+        # grep all the possible suffixes for the modality
+        modality_possible_suffix = self.possible_suffix_per_modality[modality]
+
+        # loop through the possible suffixes and grep the NIfTI files
+        nii_files_list = {}
+        for suffix in modality_possible_suffix:
+            nii_files_list.extend(self.grep_bids_files(suffix, 'nii.gz'))
+
+        # return the list of found NIfTI files
+        return nii_files_list
+
+    def grep_bids_files(self, bids_type, extension):
+        """
+        Greps the BIDS files and their layout information from the BIDSLayout
+        and return that list.
+
+        :param bids_type: the BIDS type to use to grep files (events,
+                          channels, eeg, electrodes)
+         :type bids_type: str
+        :param extension: extension of the file to look for (nii.gz, json...)
+         :type extension: str
+
+        :return: list of files from the BIDS layout
+         :rtype: list
+        """
+
+        if self.bids_ses_id:
+            return self.bids_layout.get(
+                subject     = self.bids_sub_id,
+                session     = self.bids_ses_id,
+                datatype    = self.bids_modality,
+                extension   = extension,
+                suffix      = bids_type
+            )
+        else:
+            return self.bids_layout.get(
+                subject     = self.bids_sub_id,
+                datatype    = self.bids_modality,
+                extension   = extension,
+                suffix      = bids_type
+            )
+
+    def register_raw_file(self, nifti_file):
+
+        # insert the NIfTI file
+        inserted_nii  = self.fetch_and_insert_nifti_file(nifti_file)
+
+
+    def fetch_and_insert_nifti_file(self, nifti_file, derivatives=None):
+
+        # load the Imaging object that will be used to insert the imaging data into the database
+        imaging = Imaging(self.db, self.verbose)
+
+        # load the list of associated files with the NIfTI file
+        associated_files = nifti_file.get_associations()
+
+        # load the entity information from the NIfTI file
+        entities  = nifti_file.get_entities()
+        scan_type = entities['suffix']
+        run       = entities['run']
+        task      = entities['task']
+        acq       = entities['acquisition']
+        dir       = entities['dir']
+
+        # loop through the associated files to grep JSON, bval, bvec...
+        json_file = None
+        other_assoc_files = {}
+        for assoc_file in associated_files:
+            file_info = assoc_file.get_entities()
+            if file_info['extension'] == 'json':
+                json_file = assoc_file.path
+            elif file_info['extension'] == 'bvec':
+                other_assoc_files['bvec_file'] = assoc_file.path
+            elif file_info['extension'] == 'bval':
+                other_assoc_files['bval_file'] = assoc_file.path
+            elif file_info['extension'] == 'tsv' and file_info['suffix'] == 'events':
+                other_assoc_files['task_file'] = assoc_file.path
+            elif file_info['extension'] == 'tsv' and file_info['suffix'] == 'physio':
+                other_assoc_files['physio_file'] = assoc_file.path
+
+        # read the json file if it exists
+        file_parameters = {}
+        if json_file:
+            with open(json_file) as data_file:
+                file_parameters = json.load(data_file)
+            # copy the JSON file to the LORIS BIDS import directory
+            json_path = self.copy_file_to_loris_bids_dir(json_file)
+            file_parameters['bids_json_file'] = json_path
+            json_blake2 = blake2b(json_file.encode('utf-8')).hexdigest()
+            file_parameters['bids_json_file_blake2b_hash'] = json_blake2
+
+        # grep the file type from the ImagingFileTypes table
+        file_type = imaging.determine_file_type(nifti_file.filename)
+
+        # determine the output type
+        output_type = 'derivatives' if derivatives else 'raw'
+
+        # get the acquisition date of the MRI file or the age at the time of the MRI acquisition
+        if self.scans_file:
+            scan_info = ScansTSV(self.scans_file, ni_file, self.verbose)
+            file_parameters['scan_acquisition_time'] = scan_info.get_acquisition_time()
+            file_parameters['age_at_scan'] = scan_info.get_age_at_scan()
+            # copy the scans.tsv file to the LORIS BIDS import directory
+            scans_path = scan_info.copy_scans_tsv_file_to_loris_bids_dir(
+                self.bids_sub_id, self.loris_bids_root_dir, self.data_dir
+            )
+            file_parameters['scans_tsv_file'] = scans_path
+            scans_blake2 = blake2b(self.scans_file.encode('utf-8')).hexdigest()
+            file_parameters['scans_tsv_file_bake2hash'] = scans_blake2
+
+        # add all other associated files to the file_parameters so they get inserted
+        # in parameter_file
+        for type in other_assoc_files:
+            original_file_path = other_assoc_files[type]
+            copied_path = self.copy_file_to_loris_bids_dir(original_file_path)
+            file_param_name  = 'bids' + type
+            file_parameters[param_name] = copied_path
+            file_blake2 = blake2b(original_file_path.encode('utf-8')).hexdigest()
+            hash_param_name = file_param_name + '_blake2b_hash'
+            file_parameters[hash_param_name] = file_blake2
+
+        # append the blake2b to the MRI file parameters dictionary
+        blake2 = blake2b(eeg_file.encode('utf-8')).hexdigest()
+        file_parameters['file_blake2b_hash'] = blake2
+
+        # check that the file using blake2b is not already inserted before inserting it
+        result    = imaging.grep_file_id_from_hash(blake2)
+        file_id   = result['FileID'] if result else None
+        file_path = result['File']   if result else None
+        if not file_id:
+            # grep the scan type ID from the mri_scan_type table
+            scan_type_id = self.db.grep_id_from_lookup_table(
+                id_field_name       = 'ID',
+                table_name          = 'mri_scan_type',
+                where_field_name    = 'Scan_type',
+                where_value         = scan_type,
+                insert_if_not_found = False
+            )
+
+            # copy the eeg_file to the LORIS BIDS import directory
+            file_path = self.copy_file_to_loris_bids_dir(nifti_file.path)
+
+            # insert the file along with its information into files and parameter_file tables
+            file_info = {
+                'FileType'       : file_type,
+                'File'           : file_path,
+                'SessionID'      : self.session_id,
+                'InsertedByUser' : getpass.getuser(),
+                'OutputType'     : output_type,
+                'AcquisitionProtocolID': scan_type_id
+            }
+            file_id = imaging.insert_imaging_file(file_info, file_parameters)
+
+        return {'file_id': file_id, 'file_path': file_path}
+
+    def copy_file_to_loris_bids_dir(self, file, derivatives_path=None):
+        """
+        Wrapper around the utilities.copy_file function that copies the file
+        to the LORIS BIDS import directory and returns the relative path of the
+        file (without the data_dir part).
+
+        :param file: full path to the original file
+         :type file: str
+        :param derivatives_path: path to the derivative folder
+         :type derivatives_path: str
+
+        :return: relative path to the copied file
+         :rtype: str
+        """
+
+        # determine the path of the copied file
+        copy_file = self.loris_bids_eeg_rel_dir
+        if self.bids_ses_id:
+            copy_file += os.path.basename(file)
+        else:
+            # make sure the ses- is included in the new filename if using
+            # default visit label from the LORIS config
+            copy_file += str.replace(
+                os.path.basename(file),
+                "sub-" + self.bids_sub_id,
+                "sub-" + self.bids_sub_id + "_ses-" + self.default_vl
+            )
+        if derivatives_path:
+            # create derivative subject/vl/modality directory
+            lib.utilities.create_dir(
+                derivatives_path + self.loris_bids_eeg_rel_dir,
+                self.verbose
+            )
+            copy_file = derivatives_path + copy_file
+        else:
+            copy_file = self.loris_bids_root_dir + copy_file
+
+        # copy the file
+        utilities.copy_file(file, copy_file, self.verbose)
+
+        # determine the relative path and return it
+        relative_path = copy_file.replace(self.data_dir, "")
+
+        return relative_path

--- a/python/lib/scanstsv.py
+++ b/python/lib/scanstsv.py
@@ -93,7 +93,7 @@ class ScansTSV:
         age_header_list = ['age', 'age_at_scan', 'age_acq_time']
 
         for header_name in age_header_list:
-            if header_name in self.tsv_headers:
+            if header_name in self.tsv_headers and self.acquisition_data:
                 return self.acquisition_data[header_name].strip()
 
         return None

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -9,6 +9,8 @@ import tarfile
 import scipy.io
 import numpy
 import lib.exitcode
+import numpy as np
+import nibabel as nib
 
 
 __license__ = "GPLv3"
@@ -138,3 +140,23 @@ def update_set_file_path_info(set_file, fdt_file):
 
     # write the new .set file with the correct path info
     scipy.io.savemat(set_file, dataset, False)
+
+
+def get_nifti_image_length_parameters(nifti_filepath):
+
+    img = nib.load(nifti_filepath)
+
+    # get the voxel/time length array of the image
+    length = img.shape
+
+    return length
+
+
+def get_nifti_image_step_parameters(nifti_filepath):
+
+    img = nib.load(nifti_filepath)
+
+    # get the voxel step/time step of the image
+    step = img.header.get_zooms()
+
+    return step

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -9,8 +9,6 @@ import tarfile
 import scipy.io
 import numpy
 import lib.exitcode
-import numpy as np
-import nibabel as nib
 
 
 __license__ = "GPLv3"
@@ -142,40 +140,3 @@ def update_set_file_path_info(set_file, fdt_file):
     scipy.io.savemat(set_file, dataset, False)
 
 
-def get_nifti_image_length_parameters(nifti_filepath):
-    """
-    Get the NIfTI image length dimensions (x, y, z and time for 4D dataset).
-
-    :param nifti_filepath: path to the NIfTI file
-     :type nifti_filepath: str
-
-    :return: tuple with the length of each dimension of the NIfTI file
-     :rtype: tuple
-    """
-
-    img = nib.load(nifti_filepath)
-
-    # get the voxel/time length array of the image
-    length = img.shape
-
-    return length
-
-
-def get_nifti_image_step_parameters(nifti_filepath):
-    """
-    Get the NIfTI image step information (xstep, ystep, zstep and number of volumes
-    for 4D dataset)
-
-    :param nifti_filepath: path to the NIfTI file
-     :type nifti_filepath: str
-
-    :return: tuple with the step information for the NIfTI file
-     :rtype: tuple
-    """
-
-    img = nib.load(nifti_filepath)
-
-    # get the voxel step/time step of the image
-    step = img.header.get_zooms()
-
-    return step

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -143,6 +143,15 @@ def update_set_file_path_info(set_file, fdt_file):
 
 
 def get_nifti_image_length_parameters(nifti_filepath):
+    """
+    Get the NIfTI image length dimensions (x, y, z and time for 4D dataset).
+
+    :param nifti_filepath: path to the NIfTI file
+     :type nifti_filepath: str
+
+    :return: tuple with the length of each dimension of the NIfTI file
+     :rtype: tuple
+    """
 
     img = nib.load(nifti_filepath)
 
@@ -153,6 +162,16 @@ def get_nifti_image_length_parameters(nifti_filepath):
 
 
 def get_nifti_image_step_parameters(nifti_filepath):
+    """
+    Get the NIfTI image step information (xstep, ystep, zstep and number of volumes
+    for 4D dataset)
+
+    :param nifti_filepath: path to the NIfTI file
+     :type nifti_filepath: str
+
+    :return: tuple with the step information for the NIfTI file
+     :rtype: tuple
+    """
 
     img = nib.load(nifti_filepath)
 

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -138,5 +138,3 @@ def update_set_file_path_info(set_file, fdt_file):
 
     # write the new .set file with the correct path info
     scipy.io.savemat(set_file, dataset, False)
-
-


### PR DESCRIPTION
### Description

This allows the import of MRI datasets already organized according to the BIDS standards. The following BIDS modalities/entities are supported on the MRI side:
`anat`, `func`, `dwi`, `fmap`

More modalities will come when they will officially be released in the BIDS standards.

**Note:** if a BIDS imaging scan type (aka, the BIDS suffix which is the last part of the filename like `T1w`, `T2w`, `dwi`, `FLAIR`...) is not found in the `mri_scan_type` table, the BIDS insertion script will insert a new scan type in that table so it can be used to insert the file.

### This resolves

#451 

### Caveats for existing projects

New dependencies were added to be able to create a pic of the NIfTI files imported via the BIDS structure. To install those dependencies, make sure to first source the LORIS-MRI python virtual environment (`source /data/%PROJECT%/bin/mri/python_virtualenvs/loris-mri-python/bin/activate`) and run the following commands (without sudo):

```
pip install matplotlib
pip install nose
pip install sklearn
pip instal nilearn
```