### PR TITLE
[Install] Removed the site question from the install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ For the defacing scripts, you will also need to download the pre-compiled `bic-m
  * What is the project name? $projectname
  * What is your email address? 
  * What prod file name would you like to use? default: prod  [leave blank]
- * Enter the list of Site names (space separated) site1 site2
 
   If the imaging install script reports errors in creating directories (due to /data/ mount permissions), review and manually execute `mkdir/chmod/chown` commands starting at [imaging_install.sh:L97](https://github.com/aces/Loris-MRI/blob/master/imaging_install.sh#L97)
 

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -54,9 +54,7 @@ if [ -z "$prodfilename" ]; then
     prodfilename="prod"
 fi 
  
-read -p "Enter the list of Site names (space separated) " site
 mridir=`pwd`
-#read -p "Enter Full Loris-code directory path "   lorisdir
 
 
 #################################################################################################

--- a/imaging_install_MacOSX.sh
+++ b/imaging_install_MacOSX.sh
@@ -35,7 +35,6 @@ if [ -z "$prodfilename" ]; then
     prodfilename="prod"
 fi 
  
-read -p "Enter the list of Site names (space separated) " site
 mridir=`pwd`
 
 #####################################################################################


### PR DESCRIPTION
### Description

PR #334 removed the creation of subdirectories in the `/data/incoming` directory but the question about the list of sites to provide at the time of install was not removed.

This PR updates the install instruction from the install scripts (Linux and Mac OS) and the `README.md` to remove that question when running the install script since the variable `site` is not used anywhere in the script.

### This resolves

- [x] part 2 of #334 that was missed...