### PR TITLE
remove unnecessary extra extraction from tarchive_validation.pl

### DIFF
--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -314,20 +314,6 @@ if (defined $subjectIDsref->{'CandMismatchError'}) {
 }
 
 ################################################################
-### Extract the tarchive and feed the dicom data dir to ######## 
-### The uploader ###############################################
-################################################################
-my ($ExtractSuffix,$study_dir,$header) = 
-    $utility->extractAndParseTarchive($tarchive, $upload_id);
-
-################################################################
-# Optionally do extra filtering on the dicom data, if needed ###
-################################################################
-if ( defined( &Settings::dicomFilter )) {
-    Settings::dicomFilter($study_dir, \%tarchiveInfo);
-}
-
-################################################################
 ##Update the IsTarchiveValidated flag in the mri_upload table ##
 ################################################################
 $query = "UPDATE mri_upload SET IsTarchiveValidated='1' WHERE UploadID=?";


### PR DESCRIPTION
### Description

In `tarchive_validation.pl`, the extraction of the tarchive is done to call a function that does not exist and have not existed for years. This removes the unnecessary additional extraction that contributes to slowing the insertion pipeline.

Notes for imaging meeting:
- even if `dicomFilter` was filtering the DICOM, it would not update the `tarchive` so it would just be doing it with no follow up
- no studies are using such a function in their `prod` file (CCNA, IBIS, PREVENT-AD, QPN, myelineurogene...)

Should be safe to remove but will discuss at the next imaging meeting just in case.
