### PR TITLE
[bug fix] Fixes bug encountered when validating candidate for phantoms

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1773,6 +1773,17 @@ sub validateCandidate {
     my ($subjectIDsref)= @_;
     my $CandMismatchError = undef;
     
+    ############################################################
+    ################ No Checking if the subject is Phantom #####
+    ############################################################
+    if ($subjectIDsref->{'isPhantom'}) {
+        # CandID/PSCID errors don't apply to phantoms, so we don't
+        # want to trigger
+        # the check which aborts the insertion
+        $CandMismatchError = undef;
+        return $CandMismatchError;
+    }
+    
     #################################################################
     ## Check if CandID exists
     #################################################################
@@ -1807,17 +1818,6 @@ sub validateCandidate {
             print LOG "\n=> $CandMismatchError";
             return $CandMismatchError;
         }
-    }
-
-    ############################################################
-    ################ No Checking if the subject is Phantom #####
-    ############################################################
-    if ($subjectIDsref->{'isPhantom'}) {
-        # CandID/PSCID errors don't apply to phantoms, so we don't
-        # want to trigger
-        # the check which aborts the insertion
-        $CandMismatchError = undef;
-        return $CandMismatchError;
     }
 
     ############################################################


### PR DESCRIPTION
### Description

In the `validateCandidate` function of the library `MRIProcessingUtility.pm`,  the check to see if it is a phantom scan happens to low in the function so when checking the patient name of a phantom scan, there is always an MRICandidateError logged and returned for phantom scan.

In this PR, the check is moved at the beginning of the function so that no further candidate validation is performed on a phantom scan.

### This fixes

- a bug found when upgrading CCNA to 21.0