### PR TITLE
[config update] profileTemplate cleanup

### DIFF
--- a/dicom-archive/profileTemplate.pl
+++ b/dicom-archive/profileTemplate.pl
@@ -47,6 +47,7 @@ sub getSubjectIDs {
 
         $subjectID{'CandID'}     = NeuroDB::MRI::my_trim(NeuroDB::MRI::getScannerCandID($scannerID, $db));
         $subjectID{'visitLabel'} = NeuroDB::MRI::my_trim($patientName);
+        $subjectID{'isPhantom'} = 1;
 
         $subjectID{'createVisitLabel'} = 1;
 
@@ -57,6 +58,7 @@ sub getSubjectIDs {
         $subjectID{'PSCID'}      = NeuroDB::MRI::my_trim($1);
         $subjectID{'CandID'}     = NeuroDB::MRI::my_trim($2);
         $subjectID{'visitLabel'} = NeuroDB::MRI::my_trim($3);
+        $subjectID{'isPhantom'}  = 0;
 
         $subjectID{'createVisitLabel'} = 0;
 
@@ -67,16 +69,6 @@ sub getSubjectIDs {
    
     # Return subjectIDs
     return \%subjectID;
-}
-
-# determines if a given subjectID is a phantom or not
-# returns 1 if a phantom, 0 for non-phantom
-sub isPhantom {
-    my $subjectIDref = shift;
-    if($subjectIDref->{'PSCID'} =~ /PHA/i) {
-        return 1;
-    }
-    return 0;
 }
 
 # ----------- OPTIONAL SUBROUTINE


### PR DESCRIPTION
### Description

Both CCNA and IBIS set an `isPhantom` key in the `getSubjectIDs` function of the config file to specify if the scan is a phantom based on the PatientName. [The code refers to that key](https://github.com/aces/Loris-MRI/blob/b38e7c0af96a541632e3bdad14d9f1083daee43e/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm#L1789) when checking if a scan is a phantom or an actual candidate session. The `profileTemplate.pl` was not updated with these changes unfortunately so this PR takes care of it.

Also removed the `isPhantom` function of the config file as it is not used anywhere in the scripts.

### Caveat for existing project with phantom datasets

Make sure to update your config file with those changes if it was not done already.