### PR TITLE
[python] Refactor the script to use the Config class when querying the config table

### DIFF
--- a/python/bids_import.py
+++ b/python/bids_import.py
@@ -13,7 +13,7 @@ from lib.bidsreader import BidsReader
 from lib.session    import Session
 from lib.eeg        import Eeg
 from lib.mri        import Mri
-
+from lib.database_lib.config import Config
 
 __license__ = "GPLv3"
 
@@ -147,8 +147,9 @@ def read_and_insert_bids(bids_dir, config_file, verbose, createcand, createvisit
     db.connect()
 
     # grep config settings from the Config module
-    default_bids_vl = db.get_config('default_bids_vl')
-    data_dir        = db.get_config('dataDirBasepath')
+    config_obj      = Config(db, verbose)
+    default_bids_vl = config_obj.get_config('default_bids_vl')
+    data_dir        = config_obj.get_config('dataDirBasepath')
 
     # making sure that there is a final / in data_dir
     data_dir = data_dir if data_dir.endswith('/') else data_dir + "/"

--- a/python/lib/database.py
+++ b/python/lib/database.py
@@ -218,24 +218,6 @@ class Database:
         except MySQLdb.Error as err:
             raise Exception("Update query failure: " + format(err))
 
-    def get_config(self, config_name):
-        """
-        Grep the Value of a ConfigSettings from the Config table.
-
-        :param config_name: name of the ConfigSettings
-         :type config_name: str
-
-        :return: the value from the Config table or None if no value found
-         :rtype: str
-        """
-
-        query = "SELECT Value FROM Config WHERE ConfigID = (" \
-                  "SELECT ID FROM ConfigSettings WHERE Name = %s" \
-                ");"
-        config_value = self.pselect(query, (config_name,))
-
-        return config_value[0]['Value'] if config_value else None
-
     def grep_id_from_lookup_table(self, id_field_name, table_name, where_field_name,
                                   where_value, insert_if_not_found=None):
         """

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -29,14 +29,16 @@ class Eeg:
         from lib.bidsreader import BidsReader
         from lib.eeg        import Eeg
         from lib.database   import Database
+        from lib.database_lib.config import Config
 
         # database connection
         db = Database(config_file.mysql, verbose)
         db.connect()
 
         # grep config settings from the Config module
-        default_bids_vl = db.get_config('default_bids_vl')
-        data_dir        = db.get_config('dataDirBasepath')
+        config_obj      = Config(db, verbose)
+        default_bids_vl = config_obj.get_config('default_bids_vl')
+        data_dir        = config_obj.get_config('dataDirBasepath')
 
         # load the BIDS directory
         bids_reader = BidsReader(bids_dir)

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -14,7 +14,8 @@ from nilearn import image
 
 import lib.exitcode
 from lib.candidate import Candidate
-from lib.database_lib.site import Site
+from lib.database_lib.site   import Site
+from lib.database_lib.config import Config
 
 __license__ = "GPLv3"
 
@@ -344,7 +345,8 @@ class Imaging:
          :rtype subject_id_dict: dict
         """
 
-        dicom_header = self.db.get_config('lookupCenterNameUsing')
+        config_obj   = Config(self.db, self.verbose)
+        dicom_header = config_obj.get_config('lookupCenterNameUsing')
         dicom_value  = tarchive_info_dict[dicom_header]
 
         try:

--- a/python/lib/mri.py
+++ b/python/lib/mri.py
@@ -35,8 +35,9 @@ class Mri:
         db.connect()
 
         # grep config settings from the Config module
-        default_bids_vl = db.get_config('default_bids_vl')
-        data_dir        = db.get_config('dataDirBasepath')
+        config_obj      = Config(db, verbose)
+        default_bids_vl = config_obj.get_config('default_bids_vl')
+        data_dir        = config_obj.get_config('dataDirBasepath')
 
         # load the BIDS directory
         bids_reader = BidsReader(bids_dir)

--- a/python/mass_electrophysiology_chunking.py
+++ b/python/mass_electrophysiology_chunking.py
@@ -8,6 +8,7 @@ import getopt
 import lib.exitcode
 from lib.database      import Database
 from lib.physiological import Physiological
+from lib.database_lib.config import Config
 
 
 __license__ = "GPLv3"
@@ -150,7 +151,8 @@ def make_chunks(physiological_file_id, config_file, verbose):
     db.connect()
 
     # grep config settings from the Config module
-    data_dir = db.get_config('dataDirBasepath')
+    config_obj = Config(db, verbose)
+    data_dir   = config_obj.get_config('dataDirBasepath')
 
     # making sure that there is a final / in data_dir
     data_dir = data_dir if data_dir.endswith('/') else data_dir + "/"

--- a/python/mass_nifti_pic.py
+++ b/python/mass_nifti_pic.py
@@ -9,6 +9,7 @@ import getopt
 import lib.exitcode
 from lib.database import Database
 from lib.imaging  import Imaging
+from lib.database_lib.config import Config
 
 
 __license__ = "GPLv3"
@@ -149,7 +150,8 @@ def make_pic(file_id, config_file, verbose):
     db.connect()
 
     # grep config settings from the Config module
-    data_dir = db.get_config('dataDirBasepath')
+    config_obj = Config(db, verbose)
+    data_dir = config_obj.get_config('dataDirBasepath')
 
     # making sure that there is a final / in data_dir
     data_dir = data_dir if data_dir.endswith('/') else data_dir + "/"


### PR DESCRIPTION
### Description

This refactors the old python scripts to use the `python/lib/database_lib/config.py` library to query the `Config` table.

### Linked issue

https://github.com/aces/Loris-MRI/issues/523 