### PR TITLE
Remove new_scanner option from the pipeline

### DIFF
--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -180,7 +180,7 @@ referenced by `$file_ref`.
 
 INPUT: file hash ref
 
-### findScannerID($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $register\_new, $db)
+### findScannerID($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $db)
 
 Finds the scanner ID for the scanner as defined by `$manufacturer`, `$model`,
 `$serialNumber`, `$softwareVersion`, using the database attached to the DBI
@@ -194,7 +194,6 @@ INPUTS:
   - $softwareVersion: scanner's software version
   - $centerID       : scanner's center ID
   - $dbhr           : database handle reference
-  - $register\_new   : if set, will call the function `&registerScanner`
   - $db             : database object
 
 RETURNS: (int) scanner ID

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -159,7 +159,9 @@ RETURNS: array of two elements: center name and center ID
 
 ### determineScannerID($tarchiveInfo, $to\_log, $centerID, $upload\_id)
 
-Determines which scanner ID was used for DICOM acquisitions.
+Determines which scanner ID was used for DICOM acquisitions. Note, if 
+a scanner ID is not already associated to the scanner information found
+in the DICOM headers, then a new scanner will automatically be created.
 
 INPUTS:
   - $tarchiveInfo: archive information hash ref

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -18,10 +18,7 @@ utilities
 
     my ($center_name, $centerID) = $utility->determinePSC(\%tarchiveInfo,0);
 
-    my $scannerID     = $utility->determineScannerID(
-                          \%tarchiveInfo, 0,
-                          $centerID,      $NewScanner
-                        );
+    my $scannerID     = $utility->determineScannerID(\%tarchiveInfo, 0, $centerID);
 
     my $subjectIDsref = $utility->determineSubjectID(
                           $scannerID,
@@ -160,7 +157,7 @@ INPUTS:
 
 RETURNS: array of two elements: center name and center ID
 
-### determineScannerID($tarchiveInfo, $to\_log, $centerID, $NewScanner, $upload\_id)
+### determineScannerID($tarchiveInfo, $to\_log, $centerID, $upload\_id)
 
 Determines which scanner ID was used for DICOM acquisitions.
 
@@ -168,8 +165,6 @@ INPUTS:
   - $tarchiveInfo: archive information hash ref
   - $to\_log      : whether this step should be logged
   - $centerID    : center ID
-  - $NewScanner  : whether a new scanner entry should be created if the scanner
-                   used is a new scanner for the study
   - $upload\_id   : upload ID of the study
 
 RETURNS: scanner ID

--- a/docs/scripts_md/minc_insertion.md
+++ b/docs/scripts_md/minc_insertion.md
@@ -25,8 +25,6 @@ Available options are:
                for the possibility that the tarchive was moved
                to a different directory
 
-\-newScanner  : if set \[default\], new scanner will be registered
-
 \-xlog        : opens an xterm with a tail on the current log file
 
 \-verbose     : if set, be verbose
@@ -71,4 +69,4 @@ License: GPLv3
 
 # AUTHORS
 
-LORIS community &lt;loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/tarchiveLoader.md
+++ b/docs/scripts_md/tarchiveLoader.md
@@ -29,10 +29,6 @@ Available options are:
                            for the possibility that the tarchive was moved to
                            a different directory
 
-\-newScanner              : By default a new scanner will be registered if the
-                           data you upload requires it. You can risk turning
-                           it off
-
 \-keeptmp                 : Keep temporary directory. Make sense if have
                            infinite space on your server
 
@@ -51,7 +47,7 @@ Available options are:
 This script interacts with the LORIS database system. It will fetch or modify
 contents of the following tables:
 `session`, `parameter_file`, `parameter_type`, `parameter_type_category`,
-`files`, `mri_staging`, `notification_spool`
+`files`, `mri_staging`, `notification_spool`, `mri_scanner`
 
 ## Methods
 
@@ -82,4 +78,4 @@ License: GPLv3
 # AUTHORS
 
 J-Sebastian Muehlboeck based on Jonathan Harlap\\'s process\_uploads, LORIS
-community &lt;loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/tarchive_validation.md
+++ b/docs/scripts_md/tarchive_validation.md
@@ -20,8 +20,6 @@ Available options are:
                the possibility that the tarchive was moved to a
                different directory
 
-\-newScanner  : boolean, if set, register new scanners into the database
-
 \-verbose     : boolean, if set, run the script in verbose mode
 
 # DESCRIPTION
@@ -34,8 +32,8 @@ against the one inserted in the database using checksum
 \- Verification of the PSC information using whatever field containing the site
 string (typically, the patient name or patient ID)
 
-\- Verification of the `ScannerID` of the DICOM study archive (optionally
-creates a new scanner entry in the database if necessary)
+\- Verification of the `ScannerID` of the DICOM study archive (creates a
+new scanner entry in the database if necessary)
 
 \- Optionally, creation of candidates as needed and standardization of sex
 information when creating the candidates (DICOM uses M/F, LORIS database uses
@@ -65,4 +63,4 @@ License: GPLv3
 
 # AUTHORS
 
-LORIS community &lt;loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -935,7 +935,7 @@ sub mapDicomParameters {
 }
 =pod
 
-=head3 findScannerID($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $register_new, $db)
+=head3 findScannerID($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $db)
 
 Finds the scanner ID for the scanner as defined by C<$manufacturer>, C<$model>,
 C<$serialNumber>, C<$softwareVersion>, using the database attached to the DBI
@@ -949,7 +949,6 @@ INPUTS:
   - $softwareVersion: scanner's software version
   - $centerID       : scanner's center ID
   - $dbhr           : database handle reference
-  - $register_new   : if set, will call the function C<&registerScanner>
   - $db             : database object
 
 RETURNS: (int) scanner ID
@@ -957,7 +956,7 @@ RETURNS: (int) scanner ID
 =cut
 
 sub findScannerID {
-    my ($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $register_new, $db) = @_;
+    my ($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $db) = @_;
 
     my $mriScannerOB = NeuroDB::objectBroker::MriScannerOB->new( db => $db );
     my $resultsRef = $mriScannerOB->get( {
@@ -969,9 +968,6 @@ sub findScannerID {
     
     # Scanner exists
     return $resultsRef->[0]->{'ID'} if @$resultsRef;
-
-    # Scanner does not exist and we don't want to register a new one: ID defaults to 0
-    return 0 if !$register_new;
     
     # only register new scanners when told to do so !!!
     my $scanner_id = registerScanner($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $db);

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -969,7 +969,7 @@ sub findScannerID {
     # Scanner exists
     return $resultsRef->[0]->{'ID'} if @$resultsRef;
     
-    # only register new scanners when told to do so !!!
+    # register new scanners
     my $scanner_id = registerScanner($manufacturer, $model, $serialNumber, $softwareVersion, $centerID, $dbhr, $db);
 
     return $scanner_id;

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -550,7 +550,9 @@ sub determinePSC {
 
 =head3 determineScannerID($tarchiveInfo, $to_log, $centerID, $upload_id)
 
-Determines which scanner ID was used for DICOM acquisitions.
+Determines which scanner ID was used for DICOM acquisitions. Note, if 
+a scanner ID is not already associated to the scanner information found
+in the DICOM headers, then a new scanner will automatically be created.
 
 INPUTS:
   - $tarchiveInfo: archive information hash ref
@@ -587,9 +589,7 @@ sub determineScannerID {
     if ($scannerID == 0) {
         if ($to_log) {
             $message = "\nERROR: The ScannerID for this particular scanner ".
-                          "does not exist. Enable creating new ScannerIDs in ".
-                          "your profile or this archive can not be ".
-                          "uploaded.\n\n";
+                          "does not exist and could not be created.\n\n";
             $this->writeErrorLog(
                 $message, $NeuroDB::ExitCodes::SELECT_FAILURE
             );

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -23,10 +23,7 @@ utilities
 
   my ($center_name, $centerID) = $utility->determinePSC(\%tarchiveInfo,0);
 
-  my $scannerID     = $utility->determineScannerID(
-                        \%tarchiveInfo, 0,
-                        $centerID,      $NewScanner
-                      );
+  my $scannerID     = $utility->determineScannerID(\%tarchiveInfo, 0, $centerID);
 
   my $subjectIDsref = $utility->determineSubjectID(
                         $scannerID,
@@ -551,7 +548,7 @@ sub determinePSC {
 
 =pod
 
-=head3 determineScannerID($tarchiveInfo, $to_log, $centerID, $NewScanner, $upload_id)
+=head3 determineScannerID($tarchiveInfo, $to_log, $centerID, $upload_id)
 
 Determines which scanner ID was used for DICOM acquisitions.
 
@@ -559,8 +556,6 @@ INPUTS:
   - $tarchiveInfo: archive information hash ref
   - $to_log      : whether this step should be logged
   - $centerID    : center ID
-  - $NewScanner  : whether a new scanner entry should be created if the scanner
-                   used is a new scanner for the study
   - $upload_id   : upload ID of the study
 
 RETURNS: scanner ID
@@ -570,7 +565,7 @@ RETURNS: scanner ID
 sub determineScannerID {
 
     my $this = shift;
-    my ($tarchiveInfo, $to_log, $centerID, $NewScanner, $upload_id) = @_;
+    my ($tarchiveInfo, $to_log, $centerID, $upload_id) = @_;
     my $message = '';
     $to_log = 1 unless defined $to_log;
     if ($to_log) {
@@ -587,7 +582,6 @@ sub determineScannerID {
             $tarchiveInfo->{'ScannerSoftwareVersion'},
             $centerID,
             $this->{dbhr},
-            $NewScanner,
             $this->{'db'}
         );
     if ($scannerID == 0) {

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -29,8 +29,6 @@ Available options are:
                for the possibility that the tarchive was moved
                to a different directory
 
--newScanner  : if set [default], new scanner will be registered
-
 -xlog        : opens an xterm with a tail on the current log file
 
 -verbose     : if set, be verbose
@@ -119,8 +117,6 @@ my $reckless    = 0;           # this is only for playing and testing. Don't
                                # set it to 1!!!
 my $force       = 0;           # This is a flag to force the script to run  
                                # Even if the validation has failed
-my $NewScanner  = 1;           # This should be the default unless you are a 
-                               # control freak
 my $xlog        = 0;           # default should be 0
 my $bypass_extra_file_checks=0;# If you need to bypass the extra_file_checks, set to 1.
 my $acquisitionProtocol=undef; # Specify the acquisition Protocol also bypasses the checks
@@ -164,10 +160,6 @@ my @opt_table = (
                   "Loosen the validity check of the tarchive allowing for the". 
                   " possibility that the tarchive was moved to a different". 
                   " directory."],
-
-                 ["-newScanner", "boolean", 1, \$NewScanner,
-                  "By default a new scanner will be registered if the data".
-                  " you upload requires it. You can risk turning it off."],
 
                  ["Fancy options","section"],
 
@@ -489,9 +481,7 @@ $studyInfo{'DateAcquired'}           //= $file->getParameter('study:start_date')
 
 ## Determine PSC, ScannerID and Subject IDs
 my ($center_name, $centerID) = $utility->determinePSC(\%studyInfo, 0, $upload_id);
-my $scannerID = $utility->determineScannerID(
-    \%studyInfo, 0, $centerID, $NewScanner, $upload_id
-);
+my $scannerID = $utility->determineScannerID(\%studyInfo, 0, $centerID, $upload_id);
 my $subjectIDsref = $utility->determineSubjectID(
     $scannerID, \%studyInfo, 0, $upload_id, $User, $centerID
 );

--- a/uploadNeuroDB/tarchiveLoader.pl
+++ b/uploadNeuroDB/tarchiveLoader.pl
@@ -36,10 +36,6 @@ Available options are:
                            for the possibility that the tarchive was moved to
                            a different directory
 
--newScanner              : By default a new scanner will be registered if the
-                           data you upload requires it. You can risk turning
-                           it off
-
 -keeptmp                 : Keep temporary directory. Make sense if have
                            infinite space on your server
 
@@ -60,7 +56,7 @@ Available options are:
 This script interacts with the LORIS database system. It will fetch or modify
 contents of the following tables:
 C<session>, C<parameter_file>, C<parameter_type>, C<parameter_type_category>,
-C<files>, C<mri_staging>, C<notification_spool>
+C<files>, C<mri_staging>, C<notification_spool>, C<mri_scanner>
 
 
 
@@ -126,8 +122,6 @@ my $reckless    = 0;           # this is only for playing and testing. Don't
                                #set it to 1!!!
 my $force       = 0;           # This is a flag to force the script to run  
                                # Even if the validation has failed
-my $NewScanner  = 1;           # This should be the default unless you are a 
-                               #control freak
 my $xlog        = 0;           # default should be 0
 my $globArchiveLocation = 0;   # whether to use strict ArchiveLocation strings
                                # or to glob them (like '%Loc')
@@ -155,10 +149,6 @@ my @opt_table = (
                   "Loosen the validity check of the tarchive allowing for ".
                   "the possibility that the tarchive was moved to a different".
                   " directory."
-                 ],
-                 ["-newScanner", "boolean", 1, \$NewScanner, "By default a".
-                   " new scanner will be registered if the data you upload".
-                   " requires it. You can risk turning it off."
                  ],
                  ["Fancy options","section"],
 # fixme		 ["-keeptmp", "boolean", 1, \$keep, "Keep temporay directory. Make
@@ -413,7 +403,7 @@ my ($center_name, $centerID) =
 ######### Determine the ScannerID ##############################
 ################################################################
 my $scannerID = $utility->determineScannerID(
-        \%tarchiveInfo, 0, $centerID, $NewScanner, $upload_id
+        \%tarchiveInfo, 0, $centerID, $upload_id
 );
 
 ################################################################

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -24,8 +24,6 @@ Available options are:
                the possibility that the tarchive was moved to a
                different directory
 
--newScanner  : boolean, if set, register new scanners into the database
-
 -verbose     : boolean, if set, run the script in verbose mode
 
 =head1 DESCRIPTION
@@ -38,8 +36,8 @@ against the one inserted in the database using checksum
 - Verification of the PSC information using whatever field containing the site
 string (typically, the patient name or patient ID)
 
-- Verification of the C<ScannerID> of the DICOM study archive (optionally
-creates a new scanner entry in the database if necessary)
+- Verification of the C<ScannerID> of the DICOM study archive (creates a
+new scanner entry in the database if necessary)
 
 - Optionally, creation of candidates as needed and standardization of sex
 information when creating the candidates (DICOM uses M/F, LORIS database uses
@@ -110,8 +108,6 @@ my $profile     = undef;       # this should never be set unless you are in a
 my $upload_id;                 # uploadID associated with the tarchive to validate
 my $reckless    = 0;           # this is only for playing and testing. Don't
                                # set it to 1!!!
-my $NewScanner  = 1;           # This should be the default unless you are a
-                               # control freak
 my $globArchiveLocation = 0;   # whether to use strict ArchiveLocation strings
                                # or to glob them (like '%Loc')
 my $template         = "TarLoad-$hour-$min-XXXXXX"; # for tempdir
@@ -131,9 +127,6 @@ my @opt_table = (
                   "Loosen the validity check of the tarchive allowing for".
                   " the possibility that the tarchive was moved to a". 
                   " different directory."],
-                 ["-newScanner", "boolean", 1, \$NewScanner, "By default a". 
-                  " new scanner will be registered if the data you upload".
-                  " requires it. You can risk turning it off."],
 
                  ["Fancy options","section"],
 
@@ -158,7 +151,7 @@ The program does the following validation
 
 - Verify PSC information using whatever field contains site string
 
-- Verify/determine the ScannerID (optionally create a new one if necessary)
+- Verify/determine the ScannerID (create a new one if necessary)
 
 - Optionally create candidates as needed Standardize sex (DICOM uses M/F,
   DB uses Male/Female)
@@ -296,7 +289,7 @@ my ($center_name, $centerID) = $utility->determinePSC(\%tarchiveInfo, 1, $upload
 ################################################################
 ################################################################
 my $scannerID = $utility->determineScannerID(
-    \%tarchiveInfo, 1, $centerID, $NewScanner, $upload_id
+    \%tarchiveInfo, 1, $centerID, $upload_id
 );
 
 ################################################################


### PR DESCRIPTION
### Description

These changes removes the option `-new_scanner` from the pipeline scripts since by default all projects register new scanners when they are not already present in the `mri_scanner` table.

### Link to issues or PR

#526