### PR TITLE
Remove -globLocation option

### DIFF
--- a/DTIPrep/DB
+++ b/DTIPrep/DB
@@ -1,1 +1,0 @@
-../dicom-archive/DB/

--- a/batch_uploads_tarchive.pl
+++ b/batch_uploads_tarchive.pl
@@ -240,7 +240,7 @@ foreach my $input (@inputs)
 
     my $tarchive_path = "$tarchiveLibraryDir/$tarchive";
     my $command = sprintf(
-        "tarchiveLoader.pl -globLocation -profile %s -uploadID %s %s",
+        "tarchiveLoader.pl -profile %s -uploadID %s %s",
         $profile,
         quotemeta($upload_id),
         quotemeta($tarchive_path)

--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -329,7 +329,7 @@ if ($dbase) {
 # call the updateMRI_upload script###
 if ($mri_upload_update) {
     my $script =  "updateMRI_Upload.pl"
-                 . " -profile $profile -globLocation -tarchivePath $finalTarget"
+                 . " -profile $profile -tarchivePath $finalTarget"
                  . " -sourceLocation $dcm_source";
     my $output = system($script);
     if ($output!=0)  {

--- a/dicom-archive/updateMRI_Upload.pl
+++ b/dicom-archive/updateMRI_Upload.pl
@@ -26,10 +26,6 @@ B<-tarchivePath tarchivePath> : (mandatory) absolute path to the DICOM archive
 =item *
 B<-source_location source_location> : (mandatory) value to set column 
     C<DecompressedLocation> for the newly created record in table C<mri_upload> (see below)
-    
-=item *
-B<-globLocation> : loosen the validity check of the DICOM archive allowing for the 
-     possibility that it was moved to a different directory.
 
 =item *
 B<-verbose> : be verbose
@@ -120,9 +116,6 @@ my $versionInfo = sprintf "%d revision %2d", q$Revision: 1.24 $
     =~ /: (\d+)\.(\d+)/;
 
 
-my $globArchiveLocation = 0;             # whether to use strict ArchiveLocation strings
-                                         # or to glob them (like '%Loc')
-
 my $Help = <<HELP;
 *******************************************************************************
 
@@ -142,7 +135,7 @@ HELP
 my $Usage = "------------------------------------------
 $0 updates the mri_upload table to populate the fields
 
-Usage:\n\t $0 -profile <profile> -sourceLocation src -tarchivePath path [-verbose] [-globLocation] [-timeZone tz] 
+Usage:\n\t $0 -profile <profile> -sourceLocation src -tarchivePath path [-verbose] [-timeZone tz]
 \n\n See $0 -help for more info\n\n";
 
 my @arg_table =
@@ -151,9 +144,6 @@ my @arg_table =
 	  ["-profile","string",1, \$profile, "Specify the name of the config file
           which resides in .loris_mri in the current directory."],
 	  ["-verbose", "boolean", 1, \$verbose, "Be verbose."],
-      ["-globLocation", "boolean", 1, \$globArchiveLocation, "Loosen the".
-       " validity check of the tarchive allowing for the possibility that".
-       " the tarchive was moved to a different directory."],
       ["-sourceLocation", "string", 1, \$source_location, "The location".
        " where the uploaded file exists."],
       ["-tarchivePath","string",1, \$tarchive, "The absolute path to".
@@ -242,9 +232,7 @@ $tarchive_path    =~ s/$tarchiveLibraryDir\/?//g;
 
 # Check if there is already an mri upload record for the tarchive
 my $mriUploadOB = NeuroDB::objectBroker::MriUploadOB->new(db => $db);
-my $resultRef = $mriUploadOB->getWithTarchive(
-    GET_COUNT, $tarchive_path, $globArchiveLocation
-);
+my $resultRef = $mriUploadOB->getWithTarchive(GET_COUNT, $tarchive_path);
 
 if($resultRef->[0]->{'COUNT(*)'} > 0) {
    print "\n\tERROR: the tarchive is already uploaded \n\n";
@@ -256,9 +244,7 @@ if($resultRef->[0]->{'COUNT(*)'} > 0) {
 ################################################################
 
 my $tarchiveOB = NeuroDB::objectBroker::TarchiveOB->new(db => $db);
-$resultRef = $tarchiveOB->getByTarchiveLocation(
-    ['TarchiveID'], $tarchive_path, $globArchiveLocation
-);
+$resultRef = $tarchiveOB->getByTarchiveLocation(['TarchiveID'], $tarchive_path);
 
 if(@$resultRef != 1) {
     die sprintf(

--- a/docs/04-Scripts.md
+++ b/docs/04-Scripts.md
@@ -105,7 +105,7 @@ encountered cases.
 For cases when a scan has triggered a protocol violation, the MINC volume can be
   **force-loaded** into LORIS by running:
 ```
-uploadNeuroDB/minc_insertion.pl -acquisition_protocol t2w -bypass_extra_file_checks -create_minc_pics -profile prod -globLocation -force  -tarchivePath /data/project/dataTransfer/library/2009/DCM_2009-09-25_project_20110214_185904581.tar -mincPath /data/project/data/trashbin/TarLoad-3-34-pVzGC5/xxx0067_703739_v12_20090925_222403_18e1_mri.mnc
+uploadNeuroDB/minc_insertion.pl -acquisition_protocol t2w -bypass_extra_file_checks -create_minc_pics -profile prod -force  -tarchivePath /data/project/dataTransfer/library/2009/DCM_2009-09-25_project_20110214_185904581.tar -mincPath /data/project/data/trashbin/TarLoad-3-34-pVzGC5/xxx0067_703739_v12_20090925_222403_18e1_mri.mnc
 ```
 
 Note carefully the following arguments:

--- a/docs/scripts_md/ImagingUpload.md
+++ b/docs/scripts_md/ImagingUpload.md
@@ -8,6 +8,7 @@ NeuroDB::ImagingUpload -- Provides an interface to the uploaded imaging file
 
     my $imaging_upload = &NeuroDB::ImagingUpload->new(
                            \$dbh,
+                           \$db,
                            $TmpDir_decompressed_folder,
                            $upload_id,
                            $patient_name,
@@ -33,7 +34,7 @@ and updates of the `mri_upload` table according to the upload status.
 
 ## Methods
 
-### new($dbhr, $uploaded\_temp\_folder, $upload\_id, ...) >> (constructor)
+### new($dbhr, $db, $uploaded\_temp\_folder, $upload\_id, ...) >> (constructor)
 
 Creates a new instance of this class. This constructor needs the location of
 the uploaded file. Once the uploaded file has been validated, it will be
@@ -41,6 +42,7 @@ moved to a final destination directory.
 
 INPUTS:
   - $dbhr                : database handler
+  - $db                  : MOOSE database handle
   - $uploaded\_temp\_folder: temporary directory of the upload
   - $upload\_id           : `uploadID` from the `mri_upload` table
   - $pname               : patient name
@@ -147,4 +149,4 @@ License: GPLv3
 
 # AUTHORS
 
-LORIS community &lt;loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -12,9 +12,7 @@ utilities
                           $logfile, $LogDir, $verbose
                         );
 
-    %tarchiveInfo     = $utility->createTarchiveArray(
-                          $ArchiveLocation, $globArchiveLocation
-                        );
+    %tarchiveInfo     = $utility->createTarchiveArray($ArchiveLocation);
 
     my ($center_name, $centerID) = $utility->determinePSC(\%tarchiveInfo,0);
 

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -135,14 +135,12 @@ INPUTS:
 RETURNS: subject's ID hash ref containing `CandID`, `PSCID`, Visit Label 
 and `CandMismatchError` information
 
-### createTarchiveArray($tarchive, $globArchiveLocation)
+### createTarchiveArray($tarchive)
 
 Creates the DICOM archive information hash ref.
 
 INPUTS:
   - $tarchive           : tarchive's path
-  - $globArchiveLocation: globArchiveLocation argument specified when running
-                           the insertion scripts
 
 RETURNS: DICOM archive information hash ref
 

--- a/docs/scripts_md/MriUploadOB.md
+++ b/docs/scripts_md/MriUploadOB.md
@@ -35,9 +35,7 @@ NeuroDB::objectBroker::MriUploadOB -- An object broker for MRI uploads
     my $mriUploadOB = NeuroDB::objectBroker::MriUploadOB->new(db => $db);
     my $mriUploadsRef;
     try {
-        $mriUploadsRef= $mriUploadOB->getWithTarchive(
-            1, '/tmp/my_tarchive.tar.gz', 1
-        );
+        $mriUploadsRef= $mriUploadOB->getWithTarchive(1, '/tmp/my_tarchive.tar.gz');
     } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
         die sprintf(
             "Failed to retrieve MRI uploads: %s",
@@ -63,7 +61,7 @@ INPUT: the database object used to read/modify the `mri_upload` table.
 
 RETURNS: new instance of this class.
 
-### getWithTarchive($isCount, $tarchiveLocation, $isBaseNameMatch)
+### getWithTarchive($isCount, $tarchiveLocation)
 
 Fetches the entries in the `mri_upload` table that have a specific archive
 location. This method throws a `NeuroDB::objectBroker::ObjectBrokerException`
@@ -73,8 +71,6 @@ INPUTS:
     - boolean indicating if only a count of the records found is needed
       or the full record properties.
     - path of the archive location.
-    - boolean indicating if a match is sought on the full archive name
-      or only the basename.
 
 RETURNS: a reference to an array of array references. If `$isCount` is true, then
          `$returnValue->[0]->[0]` will contain the count of records sought. Otherwise
@@ -107,5 +103,5 @@ License: GPLv3
 
 # AUTHORS
 
-LORIS community &lt;loris.info@mcin.ca> and McGill Centre for Integrative
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
 Neuroscience

--- a/docs/scripts_md/TarchiveOB.md
+++ b/docs/scripts_md/TarchiveOB.md
@@ -36,7 +36,7 @@ NeuroDB::objectBroker::TarchiveOB -- An object broker for `tarchive` records
     my $tarchivesRef;
     try {
         $tarchivesRef = $tarchiveOB->getByTarchiveLocation(
-            [ 'TarchiveID' ], '/tmp/my_tarchive.tar.gz', 1
+            [ 'TarchiveID' ], '/tmp/my_tarchive.tar.gz'
         );
     } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
         die sprintf(
@@ -62,7 +62,7 @@ INPUT: the database object used to read/modify the `tarchive` table.
 
 RETURN: new instance of this class.
 
-### getByTarchiveLocation($fieldsRef, $tarchiveLocation, $baseNameMatch)
+### getByTarchiveLocation($fieldsRef, $tarchiveLocation)
 
 Fetches the records from the `tarchive` table that have a specific archive location.
 
@@ -71,8 +71,6 @@ INPUTS:
       Each element of this array must exist in `@TARCHIVE_FIELDS` or an exception
       will be thrown.
     - path of the archive used during the search.
-    - boolean indicating if an exact match is sought (false) or if only basenames
-      should be used when comparing two archive locations (true).
 
 RETURN: a reference to an array of hash references. Every hash contains the values for a given 
         row returned by the function call: the key/value pairs contain the name of a column 
@@ -95,5 +93,5 @@ License: GPLv3
 
 # AUTHORS
 
-LORIS community &lt;loris.info@mcin.ca> and McGill Centre for Integrative
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
 Neuroscience

--- a/docs/scripts_md/batch_uploads_tarchive.md
+++ b/docs/scripts_md/batch_uploads_tarchive.md
@@ -52,5 +52,5 @@ License: GPLv3
 
 # AUTHORS
 
-LORIS community &lt;loris.info@mcin.ca> and McGill Centre for Integrative
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
 Neuroscience

--- a/docs/scripts_md/dicomTar.md
+++ b/docs/scripts_md/dicomTar.md
@@ -68,5 +68,5 @@ License: GPLv3
 # AUTHORS
 
 J-Sebastian Muehlboeck,
-LORIS community &lt;loris.info@mcin.ca> and McGill Centre for Integrative
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
 Neuroscience

--- a/docs/scripts_md/minc_insertion.md
+++ b/docs/scripts_md/minc_insertion.md
@@ -21,10 +21,6 @@ Available options are:
 
 \-tarchivePath: the absolute path to the tarchive file
 
-\-globLocation: loosens the validity check of the tarchive allowing
-               for the possibility that the tarchive was moved
-               to a different directory
-
 \-xlog        : opens an xterm with a tail on the current log file
 
 \-verbose     : if set, be verbose

--- a/docs/scripts_md/tarchiveLoader.md
+++ b/docs/scripts_md/tarchiveLoader.md
@@ -25,10 +25,6 @@ Available options are:
 \-reckless                : Upload data to database even if study protocol is
                            not defined or violated
 
-\-globLocation            : Loosen the validity check of the tarchive allowing
-                           for the possibility that the tarchive was moved to
-                           a different directory
-
 \-keeptmp                 : Keep temporary directory. Make sense if have
                            infinite space on your server
 

--- a/docs/scripts_md/tarchive_validation.md
+++ b/docs/scripts_md/tarchive_validation.md
@@ -16,10 +16,6 @@ Available options are:
 \-reckless    : upload data to the database even if the study protocol
                is not defined or if it is violated
 
-\-globLocation: loosen the validity check of the tarchive allowing for
-               the possibility that the tarchive was moved to a
-               different directory
-
 \-verbose     : boolean, if set, run the script in verbose mode
 
 # DESCRIPTION

--- a/docs/scripts_md/updateMRI_Upload.md
+++ b/docs/scripts_md/updateMRI_Upload.md
@@ -12,8 +12,6 @@ updateMRI\_Upload.pl \[options\] -profile prod -tarchivePath tarchivePath -sourc
 - **-tarchivePath tarchivePath** : (mandatory) absolute path to the DICOM archive
 - **-source\_location source\_location** : (mandatory) value to set column 
     `DecompressedLocation` for the newly created record in table `mri_upload` (see below)
-- **-globLocation** : loosen the validity check of the DICOM archive allowing for the 
-     possibility that it was moved to a different directory.
 - **-verbose** : be verbose
 
 # DESCRIPTION
@@ -43,4 +41,4 @@ License: GPLv3
 # AUTHORS
 
 Zia Mohades 2014 (zia.mohades@mcgill.ca),
-LORIS community &lt;loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative Neuroscience

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -244,7 +244,7 @@ sub IsCandidateInfoValid {
         }
 
         my $command = sprintf(
-            "%s/uploadNeuroDB/tarchiveLoader.pl -globLocation -profile %s %s -uploadID %s",
+            "%s/uploadNeuroDB/tarchiveLoader.pl -profile %s %s -uploadID %s",
             quotemeta($bin_dirPath),
             $this->{'profile'},
             quotemeta($archived_file_path),
@@ -444,7 +444,7 @@ sub runTarchiveLoader {
 
 
     my $command = sprintf(
-        "%s/uploadNeuroDB/tarchiveLoader.pl -globLocation -profile %s %s -uploadID %s",
+        "%s/uploadNeuroDB/tarchiveLoader.pl -profile %s %s -uploadID %s",
         quotemeta($bin_dirPath),
         $this->{'profile'},
         quotemeta($archived_file_path),

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -440,14 +440,12 @@ sub determineSubjectID {
 
 =pod
 
-=head3 createTarchiveArray($tarchive, $globArchiveLocation)
+=head3 createTarchiveArray($tarchive)
 
 Creates the DICOM archive information hash ref.
 
 INPUTS:
   - $tarchive           : tarchive's path
-  - $globArchiveLocation: globArchiveLocation argument specified when running
-                           the insertion scripts
 
 RETURNS: DICOM archive information hash ref
 
@@ -457,11 +455,8 @@ sub createTarchiveArray {
 
     my $this = shift;
     my %tarchiveInfo;
-    my ($tarchive,$globArchiveLocation) = @_;
-    my $where = "ArchiveLocation='$tarchive'";
-    if ($globArchiveLocation) {
-        $where = "ArchiveLocation LIKE '%".basename($tarchive)."'";
-    }
+    my ($tarchive) = @_;
+    my $where = "ArchiveLocation LIKE '%" . quotemeta(basename($tarchive)) . "%'";
     my $query = "SELECT PatientName, PatientID, PatientDoB, md5sumArchive,".
                 " DateAcquired, DicomArchiveID, PatientSex,".
                 " ScannerManufacturer, ScannerModel, ScannerSerialNumber,".

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -454,7 +454,8 @@ sub createTarchiveArray {
     my $this = shift;
     my %tarchiveInfo;
     my ($tarchive) = @_;
-    my $where = "ArchiveLocation LIKE '%" . quotemeta(basename($tarchive)) . "%'";
+    # CONCAT ensures that ArchiveLocation always contains a slash at the beginning
+    my $where = "CONCAT('/', ArchiveLocation) LIKE ? ";
     my $query = "SELECT PatientName, PatientID, PatientDoB, md5sumArchive,".
                 " DateAcquired, DicomArchiveID, PatientSex,".
                 " ScannerManufacturer, ScannerModel, ScannerSerialNumber,".
@@ -464,7 +465,7 @@ sub createTarchiveArray {
         print $query . "\n";
     }
     my $sth = ${$this->{'dbhr'}}->prepare($query);
-    $sth->execute();
+    $sth->execute("%/" . quotemeta(basename($tarchive)));
 
     if ($sth->rows > 0) {
         my $tarchiveInfoRef = $sth->fetchrow_hashref();

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -17,9 +17,7 @@ utilities
                         $logfile, $LogDir, $verbose
                       );
 
-  %tarchiveInfo     = $utility->createTarchiveArray(
-                        $ArchiveLocation, $globArchiveLocation
-                      );
+  %tarchiveInfo     = $utility->createTarchiveArray($ArchiveLocation);
 
   my ($center_name, $centerID) = $utility->determinePSC(\%tarchiveInfo,0);
 

--- a/uploadNeuroDB/NeuroDB/objectBroker/MriUploadOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriUploadOB.pm
@@ -113,15 +113,16 @@ sub getWithTarchive {
 
     my $select = $isCount ? 'COUNT(*)' : join(',', @MRI_UPLOAD_FIELDS);
 
+    # CONCAT ensures that ArchiveLocation always contains a slash at the beginning
     my $query = "SELECT $select "
         .       "FROM mri_upload "
         .       "JOIN tarchive USING(TarchiveID) "
-        .       "WHERE ArchiveLocation LIKE ? ";
+        .       "WHERE CONCAT('/', ArchiveLocation) LIKE ? ";
 
     try {
         return $self->db->pselect(
             $query,
-            '%' . basename($tarchiveLocation) . '%'
+            ('%/' . quotemeta(basename($tarchiveLocation)))
         );
     } catch(NeuroDB::DatabaseException $e) {
         NeuroDB::objectBroker::ObjectBrokerException->throw(

--- a/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
@@ -118,15 +118,16 @@ sub getByTarchiveLocation {
         }
     }
 
+    # CONCAT ensures that ArchiveLocation always contains a slash at the beginning
     my $query = sprintf(
-        "SELECT %s FROM tarchive WHERE ArchiveLocation LIKE ? ",
+        "SELECT %s FROM tarchive WHERE CONCAT('/', ArchiveLocation) LIKE ? ",
         join(',', (@$fieldsRef ? @$fieldsRef : @TARCHIVE_FIELDS)),
     );
 
     try {
         return $self->db->pselect(
             $query,
-            '%' . basename($tarchiveLocation) . '%'
+            ('%/' . quotemeta(basename($tarchiveLocation)))
         );
     } catch(NeuroDB::DatabaseException $e) {
         NeuroDB::objectBroker::ObjectBrokerException->throw(

--- a/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
@@ -40,7 +40,7 @@ NeuroDB::objectBroker::TarchiveOB -- An object broker for C<tarchive> records
   my $tarchivesRef;
   try {
       $tarchivesRef = $tarchiveOB->getByTarchiveLocation(
-          [ 'TarchiveID' ], '/tmp/my_tarchive.tar.gz', 1
+          [ 'TarchiveID' ], '/tmp/my_tarchive.tar.gz'
       );
   } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
       die sprintf(
@@ -89,7 +89,7 @@ has 'db' => (is  => 'rw', isa => 'NeuroDB::Database', required => 1);
 
 =pod
 
-=head3 getByTarchiveLocation($fieldsRef, $tarchiveLocation, $baseNameMatch)
+=head3 getByTarchiveLocation($fieldsRef, $tarchiveLocation)
 
 Fetches the records from the C<tarchive> table that have a specific archive location.
 
@@ -98,8 +98,6 @@ INPUTS:
       Each element of this array must exist in C<@TARCHIVE_FIELDS> or an exception
       will be thrown.
     - path of the archive used during the search.
-    - boolean indicating if an exact match is sought (false) or if only basenames
-      should be used when comparing two archive locations (true).
 
 RETURN: a reference to an array of hash references. Every hash contains the values for a given 
         row returned by the function call: the key/value pairs contain the name of a column 
@@ -110,7 +108,7 @@ RETURN: a reference to an array of hash references. Every hash contains the valu
 =cut
 
 sub getByTarchiveLocation {
-    my($self, $fieldsRef, $tarchiveLocation, $baseNameMatch) = @_;
+    my($self, $fieldsRef, $tarchiveLocation) = @_;
 
     foreach my $f (@$fieldsRef) {
         if(!grep($f eq $_, @TARCHIVE_FIELDS)) {
@@ -121,15 +119,14 @@ sub getByTarchiveLocation {
     }
 
     my $query = sprintf(
-        "SELECT %s FROM tarchive WHERE ArchiveLocation %s",
+        "SELECT %s FROM tarchive WHERE ArchiveLocation LIKE ? ",
         join(',', (@$fieldsRef ? @$fieldsRef : @TARCHIVE_FIELDS)),
-        $baseNameMatch ? 'LIKE ?' : '=?'
     );
 
     try {
         return $self->db->pselect(
             $query,
-            $baseNameMatch ? ('%' . basename($tarchiveLocation) . '%') : $tarchiveLocation
+            '%' . basename($tarchiveLocation) . '%'
         );
     } catch(NeuroDB::DatabaseException $e) {
         NeuroDB::objectBroker::ObjectBrokerException->throw(

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -340,15 +340,15 @@ QUERY
     $ArchiveLocation = $tarchive;
     $ArchiveLocation    =~ s/$tarchiveLibraryDir\/?//g;
 
-    my $where = "WHERE ArchiveLocation LIKE '%/" . quotemeta(basename($tarchive)) . "' "
-                 . "OR ArchiveLocation = '" . quotemeta(basename($tarchive)) . "'";
+    # CONCAT ensures that ArchiveLocation always contains a slash at the beginning
     my $query = "SELECT IsTarchiveValidated, UploadID, SourceLocation "
                 . "FROM mri_upload "
-                . "JOIN tarchive USING (TarchiveID) $where ";
+                . "JOIN tarchive USING (TarchiveID) "
+                . "WHERE CONCAT('/', ArchiveLocation) LIKE ? ";
     my $sth   = $dbh->prepare($query);
     print $query . "\n" if $debug;
 
-    $sth->execute();
+    $sth->execute('%/' . quotemeta(basename($tarchive)));
     my $errorMessage;
     if ($sth->rows == 0) {
         $errorMessage = "No mri_upload with the same archive location basename as '$tarchive'\n";

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -25,10 +25,6 @@ Available options are:
 
 -tarchivePath: the absolute path to the tarchive file
 
--globLocation: loosens the validity check of the tarchive allowing
-               for the possibility that the tarchive was moved
-               to a different directory
-
 -xlog        : opens an xterm with a tail on the current log file
 
 -verbose     : if set, be verbose
@@ -123,8 +119,7 @@ my $acquisitionProtocol=undef; # Specify the acquisition Protocol also bypasses 
 my $acquisitionProtocolID;     # acquisition Protocol id
 my $extra_validation_status;   # Initialise the extra validation status
 my $create_minc_pics    = 0;   # Default is 0, set the option to overide.
-my $globArchiveLocation = 0;   # whether to use strict ArchiveLocation strings
-                               # or to glob them (like '%Loc')
+
 my $template    = "TarLoad-$hour-$min-XXXXXX"; # for tempdir
 my ($tarchive,%studyInfo,$minc);
 my $User = getpwuid($>);
@@ -155,11 +150,6 @@ my @opt_table = (
 
                  ["-tarchivePath","string",1, \$tarchive, "The absolute path". 
                   " to tarchive-file"],
-
-                 ["-globLocation", "boolean", 1, \$globArchiveLocation,
-                  "Loosen the validity check of the tarchive allowing for the". 
-                  " possibility that the tarchive was moved to a different". 
-                  " directory."],
 
                  ["Fancy options","section"],
 
@@ -342,9 +332,7 @@ QUERY
     $ArchiveLocation = $array[1];
 
     # create the studyInfo object
-    %studyInfo = $utility->createTarchiveArray(
-        $ArchiveLocation, $globArchiveLocation
-    );
+    %studyInfo = $utility->createTarchiveArray($ArchiveLocation);
 
 } elsif ($tarchive) {
     # if only the tarchive path is given as an argument, find the associated UploadID
@@ -352,11 +340,8 @@ QUERY
     $ArchiveLocation = $tarchive;
     $ArchiveLocation    =~ s/$tarchiveLibraryDir\/?//g;
 
-    my $where = "WHERE ArchiveLocation='$tarchive'";
-    if ($globArchiveLocation) {
-        $where = "WHERE ArchiveLocation LIKE '%/" . quotemeta(basename($tarchive)) . "' "
+    my $where = "WHERE ArchiveLocation LIKE '%/" . quotemeta(basename($tarchive)) . "' "
                  . "OR ArchiveLocation = '" . quotemeta(basename($tarchive)) . "'";
-    }
     my $query = "SELECT IsTarchiveValidated, UploadID, SourceLocation "
                 . "FROM mri_upload "
                 . "JOIN tarchive USING (TarchiveID) $where ";
@@ -366,9 +351,7 @@ QUERY
     $sth->execute();
     my $errorMessage;
     if ($sth->rows == 0) {
-        $errorMessage = $globArchiveLocation
-            ? "No mri_upload with the same archive location basename as '$tarchive'\n"
-            : "No mri_upload with archive location '$tarchive'\n";
+        $errorMessage = "No mri_upload with the same archive location basename as '$tarchive'\n";
         $utility->writeErrorLog(
             $errorMessage, $NeuroDB::ExitCodes::INVALID_ARG, $logfile
         );
@@ -390,9 +373,7 @@ QUERY
     }
 
     # load the DICOM archive information from the tarchive table in studyInfo object
-    %studyInfo = $utility->createTarchiveArray(
-        $ArchiveLocation, $globArchiveLocation
-    );
+    %studyInfo = $utility->createTarchiveArray($ArchiveLocation);
 }
 
 if ((!defined $is_valid || $is_valid == 0) && !$force) {

--- a/uploadNeuroDB/tarchiveLoader.pl
+++ b/uploadNeuroDB/tarchiveLoader.pl
@@ -32,10 +32,6 @@ Available options are:
 -reckless                : Upload data to database even if study protocol is
                            not defined or violated
 
--globLocation            : Loosen the validity check of the tarchive allowing
-                           for the possibility that the tarchive was moved to
-                           a different directory
-
 -keeptmp                 : Keep temporary directory. Make sense if have
                            infinite space on your server
 
@@ -123,8 +119,6 @@ my $reckless    = 0;           # this is only for playing and testing. Don't
 my $force       = 0;           # This is a flag to force the script to run  
                                # Even if the validation has failed
 my $xlog        = 0;           # default should be 0
-my $globArchiveLocation = 0;   # whether to use strict ArchiveLocation strings
-                               # or to glob them (like '%Loc')
 my $valid_study = 0;
 my $newTarchiveLocation = undef;
 my $seriesuid   = undef;       # if you want to insert a specific SeriesUID
@@ -144,11 +138,6 @@ my @opt_table = (
                  ["Advanced options","section"],
                  ["-reckless", "boolean", 1, \$reckless,"Upload data to ".
                   "database even if study protocol is not defined or violated."
-                 ],
-                 ["-globLocation", "boolean", 1, \$globArchiveLocation,
-                  "Loosen the validity check of the tarchive allowing for ".
-                  "the possibility that the tarchive was moved to a different".
-                  " directory."
                  ],
                  ["Fancy options","section"],
 # fixme		 ["-keeptmp", "boolean", 1, \$keep, "Keep temporay directory. Make
@@ -352,10 +341,7 @@ my $notifier = NeuroDB::Notify->new(\$dbh);
 ################################################################
 my $ArchiveLocation    = $tarchive;
 $ArchiveLocation       =~ s/$tarchivePath\/?//g;
-my %tarchiveInfo = $utility->createTarchiveArray(
-                       $ArchiveLocation,
-                       $globArchiveLocation
-                   );
+my %tarchiveInfo = $utility->createTarchiveArray($ArchiveLocation);
 
 ################################################################
 ################## Call the validation script ##################
@@ -366,7 +352,6 @@ my $script = sprintf(
     quotemeta($profile),
     quotemeta($upload_id)
 );
-$script .= " -globLocation " if ($globArchiveLocation);
 $script .= " -verbose " if ($verbose);
 
 ################################################################
@@ -499,7 +484,6 @@ foreach my $minc (@minc_files) {
         quotemeta($upload_id)
     );
     $script .= " -force"                    if $force;
-    $script .= " -globLocation"             if $globArchiveLocation;
     $script .= " -verbose"                  if $verbose;
     $script .= " -bypass_extra_file_checks" if $bypass_extra_file_checks;
     if ($acquisitionProtocol) {

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -20,10 +20,6 @@ Available options are:
 -reckless    : upload data to the database even if the study protocol
                is not defined or if it is violated
 
--globLocation: loosen the validity check of the tarchive allowing for
-               the possibility that the tarchive was moved to a
-               different directory
-
 -verbose     : boolean, if set, run the script in verbose mode
 
 =head1 DESCRIPTION
@@ -108,8 +104,6 @@ my $profile     = undef;       # this should never be set unless you are in a
 my $upload_id;                 # uploadID associated with the tarchive to validate
 my $reckless    = 0;           # this is only for playing and testing. Don't
                                # set it to 1!!!
-my $globArchiveLocation = 0;   # whether to use strict ArchiveLocation strings
-                               # or to glob them (like '%Loc')
 my $template         = "TarLoad-$hour-$min-XXXXXX"; # for tempdir
 my ($sex, $tarchive,%tarchiveInfo);
 my $User             = getpwuid($>);
@@ -123,10 +117,6 @@ my @opt_table = (
                  ["-reckless", "boolean", 1, \$reckless,
                   "Upload data to database even if study protocol is not".
                   " defined or violated."],
-                 ["-globLocation", "boolean", 1, \$globArchiveLocation,
-                  "Loosen the validity check of the tarchive allowing for".
-                  " the possibility that the tarchive was moved to a". 
-                  " different directory."],
 
                  ["Fancy options","section"],
 
@@ -265,10 +255,7 @@ my $utility = NeuroDB::MRIProcessingUtility->new(
 $tarchiveLibraryDir    =~ s/\/$//g;
 my $ArchiveLocation    = $tarchive;
 $ArchiveLocation       =~ s/$tarchiveLibraryDir\/?//g;
-%tarchiveInfo = $utility->createTarchiveArray(
-                    $ArchiveLocation,
-                    $globArchiveLocation
-                );
+%tarchiveInfo = $utility->createTarchiveArray($ArchiveLocation);
 
 ################################################################
 #### Verify the archive using the checksum from database #######


### PR DESCRIPTION
### Description

These changes removes the option `-globLocation` from the pipeline scripts since now the `archiveLocation` is always a relative path, hence our scripts are always being used with the `-globLocation` turned on. This gets rid of the option and keep the behaviour in the pipeline as if the option was always given (a.k.a. querying the `tarchive` table with ` WHERE ArchiveLocation LIKE basename($tarchive)`

### Link to issues or PR

#527 

### Caveat for existing projects

Ensure to remove the `-globLocation` option from any call to the scripts that used to have that option in your own scripts or cron jobs.