### PR TITLE
Use TarchiveOB and MriUploadOB through the entire LORIS-MRI codebase.

### DIFF
--- a/dicom-archive/updateMRI_Upload.pl
+++ b/dicom-archive/updateMRI_Upload.pl
@@ -244,7 +244,7 @@ if($resultRef->[0]->{'COUNT(*)'} > 0) {
 ################################################################
 
 my $tarchiveOB = NeuroDB::objectBroker::TarchiveOB->new(db => $db);
-$resultRef = $tarchiveOB->getByTarchiveLocation(['TarchiveID'], $tarchive_path);
+$resultRef = $tarchiveOB->getByTarchiveLocation($tarchive_path);
 
 if(@$resultRef != 1) {
     die sprintf(

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -135,12 +135,14 @@ and `CandMismatchError` information
 
 ### createTarchiveArray($tarchive)
 
-Creates the DICOM archive information hash ref.
+Creates the DICOM archive information hash ref for the tarchive that has the same
+basename as the file path passed as argument.
 
 INPUTS:
-  - $tarchive           : tarchive's path
+  - $tarchive           : tarchive's path (absolute or relative).
 
-RETURNS: DICOM archive information hash ref
+RETURNS: DICOM archive information hash ref if exactly one archive was found. Exits
+         when either no match or multiple matches are found.
 
 ### determinePSC($tarchiveInfo, $to\_log, $upload\_id)
 

--- a/docs/scripts_md/TarchiveOB.md
+++ b/docs/scripts_md/TarchiveOB.md
@@ -62,19 +62,16 @@ INPUT: the database object used to read/modify the `tarchive` table.
 
 RETURN: new instance of this class.
 
-### getByTarchiveLocation($fieldsRef, $tarchiveLocation)
+### getByTarchiveLocation($tarchiveLocation)
 
 Fetches the records from the `tarchive` table that have a specific archive location.
 
 INPUTS:
-    - reference to an array of the column names to return for each record found.
-      Each element of this array must exist in `@TARCHIVE_FIELDS` or an exception
-      will be thrown.
     - path of the archive used during the search.
 
 RETURN: a reference to an array of hash references. Every hash contains the values for a given 
         row returned by the function call: the key/value pairs contain the name of a column 
-        (as it appears in the array referenced by `$fieldsRef`) and the value it holds, respectively.
+        (listed in `@TARCHIVE_FIELDS`) and the value it holds, respectively.
         As an example, suppose array `$r` contains the result of a call to this method with 
         `@$fieldsRef` set to `('TarchiveID', 'SourceLocation'` one would fetch the `TarchiveID` 
         of the 4th record returned using `$r-`\[3\]->{'TarchiveID'}>.

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -458,9 +458,7 @@ sub createTarchiveArray {
     my ($tarchive) = @_;
 
     my $tarchiveOB = NeuroDB::objectBroker::TarchiveOB->new(db => $this->{'db'});
-    my $tarchiveInfoRef = $tarchiveOB->getByTarchiveLocation(
-        \@NeuroBD::objectBroker::TarchiveOB::TARCHIVE_FIELDS, $tarchive
-    );
+    my $tarchiveInfoRef = $tarchiveOB->getByTarchiveLocation($tarchive);
 
     if (!@$tarchiveInfoRef) {
         my $message = "\nERROR: Only archived data can be uploaded.".

--- a/uploadNeuroDB/NeuroDB/objectBroker/MriUploadOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriUploadOB.pm
@@ -71,7 +71,8 @@ use TryCatch;
 
 # These are the only fields modified when inserting a new MRI upload record
 my @MRI_UPLOAD_FIELDS = (
-    'UploadedBy' ,'UploadDate','TarchiveID','DecompressedLocation', 'UploadLocation', 'PatientName'
+    'UploadedBy' ,'UploadDate','TarchiveID','DecompressedLocation', 'UploadLocation', 'PatientName',
+    'IsTarchiveValidated', 'UploadID'
 );
 
 =pod
@@ -111,7 +112,9 @@ RETURNS: a reference to an array of array references. If C<$isCount> is true, th
 sub getWithTarchive {
     my($self, $isCount, $tarchiveLocation) = @_;
 
-    my $select = $isCount ? 'COUNT(*)' : join(',', @MRI_UPLOAD_FIELDS);
+    # We must preceed all the MRI upload fields with the table name they are issued from
+    # to avoid clashes with fields in table tarchive when building the SQL statement later on  
+    my $select = $isCount ? 'COUNT(*)' : join(',', (map { "mri_upload.$_" } @MRI_UPLOAD_FIELDS));
 
     # CONCAT ensures that ArchiveLocation always contains a slash at the beginning
     my $query = "SELECT $select "

--- a/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
@@ -70,7 +70,7 @@ use File::Basename;
 
 use TryCatch;
 
-our @TARCHIVE_FIELDS = qw(
+my @TARCHIVE_FIELDS = qw(
     TarchiveID ArchiveLocation PatientName PatientID PatientDoB md5sumArchive
     ScannerManufacturer ScannerModel ScannerSerialNumber ScannerSoftwareVersion
     neurodbCenterName SourceLocation
@@ -93,39 +93,28 @@ has 'db' => (is  => 'rw', isa => 'NeuroDB::Database', required => 1);
 
 =pod
 
-=head3 getByTarchiveLocation($fieldsRef, $tarchiveLocation)
+=head3 getByTarchiveLocation($tarchiveLocation)
 
 Fetches the records from the C<tarchive> table that have a specific archive location.
 
 INPUTS:
-    - reference to an array of the column names to return for each record found.
-      Each element of this array must exist in C<@TARCHIVE_FIELDS> or an exception
-      will be thrown.
     - path of the archive used during the search.
 
 RETURN: a reference to an array of hash references. Every hash contains the values for a given 
         row returned by the function call: the key/value pairs contain the name of a column 
-        (as it appears in the array referenced by C<$fieldsRef>) and the value it holds, respectively.
+        (listed in C<@TARCHIVE_FIELDS>) and the value it holds, respectively.
         As an example, suppose array C<$r> contains the result of a call to this method with 
         C<@$fieldsRef> set to C<('TarchiveID', 'SourceLocation'> one would fetch the C<TarchiveID> 
         of the 4th record returned using C<$r->[3]->{'TarchiveID'}>.
 =cut
 
 sub getByTarchiveLocation {
-    my($self, $fieldsRef, $tarchiveLocation) = @_;
-
-    foreach my $f (@$fieldsRef) {
-        if(!grep($f eq $_, @TARCHIVE_FIELDS)) {
-            NeuroDB::objectBroker::ObjectBrokerException->throw(
-                errorMessage => "Failed to retrieve tarchive record: invalid tarchive field $f"
-            );
-        }
-    }
+    my($self, $tarchiveLocation) = @_;
 
     # CONCAT ensures that ArchiveLocation always contains a slash at the beginning
     my $query = sprintf(
         "SELECT %s FROM tarchive WHERE CONCAT('/', ArchiveLocation) LIKE ? ",
-        join(',', (@$fieldsRef ? @$fieldsRef : @TARCHIVE_FIELDS)),
+        join(',', @TARCHIVE_FIELDS),
     );
 
     try {

--- a/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
@@ -70,7 +70,11 @@ use File::Basename;
 
 use TryCatch;
 
-my @TARCHIVE_FIELDS = qw(TarchiveID ArchiveLocation);
+our @TARCHIVE_FIELDS = qw(
+    TarchiveID ArchiveLocation PatientName PatientID PatientDoB md5sumArchive
+    ScannerManufacturer ScannerModel ScannerSerialNumber ScannerSoftwareVersion
+    neurodbCenterName SourceLocation
+);
 
 =pod
 


### PR DESCRIPTION
Code that searches for either an archive with a specific basename or an MRI upload ties to an archive with a specific basename should be refactored to use either the `TarchiveOB` or `MriUploadOB`. 

Fixes #531 