### PR TITLE
[bug_fix] Fix pipelines errors when running the pipeline on a Mac OS X sandbox

### DIFF
--- a/INSTALL.Mac.md
+++ b/INSTALL.Mac.md
@@ -96,6 +96,26 @@ pip install nilearn
 brew install md5sha1sum
 ```
 
+## Install GNU `grep`
+ 
+One of the command run in the insertion pipeline uses a functionality of `grep` that
+can only be found in the GNU version of `grep` for Mac. The default installed version
+of `grep` in a Mac install does not include the possibility to search based on a 
+perl regular expression (option `-P`).
+```
+brew install grep
+```
+
+And add the following to the .bash_profile of the user that will be running the 
+pipeline so that the Linux `grep` is used when running the pipeline instead of 
+the Mac `grep`.
+
+```
+# Add path to linux grep instead of the Mac grep as the Mac one does 
+# not have all the functionatities needed by the LORIS imaging pipeline
+PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"
+```
+
 ## Run install script for Mac: imaging_install_MacOSX.sh 
 
 ```

--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -200,10 +200,10 @@ my $system          = `uname`;
 
 
 # Remove all files starting with . in the dcm_source directory
-my $cmd = "cd " . $dcm_source . "; find -type f -name '.*' | xargs rm -f";
+my $cmd = "cd " . $dcm_source . "; find . -type f -name '.*' | xargs rm -f";
 system($cmd);
 # Remove __MACOSX directory
-my $cmd = "cd " . $dcm_source . "; find -name '__MACOSX' | xargs rm -rf";
+$cmd = "cd " . $dcm_source . "; find . -name '__MACOSX' | xargs rm -rf";
 system($cmd);
 
 # create new summary object

--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -199,12 +199,10 @@ $hostname = inet_ntoa($hostname);
 my $system          = `uname`;
 
 
-# Remove all files starting with . in the dcm_source directory
-my $cmd = "cd " . $dcm_source . "; find . -type f -name '.*' | xargs rm -f";
-system($cmd);
-# Remove __MACOSX directory
-$cmd = "cd " . $dcm_source . "; find . -name '__MACOSX' | xargs rm -rf";
-system($cmd);
+# Remove all files starting with . and __MACOSX in the dcm_source directory
+my @args = ($dcm_source);
+push(@args, qw/-type -f -name __MACOSX -delete -o -name .* -delete/);
+system('find', @args);
 
 # create new summary object
 my $summary = DICOM::DCMSUM->new($dcm_source,$targetlocation);

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -189,7 +189,7 @@ sub IsCandidateInfoValid {
     ####Get a list of files from the folder#####################
     #############Loop through the files#########################
     ############################################################
-    my $cmd = "find -path " . quotemeta($this->{'uploaded_temp_folder'}) . " -name '__MACOSX' -delete ";
+    my $cmd = "find " . quotemeta($this->{'uploaded_temp_folder'}) . " -name '__MACOSX' -delete ";
     print "\n $cmd \n";
     system($cmd);
 


### PR DESCRIPTION
### Description

Fixed several errors that occurs when running the imaging pipeline on a Mac sandbox, including some Mac install updates. 

Note, the changes made do not change the behaviour of the pipeline on a Linux computer.