### PR TITLE
[bug fix] Fixes a bug in MakeArchiveLocationRelative.pl

### DIFF
--- a/tools/MakeArchiveLocationRelative.pl
+++ b/tools/MakeArchiveLocationRelative.pl
@@ -106,7 +106,7 @@ print "\n==> Successfully connected to database \n";
 
 my $configOB = NeuroDB::objectBroker::ConfigOB->new(db => $db);
 
-my $tarchiveLibraryDir = $configOB->getDataDirPath();
+my $tarchiveLibraryDir = $configOB->getTarchiveLibraryDir();
 $tarchiveLibraryDir    =~ s/\/$//g;
 
 


### PR DESCRIPTION
During the refactoring of the config table SQL call, a typo was inserted in `MakeArchiveLocationRelative.pl` rendering the script to not run properly as instead of getting the `tarchiveLibraryDir`, the script fetched `dataDir` config setting.