### PR TITLE
Fixed invalid find command in dicomTar.pl.

### DIFF
--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -201,7 +201,7 @@ my $system          = `uname`;
 
 # Remove all files starting with . and __MACOSX in the dcm_source directory
 my @args = ($dcm_source);
-push(@args, qw/-type -f -name __MACOSX -delete -o -name .* -delete/);
+push(@args, qw/-type f -name __MACOSX -delete -o -name .* -delete/);
 system('find', @args);
 
 # create new summary object


### PR DESCRIPTION
Fixed the invalid find command in script `dicomTar.pl` that fails to delete files with name `__MACOSX`.