### PR TITLE
Missing notifications when the pipeline cannot create a visit.

### DIFF
--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -541,11 +541,6 @@ my($sessionRef, $errMsg) = NeuroDB::MRI::getSessionInformation(
     $db
 );
 
-# Copy the session info into the %$subjectIDsref hash array
-$subjectIDsref->{'SessionID'}    = $sessionRef->{'ID'};
-$subjectIDsref->{'ProjectID'}    = $sessionRef->{'ProjectID'};
-$subjectIDsref->{'SubprojectID'} = $sessionRef->{'SubprojectID'};
- 
 # Session cannot be retrieved from the DB and, if createVisitLabel is set to
 # 1, creation of a new session failed
 if (!$sessionRef) {
@@ -561,6 +556,11 @@ if (!$sessionRef) {
         : $NeuroDB::ExitCodes::GET_SESSION_ID_FAILURE);
 } 
 
+# Copy the session info into the %$subjectIDsref hash array
+$subjectIDsref->{'SessionID'}    = $sessionRef->{'ID'};
+$subjectIDsref->{'ProjectID'}    = $sessionRef->{'ProjectID'};
+$subjectIDsref->{'SubprojectID'} = $sessionRef->{'SubprojectID'};
+ 
 ################################################################
 ############ Compute the md5 hash ##############################
 ################################################################


### PR DESCRIPTION
When the pipeline tries to create a visit to insert a scan and cannot do so because either the project ID or subproject ID in the `prod` file are invalid, there should be an entry in table `notification_spool` indicating so.

# To test

1. Edit your `prod` file and make sure that `createVisitLabel` is set to 1. 
2. In your `prod` file, Specify a `SubprojectID` that does not exist for your project
3. Try to insert a scan for a candidate/visit such that there are no entries in table `session` for that candidate/visit.
 
Ensure that once the pipeline finishes, there is a notification in table `notification_spool` stating that the projectID/subprojectID specifications are invalid and the session could not be created.

Fixes #541 