### PR TITLE
Ensure Reason column of table MRICandidateErrors does not contain newlines

### DIFF
--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -513,6 +513,16 @@ if (defined($subjectIDsref->{'CandMismatchError'})) {
         "(SeriesUID, TarchiveID, MincFile, PatientName, Reason) ".
         "VALUES (?, ?, ?, ?, ?)";
     my $candlogSth = $dbh->prepare($logQuery);
+
+    # Strip all trailing newlines from the error message. Reason:
+    # you cannot search for records in the LORIS MRI violations
+    # module that have a message (i.e. a rejection reason) containing
+    # a newline
+    my $originalSeparatorValue = $/;
+    $/ = '';
+    chomp $CandMismatchError;
+    $/ = $originalSeparatorValue;
+
     $candlogSth->execute(
         $file->getParameter('series_instance_uid'),
         $studyInfo{'TarchiveID'},


### PR DESCRIPTION
As the title says. Reasons with newlines have been found to cause problems in the MRI Violations module on the LORIS side. See https://github.com/aces/Loris/issues/6366

# Associated PR on the LORIS side:

https://github.com/aces/Loris/pull/6366

Note: although these PRs are related, they can be merged separately.