### PR TITLE
[python] fix bug when visits have different modalities

### DIFF
--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -201,18 +201,21 @@ class BidsReader:
         cand_session_modalities_list = []
 
         for subject, visit_list in self.cand_sessions_list.items():
-            cand_session_dict = {'bids_sub_id': subject}
             if visit_list:
                 for visit in visit_list:
-                    cand_session_dict['bids_ses_id'] = visit
                     modalities = self.bids_layout.get_datatype(subject=subject, session=visit)
-                    cand_session_dict['modalities'] = modalities
+                    cand_session_modalities_list.append({
+                        'bids_sub_id': subject,
+                        'bids_ses_id': visit,
+                        'modalities' : modalities
+                    })
             else:
-                cand_session_dict['bids_ses_id'] = None
                 modalities = self.bids_layout.get_datatype(subject=subject)
-                cand_session_dict['modalities'] = modalities
-
-            cand_session_modalities_list.append(cand_session_dict)
+                cand_session_modalities_list.append({
+                    'bids_sub_id': subject,
+                    'bids_ses_id': None,
+                    'modalities' : modalities
+                })
 
         if self.verbose:
             print('\t=> Done grepping the different modalities from the BIDS layout\n')


### PR DESCRIPTION
There is a bug in the current code for the BIDS import script that does not allow sessions to import all modalities when session have different modalities.

Example of a dataset with different modalities per visits:
```
sub-01
  |__ ses-01
         |__ func
         |__ fmap
  |__ ses-02
         |__ func
         |__ fmap
  |__ ses-03
          |__ anat
```
In the case of such a dataset, only `anat` modalities would be inserted before the bug fix (the content of the latest visit)...

This PR fixes this bug and allows for the insertion of all modalities into the database even when sessions do not have the same modalities.