### PR TITLE
Get rid of master references in the docs to use the main branch instead

### DIFF
--- a/INSTALL.Mac.md
+++ b/INSTALL.Mac.md
@@ -7,7 +7,7 @@ For best results, we recommend installing LORIS on Ubuntu or CentOS.
 This file provides guidance on how to install the imaging pipeline on your Mac computer. LORIS must already be installed.
 
 It has been tested for Mac OS X 10.13. 
-Updates and contributions welcome (also see [Contributing Guide](https://github.com/aces/Loris/blob/master/CONTRIBUTING.md)) 
+Updates and contributions welcome (also see [Contributing Guide](https://github.com/aces/Loris/blob/main/CONTRIBUTING.md)) 
 
 ## Get the code
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ See [aces/Loris](https://github.com/aces/loris) README.md for further informatio
    sudo mkdir -p /data/$projectname/bin/mri
    sudo chown -R lorisadmin:lorisadmin /data/$projectname
    cd /data/$projectname/bin
-   git clone -b master https://github.com/aces/Loris-MRI.git mri
    ```
+
+Get the code: Download the latest release from the 
+[releases page](https://github.com/aces/Loris-MRI/releases) 
+and extract it to `/data/$projectname/bin/mri`
 
 #### 2. Install Python 3 with `pip` and `virtualenv`
 
@@ -81,7 +84,7 @@ For the defacing scripts, you will also need to download the pre-compiled `bic-m
   If the imaging install script reports errors in creating directories 
   (due to `/data/` mount permissions), review and manually execute 
   `mkdir/chmod/chown` commands starting at 
-  [imaging_install.sh:L97](https://github.com/aces/Loris-MRI/blob/master/imaging_install.sh#L97)
+  [imaging_install.sh:L97](https://github.com/aces/Loris-MRI/blob/main/imaging_install.sh#L97)
 
   Note: The installer will allow Apache to write to the `/data/` directories by 
   adding user `lorisadmin` to the Apache linux group.  To ensure this change takes 

--- a/docs/02-Install.md
+++ b/docs/02-Install.md
@@ -162,7 +162,7 @@ uploaded through the Imaging Uploader GUI or not, pipeline insertion progress
 can be consulted through a live 'Log Viewer' panel.
 Some settings need to be configured properly (`php.ini` variables, 
 `MRI-Upload Directory` and `ImagingUploader Auto Launch`), and are documented in 
-the [LORIS repository: Imaging Uploader Specification](https://github.com/aces/Loris/blob/master/modules/imaging_uploader/README.md).
+the [LORIS repository: Imaging Uploader Specification](https://github.com/aces/Loris/blob/main/modules/imaging_uploader/README.md).
 
 
 2. **DICOM Archive**
@@ -175,7 +175,7 @@ Patient Name/Patient ID header values are displayed in full, or show up as
 **INVALID-HIDDEN**.
 
 More detailed specifications can be consulted in the 
-[LORIS repository: DICOM Archive Specification](https://github.com/aces/Loris/blob/master/modules/dicom_archive/README.md).
+[LORIS repository: DICOM Archive Specification](https://github.com/aces/Loris/blob/main/modules/dicom_archive/README.md).
 
 
 3. **Imaging Browser**
@@ -189,7 +189,7 @@ some files. Ensure that:
   `Images` settings are set (typically: `/data/$PROJECT/data/`). 
     
 More detailed specifications can be consulted in the 
-[LORIS repository: Imaging Browser Specification](https://github.com/aces/Loris/blob/master/modules/imaging_browser/README.md).
+[LORIS repository: Imaging Browser Specification](https://github.com/aces/Loris/blob/main/modules/imaging_browser/README.md).
 
 4. **Brainbrowser**
 
@@ -203,7 +203,7 @@ images directly from the filesystem. Ensure that:
       proper MINC toolkit path in the `<MINCToolsPath>` tagset.
       
 More detailed specifications can be consulted in the 
-[LORIS repository: Brainbrowser Specification](https://github.com/aces/Loris/blob/master/modules/brainbrowser/README.md).
+[LORIS repository: Brainbrowser Specification](https://github.com/aces/Loris/blob/main/modules/brainbrowser/README.md).
 
 
 5. **MRI Violated Scans**
@@ -217,7 +217,7 @@ Imaging Browser module. Violated scans can be viewed and the type of error
 (scan identification, protocol violation) can be reviewed from the front-end.
 
 More detailed specifications can be consulted in the 
-[LORIS repository: MRI Violated Scans Specification](https://github.com/aces/Loris/blob/master/modules/mri_violations/README.md).
+[LORIS repository: MRI Violated Scans Specification](https://github.com/aces/Loris/blob/main/modules/mri_violations/README.md).
 
 
 6. **Electrophysiology Browser**

--- a/docs/AppendixA-Troubleshooting_guideline.md
+++ b/docs/AppendixA-Troubleshooting_guideline.md
@@ -92,7 +92,7 @@ Error and output messages from the imaging insertion scripts are logged in files
 ***Caveat:*** When the imaging insertion pipeline is auto-launched by the
   Imaging Uploader module, the pipeline scripts' log files are output to
   `/tmp/` and deleted. To avoid deletion, edit the Server Processes Manager
-  function [deleteProcessFiles()](https://github.com/aces/Loris/blob/master/modules/server_processes_manager/php/AbstractServerProcess.class.inc#L521)
+  function [deleteProcessFiles()](https://github.com/aces/Loris/blob/main/modules/server_processes_manager/php/AbstractServerProcess.class.inc#L521)
   to return false instead of true.
 
 ### A.4 Insertion script troubleshooting notes


### PR DESCRIPTION
This gets rid of references to the `master` branch from the LORIS-MRI documentations and uses the new defaults `main` branch instead.

The README instruction was also modified in favour of installing releases instead of cloning `master` as users should use official releases instead of the development branch. This mimics the behaviour from the LORIS repo.