### PR TITLE
Populate the added AcquisitionDate field in the files table

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1237,6 +1237,13 @@ sub registerScanIntoDB {
             $file_path
         );
 
+        #### set the acquisition_date
+        my $acquisition_date = $${minc_file}->getParameter('acquisition_date') || undef;
+        $${minc_file}->setFileData(
+            'AcquisitionDate',
+            $acquisition_date
+        );
+
         ########################################################
         ### record which tarchive was used to make this file ###
         ########################################################


### PR DESCRIPTION
This modifies the pipeline to include the insertion of the acquisition date information in the new `AcquisitionDate` field of the `files` table that is introduced by https://github.com/aces/Loris/pull/6892.

Reasons for adding this field in the files table are summarized in https://github.com/aces/Loris/issues/6883.

See #553 for the LORIS-MRI issue.