### PR TITLE
Fixed script imaging_install.sh that fails on CentOS.

### DIFF
--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -203,11 +203,10 @@ echo
 ################################################################################################
 #####################################DICOM TOOLKIT##############################################
 ################################################################################################
-os_distro=$(lsb_release -si)
-if [ $os_distro  = "CentOS" ]; then
+if cat /etc/os-release | grep ^NAME | fgrep -q CentOS ; then
     echo "You are running CentOS. Please also see Loris-MRI Readme for notes and links to further documentation in our main GitHub Wiki on how to install the DICOM Toolkit and other required dependencies."
 else
-    #Check if apt-get is install
+    #Check if apt-get is installed
     APTGETCHECK=`which apt-get`
     if [ ! -f "$APTGETCHECK" ]; then
         echo "\nERROR: Unable to find apt-get"


### PR DESCRIPTION
Script `imaging_install.sh` fails on CentOS. The script uses Unix command `lsb_release` in an attempt to find what OS the user is using but this command does not exist on CentOS...This PR uses a more reliable way to determine the system's OS.

Although not directly related to this PR, I also updated the install wiki for CentOS: https://github.com/aces/Loris/wiki/CentOS-Imaging-installation-transcript. The updates mentions two additional Python libraries that need to be installed for `imaging_install.sh` to work on CentOS. When testing that the new `imaging_install.sh` script in this PR, be sure to follow the **new** CentOS install instructions.