### PR TITLE
Missing import fix

### DIFF
--- a/python/lib/candidate.py
+++ b/python/lib/candidate.py
@@ -3,7 +3,7 @@
 import random
 from dateutil.parser import parse
 import lib.exitcode
-
+import sys
 
 __license__ = "GPLv3"
 


### PR DESCRIPTION
L106 is using sys without importing it, causing a python error.