### PR TITLE
[23.0.0][Bugfix] Fixing error for deleting __MACOSX folder

### DIFF
--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -201,7 +201,8 @@ my $system          = `uname`;
 
 # Remove all files starting with . and __MACOSX in the dcm_source directory
 my @args = ($dcm_source);
-push(@args, qw/-type f -name __MACOSX -delete -o -name .* -delete/);
+push(@args, qw/-type f -name .* -delete -o -type d -name __MACOSX -exec rm -rf {} +/);
+print "find @args";
 system('find', @args);
 
 # create new summary object

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -189,7 +189,7 @@ sub IsCandidateInfoValid {
     ####Get a list of files from the folder#####################
     #############Loop through the files#########################
     ############################################################
-    my $cmd = "find " . quotemeta($this->{'uploaded_temp_folder'}) . " -name '__MACOSX' -delete ";
+    my $cmd = "find " . quotemeta($this->{'uploaded_temp_folder'}) . " -name '__MACOSX' -exec rm -rf {} + ";
     print "\n $cmd \n";
     system($cmd);
 


### PR DESCRIPTION
Was getting this error when trying to insert a scan:

```
 find \/data\/not_backed_up\/ImagingUpload\-17\-45\-h4XhVY -name '__MACOSX' -delete  
find: cannot delete ‘/data/not_backed_up/ImagingUpload-17-45-h4XhVY/__MACOSX’: Directory not empty
```