### PR TITLE
[22.0][Bugfix] Undef EchoTime, RepTime and SliceThickness

### DIFF
--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -327,11 +327,11 @@ QUERY
         if ($invT eq '') {
             $invT = undef;
         }
-        if ($seriesName =~ /ColFA$/i) {
-            $echoT        = undef;    
-            $repT         = undef;
-            $sl_thickness = undef;
-        }
+
+        $echoT        = undef unless ($echoT =~ /\d+/);
+        $repT         = undef unless ($repT =~ /\d+/);
+        $sl_thickness = undef unless ($sl_thickness =~ /\d+/);
+
         if ($modality eq 'MR') {
             my @values = 
               (
@@ -340,7 +340,8 @@ QUERY
                $invT,       $sl_thickness, $phaseEncode, 
                $num,        $seriesUID,    $modality
               );
-            $success = $insert_series->execute(@values);
+        print "@values\n";    
+	$success = $insert_series->execute(@values);
         } elsif ($modality eq 'PT') {
             my @values = 
               (

--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -340,8 +340,7 @@ QUERY
                $invT,       $sl_thickness, $phaseEncode, 
                $num,        $seriesUID,    $modality
               );
-        print "@values\n";    
-	$success = $insert_series->execute(@values);
+	    $success = $insert_series->execute(@values);
         } elsif ($modality eq 'PT') {
             my @values = 
               (


### PR DESCRIPTION
Was having issues with inserting an image for DTI_TENSOR that had no values for EchoTime, RepTime and SliceThickness. 

This fix generalizes that any series type with empty values for those fields should be replaced by `undef`.