### PR TITLE
Fix create candidate bug in 22.0.0 when Config createCandidate is set to yes

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -416,9 +416,11 @@ sub determineSubjectID {
     );
 
     # create the candidate if it does not exist
-    $this->CreateMRICandidates(
-        $subjectIDsref, $tarchiveInfo, $User, $centerID, $upload_id
-    );
+    unless (NeuroDB::MRI::subjectIDExists('PSCID', $subjectIDsref->{'PSCID'}, $this->{dbhr})) {
+        $this->CreateMRICandidates(
+            $subjectIDsref, $tarchiveInfo, $User, $centerID, $upload_id
+        );
+    }
 
     # check if the candidate information is valid
     $subjectIDsref->{'CandMismatchError'} = $this->validateCandidate($subjectIDsref, $upload_id);

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -416,7 +416,10 @@ sub determineSubjectID {
     );
 
     # create the candidate if it does not exist
-    unless (NeuroDB::MRI::subjectIDExists('PSCID', $subjectIDsref->{'PSCID'}, $this->{dbhr})) {
+    unless (
+        NeuroDB::MRI::subjectIDExists('PSCID', $subjectIDsref->{'PSCID'}, $this->{dbhr})
+        || NeuroDB::MRI::subjectIDExists('CandID', $subjectIDsref->{'CandID'}, $this->{dbhr})
+      ) {
         $this->CreateMRICandidates(
             $subjectIDsref, $tarchiveInfo, $User, $centerID, $upload_id
         );


### PR DESCRIPTION
When the Config setting `createCandidates` is set to Yes, the pipeline always go into the `CreateMRICandidates` function of `MRIProcessingUtility.pm` and returns the following error:

```
Spool message is: ERROR: Cannot create candidate (MTL0001, 123456) as a candidate with PSCID=MTL0001 already exists
```

This adds an if statement before calling the function `CreateMRICandidates` to check first if a candidate with the PSCID already exists. If it exists, the call to the function `CreateMRICandidates` will be skipped.

NOTES: this bug fix does not apply to 23.0 since the code to determine candidate information has been revamped and is working well.