### PR TITLE
fix scan.json wrongly taken instead of scan.tsv

### DIFF
--- a/python/lib/mri.py
+++ b/python/lib/mri.py
@@ -143,7 +143,7 @@ class Mri:
         self.scans_file = None
         if self.bids_layout.get(suffix='scans', subject=self.psc_id, return_type='filename'):
             self.scans_file = \
-            self.bids_layout.get(suffix='scans', subject=self.psc_id, return_type='filename')[0]
+            self.bids_layout.get(suffix='scans', subject=self.psc_id, return_type='filename', extension='tsv')[0]
 
         # loop through NIfTI files and register them in the DB
         for nifti_file in self.nifti_files:


### PR DESCRIPTION
This PR fix issue #577
In importing bids dataset, scan.json is wrongly parsed instead of scan.tsv

The solution has been consulted with @cmadjar , who provided input and shares the credit.
Please assign @cmadjar as one reviewer.

cc:
@gdevenyi