### PR TITLE
Remove warnings in minc_insertion scripts when -bypass_extra_file_checks is used

### DIFF
--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -205,7 +205,8 @@ INPUTS:
 RETURNS:
   - $acquisitionProtocol     : acquisition protocol
   - $acquisitionProtocolID   : acquisition protocol ID
-  - $extra\_validation\_status : extra validation status ("pass", "exclude", "warning")
+  - $extra\_validation\_status : extra validation status ("pass", "exclude", "warning") or
+                               `undef` if `$bypass_extra_file_checks` is set.
 
 ### extra\_file\_checks($scan\_type, $file, $subjectIdsref, $pname)
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -675,7 +675,8 @@ INPUTS:
 RETURNS:
   - $acquisitionProtocol     : acquisition protocol
   - $acquisitionProtocolID   : acquisition protocol ID
-  - $extra_validation_status : extra validation status ("pass", "exclude", "warning")
+  - $extra_validation_status : extra validation status ("pass", "exclude", "warning") or
+                               C<undef> if C<$bypass_extra_file_checks> is set.
 
 =cut
 
@@ -1190,7 +1191,8 @@ sub registerScanIntoDB {
         || (defined(&Settings::isFileToBeRegisteredGivenProtocol)
             && Settings::isFileToBeRegisteredGivenProtocol($acquisitionProtocol)
            )
-        ) && $extra_validation_status !~ /exclude/) {
+        ) && (!defined($extra_validation_status) || $extra_validation_status !~ /exclude/)
+    ) {
 
         ########################################################
         # convert the textual scan_type into the scan_type id ##

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -603,7 +603,11 @@ my $acquisitionProtocolIDFromProd = $utility->registerScanIntoDB(
 # if the scan was inserted into the files table and there is an
 # extra_validation_status set to 'warning', update the mri_violations_log table
 # MincFile field with the path of the file in the assembly directory
-if (defined $acquisitionProtocolIDFromProd && $extra_validation_status eq 'warning') {
+if (
+       defined $acquisitionProtocolIDFromProd
+    && defined($extra_validation_status)
+    && $extra_validation_status eq 'warning'
+) {
     $utility->update_mri_violations_log_MincFile_path($file);
 }
 


### PR DESCRIPTION
This PR removes warnings that were issued when script `minc_insertion.pl` was run with option `bypass_extra_file_checks`. 

Fixes #575.
