### PR TITLE
Fixed wrong parameter name for scan acquisition date in imaging_non_minc_insertion.pl

### DIFF
--- a/uploadNeuroDB/imaging_non_minc_insertion.pl
+++ b/uploadNeuroDB/imaging_non_minc_insertion.pl
@@ -531,7 +531,7 @@ $file->setFileData( 'SessionID', $session_id );
 # set acquisition date
 my ($ss, $mm, $hh, $day, $month, $yy, $zone) = strptime( $date_acquired );
 $date_acquired = sprintf( "%4d-%02d-%02d", $yy+1900, $month+1, $day );
-$file->setParameter( 'AcquisitionDate', $date_acquired );
+$file->setParameter( 'acquisition_date', $date_acquired );
 
 # set output type
 $file->setFileData( 'OutputType', $output_type );


### PR DESCRIPTION
This bug was due to the fact that when the acquisition date is inserted in table `parameter_file`, the name of the parameter used is incorrect. This PR changes it to the correct value.

Fixes #572.