### PR TITLE
mass_nifti_pic.py does not handle file ID ranges well.

### DIFF
--- a/python/mass_nifti_pic.py
+++ b/python/mass_nifti_pic.py
@@ -68,7 +68,7 @@ def main():
     if (smallest_id == largest_id):
         make_pic(smallest_id, config_file, verbose)
     else:
-        for file_id in range(smallest_id, largest_id):
+        for file_id in range(smallest_id, largest_id + 1):
             make_pic(file_id, config_file, verbose)
 
 


### PR DESCRIPTION
When using a file ID range with the `mass_nifti_pic.py` script, the image associated to the last (max) file ID is not generated. This PR corrects this.

Fixes #583 