### PR TITLE
minc_insertion.pl crashes when used with option -create_minc_pics.

### DIFF
--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -258,7 +258,7 @@ INPUT: file hashref
 RETURNS: 1 if the file is unique (or if hashes are not being tracked) or 0
 otherwise.
 
-### make\_pics($file\_ref, $data\_dir, $dest\_dir, $horizontalPics)
+### make\_pics($file\_ref, $data\_dir, $dest\_dir, $horizontalPics, $db)
 
 Generates check pics for the Imaging Browser module for the `NeuroDB::File`
 object referenced by `$file_ref`.

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1203,7 +1203,7 @@ sub is_unique_hash {
 
 =pod
 
-=head3 make_pics($file_ref, $data_dir, $dest_dir, $horizontalPics)
+=head3 make_pics($file_ref, $data_dir, $dest_dir, $horizontalPics, $db)
 
 Generates check pics for the Imaging Browser module for the C<NeuroDB::File>
 object referenced by C<$file_ref>.

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -655,7 +655,7 @@ if ($create_nii) {
 if ($create_minc_pics) {
     print "\nCreating Minc Pics\n" if $verbose;
     NeuroDB::MRI::make_pics(
-        \$file, $data_dir, "$data_dir/pic", $horizontalPics
+        \$file, $data_dir, "$data_dir/pic", $horizontalPics, $db
     );
 }
 


### PR DESCRIPTION
As the tile says. The bug was due to a missing argument when calling function `MRI::make_pics`

Fixes #576 