### PR TITLE
Fix uninitialized value warning in batch_uploads_imageuploader.pl

### DIFF
--- a/batch_uploads_imageuploader.pl
+++ b/batch_uploads_imageuploader.pl
@@ -162,7 +162,7 @@ my ($stdoutbase, $stderrbase) = ("$data_dir/batch_output/imuploadstdout.log",
 				 "$data_dir/batch_output/imuploadstderr.log");
 
 
-while($_ = $ARGV[0], /^-/) {
+while($_ = $ARGV[0] // '', /^-/) {
     shift;
     last if /^--$/; ## -- ends argument processing
     if (/^-D/) { $debug++ } ## debug level


### PR DESCRIPTION
Fix the warning 
```
Use of uninitialized value $_ in pattern match (m//) at ./batch_uploads_imageuploader.pl line 165.
```
in batch_uploads_imageuploader.pl