### PR TITLE
fix bids import acquisition time error

### DIFF
--- a/python/lib/scanstsv.py
+++ b/python/lib/scanstsv.py
@@ -68,7 +68,16 @@ class ScansTSV:
         """
 
         if 'acq_time' in self.acquisition_data:
-            eeg_acq_time = self.acquisition_data['acq_time']
+            if isinstance(self.tsv_entries, list):
+                acq_time_List = [ele for ele in self.tsv_entries if self.acquisition_file in ele['filename']]
+                if len(acq_time_List) == 1:
+                    #the variable name could be mri_acq_time, but is eeg originally.
+                    eeg_acq_time = acq_time_List[0]['acq_time']
+                else:
+                    print('more than one or none acquisition time has been found for ', self.acquisition_file)
+                    exit()
+            else: 
+                eeg_acq_time = self.acquisition_data['acq_time']
             try:
                 eeg_acq_time = parse(eeg_acq_time)
             except ValueError as e:


### PR DESCRIPTION
This PR fix issue #586
In importing bids dataset, scantsv.py is not able get acquisition time for mri.
The cause is that self.tsv_entries is a list of dict rather than a dict.

The solution: 
if it is a list, then
filtered out the unrelated dict objects for the current acquisition_file, and handle error in case of more than one entry exist. Then go from there.

cc:
@gdevenyi