### PR TITLE
Fix bug occurring when multiple MRI pipeline processes are running simultaneously

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1549,7 +1549,7 @@ sub isDicomImage {
     # not return one file per line but many files in one line. Writing in a
     # temporary file on which we run the command `cat` seems to be the only option
     # that works at the moment...
-    my $tmp_file = $ENV{'TMPDIR'} . "/tmp_list";
+    my $tmp_file = $ENV{'TMPDIR'} . "/tmp_list.$$";
     open(my $fh, '>', $tmp_file) or die "Could not open file '$tmp_file' $!";
     foreach my $file (@files_list) {
         printf $fh "%s\n", quotemeta($file);


### PR DESCRIPTION
When the MRI pipeline performs a check on each file in an archive to see if it is a DICOM file, it first builds the list of files in the archive and writes it an a temporary file. The problem is that the path of this temporary file is always the same, irrespective of the MRI pipeline process that writes/uses it. Consequently, it can contain files that belong to multiple MRI pipeline processes if two or more are running concurrently.

Fixes #594 