### PR TITLE
Allow delete script to be run without the MySQL PROCESS privilege.

### DIFF
--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -1869,7 +1869,7 @@ sub updateSQLBackupFile {
         
     # Run the mysqldump command for the current table and store the
     # result in $tmpSqlBackupFile (overwrite contents)
-    my $mysqldumpOptions = '--no-create-info --compact --single-transaction --skip-extended-insert';
+    my $mysqldumpOptions = '--no-create-info --compact --single-transaction --skip-extended-insert --no-tablespaces';
     
     my $warningToIgnore = 'mysqldump: [Warning] Using a password on the command line interface can be insecure.';
     my $cmd = sprintf(


### PR DESCRIPTION
The current version of the imaging upload delete script cannot create backups of the database information deleted unless the  MySQL user used when running the script has the `PROCESS` privilege. This is due to the fact that the script uses `mysqldump` to back up the information it deletes and table spaces are backed up by default. But the delete script does not need to back up table spaces, so option `--no-tablespaces` should be used.