### PR TITLE
Bugfix - No acquisition time found

### DIFF
--- a/python/lib/scanstsv.py
+++ b/python/lib/scanstsv.py
@@ -69,12 +69,12 @@ class ScansTSV:
 
         if 'acq_time' in self.acquisition_data:
             if isinstance(self.tsv_entries, list):
-                acq_time_List = [ele for ele in self.tsv_entries if self.acquisition_file in ele['filename']]
+                acq_time_List = [ele for ele in self.tsv_entries if ele['filename'] in self.acquisition_file]
                 if len(acq_time_List) == 1:
                     #the variable name could be mri_acq_time, but is eeg originally.
                     eeg_acq_time = acq_time_List[0]['acq_time']
                 else:
-                    print('more than one or none acquisition time has been found for ', self.acquisition_file)
+                    print('More than one or no acquisition time has been found for ', self.acquisition_file)
                     exit()
             else: 
                 eeg_acq_time = self.acquisition_data['acq_time']


### PR DESCRIPTION
The PR fixes a script failure:
`More than one or no acquisition time has been found for  /data/loris-mri/data/bids_files/sub-OTT173/ieeg/sub-OTT173_task-test_acq-seeg_ieeg.edf
`

https://github.com/aces/Loris-MRI/blob/7c46cac107968517e5f7b5c75d529352d18c9109/python/lib/scanstsv.py#L72
```
if 'acq_time' in self.acquisition_data:
            if isinstance(self.tsv_entries, list):
                acq_time_List = [ele for ele in self.tsv_entries if self.acquisition_file in ele['filename']]
                if len(acq_time_List) == 1:
                    #the variable name could be mri_acq_time, but is eeg originally.
                    eeg_acq_time = acq_time_List[0]['acq_time']
                else:
                    print('more than one or none acquisition time has been found for ', self.acquisition_file)
                    exit()
```

self.acquisition_file: /data/loris-mri/data/bids_files/sub-OTT173/ieeg/sub-OTT173_task-test_acq-seeg_ieeg.edf
ele['filename']: ieeg/sub-OTT173_task-test_acq-seeg_ieeg.edf

The inclusion in `acq_time_List = [ele for ele in self.tsv_entries if self.acquisition_file in ele['filename']]` needs to be reversed in order to work.