### PR TITLE
EEG-BIDS pipeline - Derivatives support: annotations

### DIFF
--- a/python/lib/database_lib/physiologicalannotationarchive.py
+++ b/python/lib/database_lib/physiologicalannotationarchive.py
@@ -1,6 +1,5 @@
 """This class performs database queries for the physiological_annotation_archive table"""
 
-import datetime
 
 __license__ = "GPLv3"
 
@@ -56,4 +55,3 @@ class PhysiologicalAnnotationArchive:
             column_names = ('PhysiologicalFileID', 'Blake2bHash', 'FilePath'),
             values       = (physiological_file_id, blake2, archive_path)
         )
-

--- a/python/lib/database_lib/physiologicalannotationarchive.py
+++ b/python/lib/database_lib/physiologicalannotationarchive.py
@@ -1,0 +1,59 @@
+"""This class performs database queries for the physiological_annotation_archive table"""
+
+import datetime
+
+__license__ = "GPLv3"
+
+
+class PhysiologicalAnnotationArchive:
+
+    def __init__(self, db, verbose):
+        """
+        Constructor method for the PhysiologicalAnnotationArchive class.
+
+        :param db                 : Database class object
+         :type db                 : object
+        :param verbose            : whether to be verbose
+         :type verbose            : bool
+        """
+
+        self.db = db
+        self.table = 'physiological_annotation_archive'
+        self.verbose = verbose
+
+    def grep_from_physiological_file_id(self, physiological_file_id):
+        """
+        Gets rows given a physiological_file_id
+
+        :param physiological_file_id : Physiological file's ID
+         :type physiological_file_id : int
+
+        :return                      : list of dict containing rows data if found or None
+         :rtype                      : list
+        """
+
+        return self.db.pselect(
+            query="SELECT * FROM " + self.table + " WHERE PhysiologicalFileID = %s",
+            args=(physiological_file_id,)
+        )
+
+    def insert(self, physiological_file_id, blake2, archive_path):
+        """
+        Inserts a new entry in the physiological_annotation_archive table.
+
+        :param physiological_file_id : Physiological file's ID
+         :type physiological_file_id : int
+
+        :param blake2                : blake2b hash
+         :type blake2                : string
+
+        :param archive_path          : Archive's path
+         :type archive_path          : string
+        """
+
+        self.db.insert(
+            table_name   = self.table,
+            column_names = ('PhysiologicalFileID', 'Blake2bHash', 'FilePath'),
+            values       = (physiological_file_id, blake2, archive_path)
+        )
+

--- a/python/lib/database_lib/physiologicalannotationfile.py
+++ b/python/lib/database_lib/physiologicalannotationfile.py
@@ -1,6 +1,5 @@
 """This class performs database queries for the physiological_annotation_file table"""
 
-import datetime
 
 __license__ = "GPLv3"
 
@@ -58,8 +57,8 @@ class PhysiologicalAnnotationFile:
 
         annotation_paths = self.db.pselect(
             query = "SELECT DISTINCT FilePath "
-                "FROM physiological_annotation_file "
-                "WHERE PhysiologicalFileID = %s",
+                    "FROM physiological_annotation_file "
+                    "WHERE PhysiologicalFileID = %s",
             args=(physiological_file_id,)
         )
 

--- a/python/lib/database_lib/physiologicalannotationfile.py
+++ b/python/lib/database_lib/physiologicalannotationfile.py
@@ -1,0 +1,66 @@
+"""This class performs database queries for the physiological_annotation_file table"""
+
+import datetime
+
+__license__ = "GPLv3"
+
+
+class PhysiologicalAnnotationFile:
+
+    def __init__(self, db, verbose):
+        """
+        Constructor method for the PhysiologicalAnnotationFile class.
+
+        :param db                 : Database class object
+         :type db                 : object
+        :param verbose            : whether to be verbose
+         :type verbose            : bool
+        """
+
+        self.db = db
+        self.table = 'physiological_annotation_file'
+        self.verbose = verbose
+
+    def insert(self, physiological_file_id, annotation_file_type, annotation_file):
+        """
+        Inserts a new entry in the physiological_annotation_file table.
+
+        :param physiological_file_id : physiological file's ID
+         :type physiological_file_id : int
+
+        :param annotation_file_type  : type of the annotation file
+         :type annotation_file_type  : str
+
+        :param annotation_file       : path of the annotation file
+         :type annotation_file       : str
+
+        :return                      : id of the row inserted
+         :rtype                      : int
+        """
+
+        return self.db.insert(
+            table_name   = self.table,
+            column_names = ('PhysiologicalFileID', 'FileType', 'FilePath'),
+            values       = (physiological_file_id, annotation_file_type, annotation_file),
+            get_last_id  = True
+        )
+
+    def grep_annotation_paths_from_physiological_file_id(self, physiological_file_id):
+        """
+        Gets the FilePath given a physiological_file_id
+
+        :param physiological_file_id : Physiological file's ID
+         :type physiological_file_id : int
+
+        :return                      : list of FilePath if any or None
+         :rtype                      : list
+        """
+
+        annotation_paths = self.db.pselect(
+            query = "SELECT DISTINCT FilePath "
+                "FROM physiological_annotation_file "
+                "WHERE PhysiologicalFileID = %s",
+            args=(physiological_file_id,)
+        )
+
+        annotation_paths = [annotation_path['FilePath'] for annotation_path in annotation_paths]

--- a/python/lib/database_lib/physiologicalannotationinstance.py
+++ b/python/lib/database_lib/physiologicalannotationinstance.py
@@ -1,6 +1,5 @@
 """This class performs database queries for the physiological_annotation_instance table"""
 
-import datetime
 
 __license__ = "GPLv3"
 
@@ -59,10 +58,8 @@ class PhysiologicalAnnotationInstance:
         self.db.insert(
             table_name   = self.table,
             column_names = (
-               'AnnotationFileID', 'AnnotationParameterID', 'Onset', 'Duration',
-               'AnnotationLabelID', 'Channels', 'AbsoluteTime', 'Description'
+                'AnnotationFileID', 'AnnotationParameterID', 'Onset', 'Duration',
+                'AnnotationLabelID', 'Channels', 'AbsoluteTime', 'Description'
             ),
             values       = annotation_data
         )
-
-

--- a/python/lib/database_lib/physiologicalannotationinstance.py
+++ b/python/lib/database_lib/physiologicalannotationinstance.py
@@ -1,0 +1,68 @@
+"""This class performs database queries for the physiological_annotation_instance table"""
+
+import datetime
+
+__license__ = "GPLv3"
+
+
+class PhysiologicalAnnotationInstance:
+
+    def __init__(self, db, verbose):
+        """
+        Constructor method for the PhysiologicalAnnotationInstance class.
+
+        :param db                 : Database class object
+         :type db                 : object
+        :param verbose            : whether to be verbose
+         :type verbose            : bool
+        """
+
+        self.db = db
+        self.table = 'physiological_annotation_instance'
+        self.verbose = verbose
+
+    def grep_annotation_from_physiological_file_id(self, physiological_file_id):
+        """
+        Greps all entries present in the physiological_annotation_instance,
+        physiological_annotation_file, physiological_annotation_label and
+        physiological_annotation_parameter tables for a
+        given PhysiologicalFileID and returns its result.
+
+        :param physiological_file_id: physiological file's ID
+         :type physiological_file_id: int
+
+        :return: tuple of dictionaries with one entry in the tuple
+                 corresponding to one entry in physiological_annotation_instance
+         :rtype: tuple
+        """
+
+        results = self.db.pselect(
+            query="SELECT * "
+                  "FROM " + self.table + " i "
+                  "JOIN physiological_annotation_file f ON i.AnnotationFileID = f.AnnotationFileID "
+                  "JOIN physiological_annotation_label l ON l.AnnotationLabelID = i.AnnotationLabelID "
+                  "JOIN physiological_annotation_parameter p ON p.AnnotationFileID = i.AnnotationFileID "
+                  "WHERE PhysiologicalFileID = %s",
+            args=(physiological_file_id,)
+        )
+
+        return results
+
+    def insert(self, annotation_data):
+        """
+        Inserts a new entry in the physiological_annotation_instance table.
+
+        :param annotation_data : Annotation data
+         :type annotation_data : list
+        """
+
+        self.db.insert(
+            table_name   = self.table,
+            column_names = (
+               'AnnotationFileID', 'AnnotationParameterID', 'Onset', 'Duration',
+               'AnnotationLabelID', 'Channels', 'AbsoluteTime', 'Description'
+            ),
+            values       = annotation_data
+        )
+
+

--- a/python/lib/database_lib/physiologicalannotationlabel.py
+++ b/python/lib/database_lib/physiologicalannotationlabel.py
@@ -20,7 +20,7 @@ class PhysiologicalAnnotationLabel:
         self.table = 'physiological_annotation_label'
         self.verbose = verbose
 
-    def insert(self, labelData):
+    def insert(self, annotation_file_id, label_name, label_desc):
         """
         Inserts a new entry in the physiological_annotation_label table.
 
@@ -30,8 +30,8 @@ class PhysiologicalAnnotationLabel:
 
         self.db.insert(
             table_name   = self.table,
-            column_names = ('LabelName', 'LabelDescription'),
-            values       = labelData
+            column_names = ('AnnotationFileID', 'LabelName', 'LabelDescription'),
+            values       = (annotation_file_id, label_name, label_desc)
         )
 
     def grep_id(self, label, insert_if_not_found):

--- a/python/lib/database_lib/physiologicalannotationlabel.py
+++ b/python/lib/database_lib/physiologicalannotationlabel.py
@@ -1,0 +1,55 @@
+"""This class performs database queries for the physiological_annotation_label table"""
+
+import datetime
+
+__license__ = "GPLv3"
+
+
+class PhysiologicalAnnotationLabel:
+
+    def __init__(self, db, verbose):
+        """
+        Constructor method for the PhysiologicalAnnotationLabel class.
+
+        :param db                 : Database class object
+         :type db                 : object
+        :param verbose            : whether to be verbose
+         :type verbose            : bool
+        """
+
+        self.db = db
+        self.table = 'physiological_annotation_label'
+        self.verbose = verbose
+
+    def insert(self, labelData):
+        """
+        Inserts a new entry in the physiological_annotation_label table.
+
+        :param labelData : list of tuples (labelName, labelDescription)
+         :type labelData : list
+        """
+
+        self.db.insert(
+            table_name   = self.table,
+            column_names = ('LabelName', 'LabelDescription'),
+            values       = labelData
+        )
+
+    def grep_id(self, label, insert_if_not_found):
+        """
+        Gets the physiological_annotation_label AnnotationLabelID given a labelName
+
+        :param label               : labelName
+         :type label               : string
+
+        :param insert_if_not_found : if value is inserted if not found
+         :type insert_if_not_found : bool
+
+        :return                      : id of the row if found or None
+         :rtype                      : int
+        """
+
+        return self.db.grep_id_from_lookup_table(
+            'AnnotationLabelID', self.table, 'LabelName', label, insert_if_not_found=insert_if_not_found
+        )
+

--- a/python/lib/database_lib/physiologicalannotationlabel.py
+++ b/python/lib/database_lib/physiologicalannotationlabel.py
@@ -1,6 +1,5 @@
 """This class performs database queries for the physiological_annotation_label table"""
 
-import datetime
 
 __license__ = "GPLv3"
 
@@ -52,4 +51,3 @@ class PhysiologicalAnnotationLabel:
         return self.db.grep_id_from_lookup_table(
             'AnnotationLabelID', self.table, 'LabelName', label, insert_if_not_found=insert_if_not_found
         )
-

--- a/python/lib/database_lib/physiologicalannotationparameter.py
+++ b/python/lib/database_lib/physiologicalannotationparameter.py
@@ -1,0 +1,66 @@
+"""This class performs database queries for the physiological_annotation_parameter table"""
+
+import datetime
+
+__license__ = "GPLv3"
+
+
+class PhysiologicalAnnotationParameter:
+
+    def __init__(self, db, verbose):
+        """
+        Constructor method for the PhysiologicalAnnotationParameter class.
+
+        :param db                 : Database class object
+         :type db                 : object
+        :param verbose            : whether to be verbose
+         :type verbose            : bool
+        """
+
+        self.db = db
+        self.table = 'physiological_annotation_parameter'
+        self.verbose = verbose
+
+    def insert(self, annotation_file_id, sources, author):
+        """
+        Inserts a new entry in the physiological_annotation_parameter table.
+
+        :param annotation_file_id : annotation file's ID
+         :type annotation_file_id : int
+
+        :param sources            : Description of the file(s) used to make the annotations
+         :type sources            : string
+
+        :param author             : Annotation's author
+         :type author             : string
+        """
+
+        self.db.insert(
+            table_name   = self.table,
+            column_names = ('AnnotationFileID', 'Sources', 'Author'),
+            values       = (annotationFileID, sources, author)
+        )
+
+    def grep_id_from_physiological_file_id(self, physiological_file_id):
+        """
+        Gets the AnnotationParameterID given a physiological_file_id
+
+        :param physiological_file_id : Physiological file's ID
+         :type physiological_file_id : int
+
+        :return                      : id of the row if found or None
+         :rtype                      : int
+        """
+
+        paramID = self.db.pselect(
+            query="SELECT AnnotationParameterID "
+            "FROM " + self.table + " p "
+            "JOIN physiological_annotation_file f ON f.AnnotationFileID = p.AnnotationFileID "
+            "WHERE f.PhysiologicalFileID = %s "
+            "LIMIT 1",
+            args=(physiological_file_id,)
+        )
+
+        return paramID[0]['AnnotationParameterID'] if paramID else None
+
+

--- a/python/lib/database_lib/physiologicalannotationparameter.py
+++ b/python/lib/database_lib/physiologicalannotationparameter.py
@@ -1,6 +1,5 @@
 """This class performs database queries for the physiological_annotation_parameter table"""
 
-import datetime
 
 __license__ = "GPLv3"
 
@@ -38,7 +37,7 @@ class PhysiologicalAnnotationParameter:
         self.db.insert(
             table_name   = self.table,
             column_names = ('AnnotationFileID', 'Sources', 'Author'),
-            values       = (annotationFileID, sources, author)
+            values       = (annotation_file_id, sources, author)
         )
 
     def grep_id_from_physiological_file_id(self, physiological_file_id):
@@ -62,5 +61,3 @@ class PhysiologicalAnnotationParameter:
         )
 
         return paramID[0]['AnnotationParameterID'] if paramID else None
-
-

--- a/python/lib/database_lib/physiologicalannotationrel.py
+++ b/python/lib/database_lib/physiologicalannotationrel.py
@@ -1,0 +1,37 @@
+"""This class performs database queries for the physiological_annotation_rel table"""
+
+
+__license__ = "GPLv3"
+
+
+class PhysiologicalAnnotationRel:
+
+    def __init__(self, db, verbose):
+        """
+        Constructor method for the PhysiologicalAnnotationRel class.
+
+        :param db                 : Database class object
+         :type db                 : object
+        :param verbose            : whether to be verbose
+         :type verbose            : bool
+        """
+
+        self.db = db
+        self.table = 'physiological_annotation_rel'
+        self.verbose = verbose
+
+    def insert(self, annotation_data_id, annotation_metadata_id):
+        """
+        Inserts a new entry in the physiological_annotation_rel table.
+
+        :param annotation_data_id : ID of the annotation TSV file
+         :type annotation_data_id : int
+        :param annotation_metadata_id : ID of the annotation JSON file
+         :type annotation_metadata_id : int
+        """
+
+        self.db.insert(
+            table_name   = self.table,
+            column_names = ('AnnotationTSV', 'AnnotationJSON'),
+            values       = (annotation_data_id, annotation_metadata_id)
+        )

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -345,7 +345,7 @@ class Eeg:
             subject   = self.bids_sub_id,
             session   = self.bids_ses_id,
             scope     = 'derivatives' if derivatives else 'raw',
-            datatype  = self.bids_modality,
+            # datatype  = self.bids_modality,
             suffix    = self.bids_modality,
             extension = ['set', 'edf', 'vhdr', 'vmrk', 'eeg', 'bdf']
         )

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -737,10 +737,10 @@ class Eeg:
                 annotation_paths = []
                 annotation_paths.extend([
                     self.copy_file_to_loris_bids_dir(
-                        annotation_metadata_file.path, derivatives
+                        annotation_data_file.path, derivatives
                     ),
                     self.copy_file_to_loris_bids_dir(
-                        annotation_data_file.path, derivatives
+                        annotation_metadata_file.path, derivatives
                     )
                 ])
 

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -3,19 +3,17 @@
 import os
 import json
 import getpass
-import string
 from pyblake2 import blake2b
 
 import lib.exitcode
 import lib.utilities as utilities
-from lib.database                                    import Database
 from lib.candidate                                   import Candidate
 from lib.session                                     import Session
 from lib.physiological                               import Physiological
-from lib.bidsreader                                  import BidsReader
 from lib.scanstsv                                    import ScansTSV
 from lib.database_lib.physiologicalannotationfile    import PhysiologicalAnnotationFile
 from lib.database_lib.physiologicalannotationarchive import PhysiologicalAnnotationArchive
+
 
 __license__ = "GPLv3"
 
@@ -138,7 +136,7 @@ class Eeg:
             if 'subproject' in row:
                 subproject_info = db.pselect(
                     "SELECT SubprojectID FROM subproject WHERE title = %s",
-                    [row['subproject'],]
+                    [row['subproject'], ]
                 )
                 if(len(subproject_info) > 0):
                     self.subproject_id = subproject_info[0]['SubprojectID']
@@ -261,10 +259,29 @@ class Eeg:
             original_file_data = inserted_eeg['original_file_data']
 
             # insert related electrode, channel and event information
-            electrode_file_path   = self.fetch_and_insert_electrode_file(eeg_file_id, original_file_data.path, derivatives)
-            channel_file_path     = self.fetch_and_insert_channel_file(eeg_file_id, original_file_data.path, derivatives)
-            event_file_path       = self.fetch_and_insert_event_file(eeg_file_id, original_file_data.path, derivatives)
-            annotation_file_paths = self.fetch_and_insert_annotation_files(eeg_file_id, original_file_data.path, derivatives)
+            electrode_file_path = self.fetch_and_insert_electrode_file(
+                eeg_file_id,
+                original_file_data.path,
+                derivatives
+            )
+
+            channel_file_path = self.fetch_and_insert_channel_file(
+                eeg_file_id,
+                original_file_data.path,
+                derivatives
+            )
+
+            event_file_path = self.fetch_and_insert_event_file(
+                eeg_file_id,
+                original_file_data.path,
+                derivatives
+            )
+
+            annotation_file_paths = self.fetch_and_insert_annotation_files(
+                eeg_file_id,
+                original_file_data.path,
+                derivatives
+            )
 
             # archive all files in a tar ball for downloading all files at once
             files_to_archive = (self.data_dir + eeg_file_path,)
@@ -711,7 +728,9 @@ class Eeg:
             return None
         else:
             physiological_annotation_file_obj = PhysiologicalAnnotationFile(self.db, self.verbose)
-            annotation_paths = physiological_annotation_file_obj.grep_annotation_paths_from_physiological_file_id(physiological_file_id)
+            annotation_paths = physiological_annotation_file_obj.grep_annotation_paths_from_physiological_file_id(
+                physiological_file_id
+            )
 
             if not annotation_paths:
                 # copy the annotation file to the LORIS BIDS import directory
@@ -869,10 +888,6 @@ class Eeg:
          :type eeg_file_id     : int
         """
 
-        # load the Physiological object that will be used to insert the
-        # physiological archive into the database
-        physiological = Physiological(self.db, self.verbose)
-
         # check if archive is on the filesystem
         archive_full_path = self.data_dir + archive_rel_name
         blake2            = None
@@ -908,4 +923,3 @@ class Eeg:
         # insert the archive into the physiological_annotation_archive table
         blake2 = blake2b(archive_full_path.encode('utf-8')).hexdigest()
         physiological_annotation_archive_obj.insert(eeg_file_id, blake2, archive_rel_name)
-

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -656,10 +656,10 @@ class Physiological:
             if not row['onset'].isdecimal():
                 row['onset'] = None
 
-            if "n/a" in row['channels']:
+            if row['channels'] and "n/a" in row['channels']:
                 row['channels'] = None
 
-            if "n/a" in row['absolute_time']:
+            if row['absolute_time'] and "n/a" in row['absolute_time']:
                 row['absolute_time'] = None
 
             labelID = self.physiological_annotation_label_obj.grep_id(row['label'], insert_if_not_found=True)

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -588,6 +588,9 @@ class Physiological:
          :type physiological_file_id    : int
         :param blake2                   : blake2b hash of the annotation file
          :type blake2                   : str
+
+        :return: annotation file id
+         :rtype: int
         """
 
         optional_fields = (
@@ -617,6 +620,8 @@ class Physiological:
             physiological_file_id, 'annotation_file_blake2b_hash', blake2
         )
 
+        return annotation_file_id
+
     def insert_annotation_data(self, annotation_data, annotation_file, physiological_file_id, blake2):
         """
         Inserts the annotation information read from the file *annotations.tsv
@@ -633,6 +638,9 @@ class Physiological:
          :type physiological_file_id: int
         :param blake2               : blake2b hash of the task event file
          :type blake2               : str
+        
+        :return: annotation file id
+         :rtype: int
         """
 
         annotation_file_id = self.physiological_annotation_file_obj.insert(
@@ -685,6 +693,8 @@ class Physiological:
         self.insert_physio_parameter_file(
             physiological_file_id, 'annotation_file_blake2b_hash', blake2
         )
+
+        return annotation_file_id
 
     def grep_archive_info_from_file_id(self, physiological_file_id):
         """

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -608,7 +608,9 @@ class Physiological:
             annotation_metadata['Sources'],
             annotation_metadata['Author']
         )
-        self.physiological_annotation_label_obj.insert(list(annotation_metadata['LabelDescription'].items()))
+
+        for label_name, label_desc in annotation_metadata['LabelDescription'].items():
+            self.physiological_annotation_label_obj.insert(annotation_file_id, label_name, label_desc)
 
         # insert blake2b hash of annotation file into physiological_parameter_file
         self.insert_physio_parameter_file(

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -659,6 +659,9 @@ class Physiological:
             if "n/a" in row['channels']:
                 row['channels'] = None
 
+            if "n/a" in row['absolute_time']:
+                row['absolute_time'] = None
+
             labelID = self.physiological_annotation_label_obj.grep_id(row['label'], insert_if_not_found=True)
             paramID = self.physiological_annotation_parameter_obj.grep_id_from_physiological_file_id(
                 physiological_file_id


### PR DESCRIPTION
This PR adds support for derivatives, specifically annotations.
Annotations are added using 2 files, *_annotations.json (metadata) and _annotations.tsv (data), both mandatory.
For a template:  ([tsv](https://github.com/bids-standard/bids-examples/blob/9893043f52ab1cec144d1b6069497ef48edc9570/eeg_face13/derivatives/BIDS-Lossless-EEG/sub-001/eeg/sub-001_task-faceFO_annotations.tsv)) ([json](https://github.com/bids-standard/bids-examples/blob/9893043f52ab1cec144d1b6069497ef48edc9570/eeg_face13/derivatives/BIDS-Lossless-EEG/sub-001/eeg/sub-001_task-faceFO_annotations.json)) 

To test 
The PR depends on an SQL patch from https://github.com/aces/Loris/pull/7345 

PyBIDS won't detect *_annotations.json and _annotations.tsv with validate turned on without the [force_index](https://bids-standard.github.io/pybids/generated/bids.layout.BIDSLayout.html) option, as it ignores files that do not follow a naming convention allowed by the specs. The annotation specs are currently discussed in[ BIDS Extension Proposal 21](https://docs.google.com/document/d/1PmcVs7vg7Th-cGC-UrX8rAhKUHIzOI-uIOh69_mvdlw/edit#heading=h.mqkmyp254xh6).


Related to #450 