### PR TITLE
Encoding issue

### DIFF
--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -27,7 +27,7 @@ def read_tsv_file(tsv_file):
     """
 
     results = []
-    with open(tsv_file) as file:
+    with open(tsv_file, encoding='utf-8-sig') as file:
         reader = csv.DictReader(file, delimiter="\t")
 
         for row in reader:


### PR DESCRIPTION
## BIDS parser
when a byte-order mark (BOM) is present, the script fails (participant_id is not found in participants.tsv) since the field extracted is \ufeffparticipant_id (happened on 2 different instances).
Modifying the tsv parser to add an encoding parameter fixed the issue.

```
> print(row)
OrderedDict([('\ufeffparticipant_id', 'sub-OTT174'), ('age', 'n/a'), ('sex', 'n/a'), ('hand', 'n/a')])
```
```
Traceback (most recent call last):
  File "bids_import.py", line 454, in <module>
    main()
  File "bids_import.py", line 75, in main
    read_and_insert_bids(bids_dir, config_file, verbose, createcand, createvisit)
  File "bids_import.py", line 158, in read_and_insert_bids
    bids_reader = BidsReader(bids_dir, verbose)
  File "/data/loris-mri/bin/mri/python/lib/bidsreader.py", line 62, in __init__
    self.participants_info = self.load_candidates_from_bids()
  File "/data/loris-mri/bin/mri/python/lib/bidsreader.py", line 114, in load_candidates_from_bids
    self.candidates_list_validation(participants_info)
  File "/data/loris-mri/bin/mri/python/lib/bidsreader.py", line 145, in candidates_list_validation
    row['participant_id'] = row['participant_id'].replace('sub-', '')
KeyError: 'participant_id'
```