### PR TITLE
Fix scan's IDs set to unknown but file named with a different ScanType

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -639,7 +639,7 @@ INPUTS:
   - $type: scan type
   - $db  : database object
 
-RETURNS: ID of the scan type
+RETURNS: ID of the scan type or undef
 
 =cut
 
@@ -652,17 +652,8 @@ sub scan_type_text_to_id {
     my $mriScanTypeRef = $mriScanTypeOB->get(
         0, { Scan_type => $type }
     );
-    $mriScanTypeRef = $mriScanTypeOB->get(0, { Scan_type => 'unknown' }) if !@$mriScanTypeRef;
-    if(!@$mriScanTypeRef) {
-        NeuroDB::UnexpectedValueException->throw(
-            errorMessage => sprintf(
-                "Unknown acquisition protocol %s and scan type 'unknown' does not exist in the database",
-                $type
-            ) 
-        );
-    }
-    
-    return $mriScanTypeRef->[0]->{'ID'};
+
+    return @$mriScanTypeRef ? $mriScanTypeRef->[0]->{'ID'} : undef;
 }
 
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -765,7 +765,6 @@ sub getAcquisitionProtocol {
 
         # if no acquisition protocol ID returned, look for the 'unknown' protocol ID
         unless ($acquisitionProtocolID) {
-            $acquisitionProtocol = 'unknown';
             $acquisitionProtocolID = NeuroDB::MRI::scan_type_text_to_id(
                 'unknown', $this->{'db'}
             );

--- a/uploadNeuroDB/imaging_non_minc_insertion.pl
+++ b/uploadNeuroDB/imaging_non_minc_insertion.pl
@@ -336,26 +336,26 @@ unless ($sth->rows > 0) {
 
 # verify that an acquisition protocol ID exists for $scan_type
 my $acqProtocolID = NeuroDB::MRI::scan_type_text_to_id($scan_type, $db);
-if ($acqProtocolID =~ /unknown/){
+unless ($acqProtocolID) {
     $message = "\n\tERROR: no AcquisitionProtocolID found for $scan_type.\n\n";
     # write error message in the log file
-    $utility->writeErrorLog( $message, $NeuroDB::ExitCodes::UNKNOWN_PROTOCOL, $log_file );
+    $utility->writeErrorLog($message, $NeuroDB::ExitCodes::UNKNOWN_PROTOCOL,
+        $log_file);
     # insert error message into notification spool table
     $notifier->spool(
-        'imaging non minc file insertion',    $message,   0,
+        'imaging non minc file insertion', $message, 0,
         'imaging_non_minc_insertion.pl', $upload_id, 'Y',
         'N'
     );
     exit $NeuroDB::ExitCodes::UNKNOWN_PROTOCOL;
-} else {
-    $message = "\nFound protocol ID $acqProtocolID for $scan_type.\n\n";
-    $notifier->spool(
-        'imaging non minc file insertion',    $message,   0,
-        'imaging_non_minc_insertion.pl', $upload_id, 'Y',
-        'Y'
-    )
 }
 
+$message = "\nFound protocol ID $acqProtocolID for $scan_type.\n\n";
+$notifier->spool(
+    'imaging non minc file insertion', $message,   0,
+    'imaging_non_minc_insertion.pl',   $upload_id, 'Y',
+    'Y'
+);
 
 
 
@@ -544,9 +544,9 @@ $file->setFileData( 'OutputType', $output_type );
 # note, have to give an array of checks, for now, hardcoding it to 'pass'
 # until we end up with a case where this should not be the case.
 my $acquisitionProtocolIDFromProd = $utility->registerScanIntoDB(
-    \$file,     undef,    $subjectIDsref, $scan_type,
-    $file_path, ['pass'], $reckless,      $session_id,
-    $upload_id
+    \$file,     undef,         $subjectIDsref, $scan_type,
+    $file_path, ['pass'],      $reckless,      $session_id,
+    $upload_id, $acqProtocolID
 );
 if ( $acquisitionProtocolIDFromProd ) {
     my $registered_file = $file->getFileDatum('File');

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -677,10 +677,10 @@ if($acquisitionProtocol =~ /unknown/) {
 ################################################################
 
 my $acquisitionProtocolIDFromProd = $utility->registerScanIntoDB(
-    \$file,               \%studyInfo,                   $subjectIDsref,
-    $acquisitionProtocol, $minc,                         $extra_validation_status,
-    $reckless,            $subjectIDsref->{'SessionID'}, $upload_id,
-    $hrrt
+    \$file,                 \%studyInfo,                   $subjectIDsref,
+    $acquisitionProtocol,   $minc,                         $extra_validation_status,
+    $reckless,              $subjectIDsref->{'SessionID'}, $upload_id,
+    $acquisitionProtocolID, $hrrt
 );
 
 # if the scan was inserted into the files table and there is an


### PR DESCRIPTION
Resolves an issue where some files where inserted into the `files` table with `AcquisitionProtocolID` linking to the `unknown` scan type but the File was actually named `<study>_<candID>_<visit>_F18tracerOSEM.mnc`, `F18tracerOSEM` being the correct scan type.

What happened is that `F18tracerOSEM` was not in `mri_scan_type` so the pipeline fetched the ID of the `unknown` scan type in `scan_type_text_to_id` but never updated the scan type to `unknown` leading to inconsistent linking into the database.

This refactors the `scan_type_text_to_id` function to remove the part where it looks for the unknown type as this should be done outside of the function.