### PR TITLE
Display more elaborate message in the error for comparison of subjects present in participants.tsv and the ones present in the BIDS layout

### DIFF
--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -135,7 +135,7 @@ class BidsReader:
 
         mismatch_message = "\nERROR: Participant ID mismatch between " \
                            "participants.tsv and raw data found in the BIDS " \
-                           "directory/n"
+                           "directory\n"
 
         # check that all subjects listed in participants_info are also in
         # subjects array and vice versa
@@ -144,6 +144,8 @@ class BidsReader:
             row['participant_id'] = row['participant_id'].replace('sub-', '')
             if not row['participant_id'] in subjects:
                 print(mismatch_message)
+                print(row['participant_id'] + 'is missing from the BIDS Layout\n')
+                print('List of subjects parsed by the BIDS layout: ' + ', '.join(subjects) + '\n')
                 sys.exit(lib.exitcode.BIDS_CANDIDATE_MISMATCH)
             # remove the subject from the list of subjects
             subjects.remove(row['participant_id'])

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -135,7 +135,7 @@ class BidsReader:
 
         mismatch_message = ("\nERROR: Participant ID mismatch between "
                             "participants.tsv and raw data found in the BIDS "
-                           "directory\n"
+                            "directory")
 
         # check that all subjects listed in participants_info are also in
         # subjects array and vice versa

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -145,7 +145,7 @@ class BidsReader:
             if not row['participant_id'] in subjects:
                 print(mismatch_message)
                 print(row['participant_id'] + 'is missing from the BIDS Layout')
-                print('List of subjects parsed by the BIDS layout: ' + ', '.join(subjects) + '\n')
+                print('List of subjects parsed by the BIDS layout: ' + ', '.join(subjects))
                 sys.exit(lib.exitcode.BIDS_CANDIDATE_MISMATCH)
             # remove the subject from the list of subjects
             subjects.remove(row['participant_id'])

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -144,7 +144,7 @@ class BidsReader:
             row['participant_id'] = row['participant_id'].replace('sub-', '')
             if not row['participant_id'] in subjects:
                 print(mismatch_message)
-                print(row['participant_id'] + 'is missing from the BIDS Layout\n')
+                print(row['participant_id'] + 'is missing from the BIDS Layout')
                 print('List of subjects parsed by the BIDS layout: ' + ', '.join(subjects) + '\n')
                 sys.exit(lib.exitcode.BIDS_CANDIDATE_MISMATCH)
             # remove the subject from the list of subjects

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -133,8 +133,8 @@ class BidsReader:
 
         subjects = self.bids_layout.get_subjects()
 
-        mismatch_message = "\nERROR: Participant ID mismatch between " \
-                           "participants.tsv and raw data found in the BIDS " \
+        mismatch_message = ("\nERROR: Participant ID mismatch between "
+                            "participants.tsv and raw data found in the BIDS "
                            "directory\n"
 
         # check that all subjects listed in participants_info are also in


### PR DESCRIPTION
This PR improves a little the logs of the error when doing comparison between the list of subjects present in participants.tsv and the list of subjects grepped by the BIDS reader.

