### PR TITLE
BIDS import - handle multiple physiology files and derivatives

### DIFF
--- a/python/bids_import.py
+++ b/python/bids_import.py
@@ -211,6 +211,7 @@ def read_and_insert_bids(bids_dir, config_file, verbose, createcand, createvisit
         bids_session = row['bids_ses_id']
         visit_label  = bids_session if bids_session else default_bids_vl
         loris_bids_visit_rel_dir    = 'sub-' + row['bids_sub_id'] + '/' + 'ses-' + visit_label
+
         for modality in row['modalities']:
             loris_bids_modality_rel_dir = loris_bids_visit_rel_dir + '/' + modality + '/'
             lib.utilities.create_dir(loris_bids_root_dir + loris_bids_modality_rel_dir, verbose)

--- a/python/bids_import.py
+++ b/python/bids_import.py
@@ -5,6 +5,7 @@
 import os
 import sys
 import getopt
+import re
 import lib.exitcode
 import lib.utilities
 from lib.database   import Database
@@ -228,7 +229,6 @@ def read_and_insert_bids(bids_dir, config_file, verbose, createcand, createvisit
                     loris_bids_root_dir    = loris_bids_root_dir
                 )
 
-
             elif modality in ['anat', 'dwi', 'fmap', 'func']:
                 Mri(
                     bids_reader   = bids_reader,
@@ -270,8 +270,8 @@ def create_loris_bids_directory(bids_reader, data_dir, verbose):
 
     # determine the root directory of the LORIS BIDS and create it if does
     # not exist
-    name = bids_reader.dataset_name.replace(" ", "_")  # get name of the dataset
-    version = bids_reader.bids_version  # get BIDSVersion of the dataset
+    name = re.sub("[^0-9a-zA-Z]+", "_", bids_reader.dataset_name) # get name of the dataset
+    version = re.sub("[^0-9a-zA-Z\.]+", "_", bids_reader.bids_version) # get BIDSVersion of the dataset
 
     # the LORIS BIDS directory will be in data_dir/BIDS/ and named with the
     # concatenation of the dataset name and the BIDS version
@@ -353,7 +353,7 @@ def grep_or_create_candidate_db_info(bids_reader, bids_id,        db,
 
 
 def grep_or_create_session_db_info(
-        bids_id,   cand_id,     visit_label,    
+        bids_id,   cand_id,     visit_label,
         db,        createvisit, verbose,       loris_bids_dir,
         center_id, project_id,  subproject_id):
     """
@@ -387,7 +387,7 @@ def grep_or_create_session_db_info(
     """
 
     session = Session(
-        verbose, cand_id, visit_label, 
+        verbose, cand_id, visit_label,
         center_id, project_id, subproject_id
     )
     loris_vl_info = session.get_session_info_from_loris(db)
@@ -438,7 +438,7 @@ def grep_candidate_sessions_info(bids_ses,    bids_id,    cand_id,       loris_b
     """
 
     loris_sessions_info = []
-    
+
     if not bids_ses:
         loris_ses_info = grep_or_create_session_db_info(
             bids_id,     cand_id,    default_vl,     db,
@@ -454,7 +454,7 @@ def grep_candidate_sessions_info(bids_ses,    bids_id,    cand_id,       loris_b
                 center_id,   project_id, subproject_id
             )
             loris_sessions_info.append(loris_ses_info)
-        
+
     return loris_sessions_info
 
 

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -90,26 +90,23 @@ class BidsReader:
         if self.verbose:
             print('Loading the BIDS dataset with BIDS layout library...\n')
 
-        bids_config = os.environ['LORIS_MRI'] + "/python/lib/bids.json"
-        exclude_arr = ['/code/', '/sourcedata/', '/log/', '.git/']
-        force_arr   = re.compile("_annotations\.(tsv|json)$")
+        bids_config   = os.environ['LORIS_MRI'] + "/python/lib/bids.json"
+        exclude_arr   = ['/code/', '/sourcedata/', '/log/', '.git/']
+        force_arr     = [re.compile("_annotations\.(tsv|json)$")]
 
         # BIDSLayoutIndexer is required for PyBIDS >= 0.12.1
         bids_pack_version = list(map(int, bids.__version__.split('.')))
-        if (bids_pack_version[0] > 0
-            or bids_pack_version[1] > 12
-            or (bids_pack_version[1] == 12 and bids_pack_version[2] > 0)):
-            bids_layout = BIDSLayout(
-                root=self.bids_dir,
-                # disabled until is a workaround for https://github.com/bids-standard/pybids/issues/760 is found
-                # [file] bids_import.py [function] read_and_insert_bids [line] for modality in row['modalities']: (row['modalities'] is empty)
-                # indexer=BIDSLayoutIndexer(config_filename=bids_config, ignore=exclude_arr, force_index=force_arr)
-                config=bids_config,
-                ignore=exclude_arr,
-                force_index=force_arr
-            )
-        else:
-            bids_layout = BIDSLayout(root=self.bids_dir, config=bids_config, ignore=exclude_arr, force_index=force_arr)
+        # disabled until is a workaround for https://github.com/bids-standard/pybids/issues/760 is found
+        # [file] bids_import.py [function] read_and_insert_bids [line] for modality in row['modalities']: (row['modalities'] is empty)
+        #if (bids_pack_version[0] > 0
+        #    or bids_pack_version[1] > 12
+        #    or (bids_pack_version[1] == 12 and bids_pack_version[2] > 0)):
+        #    bids_layout = BIDSLayout(
+        #        root=self.bids_dir,
+        #        indexer=BIDSLayoutIndexer(config_filename=bids_config, ignore=exclude_arr, force_index=force_arr)
+        #    )
+        #else:
+        bids_layout = BIDSLayout(root=self.bids_dir, config=bids_config, ignore=exclude_arr, force_index=force_arr, derivatives=True)
 
         if self.verbose:
             print('\t=> BIDS dataset loaded with BIDS layout\n')

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -287,7 +287,7 @@ class BidsReader:
     @staticmethod
     def grep_file(files_list, match_pattern, derivative_pattern=None):
         """
-        Grep a file based on a match pattern and returns it.
+        Grep a unique file based on a match pattern and returns it.
 
         :param files_list        : list of files to look into
          :type files_list        : list
@@ -297,11 +297,10 @@ class BidsReader:
                                    is a derivative file
          :type derivative_pattern: str
 
-        :return: name of the file that matches the pattern
+        :return: name of the first file that matches the pattern
          :rtype: str
         """
 
-        raw_file = None
         for filename in files_list:
             if not derivative_pattern:
                 if 'derivatives' in filename:
@@ -309,10 +308,10 @@ class BidsReader:
                     continue
                 elif re.search(match_pattern, filename):
                     # grep the file that matches the match_pattern (extension)
-                    raw_file = filename
+                    return filename
             else:
                 matches_derivative = re.search(derivative_pattern, filename)
                 if re.search(match_pattern, filename) and matches_derivative:
-                    raw_file = filename
+                    return filename
 
-        return raw_file
+        return None

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -92,6 +92,7 @@ class BidsReader:
 
         bids_config = os.environ['LORIS_MRI'] + "/python/lib/bids.json"
         exclude_arr = ['/code/', '/sourcedata/', '/log/', '.git/']
+        force_arr   = re.compile("_annotations\.(tsv|json)$")
 
         # BIDSLayoutIndexer is required for PyBIDS >= 0.12.1
         bids_pack_version = list(map(int, bids.__version__.split('.')))
@@ -100,10 +101,15 @@ class BidsReader:
             or (bids_pack_version[1] == 12 and bids_pack_version[2] > 0)):
             bids_layout = BIDSLayout(
                 root=self.bids_dir,
-                indexer=BIDSLayoutIndexer(config_filename=bids_config, ignore=exclude_arr)
+                # disabled until is a workaround for https://github.com/bids-standard/pybids/issues/760 is found
+                # [file] bids_import.py [function] read_and_insert_bids [line] for modality in row['modalities']: (row['modalities'] is empty)
+                # indexer=BIDSLayoutIndexer(config_filename=bids_config, ignore=exclude_arr, force_index=force_arr)
+                config=bids_config,
+                ignore=exclude_arr,
+                force_index=force_arr
             )
         else:
-            bids_layout = BIDSLayout(root=self.bids_dir, config=bids_config, ignore=exclude_arr)
+            bids_layout = BIDSLayout(root=self.bids_dir, config=bids_config, ignore=exclude_arr, force_index=force_arr)
 
         if self.verbose:
             print('\t=> BIDS dataset loaded with BIDS layout\n')

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -76,8 +76,6 @@ class BidsReader:
         # load BIDS modality information
         self.cand_session_modalities_list = self.load_modalities_from_bids()
 
-        # grep the derivatives
-        self.derivatives_list = self.load_derivatives_from_bids()
 
     def load_bids_data(self):
         """
@@ -247,45 +245,6 @@ class BidsReader:
 
         return cand_session_modalities_list
 
-    def load_derivatives_from_bids(self):
-        """
-        Reads and grep all derivative datasets directly from the BIDS structure.
-
-        :return: list of derivatives with their information
-         :rtype: list
-        """
-
-        # return None if no derivatives folder found
-        if not os.path.isdir(self.bids_dir + "/derivatives"):
-            return None
-
-        # grep the list of the derivatives folders
-        derivatives_list = []
-        for dirPath, subdirList, fileList in os.walk(self.bids_dir):
-            if re.search('derivatives$', dirPath):
-                # skip the .git paths
-                if '.git/' in dirPath:
-                    continue
-                # grep only the derivatives folders
-                if os.path.dirname(dirPath) + "/" == self.bids_dir:
-                    # if dirPath == BIDS directory, then no derivatives parent
-                    parent = None
-                else:
-                    # else, the parent is in the path of the derivatives folder
-                    parent = dirPath.replace(self.bids_dir, "")
-                for subdir in subdirList:
-                    # loop through derivatives subdirectories & grep info
-                    derivatives_info = {
-                        'rootdir'         : dirPath,
-                        'derivative_name' : subdir,
-                        'parent'          : parent
-                    }
-                    # append the dictionary derivatives_info to the list of
-                    # derivatives
-                    derivatives_list.append(derivatives_info)
-            continue
-
-        return derivatives_list
 
     @staticmethod
     def grep_file(files_list, match_pattern, derivative_pattern=None):

--- a/python/lib/database.py
+++ b/python/lib/database.py
@@ -257,7 +257,7 @@ class Database:
 
         if not id:
             message = "\nERROR: " + where_value + " " + where_field_name + \
-                      " does not exist in " + table_name + "database table\n"
+                      " does not exist in " + table_name + " database table\n"
             print(message)
             sys.exit(lib.exitcode.SELECT_FAILURE)
 

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -129,8 +129,8 @@ class Eeg:
         self.cand_id         = self.loris_cand_info['CandID']
         self.center_id       = self.loris_cand_info['RegistrationCenterID']
         self.project_id      = self.loris_cand_info['RegistrationProjectID']
-        
-        self.subproject_id   = None 
+
+        self.subproject_id   = None
         for row in bids_reader.participants_info:
             if not row['participant_id'] == self.psc_id:
                 continue
@@ -142,7 +142,7 @@ class Eeg:
                 if(len(subproject_info) > 0):
                     self.subproject_id = subproject_info[0]['SubprojectID']
             break
-                
+
         self.session_id      = self.get_loris_session_id()
 
         # grep the channels, electrodes, eeg and events files

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -311,8 +311,8 @@ class Eeg:
             subject   = self.bids_sub_id,
             session   = self.bids_ses_id,
             scope     = 'derivatives' if derivatives else 'raw',
-            #datatype = self.bids_modality,
-            #suffix   = self.bids_modality,
+            datatype  = self.bids_modality,
+            suffix    = self.bids_modality,
             extension = ['set', 'edf', 'vhdr', 'vmrk', 'eeg', 'bdf']
         )
 

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -191,7 +191,7 @@ class Physiological:
 
         results = self.db.pselect(
             query="SELECT ParameterTypeID "
-                  "FROM parameter_type "   
+                  "FROM parameter_type "
                   "WHERE Name = %s "
                   "AND SourceFrom='physiological_parameter_file'",
             args=(parameter_name,)
@@ -244,7 +244,7 @@ class Physiological:
                   'WHERE Name = %s ',
             args=('Electrophysiology Variables',)
         )
-        
+
         if not category_result:
             return None
 
@@ -456,7 +456,7 @@ class Physiological:
                     # replace n/a, N/A, na, NA by None which will translate to NULL
                     # in the physiological_channel table
                     row[field] = None
-                    
+
             values_tuple = (
                 str(physiological_file_id),
                 str(physio_channel_type_id),
@@ -510,6 +510,7 @@ class Physiological:
             'ResponseTime',        'EventCode', 'EventValue', 'EventSample',
             'EventType',           'FilePath'
         )
+
         event_values = []
         for row in event_data:
             optional_fields = (
@@ -520,10 +521,18 @@ class Physiological:
             for field in optional_fields:
                 if field not in row.keys():
                     row[field] = None
+
             # TODO: remove the following if once received confirmation from
             # TODO: James it was an error.
             if "NaN" in row['duration']:
                 row['duration'] = 0
+
+            sample = None
+            if row['event_sample'] and (type(row['event_sample']) == int or type(row['event_sample']) == float):
+                sample = row['event_sample']
+            if row['sample'] and (type(row['sample']) == int or type(row['sample']) == float):
+                sample = row['sample']
+
             values_tuple = (
                 str(physiological_file_id),
                 row['onset'],
@@ -531,8 +540,8 @@ class Physiological:
                 row['trial_type'],
                 row['response_time'],
                 row['event_code'],
-                row['event_value']  or row['value'],
-                row['event_sample'] or row['sample'],
+                str(row['event_value']) or str(row['value']),
+                sample,
                 row['event_type'],
                 event_file
             )

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -534,6 +534,12 @@ class Physiological:
             if row['sample'] and (type(row['sample']) == int or type(row['sample']) == float):
                 sample = row['sample']
 
+            event_value = None
+            if row['event_value']:
+                event_value = str(row['event_value'])
+            elif row['value']:
+                event_value = str(row['value'])
+
             values_tuple = (
                 str(physiological_file_id),
                 row['onset'],
@@ -541,7 +547,7 @@ class Physiological:
                 row['trial_type'],
                 row['response_time'],
                 row['event_code'],
-                str(row['event_value']) or str(row['value']),
+                event_value,
                 sample,
                 row['event_type'],
                 event_file

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -349,7 +349,8 @@ class Physiological:
             optional_fields = ('type', 'material', 'impedance')
             for field in optional_fields:
                 if field not in row.keys():
-                    row[field] = None
+                    continue
+
                 if field == 'type':
                     row['type_id'] = self.db.grep_id_from_lookup_table(
                         id_field_name       = 'PhysiologicalElectrodeTypeID',
@@ -368,10 +369,10 @@ class Physiological:
                     )
 
             values_tuple = (
-                str(physiological_file_id), row['type_id'],
-                row['material_id'],         row['name'],
+                str(physiological_file_id), row.get('type_id'),
+                row.get('material_id'),     row['name'],
                 row['x'],                   row['y'],
-                row['z'],                   row['impedance'],
+                row['z'],                   row.get('impedance'),
                 electrode_file
             )
             electrode_values.append(values_tuple)


### PR DESCRIPTION
The current version of eeg.py handles the import of a single physiology file per subject/modality folder. This extends the current code to import all the physiology files present with their appropriate metadata.

-- note: 
~~The derivative case is broken until I revisit #608 ([code L162-165](https://github.com/aces/Loris-MRI/pull/608/files#diff-250dc8b14f8948bfc4cf003892b0da4257fc45681b3e49d5a7af615e552ea5bbR163) is already commented so it does not break anything).~~
The derivative case is fixed and needs testing.