### PR TITLE
Add missing CPAN library to install

### DIFF
--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -82,6 +82,7 @@ sudo -S cpan install Throwable
 sudo -S cpan install Digest::BLAKE2
 sudo -S cpan install File::Type
 sudo -S cpan install String::ShellQuote
+sudo -S cpan install DateTime
 echo
 
 ################################################################################


### PR DESCRIPTION
The DateTime CPAN library was missing from the cpan install commands of the install script. This PR adds it.

Note: this library was added by the PET insertion pipeline