### PR TITLE
[docs] Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-This Readme covers release 22.0.* of the LORIS Imaging Insertion Pipeline for Ubuntu or CentOS systems
+This Readme covers release 24.0.* of the LORIS Imaging Insertion Pipeline for Ubuntu or CentOS systems
 
-This repo accompanies the [LORIS neuroimaging data platform main repo](https://github.com/aces/Loris/releases)</b>, release 22.0.*.<br>
+This repo accompanies the [LORIS neuroimaging data platform main repo](https://github.com/aces/Loris/releases)</b>, release 24.0.*.<br>
 For documentation and detailed setup information, please see the [LORIS-MRI documentation](docs/) for your installed version</b>.
 
 This repo can be installed on the same VM as the main LORIS codebase, or on a different machine such as a designated fileserver where large imaging filesets are to be stored. 


### PR DESCRIPTION
Fixed typo in README. It said 22.0.* when it should have been 24.0*.

This fixes #633.