### PR TITLE
Remove the duplicated section of code due to a bad rebase when rebasing the HRRT PR branch with main

### DIFF
--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -425,18 +425,6 @@ if ($hrrt) {
 
 
 
-## Determine PSC, ScannerID and Subject IDs
-my ($center_name, $centerID) = $utility->determinePSC(\%studyInfo, 0, $upload_id);
-my $scannerID = $utility->determineScannerID(
-    \%studyInfo, 0, $centerID, $NewScanner, $upload_id
-);
-my $subjectIDsref = $utility->determineSubjectID(
-    $scannerID, \%studyInfo, 0, $upload_id, $User, $centerID
-);
-
-
-
-
 # filters out parameters of length > NeuroDB::File::MAX_DICOM_PARAMETER_LENGTH
 $message = "\n--> filters out parameters of length > "
     . NeuroDB::File::MAX_DICOM_PARAMETER_LENGTH . " for $minc\n";
@@ -498,6 +486,15 @@ $studyInfo{'ScannerModel'}           //= $file->getParameter('study:device_model
 $studyInfo{'ScannerSerialNumber'}    //= $file->getParameter('study:serial_no');
 $studyInfo{'ScannerSoftwareVersion'} //= $file->getParameter('study:software_version');
 $studyInfo{'DateAcquired'}           //= $file->getParameter('study:start_date');
+
+## Determine PSC, ScannerID and Subject IDs
+my ($center_name, $centerID) = $utility->determinePSC(\%studyInfo, 0, $upload_id);
+my $scannerID = $utility->determineScannerID(
+    \%studyInfo, 0, $centerID, $NewScanner, $upload_id
+);
+my $subjectIDsref = $utility->determineSubjectID(
+    $scannerID, \%studyInfo, 0, $upload_id, $User, $centerID
+);
 
 ## Validate that the candidate exists and that PSCID matches CandID
 if (defined($subjectIDsref->{'CandMismatchError'})) {

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -446,39 +446,6 @@ $file->filterParameters();
 
 
 
-
-## Validate that the candidate exists and that PSCID matches CandID
-if (defined($subjectIDsref->{'CandMismatchError'})) {
-    my $CandMismatchError = $subjectIDsref->{'CandMismatchError'};
-
-    $message = "\nCandidate Mismatch Error is $CandMismatchError\n";
-    print LOG $message;
-    print LOG " -> WARNING: This candidate was invalid. Logging to
-              MRICandidateErrors table with reason $CandMismatchError";
-
-    my $logQuery = "INSERT INTO MRICandidateErrors".
-        "(SeriesUID, TarchiveID, MincFile, PatientName, Reason) ".
-        "VALUES (?, ?, ?, ?, ?)";
-    my $candlogSth = $dbh->prepare($logQuery);
-    $candlogSth->execute(
-        $file->getParameter('series_instance_uid'),
-        $studyInfo{'TarchiveID'},
-        NeuroDB::MRI::get_trashbin_file_rel_path($minc),
-        $studyInfo{'PatientName'},
-        $CandMismatchError
-    );
-
-    $notifier->spool('tarchive validation', $message, 0,
-        'minc_insertion.pl', $upload_id, 'Y',
-        $notify_notsummary);
-
-    exit $NeuroDB::ExitCodes::CANDIDATE_MISMATCH;
-}
-
-
-
-
-
 # If studyInfo is not defined (a.k.a. no uploadID or tarchiveID associated with
 # this MINC file), verify that the seriesUID of the MINC file we want to insert is
 # not present in the tarchive_series table. If it is, then exit with proper message.


### PR DESCRIPTION
A part of the code in minc_insertion.pl has been duplicated by a rebase done on the HRRT PR. This caused a section of the script to be duplicated. Kept the second instance in the script so that it works for both MRI and HRRT PET data. 

Note: for PET data, there is no `PatientName` in the `$studyInfo` hash as there are no DICOM for HRRT data. Instead, it is getting that information from the MINC header `patient:full_name`, hence why needed to keep the second instance of the duplicated code instead of the first one.