### PR TITLE
[Perl] Set default ScannerID value to NULL

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -363,8 +363,8 @@ sub identify_scan_db {
         Software      => $fileref->getParameter('software_versions')
     });
     
-    # default ScannerID to 0 if we have no better clue.
-    my $ScannerID = @$resultsRef> 0 ? $resultsRef->[0]->{'ID'} : 0;
+    # default ScannerID to NULL if we have no better clue.
+    my $ScannerID = @$resultsRef> 0 ? $resultsRef->[0]->{'ID'} : undef;
     
     #===========================================================#
     # Get the list of lines in the mri_protocol table that      #
@@ -375,7 +375,7 @@ sub identify_scan_db {
               JOIN mri_protocol_group_target mpgt USING (MriProtocolGroupID)
               WHERE (
                         (Center_name = ? AND ScannerID = ?)
-                     OR ((Center_name='ZZZZ' OR Center_name='AAAA') AND ScannerID='0'))";
+                     OR ((Center_name='ZZZZ' OR Center_name='AAAA') AND ScannerID IS NULL))";
 
     #============================================================#
     # Add to the query the clause related to the Project ID, the #


### PR DESCRIPTION
Modified the Perl pipeline to reflect that the new default value of ScannerID is NULL in the mri_protocol table. This PR should only be merged when [#7496](https://github.com/aces/Loris/pull/7496) is ready to be merged as well.

**Testing instructions**
1. Choose one subject from the RaisinBread dataset to be deleted and re-inserted. The recommended patient is `ROM248` since this patient has not been QC'ed yet and thus the script `delete_imaging_upload.pl`
2. Delete the patient using `delete_imaging_upload.pl`.
3. Run the insertion pipeline and verify that no errors have occurred.