### PR TITLE
Add database connection check in imaging_install.sh

### DIFF
--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -59,7 +59,7 @@ mridir=`pwd`
 # Test the connection to the database before proceeding
 echo "Testing connection to database..."
 
-test_query_output=$(mysql -u $mysqluser -p${mysqlpass} -h $mysqlhost -e ';' 2>&1)
+test_query_output=$(mysql -u $mysqluser -p${mysqlpass} -h $mysqlhost -D $mysqldb -e ';' 2>&1)
 
 if [[ $? -ne 0 ]];
 then

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -63,7 +63,6 @@ test_query_output=$(mysql -u $mysqluser -p${mysqlpass} -h $mysqlhost -D $mysqldb
 
 if [[ $? -ne 0 ]];
 then
-	
 	# If the the MySQL error code was 1045, then there is an error with the username and/or password.
 	# The appropriate message is then printed out. If it is a different error code, then the error message from MySQL
 	# is printed out instead.

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -56,6 +56,30 @@ fi
  
 mridir=`pwd`
 
+# Test the connection to the database before proceeding
+echo "Testing connection to database..."
+
+test_query_output=$(mysql -u $mysqluser -p${mysqlpass} -h $mysqlhost -e ';' 2>&1)
+
+if [[ $? -ne 0 ]];
+then
+	
+	# If the the MySQL error code was 1045, then there is an error with the username and/or password.
+	# The appropriate message is then printed out. If it is a different error code, then the error message from MySQL
+	# is printed out instead.
+    if [[ $test_query_output == *"ERROR 1045"* ]];
+    then
+        echo "ERROR: invalid username and/or password. Aborting..." >&2
+    else
+        echo "ERROR: unable to connect to database. The MySQL error is provided below:" >&2
+        echo $test_query_output >&2
+        echo "Aborting..."
+    fi
+
+    exit 1
+fi
+
+echo "Successfully connected to database\n"
 
 #################################################################################################
 ############################INSTALL THE PERL LIBRARIES###########################################

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -67,16 +67,16 @@ then
 	# If the the MySQL error code was 1045, then there is an error with the username and/or password.
 	# The appropriate message is then printed out. If it is a different error code, then the error message from MySQL
 	# is printed out instead.
-    if [[ $test_query_output == *"ERROR 1045"* ]];
-    then
-        echo "ERROR: invalid username and/or password. Aborting..." >&2
-    else
-        echo "ERROR: unable to connect to database. The MySQL error is provided below:" >&2
-        echo $test_query_output >&2
-        echo "Aborting..."
-    fi
-
-    exit 1
+	if [[ $test_query_output == *"ERROR 1045"* ]];
+	then
+		echo "ERROR: invalid username and/or password. Aborting..." >&2
+	else
+		echo "ERROR: unable to connect to database. The MySQL error is provided below:" >&2
+		echo $test_query_output >&2
+		echo "Aborting..."
+	fi
+	
+	exit 1
 fi
 
 echo "Successfully connected to database\n"


### PR DESCRIPTION
### Description
In an effort to make `imaging_install.sh` more error-proof, a new check is added to ensure that the connection to the database is valid. If the user provides invalid credentials (username and/or password), then the script will alert them and abort. For any other connection problems, the MySQL error message is printed out instead. This address the second task in #498. 

### How to test
1. Run the `imaging_install.sh` script with incorrect username and password a check that the script catches the error and exits. The error printed out should be:
`ERROR: invalid username and/or password. Aborting...`
2. Run the script again with other incorrect credentials (i.e host, database name, etc.) and see if the script catches those errors as well.
3. Run the script with correct credentials to ensure that everything runs smoothly.