### PR TITLE
Improved distribution detection to imaging_install.sh

### DIFF
--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -240,6 +240,7 @@ elif [[ " ${redhat[*]} " =~ " $os_distro " ]]; then
 	echo "You are running ${os_distro}. Please also see Loris-MRI Readme for notes and links to further documentation in our main GitHub Wiki on how to install the DICOM Toolkit and other required dependencies for RedHat-based distributions."
 fi
 
+######################################################################
 ###### Update the Database table, Config, with the user values #######
 ######################################################################
 echo "Populating database configuration entries for the Imaging Pipeline and LORIS-MRI code and images Path:"

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -218,21 +218,28 @@ echo
 ################################################################################################
 #####################################DICOM TOOLKIT##############################################
 ################################################################################################
-if cat /etc/os-release | grep ^NAME | fgrep -q CentOS ; then
-    echo "You are running CentOS. Please also see Loris-MRI Readme for notes and links to further documentation in our main GitHub Wiki on how to install the DICOM Toolkit and other required dependencies."
-else
-    #Check if apt-get is installed
-    APTGETCHECK=`which apt-get`
-    if [ ! -f "$APTGETCHECK" ]; then
-        echo "\nERROR: Unable to find apt-get"
-        echo "Please ask your sysadmin or install apt-get\n"
-        exit
-    fi
 
-    echo "Installing DICOM Toolkit (May prompt for sudo password)"
-    sudo -S apt-get install dcmtk
+# Detecting distribution
+os_distro=$(hostnamectl |awk -F: '/Operating System:/{print $2}'|cut -f2 -d ' ')
+debian=("Debian" "Ubuntu")
+redhat=("Red" "CentOS" "Fedora" "Oracle")
+
+if [[ " ${debian[*]} " =~ " $os_distro " ]]; then
+	#Check if apt-get is installed
+	APTGETCHECK=`which apt-get`
+	if [ ! -f "$APTGETCHECK" ]; then
+		echo "\nERROR: Unable to find apt-get"
+		echo "Please ask your sysadmin or install apt-get\n"
+		exit
+	fi
+
+	echo "Installing DICOM Toolkit (May prompt for sudo password)"
+	sudo -S apt-get install dcmtk
+	
+elif [[ " ${redhat[*]} " =~ " $os_distro " ]]; then
+	echo "You are running ${os_distro}. Please also see Loris-MRI Readme for notes and links to further documentation in our main GitHub Wiki on how to install the DICOM Toolkit and other required dependencies for RedHat-based distributions."
 fi
-######################################################################
+
 ###### Update the Database table, Config, with the user values #######
 ######################################################################
 echo "Populating database configuration entries for the Imaging Pipeline and LORIS-MRI code and images Path:"


### PR DESCRIPTION
### Description
Improved distribution detection by adding support for all Debian-based (Ubuntu, Debian) and RedHat-based (RedHat, CentOS, Fedora, Oracle) distributions. This PR addresses the third task in #498. The added code is also based off the code provided in #498. 

### Testing instructions
1. First, run the following command in the terminal to check that it can properly detect your Linux distribution:
```bash
hostnamectl |awk -F: '/Operating System:/{print $2}'|cut -f2 -d ' '
``` 
2. Next, create a bash script containing only the block of code below. Ensure that if you are running a Debian distribution that DICOM Toolkit automatically installs:
```bash
os_distro=$(hostnamectl |awk -F: '/Operating System:/{print $2}'|cut -f2 -d ' ')
debian=("Debian" "Ubuntu")
redhat=("Red" "CentOS" "Fedora" "Oracle")

if [[ " ${debian[*]} " =~ " $os_distro " ]]; then
    #Check if apt-get is installed
    APTGETCHECK=`which apt-get`
    if [ ! -f "$APTGETCHECK" ]; then
        echo "\nERROR: Unable to find apt-get"
        echo "Please ask your sysadmin or install apt-get\n"
        exit
    fi

    echo "Installing DICOM Toolkit (May prompt for sudo password)"
    sudo -S apt-get install dcmtk

elif [[ " ${redhat[*]} " =~ " $os_distro " ]]; then
    echo "You are running ${os_distro}. Please also see Loris-MRI Readme for notes and links to further documentation in our main GitHub Wiki on how to install the DICOM Toolkit and other required dependencies for RedHat-based distributions."
fi
``` 
3. Manipulate the variable `os_distro` and manually assign distributions to test if the code works for distributions other than your own.
4. Run `imaging_install.sh` to ensure that everything runs smoothly.