### PR TITLE
Add Current stage when creating the visit for the bids_import.py pipeline

### DIFF
--- a/python/lib/session.py
+++ b/python/lib/session.py
@@ -75,8 +75,8 @@ class Session:
             print("Creating visit " + self.visit_label \
                   + " for CandID "  + self.cand_id)
 
-        column_names = ('CandID', 'Visit_label', 'CenterID')
-        values = (self.cand_id, self.visit_label, str(self.center_id))
+        column_names = ('CandID', 'Visit_label', 'CenterID', 'Current_stage')
+        values = (self.cand_id, self.visit_label, str(self.center_id), 'Not Started')
 
         if self.project_id:
             column_names = column_names + ('ProjectID',)


### PR DESCRIPTION
Current_stage is not set when creating a visit via the bids_import.py pipeline which causes the frontend to crash when trying to load the candidate page in access profile.

```
PHP Fatal error:  Uncaught TypeError: Return value of Utility::getStageUsingCandID() must be of the type string, null returned in /var/www
> /loris/php/libraries/Utility.class.inc:632\nStack trace:\n#0 /var/www/loris/modules/instrument_list/php/instrument_list.class.inc(177): Utility::getStageUsingCandID('207019')\n#1 /var/www/loris/php/libraries/NDB_Page.class.inc(
> 707): LORIS\\instrument_list\\Instrument_List->setup()\n#2 /var/www/loris/src/Middleware/UserPageDecorationMiddleware.php(234): NDB_Page->handle(Object(Laminas\\Diactoros\\ServerRequest))\n#3 /var/www/loris/src/Middleware/PageD
> ecorationMiddleware.php(56): LORIS\\Middleware\\UserPageDecorationMiddleware->process(Object(Laminas\\Diactoros\\ServerRequest), Object(LORIS\\instrument_list\\Instrument_List))\n#4 /var/www/loris/php/libraries/NDB_Page.class.i
> nc(692): LORIS\\Middleware\\PageDecorationMiddleware->process(Object(Laminas\\Diactoros\\ServerRequest), Object(LORIS\\instrument_list\\Instrument_List))\n#5 /var/www/loris/modules/instrument_list/php/instrument_list.class.inc(
> 137): NDB_Page->pro in /var/www/loris/php/libraries/Utility.class.inc on line 632, referer: https://ipmsa-loris.bic.mni.mcgill.ca/candidate_profile/207019/
```

The changes here add a "Not Started" value for the `Current_stage` of the visit when a new visit is created in the `session` table.