### PR TITLE
Added a GitHub Action that will run flake8 on submitted PRs

### DIFF
--- a/.github/workflows/flake8_python_linter.yml
+++ b/.github/workflows/flake8_python_linter.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           # For more flake 8 arguments, visit the link below:
           # https://flake8.pycqa.org/en/latest/user/options.html
-		  # Currently, flake8 ignores the following;
-		  #		W291: Trailing whitespace
-		  #		W292: No newline at end of file
-		  #		W293: Blank line contains whitespace
+	  			# Currently, flake8 ignores the following;
+	  			#	W291: Trailing whitespace
+		  		#		W292: No newline at end of file
+		  		#		W293: Blank line contains whitespace
           flake8_args: "--ignore=W291,W292,W293"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/flake8_python_linter.yml
+++ b/.github/workflows/flake8_python_linter.yml
@@ -29,6 +29,12 @@ jobs:
           #     W291: Trailing whitespace
           #     W292: No newline at end of file
           #     W293: Blank line contains whitespace
-          flake8_args: "--ignore=W291,W292,W293 --max-line-length 120"
+          #     E202: Whitespace before ')'
+          #     E203: Whitespace before ':'
+          #     E221: Multiple spaces before operator
+          #     E241: Multiple spaces after ','
+          #     E251: Unexpected spaces around keyword / parameter equals
+          #     E272: Multiple spaces before keyword
+          flake8_args: "--ignore=W291,W292,W293,E202,E203,E221,E241,E251,E272 --max-line-length 120"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/flake8_python_linter.yml
+++ b/.github/workflows/flake8_python_linter.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           # For more flake 8 arguments, visit the link below:
           # https://flake8.pycqa.org/en/latest/user/options.html
-	  			# Currently, flake8 ignores the following;
-	  			#	W291: Trailing whitespace
-		  		#		W292: No newline at end of file
-		  		#		W293: Blank line contains whitespace
+          # Currently, flake8 ignores the following;
+          #     W291: Trailing whitespace
+          #     W292: No newline at end of file
+          #     W293: Blank line contains whitespace
           flake8_args: "--ignore=W291,W292,W293"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/flake8_python_linter.yml
+++ b/.github/workflows/flake8_python_linter.yml
@@ -29,6 +29,6 @@ jobs:
           #     W291: Trailing whitespace
           #     W292: No newline at end of file
           #     W293: Blank line contains whitespace
-          flake8_args: "--ignore=W291,W292,W293"
+          flake8_args: "--ignore=W291,W292,W293 --max-line-length 120"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/flake8_python_linter.yml
+++ b/.github/workflows/flake8_python_linter.yml
@@ -1,0 +1,34 @@
+# This workflow runs flake8 with reviewdog. The documentation can be found below:
+# https://github.com/marketplace/actions/run-flake8-with-reviewdog
+# Flake8 is a Python linter that analyzes code and checks for programming and stylistic errors
+name: Flake8 Linter
+
+# This workflow acts only on pull requests
+on: pull_request
+
+jobs:
+  
+  flake8-lint:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v2
+      
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      
+      - name: Flake8 Lint
+        uses: reviewdog/action-flake8@v3
+        with:
+          # For more flake 8 arguments, visit the link below:
+          # https://flake8.pycqa.org/en/latest/user/options.html
+		  # Currently, flake8 ignores the following;
+		  #		W291: Trailing whitespace
+		  #		W292: No newline at end of file
+		  #		W293: Blank line contains whitespace
+          flake8_args: "--ignore=W291,W292,W293"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -15,3 +15,4 @@ python-dateutil
 nibabel
 numpy
 scipy
+flake8


### PR DESCRIPTION
### Summary
A new Python linter, flake8, has been added as a GitHub Action. It will run on every submitted PR and annotate all the errors that it finds. This PR addresses the issue #649. 

Documentation for the GitHub Action can be found [here](https://github.com/marketplace/actions/run-flake8-with-reviewdog). Essentially, this GitHub Action runs flake8 with [reviewdog](https://github.com/reviewdog/reviewdog). Reviewdog parses the output from flake8 and uses to it annotate code in the PR.