### PR TITLE
Flake8 with mriupload.py

### DIFF
--- a/python/lib/database_lib/mriupload.py
+++ b/python/lib/database_lib/mriupload.py
@@ -1,7 +1,5 @@
 """This class performs database queries for the mri_upload table"""
 
-import datetime
-
 __license__ = "GPLv3"
 
 


### PR DESCRIPTION
### Summary
Ran flake8 and corrected some errors that were caught. In some of the Python files, I decided to ignore some errors (these errors are not on the list in `.github/workflows/flake8_python_linter.yml`) due to unique formatting that helped make the code more readable. Once #651 has been merged, you will be able to see these errors here on GitHub. 