### PR TITLE
Flake8 with mass_electrophysiology_chunking.py

### DIFF
--- a/python/mass_electrophysiology_chunking.py
+++ b/python/mass_electrophysiology_chunking.py
@@ -44,7 +44,7 @@ def main():
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], 'hp:s:l:v', long_options)
-    except getopt.GetoptError as err:
+    except getopt.GetoptError:
         print(usage)
         sys.exit(lib.exitcode.GETOPT_FAILURE)
 


### PR DESCRIPTION
### Summary
Ran flake8 and corrected some errors that were caught. In some of the Python files, I decided to ignore some errors (these errors are not on the list in `.github/workflows/flake8_python_linter.yml`) due to unique formatting that helped make the code more readable. Once #651 has been merged, you will be able to see these errors here on GitHub. 