### PR TITLE
Flake8 with eeglab_to_chunks.py

### DIFF
--- a/python/react-series-data-viewer/eeglab_to_chunks.py
+++ b/python/react-series-data-viewer/eeglab_to_chunks.py
@@ -1,12 +1,13 @@
 import argparse
 import mne.io
-import numpy as np
 import mne.io.eeglab.eeglab as mne_eeglab
 import chunking
 import sys
 
+
 def load_channels(path):
     return mne.io.read_raw_eeglab(path, preload=False)
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
### Summary
Ran flake8 and corrected some errors that were caught. In some of the Python files, I decided to ignore some errors (these errors are not on the list in `.github/workflows/flake8_python_linter.yml`) due to unique formatting that helped make the code more readable. Once #651 has been merged, you will be able to see these errors here on GitHub. 