### PR TITLE
Flake8 with candidate.py

### DIFF
--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -1,7 +1,10 @@
 """Reads a BIDS structure into a data dictionary using bids.grabbids."""
 
+import csv
+import random
 import re
 import os
+import glob
 import sys
 import json
 
@@ -21,10 +24,9 @@ except ImportError:
 # BIDSLayoutIndexer is required for PyBIDS >= 0.12.1
 bids_pack_version = list(map(int, bids.__version__.split('.')))
 if (bids_pack_version[0] > 0
-        or bids_pack_version[1] > 12
-        or (bids_pack_version[1] == 12 and bids_pack_version[2] > 0)):
-    
-	from bids import BIDSLayoutIndexer
+    or bids_pack_version[1] > 12
+    or (bids_pack_version[1] == 12 and bids_pack_version[2] > 0)):
+    from bids import BIDSLayoutIndexer
 
 __license__ = "GPLv3"
 
@@ -91,7 +93,7 @@ class BidsReader:
         force_arr     = [re.compile("_annotations\.(tsv|json)$")]
 
         # BIDSLayoutIndexer is required for PyBIDS >= 0.12.1
-        # bids_pack_version = list(map(int, bids.__version__.split('.')))
+        bids_pack_version = list(map(int, bids.__version__.split('.')))
         # disabled until is a workaround for https://github.com/bids-standard/pybids/issues/760 is found
         # [file] bids_import.py [function] read_and_insert_bids [line] for modality in row['modalities']: (row['modalities'] is empty)
         #if (bids_pack_version[0] > 0

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -1,10 +1,7 @@
 """Reads a BIDS structure into a data dictionary using bids.grabbids."""
 
-import csv
-import random
 import re
 import os
-import glob
 import sys
 import json
 
@@ -24,9 +21,10 @@ except ImportError:
 # BIDSLayoutIndexer is required for PyBIDS >= 0.12.1
 bids_pack_version = list(map(int, bids.__version__.split('.')))
 if (bids_pack_version[0] > 0
-    or bids_pack_version[1] > 12
-    or (bids_pack_version[1] == 12 and bids_pack_version[2] > 0)):
-    from bids import BIDSLayoutIndexer
+        or bids_pack_version[1] > 12
+        or (bids_pack_version[1] == 12 and bids_pack_version[2] > 0)):
+    
+	from bids import BIDSLayoutIndexer
 
 __license__ = "GPLv3"
 
@@ -93,7 +91,7 @@ class BidsReader:
         force_arr     = [re.compile("_annotations\.(tsv|json)$")]
 
         # BIDSLayoutIndexer is required for PyBIDS >= 0.12.1
-        bids_pack_version = list(map(int, bids.__version__.split('.')))
+        # bids_pack_version = list(map(int, bids.__version__.split('.')))
         # disabled until is a workaround for https://github.com/bids-standard/pybids/issues/760 is found
         # [file] bids_import.py [function] read_and_insert_bids [line] for modality in row['modalities']: (row['modalities'] is empty)
         #if (bids_pack_version[0] > 0

--- a/python/lib/candidate.py
+++ b/python/lib/candidate.py
@@ -86,7 +86,7 @@ class Candidate:
             if 'site' in row:
                 site_info = db.pselect(
                     "SELECT CenterID FROM psc WHERE Name = %s",
-                    [row['site'],]
+                    [row['site'], ]
                 )
                 if(len(site_info) > 0):
                     self.center_id = site_info[0]['CenterID']
@@ -99,24 +99,24 @@ class Candidate:
             if 'project' in row:
                 project_info = db.pselect(
                     "SELECT ProjectID FROM Project WHERE Name = %s",
-                    [row['project'],]
+                    [row['project'], ]
                 )
                 if(len(project_info) > 0):
                     self.project_id = project_info[0]['ProjectID']
 
         if not self.center_id:
-            print("ERROR: could not determine site for " + self.psc_id + "." + \
-                  " Please check that your psc table contains a site with an" \
-                  " alias matching the BIDS participant_id or a name matching the site mentioned in" \
-                  " participants.tsv's site column")
+            print("ERROR: could not determine site for " + self.psc_id + "."
+                  + " Please check that your psc table contains a site with an"
+                  + " alias matching the BIDS participant_id or a name matching the site mentioned in"
+                  + " participants.tsv's site column")
             sys.exit(lib.exitcode.PROJECT_CUSTOMIZATION_FAILURE)
 
         if self.verbose:
-            print("Creating candidate with " + \
-                  "PSCID     = " + self.psc_id + ", " + \
-                  "CandID    = " + str(self.cand_id) + ", " + \
-                  "CenterID  = " + str(self.center_id)  + ", " + \
-                  "ProjectID = " + str(self.project_id))
+            print("Creating candidate with \n"
+                  + "PSCID     = " + self.psc_id + ",\n"
+                  + "CandID    = " + str(self.cand_id) + ",\n"
+                  + "CenterID  = " + str(self.center_id)  + ",\n"
+                  + "ProjectID = " + str(self.project_id))
 
         insert_col = ('PSCID', 'CandID', 'RegistrationCenterID')
         insert_val = (self.psc_id, str(self.cand_id), str(self.center_id))


### PR DESCRIPTION
### Summary
Ran flake8 and corrected some errors that were caught. In some of the Python files, I decided to ignore some errors (these errors are not on the list in `.github/workflows/flake8_python_linter.yml`) due to unique formatting that helped make the code more readable. Once #651 has been merged, you will be able to see these errors here on GitHub. 