### PR TITLE
Flake8 on bidsreader.py

### DIFF
--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -1,10 +1,7 @@
 """Reads a BIDS structure into a data dictionary using bids.grabbids."""
 
-import csv
-import random
 import re
 import os
-import glob
 import sys
 import json
 
@@ -24,9 +21,10 @@ except ImportError:
 # BIDSLayoutIndexer is required for PyBIDS >= 0.12.1
 bids_pack_version = list(map(int, bids.__version__.split('.')))
 if (bids_pack_version[0] > 0
-    or bids_pack_version[1] > 12
-    or (bids_pack_version[1] == 12 and bids_pack_version[2] > 0)):
-    from bids import BIDSLayoutIndexer
+        or bids_pack_version[1] > 12
+        or (bids_pack_version[1] == 12 and bids_pack_version[2] > 0)):
+    
+	from bids import BIDSLayoutIndexer
 
 __license__ = "GPLv3"
 
@@ -93,7 +91,7 @@ class BidsReader:
         force_arr     = [re.compile("_annotations\.(tsv|json)$")]
 
         # BIDSLayoutIndexer is required for PyBIDS >= 0.12.1
-        bids_pack_version = list(map(int, bids.__version__.split('.')))
+        # bids_pack_version = list(map(int, bids.__version__.split('.')))
         # disabled until is a workaround for https://github.com/bids-standard/pybids/issues/760 is found
         # [file] bids_import.py [function] read_and_insert_bids [line] for modality in row['modalities']: (row['modalities'] is empty)
         #if (bids_pack_version[0] > 0


### PR DESCRIPTION
### Summary
Ran flake8 and corrected some errors that were caught. In some of the Python files, I decided to ignore some errors (these errors are not on the list in `.github/workflows/flake8_python_linter.yml`) due to unique formatting that helped make the code more readable. Once #651 has been merged, you will be able to see these errors here on GitHub. 