### PR TITLE
Move imaging scripts from /data to /opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ For the defacing scripts, you will also need to download the pre-compiled `bic-m
   `mkdir/chmod/chown` commands starting at 
   [imaging_install.sh:L97](https://github.com/aces/Loris-MRI/blob/main/imaging_install.sh#L97)
 
-  Note: The installer will allow Apache to write to the `/data/` directories by 
+  Note: The installer will allow Apache to write to the `/data/` and `/opt/` directories by 
   adding user `lorisadmin` to the Apache linux group.  To ensure this change takes 
   effect, log out and log back into your terminal session before running the 
   imaging pipeline. The installer will also set Apache group ownership of certain 
-  `/data/` subdirectories.
+  `/data/` and `/opt/` subdirectories.
 
 #### 5. Configure paths and environment
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@ See [aces/Loris](https://github.com/aces/loris) README.md for further informatio
 #### 1. Create directories and download Loris-MRI code
 
    ```bash
-   sudo mkdir -p /data/$projectname/bin/mri
+   sudo mkdir -p /data/$projectname
+   sudo mkdir -p /opt/$projectname/bin/mri
    sudo chown -R lorisadmin:lorisadmin /data/$projectname
-   cd /data/$projectname/bin
+   sudo chown -R lorisadmin:lorisadmin /opt/$projectnawe
+   cd /opt/$projectname/bin
    ```
 
 Get the code: Download the latest release from the 
 [releases page](https://github.com/aces/Loris-MRI/releases) 
-and extract it to `/data/$projectname/bin/mri`
+and extract it to `/opt/$projectname/bin/mri`
 
 #### 2. Install Python 3 with `pip` and `virtualenv`
 
@@ -67,7 +69,7 @@ For the defacing scripts, you will also need to download the pre-compiled `bic-m
 #### 4. Run installer to set up directories, configure environment, install Perl libraries and DICOM toolkit:
 
    ```bash 
-   cd /data/$projectname/bin/mri/
+   cd /opt/$projectname/bin/mri/
    bash ./imaging_install.sh
    ```
 
@@ -97,7 +99,7 @@ For the defacing scripts, you will also need to download the pre-compiled `bic-m
 
    Ensure that `/home/lorisadmin/.bashrc` includes the statement:
 
-   ```source /data/$projectname/bin/mri/environment```
+   ```source /opt/$projectname/bin/mri/environment```
 
    Then source the `.bashrc` file.   
 

--- a/docs/02-Install.md
+++ b/docs/02-Install.md
@@ -87,7 +87,7 @@ Under the `Study` section:
  * `ImagingUploader Auto Launch`: used by the Imaging Uploader to automatically launch the insertion scripts on the uploaded scan
  
 Under the `Paths` section: 
- * `LORIS-MRI Code`: where the LORIS-MRI codebase is installed; typically `/data/$PROJECT/bin/mri/`
+ * `LORIS-MRI Code`: where the LORIS-MRI codebase is installed; typically `/opt/$PROJECT/bin/mri/`
  * `MRI-Upload Directory`: where the uploaded scans get stored; typically `/data/incoming/`
  * `Images`: where the images displayed in Imaging Browser are stored; typically `/data/$PROJECT/data/`
  
@@ -105,7 +105,7 @@ Under the `Imaging Pipeline` section:
     table and visible in the front-end via the Imaging Browser module
  * `User to notify when executing the pipeline`: user email address to be used when
     notification is to be sent by the pipeline
- * `Full path to get_dicom_info.pl script`: typically `/data/$PROJECT/bin/mri/dicom-arhive/get_dicom_info.pl`
+ * `Full path to get_dicom_info.pl script`: typically `/opt/$PROJECT/bin/mri/dicom-arhive/get_dicom_info.pl`
  * `Horizontal pictures creation`: specifies whether or not argument -horizontal
     should be used by mincpik when generating pictures to be displayed in Imaging Browser
  * `NIfTI file creation`: used to enable or disable automated NIfTI file creation
@@ -232,16 +232,16 @@ scripts (in the `python` directory). It accesses data stored in the
 
 #### Filesystem
 
-- `/data/*` subdirectories were created by the imaging install script. If not,
+- `/data/*` and `/opt/*` subdirectories were created by the imaging install script. If not,
     it may be due to `root:root` ownership of the `/data/` mount on your
     system. Ensure these subdirectories are created manually, particularly:
-    `/data/$PROJECT/bin/mri/`, `/data/incoming/`, and those inside 
+    `/opt/$PROJECT/bin/mri/`, `/data/incoming/`, and those inside 
     `/data/$PROJECT/data/`, namely `assembly`, `batch_output`, `logs`,
     `pic`, `tarchive`, and `trashbin`.
 
 
-- `/data/$PROJECT/` directory and subdirectories must be readable and executable
-    by the Apache linux user. It may also help to ensure the `/data/` mount is
+- `/data/$PROJECT/` and `/opt/$PROJECT/` directory and subdirectories must be readable and executable
+    by the Apache linux user. It may also help to ensure the `/data/` and `/opt/` mount is
     executable. After any modifications, ensure you restart apache.
     
 #### Customizable routines in the `prod` file
@@ -302,7 +302,7 @@ Ensure the `project/config.xml` file (in the main LORIS codebase) contains the
 
 #### 2.3.3. Verify filesystem permissions
 
-Ensure that permissions on `/data/$PROJECT`, `/data/incoming` and their
+Ensure that permissions on `/data/$PROJECT`, `/data/incoming`, `/opt/$PROJECT` and their
   subdirectories are set such that `lorisadmin` and the Apache linux user can
   read, write _and_ execute all contents.
 
@@ -312,7 +312,8 @@ The following must be recursively owned by the `lorisadmin` user and Apache grou
 /data/$PROJECT/data/
 /data/$PROJECT/bin/mri/
 /data/incoming/
-/data/$PROJECT/bin/mri/dicom-archive/.loris_mri/prod
+/opt/$PROJECT/
+/opt/$PROJECT/bin/mri/dicom-archive/.loris_mri/prod
 ```
 
 #### 2.3.4 Verify Configuration module settings for Imaging Pipeline
@@ -324,12 +325,12 @@ Under the `Imaging Pipeline` section:
  * `LORIS-MRI Data Directory` (typically `/data/$PROJECT/data/`)
  * `Study Name` (`exampleStudy`; this name will be appended as a prefix to the filenames in LORIS' Imaging Browser)
  * `User to notify when executing the pipeline`
- * `Full path to get_dicom_info.pl script`(typically `/data/$PROJECT/bin/mri/dicom-archive/get_dicom_info.pl`)
+ * `Full path to get_dicom_info.pl script`(typically `/opt/$PROJECT/bin/mri/dicom-archive/get_dicom_info.pl`)
  * `Path to Tarchives` (typically `/data/$PROJECT/data/tarchive/`)
  * `Default visit label for BIDS dataset`: (`V01` or any visit label fitting)
 
 Under the `Path` section:
- * `LORIS-MRI Code`(typically `/data/$PROJECT/bin/mri/`)
+ * `LORIS-MRI Code`(typically `/opt/$PROJECT/bin/mri/`)
  * `Images` (typically `/data/$PROJECT/data/`)
 
 Click `Submit` at the end of the Configuration page to save any changes.

--- a/docs/03-TechnicalInfrastructure.md
+++ b/docs/03-TechnicalInfrastructure.md
@@ -8,13 +8,21 @@ one located in `/data/$PROJECT`, which stores data, and `/opt/$PROJECT`, which
 stores the scripts.
 
 ```
-## Imaging pipeline file directory structure
+## Imaging pipeline file directory structures
+
+## Directory storing all the imaging scripts
+/
+|__ opt
+    |__ $PROJECT
+        |__ bin
+           |__ mri
+              |__ Loris-MRI scripts
+
+## Directory storing all imaging-related data
 /
 |__ data
     |__ incoming
     |__ $PROJECT
-        |__ bin
-        |   |__ mri
         |__ data
             |__ assembly
             |__ bids_imports

--- a/docs/03-TechnicalInfrastructure.md
+++ b/docs/03-TechnicalInfrastructure.md
@@ -3,8 +3,9 @@
 
 ## 3.1 Back end directory structure
 
-The root directory of the imaging part of a LORIS instance is typically 
-  `/data/$PROJECT`.
+The imaging part of a LORIS instance is typically separated into two directories, 
+one located in `/data/$PROJECT`, which stores data, and `/opt/$PROJECT`, which 
+stores the scripts.
 
 ```
 ## Imaging pipeline file directory structure
@@ -33,14 +34,14 @@ The root directory of the imaging part of a LORIS instance is typically
 `*` _denotes optional directories that are not automatically created by the 
 install script. They are created when running the `DTIprep` pipeline_
 
-Within that project directory, there are typically two directories:
+Within a LORIS-MRI instance there are typically two directories:
 
-- The `bin/mri` directory is a copy of all the imaging scripts downloaded from
+- The `/opt/$PROJECT/bin/mri` directory is a copy of all the imaging scripts downloaded from
     the [GitHub LORIS-MRI repository](https://github.com/aces/Loris-MRI). 
     Details about the content of this folder can be found in the
     [script section](04-Scripts.md).
 
-- The `data` directory stores all the imaging-related data that will be created
+- The `/data/$PROJECT/data` directory stores all the imaging-related data that will be created
     by the imaging scripts. 
 
 The following subsections will describe the content of the different 

--- a/docs/05-PipelineLaunchOptions.md
+++ b/docs/05-PipelineLaunchOptions.md
@@ -28,7 +28,7 @@ section.
  
 ### 5.1.1 Option 1
 
-Triggering the pipeline is done from the `/data/$PROJECT/bin/mri` directory as 
+Triggering the pipeline is done from the `/opt/$PROJECT/bin/mri` directory as 
 follows:
 
 ```
@@ -49,7 +49,7 @@ insertion pipeline manually, for every new `UploadID` separately.
 
 ### 5.1.2 Option 2 
 
-Triggering the pipeline from the `/data/$PROJECT/bin/mri` directory can also be 
+Triggering the pipeline from the `/opt/$PROJECT/bin/mri` directory can also be 
 achieved as follows: 
 
 ```
@@ -209,7 +209,7 @@ run `bids_import.py`, you need to be in the loris-mri Python virtual
 environment. It should have been sourced when sourcing your LORIS-MRI 
 environment file. If this is not sourced, then simply run the following:
 ```bash
-source /data/%PROJECT%/bin/mri/python_virtualenvs/loris-mri-python/bin/activate
+source /opt/%PROJECT%/bin/mri/python_virtualenvs/loris-mri-python/bin/activate
 ```
 To deactivate a Python virtual environment, simply type `deactivate` in the 
 terminal.

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -271,8 +271,8 @@ mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPD
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='imagePath')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='$PROJ' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='prefix')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='$email' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='mail_user')"
-mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/bin/mri/dicom-archive/get_dicom_info.pl' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='get_dicom_info')"
+mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/opt/$PROJ/bin/mri/dicom-archive/get_dicom_info.pl' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='get_dicom_info')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/data/tarchive/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='tarchiveLibraryDir')"
-mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$PROJ/bin/mri/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='MRICodePath')"
+mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/opt/$PROJ/bin/mri/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='MRICodePath')"
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='$MINC_TOOLKIT_DIR' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='MINCToolsPath')"
 echo

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -47,7 +47,7 @@ stty -echo
 read -p "What is the MySQL password? " mysqlpass; echo
 stty echo
 read -p "What is the Linux user which the installation will be based on? " USER
-read -p "What is the project name? " PROJ   ##this will be used to create all the corresponding directories...i.e /data/gusto/bin.....
+read -p "What is the project name? " PROJ   ##this will be used to create all the corresponding directories...i.e /data/gusto/data..... and /opt/gusto/bin
 read -p "What is your email address? " email
 read -p "What prod file name would you like to use? default: prod " prodfilename
 if [ -z "$prodfilename" ]; then
@@ -159,7 +159,7 @@ echo "Modifying environment script"
 sed -i "s#%PROJECT%#$PROJ#g" $mridir/environment
 sed -i "s#%MINC_TOOLKIT_DIR%#$MINC_TOOLKIT_DIR#g" $mridir/environment
 #Make sure that CIVET stuff are placed in the right place
-#source /data/$PROJ/bin/$mridirname/environment
+#source /opt/$PROJ/bin/$mridirname/environment
 export TMPDIR=/tmp
 echo
 
@@ -183,14 +183,14 @@ fi
 ######################change permissions ###########################################
 ####################################################################################
 #echo "Changing permissions"
-
-sudo chmod -R 770 $mridir/dicom-archive/.loris_mri/
+sudo chmod -R 770 /opt/$PROJ/
 sudo chmod -R 770 /data/$PROJ/
 
 # Making lorisadmin part of the apache group
 sudo usermod -a -G $group $USER
 
-#Setting group permissions for all files/dirs under /data/$PROJ/
+#Setting group permissions for all files/dirs under /data/$PROJ/ and /opt/$PROJ/
+sudo chgrp $group -R /opt/$PROJ/
 sudo chgrp $group -R /data/$PROJ/
 
 #Setting group ID for all files/dirs under /data/$PROJ/data


### PR DESCRIPTION
### Summary
All the scripts that were originally found in `/data/$PROJ/bin/mri` are now moved to `/opt/$PROJ/bin/mri`. The README documentation, docs and installation script have been updated accordingly. This addresses #479 