### PR TITLE
Start next stage

### DIFF
--- a/dicom-archive/loris_config_template.py
+++ b/dicom-archive/loris_config_template.py
@@ -11,6 +11,13 @@ mysql = {
     'port'    : ''
 }
 
+api = {
+    'host'     : 'LORISHOST',
+    'version'  : 'APIVERSION',
+    'username' : 'LORISUSER',
+    'password' : 'LORISPWD',
+}
+
 def get_subject_ids(db, dicom_value=None, scanner_id=None):
 
     subject_id_dict = {}

--- a/docs/05-PipelineLaunchOptions.md
+++ b/docs/05-PipelineLaunchOptions.md
@@ -187,20 +187,20 @@ options:
 
 To run the BIDS import, simply run:
 ```bash
-bids_import -d /PATH/TO/BIDS/TO/IMPORT -p database_config.py
+bids_import -d /PATH/TO/BIDS/TO/IMPORT -p loris_config.py
 ```
 
 If you wish to create candidates when running the import script, the `-c` 
 option needs to be added. To create sessions when running the import script, 
 the `-s` option need to be added as well.
 ```bash
-bids_import -d /PATH/TO/BIDS/TO/IMPORT -p database_config.py -c -s
+bids_import -d /PATH/TO/BIDS/TO/IMPORT -p loris_config.py -c -s
 ```
 
 Finally, the verbose option can be turned on by using the option `-v` when 
 calling the script:
 ```bash
-bids_import -d /PATH/TO/BIDS/TO/IMPORT -p database_config.py -v
+bids_import -d /PATH/TO/BIDS/TO/IMPORT -p loris_config.py -v
 ```
 
 

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -40,7 +40,8 @@ if [ ! -f "$MAKECHECK" ]; then
     exit
 fi
 
-echo "-- LORIS DB Configuration --\n"
+echo ""
+echo "-- LORIS DB Configuration --"
 read -p "What is the database name? " mysqldb
 read -p "What is the database host? " mysqlhost
 read -p "What is the MySQL user? " mysqluser
@@ -48,15 +49,17 @@ stty -echo
 read -p "What is the MySQL password? " mysqlpass; echo
 stty echo
 
-echo "-- LORIS API Configuration --\n"
+echo ""
+echo "-- LORIS API Configuration --"
 read -p "What is the LORIS url (including http(s))? " lorishost
 read -p "What is the API version (min v0.0.4-dev recommended)? " apiversion
 read -p "What is the LORIS admin user? " lorisuser
 stty -echo
-read -p "What is the LORIS user admin password? " lorispass; echo
+read -p "What is the LORIS user admin password? " lorispwd; echo
 stty echo
 
-echo "-- LORIS MRI Configuration --\n"
+echo ""
+echo "-- LORIS MRI Configuration --"
 read -p "What is the Linux user which the installation will be based on? " USER
 read -p "What is the project name? " PROJ   ##this will be used to create all the corresponding directories...i.e /data/gusto/bin.....
 read -p "What is your email address? " email

--- a/imaging_install.sh
+++ b/imaging_install.sh
@@ -40,20 +40,31 @@ if [ ! -f "$MAKECHECK" ]; then
     exit
 fi
 
+echo "-- LORIS DB Configuration --\n"
 read -p "What is the database name? " mysqldb
 read -p "What is the database host? " mysqlhost
 read -p "What is the MySQL user? " mysqluser
 stty -echo
 read -p "What is the MySQL password? " mysqlpass; echo
 stty echo
+
+echo "-- LORIS API Configuration --\n"
+read -p "What is the LORIS url (including http(s))? " lorishost
+read -p "What is the API version (min v0.0.4-dev recommended)? " apiversion
+read -p "What is the LORIS admin user? " lorisuser
+stty -echo
+read -p "What is the LORIS user admin password? " lorispass; echo
+stty echo
+
+echo "-- LORIS MRI Configuration --\n"
 read -p "What is the Linux user which the installation will be based on? " USER
 read -p "What is the project name? " PROJ   ##this will be used to create all the corresponding directories...i.e /data/gusto/bin.....
 read -p "What is your email address? " email
 read -p "What prod file name would you like to use? default: prod " prodfilename
 if [ -z "$prodfilename" ]; then
     prodfilename="prod"
-fi 
- 
+fi
+
 mridir=`pwd`
 
 # Test the connection to the database before proceeding
@@ -225,12 +236,12 @@ sed -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#
 echo "config file is located at $mridir/dicom-archive/.loris_mri/$prodfilename"
 echo
 
-echo "Creating python database config file with database credentials"
-cp $mridir/dicom-archive/database_config_template.py $mridir/dicom-archive/.loris_mri/database_config.py
-sudo chmod 640 $mridir/dicom-archive/.loris_mri/database_config.py
-sudo chgrp $group $mridir/dicom-archive/.loris_mri/database_config.py
-sed -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" $mridir/dicom-archive/database_config_template.py > $mridir/dicom-archive/.loris_mri/database_config.py
-echo "config file for python import scripts is located at $mridir/dicom-archive/.loris_mri/database_config.py"
+echo "Creating python loris config file with database and api credentials"
+cp $mridir/dicom-archive/loris_config_template.py $mridir/dicom-archive/.loris_mri/loris_config.py
+sudo chmod 640 $mridir/dicom-archive/.loris_mri/loris_config.py
+sudo chgrp $group $mridir/dicom-archive/.loris_mri/loris_config.py
+sed -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" -e "s#LORISHOST#$lorishost#g" -e "s#APIVERSION#$apiversion#g" -e "s#LORISUSER#$lorisuser#g" -e "s#LORISPWD#$lorispwd#g" $mridir/dicom-archive/loris_config_template.py > $mridir/dicom-archive/.loris_mri/loris_config.py
+echo "config file for python import scripts is located at $mridir/dicom-archive/.loris_mri/loris_config.py"
 echo
 
 ######################################################################

--- a/imaging_install_MacOSX.sh
+++ b/imaging_install_MacOSX.sh
@@ -22,7 +22,8 @@ LOGFILE="/tmp/$(basename $0).$$.tmp"
 touch $LOGFILE
 trap "rm  $LOGFILE" EXIT
 
-echo "-- LORIS DB Configuration --\n"
+echo ""
+echo "-- LORIS DB Configuration --"
 read -p "What is the database name? " mysqldb
 read -p "What is the database host? " mysqlhost
 read -p "What is the MySQL user? " mysqluser
@@ -30,15 +31,17 @@ stty -echo
 read -p "What is the MySQL password? " mysqlpass; echo
 stty echo
 
-echo "-- LORIS API Configuration --\n"
+echo ""
+echo "-- LORIS API Configuration --"
 read -p "What is the LORIS url (including http(s))? " lorishost
 read -p "What is the API version (min v0.0.4-dev recommended)? " apiversion
 read -p "What is the LORIS admin user? " lorisuser
 stty -echo
-read -p "What is the LORIS user admin password? " lorispass; echo
+read -p "What is the LORIS user admin password? " lorispwd; echo
 stty echo
 
-echo "-- LORIS MRI Configuration --\n"
+echo ""
+echo "-- LORIS MRI Configuration --"
 read -p "What is the Linux user which the installation will be based on? " USER
 read -p "What is the project name? " PROJ   ##this will be used to create all the corresponding directories...i.e /data/gusto/bin.....
 read -p "What prod file name would you like to use? default: prod " prodfilename

--- a/imaging_install_MacOSX.sh
+++ b/imaging_install_MacOSX.sh
@@ -22,19 +22,30 @@ LOGFILE="/tmp/$(basename $0).$$.tmp"
 touch $LOGFILE
 trap "rm  $LOGFILE" EXIT
 
+echo "-- LORIS DB Configuration --\n"
 read -p "What is the database name? " mysqldb
 read -p "What is the database host? " mysqlhost
 read -p "What is the MySQL user? " mysqluser
 stty -echo
 read -p "What is the MySQL password? " mysqlpass; echo
 stty echo
+
+echo "-- LORIS API Configuration --\n"
+read -p "What is the LORIS url (including http(s))? " lorishost
+read -p "What is the API version (min v0.0.4-dev recommended)? " apiversion
+read -p "What is the LORIS admin user? " lorisuser
+stty -echo
+read -p "What is the LORIS user admin password? " lorispass; echo
+stty echo
+
+echo "-- LORIS MRI Configuration --\n"
 read -p "What is the Linux user which the installation will be based on? " USER
 read -p "What is the project name? " PROJ   ##this will be used to create all the corresponding directories...i.e /data/gusto/bin.....
 read -p "What prod file name would you like to use? default: prod " prodfilename
 if [ -z "$prodfilename" ]; then
     prodfilename="prod"
-fi 
- 
+fi
+
 mridir=`pwd`
 
 #####################################################################################
@@ -120,10 +131,10 @@ sed -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#
 echo "config file is located at $mridir/dicom-archive/.loris_mri/$prodfilename"
 echo
 
-echo "Creating python database config file with database credentials"
-cp $mridir/dicom-archive/database_config_template.py $mridir/dicom-archive/.loris_mri/database_config.py
-sudo chmod 640 $mridir/dicom-archive/.loris_mri/database_config.py
-sudo chgrp $group $mridir/dicom-archive/.loris_mri/database_config.py
-sed -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" $mridir/dicom-archive/database_config_template.py > $mridir/dicom-archive/.loris_mri/database_config.py
-echo "config file for python import scripts is located at $mridir/dicom-archive/.loris_mri/database_config.py"
+echo "Creating python loris config file with database and api credentials"
+cp $mridir/dicom-archive/loris_config_template.py $mridir/dicom-archive/.loris_mri/loris_config.py
+sudo chmod 640 $mridir/dicom-archive/.loris_mri/loris_config.py
+sudo chgrp $group $mridir/dicom-archive/.loris_mri/loris_config.py
+sed -e "s#DBNAME#$mysqldb#g" -e "s#DBUSER#$mysqluser#g" -e "s#DBPASS#$mysqlpass#g" -e "s#DBHOST#$mysqlhost#g" -e "s#LORISHOST#$lorishost#g" -e "s#APIVERSION#$apiversion#g" -e "s#LORISUSER#$lorisuser#g" -e "s#LORISPWD#$lorispwd#g" $mridir/dicom-archive/loris_config_template.py > $mridir/dicom-archive/.loris_mri/loris_config.py
+echo "config file for python import scripts is located at $mridir/dicom-archive/.loris_mri/loris_config.py"
 echo

--- a/python/bids_import.py
+++ b/python/bids_import.py
@@ -214,7 +214,7 @@ def read_and_insert_bids(bids_dir, config_file, verbose, createcand, createvisit
                 for scan_data in bids_reader.bids_layout.get_collections('session', 'scans')
             ])
 
-            if len(scans_data.get('acq_time')) == 0:
+            if 'acq_time' not in scans_data.columns:
                 message = '\n\tERROR: Can\'t find scans acquisition time data'
                 print(message)
                 sys.exit(lib.exitcode.BIDS_SCANS_ACQ_TIME_MISSING)

--- a/python/bids_import.py
+++ b/python/bids_import.py
@@ -213,7 +213,13 @@ def read_and_insert_bids(bids_dir, config_file, verbose, createcand, createvisit
                 scan_data.to_df()
                 for scan_data in bids_reader.bids_layout.get_collections('session', 'scans')
             ])
-            visit_date = min(scans_data['acq_time'])
+
+            if len(scans_data.get('acq_time')) == 0:
+                message = '\n\tERROR: Can\'t find scans acquisition time data'
+                print(message)
+                sys.exit(lib.exitcode.BIDS_SCANS_ACQ_TIME_MISSING)
+
+            visit_date = min(scans_data.get('acq_time'))
 
         # greps BIDS session's info for the candidate from LORIS
         # Creates the session if it does not exist yet in LORIS and createvisit is set to true.

--- a/python/lib/api.py
+++ b/python/lib/api.py
@@ -49,9 +49,8 @@ class Api:
                 print(resp_json.get('error'))
             else:
                 self.token = resp_json.get('token')
-        except:
+        except Exception:
             print("An error occured. Can't login.")
-
 
     def start_next_stage(self, candid, visit, site, subproject, project, date):
         resp = requests.patch(

--- a/python/lib/api.py
+++ b/python/lib/api.py
@@ -13,7 +13,7 @@ class Api:
     the LORIS-MRI python code base and the LORIS backend.
     """
 
-    def __init__(self, verbose):
+    def __init__(self, config, verbose):
         """
         Constructor method for the Api class.
 
@@ -22,8 +22,6 @@ class Api:
         """
 
         self.verbose = verbose
-
-        config = __import__('api_config').config
 
         # grep config settings from the Config module
         self.url = config['host'] + '/api/' + config['version'] + '/'

--- a/python/lib/api.py
+++ b/python/lib/api.py
@@ -44,7 +44,6 @@ class Api:
 
         try:
             resp_json = json.loads(resp.content.decode('ascii'))
-            print(resp_json)
             if resp_json.get('error'):
                 print(resp_json.get('error'))
             else:
@@ -72,7 +71,7 @@ class Api:
             verify=False
         )
 
-        print('resp.status_code:')
-        print(resp.status_code)
-        print('resp.text:')
-        print(resp.text)
+        if (resp.status and resp.status.code and resp.status.code == 200):
+            print("Next stage successfully started.")
+        else:
+            print("An error occured. Can't start next stage.")

--- a/python/lib/api.py
+++ b/python/lib/api.py
@@ -13,6 +13,8 @@ class Api:
     the LORIS-MRI python code base and the LORIS backend.
     """
 
+    token = None
+
     def __init__(self, config, verbose):
         """
         Constructor method for the Api class.
@@ -69,7 +71,7 @@ class Api:
             verify=False
         )
 
-        if (resp.status and resp.status.code and resp.status.code == 200):
+        if (resp.status_code and resp.status_code == 200):
             print("Next stage successfully started.")
         else:
             print("An error occured. Can't start next stage.")

--- a/python/lib/api.py
+++ b/python/lib/api.py
@@ -1,0 +1,79 @@
+"""Allows LORIS API connectivity for LORIS-MRI python code base"""
+
+import requests
+import json
+import urllib
+
+__license__ = "GPLv3"
+
+
+class Api:
+    """
+    This class performs common tasks related to the api connectivity between
+    the LORIS-MRI python code base and the LORIS backend.
+    """
+
+    def __init__(self, verbose):
+        """
+        Constructor method for the Api class.
+
+        :param verbose    : whether to be verbose or not
+         :type verbose    : bool
+        """
+
+        self.verbose = verbose
+
+        config = __import__('api_config').config
+
+        # grep config settings from the Config module
+        self.url = config['host'] + '/api/' + config['version'] + '/'
+        self.username = config['username']
+        self.password = config['password']
+
+        self.login()
+
+    def login(self):
+        resp = requests.post(
+            url=self.url + 'login',
+            json={
+                'username': self.username,
+                'password': self.password
+            },
+            verify=False
+        )
+
+        try:
+            resp_json = json.loads(resp.content.decode('ascii'))
+            print(resp_json)
+            if resp_json.get('error'):
+                print(resp_json.get('error'))
+            else:
+                self.token = resp_json.get('token')
+        except:
+            print("An error occured. Can't login.")
+
+
+    def start_next_stage(self, candid, visit, site, subproject, project, date):
+        resp = requests.patch(
+            url=self.url + '/candidates/' + str(candid) + '/' + urllib.parse.quote(visit),
+            headers={'Authorization': 'Bearer %s' % self.token, 'LORIS-Overwrite': 'overwrite'},
+            data=json.dumps({
+                "CandID": candid,
+                "Visit": visit,
+                "Site": site,
+                "Battery": subproject,
+                "Project": project,
+                "Stages": {
+                    "Visit": {
+                        "Date": date,
+                        "Status": "In Progress",
+                    }
+                }
+            }),
+            verify=False
+        )
+
+        print('resp.status_code:')
+        print(resp.status_code)
+        print('resp.text:')
+        print(resp.text)

--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -96,15 +96,24 @@ class BidsReader:
         bids_pack_version = list(map(int, bids.__version__.split('.')))
         # disabled until is a workaround for https://github.com/bids-standard/pybids/issues/760 is found
         # [file] bids_import.py [function] read_and_insert_bids [line] for modality in row['modalities']: (row['modalities'] is empty)
-        #if (bids_pack_version[0] > 0
-        #    or bids_pack_version[1] > 12
-        #    or (bids_pack_version[1] == 12 and bids_pack_version[2] > 0)):
-        #    bids_layout = BIDSLayout(
-        #        root=self.bids_dir,
-        #        indexer=BIDSLayoutIndexer(config_filename=bids_config, ignore=exclude_arr, force_index=force_arr)
-        #    )
-        #else:
-        bids_layout = BIDSLayout(root=self.bids_dir, config=bids_config, ignore=exclude_arr, force_index=force_arr, derivatives=True)
+        ''' 
+        if (bids_pack_version[0] > 0
+            or bids_pack_version[1] > 12
+            or (bids_pack_version[1] == 12 and bids_pack_version[2] > 0)):
+            bids_layout = BIDSLayout(
+                root=self.bids_dir,
+                indexer=BIDSLayoutIndexer(config_filename=bids_config, ignore=exclude_arr, force_index=force_arr),
+                derivatives=True
+            )
+        else:
+        '''
+        bids_layout = BIDSLayout(
+            root=self.bids_dir,
+            config=bids_config,
+            ignore=exclude_arr,
+            force_index=force_arr,
+            derivatives=True
+        )
 
         if self.verbose:
             print('\t=> BIDS dataset loaded with BIDS layout\n')

--- a/python/lib/database.py
+++ b/python/lib/database.py
@@ -253,8 +253,8 @@ class Database:
             )
 
         if not id:
-            message = "\nERROR: " + where_value + " " + where_field_name + \
-                      " does not exist in " + table_name + " database table\n"
+            message = "\nERROR: " + str(where_value) + " " + str(where_field_name) + \
+                      " does not exist in " + str(table_name) + " database table\n"
             print(message)
             sys.exit(lib.exitcode.SELECT_FAILURE)
 

--- a/python/lib/exitcode.py
+++ b/python/lib/exitcode.py
@@ -47,5 +47,6 @@ TARGET_EXISTS_NO_CLOBBER  = 83  # target already exists but no -clobber option
 UNKNOWN_PROTOCOL          = 84  # if unknown acq protocol for the file to insert
 
 
-CANDIDATE_MISMATCH      = 181
-BIDS_CANDIDATE_MISMATCH = 182
+CANDIDATE_MISMATCH          = 181
+BIDS_CANDIDATE_MISMATCH     = 182
+BIDS_SCANS_ACQ_TIME_MISSING = 183

--- a/python/lib/session.py
+++ b/python/lib/session.py
@@ -137,6 +137,6 @@ class Session:
         site = db.grep_id_from_lookup_table('Name', 'psc', 'CenterID', self.center_id)
         subproject = db.grep_id_from_lookup_table('title', 'subproject', 'SubprojectID', self.subproject_id)
         project = db.grep_id_from_lookup_table('Name', 'Project', 'ProjectID', self.project_id)
-        date = datetime.fromisoformat(visit_date.replace('Z', '+00:00')).strftime('%Y-%m-%d')
+        date = visit_date[0:10]
 
         api.start_next_stage(self.cand_id, self.visit_label, site, subproject, project, date)

--- a/python/lib/session.py
+++ b/python/lib/session.py
@@ -1,7 +1,5 @@
 """This class gather functions for session handling."""
 
-from lib.api import Api
-
 __license__ = "GPLv3"
 
 
@@ -117,7 +115,7 @@ class Session:
 
         return loris_session_info[0] if loris_session_info else None
 
-    def start_visit_stage(self, db, visit_date):
+    def start_visit_stage(self, db, api, visit_date):
         """
         Start the visit using BIDS information.
 
@@ -129,8 +127,6 @@ class Session:
 
         if self.verbose:
             print("Starting visit stage for " + self.visit_label + " and CandID "  + self.cand_id)
-
-        api = Api(self.verbose)
 
         site = db.grep_id_from_lookup_table('Name', 'psc', 'CenterID', self.center_id)
         subproject = db.grep_id_from_lookup_table('title', 'subproject', 'SubprojectID', self.subproject_id)

--- a/python/lib/session.py
+++ b/python/lib/session.py
@@ -1,6 +1,5 @@
 """This class gather functions for session handling."""
 
-from datetime import datetime
 from lib.api import Api
 
 __license__ = "GPLv3"
@@ -117,7 +116,6 @@ class Session:
         )
 
         return loris_session_info[0] if loris_session_info else None
-
 
     def start_visit_stage(self, db, visit_date):
         """

--- a/python/lib/session.py
+++ b/python/lib/session.py
@@ -1,5 +1,7 @@
 """This class gather functions for session handling."""
 
+from datetime import datetime
+from lib.api import Api
 
 __license__ = "GPLv3"
 
@@ -19,7 +21,7 @@ class Session:
         db.connect()
 
         session = Session(
-            verbose, cand_id, visit_label, 
+            verbose, cand_id, visit_label,
             center_id, project_id, subproject_id
         )
 
@@ -59,7 +61,7 @@ class Session:
         self.project_id    = project_id
         self.subproject_id = subproject_id
 
-                
+
     def create_session(self, db):
         """
         Creates a session using BIDS information.
@@ -96,6 +98,7 @@ class Session:
 
         return loris_session_info
 
+
     def get_session_info_from_loris(self, db):
         """
         Grep session information from the session table using CandID and
@@ -114,3 +117,26 @@ class Session:
         )
 
         return loris_session_info[0] if loris_session_info else None
+
+
+    def start_visit_stage(self, db, visit_date):
+        """
+        Start the visit using BIDS information.
+
+        :param db        : database handler object
+         :type db        : object
+        :param visit_date: visit date
+         :type visit_date: date
+        """
+
+        if self.verbose:
+            print("Starting visit stage for " + self.visit_label + " and CandID "  + self.cand_id)
+
+        api = Api(self.verbose)
+
+        site = db.grep_id_from_lookup_table('Name', 'psc', 'CenterID', self.center_id)
+        subproject = db.grep_id_from_lookup_table('title', 'subproject', 'SubprojectID', self.subproject_id)
+        project = db.grep_id_from_lookup_table('Name', 'Project', 'ProjectID', self.project_id)
+        date = datetime.fromisoformat(visit_date.replace('Z', '+00:00')).strftime('%Y-%m-%d')
+
+        api.start_next_stage(self.cand_id, self.visit_label, site, subproject, project, date)

--- a/python/lib/session.py
+++ b/python/lib/session.py
@@ -128,6 +128,10 @@ class Session:
         if self.verbose:
             print("Starting visit stage for " + self.visit_label + " and CandID "  + self.cand_id)
 
+        if not self.subproject_id or not self.project_id:
+            print("Can't start the visit stage - No subproject and project associated with the participant data.")
+            return
+
         site = db.grep_id_from_lookup_table('Name', 'psc', 'CenterID', self.center_id)
         subproject = db.grep_id_from_lookup_table('title', 'subproject', 'SubprojectID', self.subproject_id)
         project = db.grep_id_from_lookup_table('Name', 'Project', 'ProjectID', self.project_id)


### PR DESCRIPTION
This PR adds support for a -n flag for bids_import to start the visit stage.
```python3 bids_import.py -d '/test/' -p loris_config.py -csvn```

This implementation uses a basic API class to make use of the next stage API endpoint (see #470) 
An API config data is required in dicom-archive/.loris-mri/loris_config.py with the following content:
``` 
api = {
    'host'     : '',
    'version'  : 'v0.0.4-dev',
    'username' : '',
    'password' : '',
}
``` 