### PR TITLE
Add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,5 +25,5 @@ jobs:
         stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 20 days.'
         days-before-issue-stale: 365 # ~1 year
         days-before-issue-close: 90 # ~3 months   
-        days-before-pr-stale: 45
-        days-before-pr-close: 20
+        days-before-pr-stale: 90 # ~3 months
+        days-before-pr-close: 45 # ~1.5 month

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '30 0 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 1 year with no activity.  Remove stale label or comment or this will be closed in 3 months.'
+        stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 20 days.'
+        days-before-issue-stale: 365 # ~1 year
+        days-before-issue-close: 90 # ~3 months   
+        days-before-pr-stale: 45
+        days-before-pr-close: 20


### PR DESCRIPTION
This adds a stale workflow to the LORIS-MRI code base. To be discussed tomorrow at the LORIS imaging call.