### PR TITLE
[Bugfix] call to getPSC was passed wrong variable

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -210,7 +210,7 @@ sub getSessionInformation {
     
     if($subjectIDref->{'isPhantom'}) {
         # calibration data (PHANTOM_site_date | LIVING_PHANTOM_site_date | *test*)
-        my @pscInfo = getPSC($subjectIDref->{'visitLabel'}, $dbhr, $db);
+        my @pscInfo = getPSC($subjectIDref->{'visitLabel'}, $dbh, $db);
         $centerID = $pscInfo[1];
     }
     # determine the centerID and new visit number (which is now deprecated) if getPSC() failed.

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -210,7 +210,7 @@ sub getSessionInformation {
     
     if($subjectIDref->{'isPhantom'}) {
         # calibration data (PHANTOM_site_date | LIVING_PHANTOM_site_date | *test*)
-        my @pscInfo = getPSC($subjectIDref->{'visitLabel'}, $dbh, $db);
+        my @pscInfo = getPSC($subjectIDref->{'visitLabel'}, \$dbh, $db);
         $centerID = $pscInfo[1];
     }
     # determine the centerID and new visit number (which is now deprecated) if getPSC() failed.


### PR DESCRIPTION
This PR resolved the bug reported in #674

The method `getPSC` was being passed the incorrect variable. 
`$dbhr` is not defined in the scope of the function `getSesisonInformation`, but rather the it is defined as `$dbh`. See [this line](https://github.com/aces/Loris-MRI/blob/121ae9611ff8a7f3d55f295d74011762adae9760/uploadNeuroDB/NeuroDB/MRI.pm#L141)