### PR TITLE
 Stop using config setting useProjects (projects are always "used" now) for 23.0 bug fix release

### DIFF
--- a/dicom-archive/profileTemplate.pl
+++ b/dicom-archive/profileTemplate.pl
@@ -58,7 +58,7 @@ sub getSubjectIDs {
         # ($subjectID{'SubprojectID'}) = $patientName =~ /_(\d+)$/;
         # When createVisitLabel is set to 0, $subjectID{'SubprojectID'} is ignored.
 
-        # If config setting 'useProject' and 'createVisitLabel' are true
+        # If config setting 'createVisitLabel' is true
         # then $subjectID{'ProjectID'} must be set to the project ID of the
         # newly created visit. Assuming for example that all patients
         # names that contain the string 'HOSPITAL' are associated to visit
@@ -88,7 +88,7 @@ sub getSubjectIDs {
         #     ? 1 : 2;
         # When createVisitLabel is set to 0, $subjectID{'SubprojectID'} is ignored.
         
-        # If config setting 'useProject' and 'createVisitLabel' are true
+        # If config setting 'createVisitLabel' is true
         # then $subjectID{'ProjectID'} must be set to the project ID of the
         # newly created visit. Assuming for example that candidates with a
         # candidate ID greater than 400000 are seen in project 1 and others are

--- a/docs/scripts_md/ConfigOB.md
+++ b/docs/scripts_md/ConfigOB.md
@@ -188,12 +188,6 @@ Get the is\_qsub Config setting.
 
 RETURN: (boolean) 1 if is\_qsub is set to Yes in the Config module, 0 otherwise
 
-### getUseProjects()
-
-Get the useProjects Config setting.
-
-RETURN: (boolean) 1 if useProjects is set to Yes in the Config module, 0 otherwise
-
 ### getCreateCandidates()
 
 Get the createCandidates Config setting.

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1617,7 +1617,7 @@ sub CreateMRICandidates {
     $query = "SELECT ProjectID FROM Project WHERE ProjectID = ?";
     my $sth = ${$this->{'dbhr'}}->prepare($query);
     $sth->execute($subjectIDsref->{'ProjectID'});
-          
+
     if($sth->rows != 1) {
         $message = "ERROR: Cannot create candidate $pscID with ProjectID "
                  . "$subjectIDsref->{'ProjectID'}: that project ID is invalid.\n";

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1604,31 +1604,27 @@ sub CreateMRICandidates {
     my $configOB = $this->{'configOB'};
     return if (!$configOB->getCreateCandidates());
 
-    # If projects are used, check that a ProjectID is provided for the candidate
-    # about to be created
-    if ($configOB->getUseProjects()) {
+    # Check that a ProjectID is provided for the candidate about to be created
+    if (!defined $subjectIDsref->{'ProjectID'}) {
+        $message = "ERROR: Cannot create candidate $candID/$pscID as the profile file "
+            . "does not define a ProjectID for him/her.\n";
+        $this->writeErrorLog($message, $NeuroDB::ExitCodes::INSERT_FAILURE);
+        $this->spool($message, 'Y', $upload_id, $notify_notsummary);
 
-        if (!defined $subjectIDsref->{'ProjectID'}) {
-            $message = "ERROR: Cannot create candidate $candID/$pscID as the profile file "
-                     . "does not define a ProjectID for him/her.\n";
-            $this->writeErrorLog($message, $NeuroDB::ExitCodes::INSERT_FAILURE);
-            $this->spool($message, 'Y', $upload_id, $notify_notsummary);
+        exit $NeuroDB::ExitCodes::INSERT_FAILURE;
+    }
 
-            exit $NeuroDB::ExitCodes::INSERT_FAILURE;
-        }
-        
-        $query = "SELECT ProjectID FROM Project WHERE ProjectID = ?";
-        my $sth = ${$this->{'dbhr'}}->prepare($query);
-        $sth->execute($subjectIDsref->{'ProjectID'});
+    $query = "SELECT ProjectID FROM Project WHERE ProjectID = ?";
+    my $sth = ${$this->{'dbhr'}}->prepare($query);
+    $sth->execute($subjectIDsref->{'ProjectID'});
           
-        if($sth->rows != 1) {
-            $message = "ERROR: Cannot create candidate $pscID with ProjectID "
-                     . "$subjectIDsref->{'ProjectID'}: that project ID is invalid.\n";
-            $this->writeErrorLog($message, $NeuroDB::ExitCodes::INSERT_FAILURE);
-            $this->spool($message, 'Y', $upload_id, $notify_notsummary);
+    if($sth->rows != 1) {
+        $message = "ERROR: Cannot create candidate $pscID with ProjectID "
+                 . "$subjectIDsref->{'ProjectID'}: that project ID is invalid.\n";
+        $this->writeErrorLog($message, $NeuroDB::ExitCodes::INSERT_FAILURE);
+        $this->spool($message, 'Y', $upload_id, $notify_notsummary);
 
-            exit $NeuroDB::ExitCodes::INSERT_FAILURE;
-        }  
+        exit $NeuroDB::ExitCodes::INSERT_FAILURE;
     }
 
     # Create non-existent candidate if the profile allows for Candidate creation
@@ -1644,15 +1640,12 @@ sub CreateMRICandidates {
         CandID               => $subjectIDsref->{'CandID'},
         PSCID                => $subjectIDsref->{'PSCID'},
         DoB                  => $subjectIDsref->{'PatientDoB'},
+        ProjectID            => $subjectIDsref->{'ProjectID'},
         Sex                  => $sex,
         RegistrationCenterID => $centerID,
         UserID               => $User,
     );
-    
-    # Note that we validated above that if $configOB->getUseProjects() then
-    # $subjectIDsRef->{'ProjectID'} is defined
-    $record{'ProjectID'} = $subjectIDsref->{'ProjectID'} if $configOB->getUseProjects();
-    
+
     $query = sprintf(
         "INSERT INTO candidate (%s) VALUES (%s)",
         join(',', keys %record)         . ',Date_active,Date_registered,Entity_type',

--- a/uploadNeuroDB/NeuroDB/objectBroker/ConfigOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/ConfigOB.pm
@@ -85,7 +85,6 @@ use constant CREATE_NII                => 'create_nii';
 use constant HORIZONTAL_PICS           => 'horizontalPics';
 use constant IS_QSUB                   => 'is_qsub';
 use constant CREATE_CANDIDATES         => 'createCandidates';
-use constant USE_PROJECTS              => 'useProjects';
 
 =pod
 
@@ -411,21 +410,6 @@ sub getIsQsub {
     my $self = shift;
 
     my $value = &$getConfigSettingRef($self, IS_QSUB);
-
-    return $getBooleanRef->($value);
-}
-
-=head3 getUseProjects()
-
-Get the useProjects Config setting.
-
-RETURN: (boolean) 1 if useProjects is set to Yes in the Config module, 0 otherwise
-
-=cut
-sub getUseProjects {
-    my $self = shift;
-
-    my $value = &$getConfigSettingRef($self, USE_PROJECTS);
 
     return $getBooleanRef->($value);
 }


### PR DESCRIPTION
Config setting `useProjects` has been removed from the LORIS code base since version 21.0 as projects are always "used" now. This PR removes from the LORIS-MRI codebase any reference or access to that setting.

How to test:
- Ensure setting `useProjects` is not in the DB
- Insert a scan that belongs to a candidate that does not exist in the DB and ensure that the profile file specifies a project ID and a subproject ID for that candidate/visit.
- Test that the scan is inserted successfully and that the candidate is created by the pipeline, along with the appropriate visit.

Fixes #670 for release 23.0