### PR TITLE
Add force option to gzip command to avoid question if we want to overwrite when the .nii.gz is recreated.

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1319,7 +1319,7 @@ sub gzip_file {
 
     return undef unless (-e $file);
 
-    my $gzip_cmd = "gzip $file";
+    my $gzip_cmd = "gzip -f $file";
     system($gzip_cmd);
 
     (-e "$file.gz") ? return "$file.gz" : undef;


### PR DESCRIPTION
As reported in #704, when `mass_nii.pl` is rerun to recreate `.nii.gz` files, the `gzip` command asks the user whether they want to overwrite the `.nii.gz`. Since when a `.nii.gz` file we always want the last one created when running `mass_nii.pl`, the `gzip` command has been updated to use the `-f` option so that there is no need for user input anymore.

Note: when the user answers `n` to the overwrite question, a duplicated `.nii` is created in the `assembly` folder but not link in the database so this error can result in multiple `.nii` files that are nowhere to be found in the database tables.