### PR TITLE
Fix mass_nifti_pic.py in the case there is already an entry in parameter_file for the pic path

### DIFF
--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -522,13 +522,17 @@ class Imaging:
         return file_parameters
 
     @staticmethod
-    def create_imaging_pic(file_info):
+    def create_imaging_pic(file_info, pic_rel_path=None):
         """
         Creates the preview pic that will show in the imaging browser view session
         page. This pic will be stored in the data_dir/pic folder
 
         :param file_info: dictionary with file information (path, file_id, cand_id...)
          :type file_info: dict
+        :param pic_rel_path: relative path to the pic to use if one provided. Otherwise
+                             create_imaging_pic will automatically generate the pic name
+                             based on the file path of the NIfTI file
+         :type pic_rel_path: str
 
         :return: path to the created pic
          :rtype: str

--- a/python/mass_nifti_pic.py
+++ b/python/mass_nifti_pic.py
@@ -166,9 +166,6 @@ def make_pic(file_id, config_file, force, verbose):
     # load the Imaging object
     imaging = Imaging(db, verbose)
 
-    # checks if there is already a pic for the NIfTI file
-    existing_pic_file_in_db = imaging.grep_parameter_value_from_file_id(file_id, 'check_pic_filename')
-
     # grep the NIfTI file path
     nii_file_path = imaging.grep_file_path_from_file_id(file_id)
     if not nii_file_path:
@@ -180,6 +177,9 @@ def make_pic(file_id, config_file, force, verbose):
     if not os.path.exists(data_dir + nii_file_path):
         print('WARNING: file ' + nii_file_path + ' not found on the filesystem')
         return
+
+    # checks if there is already a pic for the NIfTI file
+    existing_pic_file_in_db = imaging.grep_parameter_value_from_file_id(file_id, 'check_pic_filename')
     if existing_pic_file_in_db and not force:
         print('WARNING: there is already a pic for FileID ' + str(file_id) + '. Use -f or --force to overwrite it')
         return

--- a/python/mass_nifti_pic.py
+++ b/python/mass_nifti_pic.py
@@ -24,11 +24,12 @@ sys.path.append('/home/user/python')
 def main():
     profile     = ''
     verbose     = False
+    force       = False
     smallest_id = None
     largest_id  = None
 
     long_options = [
-        "help", "profile=", "smallest_id=", "largest_id=", "verbose"
+        "help", "profile=", "smallest_id=", "largest_id=", "force", "verbose"
     ]
 
     usage = (
@@ -39,11 +40,12 @@ def main():
                               'dicom-archive/.loris-mri\n'
         '\t-s, --smallest_id: smallest FileID for which the pic will be created\n'
         '\t-l, --largest_id : largest FileID for which the pic will be created\n'
+        '\t-f, --force      : overwrite the pic already present in the filesystem with new pic\n'
         '\t-v, --verbose    : be verbose\n'
     )
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], 'hp:s:l:v', long_options)
+        opts, args = getopt.getopt(sys.argv[1:], 'hp:s:l:fv', long_options)
     except getopt.GetoptError:
         print(usage)
         sys.exit(lib.exitcode.GETOPT_FAILURE)
@@ -58,6 +60,8 @@ def main():
             smallest_id = int(arg)
         elif opt in ('-l', '--largest_id'):
             largest_id = int(arg)
+        elif opt in ('-f', '--force'):
+            force = True
         elif opt in ('-v', '--verbose'):
             verbose = True
 
@@ -66,10 +70,10 @@ def main():
 
     # create pic for NIfTI files with a FileID between smallest_id and largest_id
     if (smallest_id == largest_id):
-        make_pic(smallest_id, config_file, verbose)
+        make_pic(smallest_id, config_file, force, verbose)
     else:
         for file_id in range(smallest_id, largest_id + 1):
-            make_pic(file_id, config_file, verbose)
+            make_pic(file_id, config_file, force, verbose)
 
 
 def input_error_checking(profile, smallest_id, largest_id, usage):
@@ -132,7 +136,7 @@ def input_error_checking(profile, smallest_id, largest_id, usage):
     return config_file
 
 
-def make_pic(file_id, config_file, verbose):
+def make_pic(file_id, config_file, force, verbose):
     """
     Call the function create_imaging_pic of the Imaging class on
     the FileID provided as argument to this function.
@@ -141,6 +145,9 @@ def make_pic(file_id, config_file, verbose):
      :type file_id    : int
     :param config_file: path to the config file with database connection information
      :type config_file: str
+    :param force      : if a pic is already present for the FileID, overwrite the pic in the filesystem with newly
+                        generated pic
+     :type force      : bool
     :param verbose    : flag for more printing if set
      :type verbose    : bool
     """
@@ -159,16 +166,22 @@ def make_pic(file_id, config_file, verbose):
     # load the Imaging object
     imaging = Imaging(db, verbose)
 
+    # checks if there is already a pic for the NIfTI file
+    existing_pic_file_in_db = imaging.grep_parameter_value_from_file_id(file_id, 'check_pic_filename')
+
     # grep the NIfTI file path
     nii_file_path = imaging.grep_file_path_from_file_id(file_id)
     if not nii_file_path:
-        print('WARNING: no file in the database with FileID = ' + file_id)
+        print('WARNING: no file in the database with FileID = ' + str(file_id))
         return
     if not re.search('.nii.gz$', nii_file_path):
         print('WARNING: wrong file type. File ' + nii_file_path + ' is not a .nii.gz file')
         return
     if not os.path.exists(data_dir + nii_file_path):
         print('WARNING: file ' + nii_file_path + ' not found on the filesystem')
+        return
+    if existing_pic_file_in_db and not force:
+        print('WARNING: there is already a pic for FileID ' + str(file_id) + '. Use -f or --force to overwrite it')
         return
 
     # grep the time length from the NIfTI file header
@@ -180,7 +193,7 @@ def make_pic(file_id, config_file, verbose):
     # grep the CandID of the file
     cand_id = imaging.grep_cand_id_from_file_id(file_id)
     if not cand_id:
-        print('WARNING: CandID not found for FileID ' + file_id)
+        print('WARNING: CandID not found for FileID ' + str(file_id))
 
     # create the pic
     pic_rel_path = imaging.create_imaging_pic(
@@ -190,14 +203,16 @@ def make_pic(file_id, config_file, verbose):
             'file_rel_path': nii_file_path,
             'is_4D_dataset': is_4d_dataset,
             'file_id'      : file_id
-        }
+        },
+        existing_pic_file_in_db
     )
     if not os.path.exists(data_dir + 'pic/' + pic_rel_path):
         print('WARNING: the pic ' + data_dir + 'pic/' + pic_rel_path + 'was not created')
         return
 
     # insert the relative path to the pic in the parameter_file table
-    imaging.insert_parameter_file(file_id, 'check_pic_filename', pic_rel_path)
+    if not existing_pic_file_in_db:
+        imaging.insert_parameter_file(file_id, 'check_pic_filename', pic_rel_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes a few bugs found when testing mass_nifti_pic.py:
- fixes the warning printed
- checks whether a pic has already been created and is present in parameter_file. If so, print a warning that the pic already exists and that if the user wishes to recreate it, the option `--force`/`-f` should be used when running the script
- adds a force option to force the re-creation of the pic on the filesystem with the same path as the path already stored in the database