### PR TITLE
Fix bug in findScannerID function call in register_processed_data.pl

### DIFF
--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -265,7 +265,7 @@ if  ($file->getFileDatum('FileType') eq 'mnc')  {
         $scannerInfo{'ScannerManufacturer'}, $scannerInfo{'ScannerModel'},
         $scannerInfo{'ScannerSerialNumber'}, $scannerInfo{'ScannerSoftwareVersion'},
         $centerID,                           \$dbh,
-        0,                                   $db
+        $db
     );
 }else   {
     $scannerID  =   getScannerID($sourceFileID,$dbh);


### PR DESCRIPTION
This fixes a bug where the call to the NeuroDB::MRI::findScannerID function had an extra argument causing the following error:
```
Attribute (db) does not pass the type constraint because: Validation failed for 'NeuroDB::Database' with value 0 (not isa NeuroDB::Database) at /usr/local/lib/x86_64-linux-gnu/perl/5.22.1/Moose/Object.pm line 24
	Moose::Object::new('NeuroDB::objectBroker::MriScannerOB', 'db', 0) called at /data/qpn/bin/mri/uploadNeuroDB/NeuroDB/MRI.pm line 969
	NeuroDB::MRI::findScannerID('SIEMENS  ', 'TrioTim  ', '35008  ', 'syngo MR B17 ', 1, 'REF(0x490d7b8)', 0, 'NeuroDB::Database=HASH(0x49d6fb0)') called at /data/preventAD/bin/mri/uploadNeuroDB/register_processed_data.pl line 266
Argument "8Exiting now\n\n" isn't numeric in right bitshift (>>) at run_defacing_script.pl line 682.
 at run_defacing_script.pl line 682.
	main::register_defaced_files(HASH(0x4770eb8)) called at run_defacing_script.pl line 286
Argument "\nAn error occurred when running register_processed_data..." isn't numeric in right bitshift (>>) at run_defacing_script.pl line 682.
 at run_defacing_script.pl line 682.
	main::register_defaced_files(HASH(0x4770eb8)) called at run_defacing_script.pl line 286
```