### PR TITLE
Repair invalid code in uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1754,7 +1754,7 @@ sub CreateMRICandidates {
     );
 
     print "$query\n" if ($this->{debug});
-    my $sth = ${$this->{'dbhr'}}->prepare($query);
+    $sth = ${$this->{'dbhr'}}->prepare($query);
     $sth->execute(values %record);
 
     $message = "\n==> CREATED NEW CANDIDATE: $candID";


### PR DESCRIPTION
The code in class `uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm` does not compile: variable `$sth` is declared twice (with `my`) in method `CreateMRICandidates`.

Fixes #720