### PR TITLE
uploadNeuroDB/imaging_non_minc_insertion.pl now works with all versions of Perl

### DIFF
--- a/uploadNeuroDB/imaging_non_minc_insertion.pl
+++ b/uploadNeuroDB/imaging_non_minc_insertion.pl
@@ -389,7 +389,7 @@ if ($metadata_file) {
     close( FILE );
 
     my $metadata = decode_json($json);
-    foreach my $parameter (sort keys $metadata) {
+    foreach my $parameter (sort keys %$metadata) {
         $file->setParameter( $parameter, $metadata->{$parameter} );
     }
 }


### PR DESCRIPTION
Script uploadNeuroDB/imaging_non_minc_insertion.pl uses code that is no longer supported in earlier versions of Perl. This PR refactors the script so that it works with all Perl versions.

Fixes #721 