### PR TITLE
Map n/a values for electrodes X, Y and Z fields to NULL in physiological_electrode table

### DIFF
--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -375,11 +375,16 @@ class Physiological:
                         insert_if_not_found = True
                     )
 
+            # map the X, Y and Z 'n/a' values to NULL
+            x_value = None if row['x'] == 'n/a' else row['x']
+            y_value = None if row['y'] == 'n/a' else row['y']
+            z_value = None if row['z'] == 'n/a' else row['z']
+
             values_tuple = (
                 str(physiological_file_id), row.get('type_id'),
                 row.get('material_id'),     row['name'],
-                row['x'],                   row['y'],
-                row['z'],                   row.get('impedance'),
+                x_value,                    y_value,
+                z_value,                    row.get('impedance'),
                 electrode_file
             )
             electrode_values.append(values_tuple)


### PR DESCRIPTION
When the values for X, Y and Z in the BIDS `*electrodes.tsv` file are set to `n/a`, map those values to `NULL` so that it can be inserted into the `physiological_electrode` table in the DB.

Important note: requires the SQL patch from the following PR https://github.com/aces/Loris/pull/7849