### PR TITLE
Fixes a NoneType error bug when no entry in scans.tsv for a given file and trying to look for an acquisition date

### DIFF
--- a/python/lib/scanstsv.py
+++ b/python/lib/scanstsv.py
@@ -68,12 +68,16 @@ class ScansTSV:
          :rtype: str
         """
 
+        if not self.acquisition_data:
+            # if no entry in self.acquisition_data, then no information available to get the acquisition time
+            return None
+
         if 'acq_time' in self.acquisition_data:
             if isinstance(self.tsv_entries, list):
-                acq_time_List = [ele for ele in self.tsv_entries if ele['filename'] in self.acquisition_file]
-                if len(acq_time_List) == 1:
+                acq_time_list = [ele for ele in self.tsv_entries if ele['filename'] in self.acquisition_file]
+                if len(acq_time_list) == 1:
                     # the variable name could be mri_acq_time, but is eeg originally.
-                    eeg_acq_time = acq_time_List[0]['acq_time']
+                    eeg_acq_time = acq_time_list[0]['acq_time']
                 else:
                     print('More than one or no acquisition time has been found for ', self.acquisition_file)
                     exit()


### PR DESCRIPTION
This PR fixes a NoneType error that gets issued when no entry was found for a given *nii.gz or EEG file in scans.tsv to determine the acquisition date.