### PR TITLE
Update get dicom info documentation to remove non-existant options

### DIFF
--- a/dicom-archive/get_dicom_info.pl
+++ b/dicom-archive/get_dicom_info.pl
@@ -72,10 +72,6 @@ Available options are:
 -error_string      : string to use for reporting empty fields
 
 
--verbose                : Be verbose if set
-
--version                : Print CVS version number and exit
-
 
 =head1 DESCRIPTION
 

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -134,7 +134,7 @@ INPUTS:
   - $type: scan type
   - $db  : database object
 
-RETURNS: ID of the scan type
+RETURNS: ID of the scan type or undef
 
 ### in\_range($value, $range\_string)
 

--- a/docs/scripts_md/get_dicom_info.md
+++ b/docs/scripts_md/get_dicom_info.md
@@ -60,10 +60,6 @@ Available options are:
 
 \-error\_string      : string to use for reporting empty fields
 
-\-verbose                : Be verbose if set
-
-\-version                : Print CVS version number and exit
-
 # DESCRIPTION
 
 A tool to read information out of the DICOM file headers.


### PR DESCRIPTION
Some options were still being described for get_dicom_info.pl even though they were removed from the script as noticed in https://github.com/aces/Loris-MRI/issues/710. This updates the different documents accordingly.

Note: mass_perldoc script was used to regenerate the MD files and picked up a documentation change in MRI.pm as well so the MD file of MRI.pm is being updated as well.