### PR TITLE
Remove extra variable from call to determineScannerID function from minc_insertion.pl

### DIFF
--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -489,9 +489,7 @@ $studyInfo{'DateAcquired'}           //= $file->getParameter('study:start_date')
 
 ## Determine PSC, ScannerID and Subject IDs
 my ($center_name, $centerID) = $utility->determinePSC(\%studyInfo, 0, $upload_id);
-my $scannerID = $utility->determineScannerID(
-    \%studyInfo, 0, $centerID, $NewScanner, $upload_id
-);
+my $scannerID = $utility->determineScannerID(\%studyInfo, 0, $centerID, $upload_id);
 my $subjectIDsref = $utility->determineSubjectID(
     $scannerID, \%studyInfo, 0, $upload_id, $User, $centerID
 );


### PR DESCRIPTION
The `determineScannerID` function of the `MRIProcessingUtility.pm` class takes the following arguments:
```
  - $tarchiveInfo: archive information hash ref
  - $to_log      : whether this step should be logged
  - $centerID    : center ID
  - $upload_id   : upload ID of the study
```

In minc_insertion.pl, `determineScannerID` is called with the following arguments: `\%studyInfo, 0, $centerID, $NewScanner, $upload_id`

$NewScanner needed to be removed from the function call. Probably the result of a bad conflict resolution...