### PR TITLE
Fix the paths in the environment file to be in /opt now that the install script installs LORIS-MRI in /opt

### DIFF
--- a/environment
+++ b/environment
@@ -3,15 +3,15 @@ source %MINC_TOOLKIT_DIR%/minc-toolkit-config.sh
 umask 0002
 
 # export PATH, PERL5LIB, TMPDIR and LORIS_CONFIG variables
-export PATH=/data/%PROJECT%/bin/mri:/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/uploadNeuroDB/bin:/data/%PROJECT%/bin/mri/dicom-archive:/data/%PROJECT%/bin/mri/python:/data/%PROJECT%/bin/mri/tools:/data/%PROJECT%/bin/mri/python/react-series-data-viewer:%MINC_TOOLKIT_DIR%/bin:$PATH
-export PERL5LIB=/data/%PROJECT%/bin/mri/uploadNeuroDB:/data/%PROJECT%/bin/mri/dicom-archive:$PERL5LIB
+export PATH=/opt/%PROJECT%/bin/mri:/opt/%PROJECT%/bin/mri/uploadNeuroDB:/opt/%PROJECT%/bin/mri/uploadNeuroDB/bin:/opt/%PROJECT%/bin/mri/dicom-archive:/opt/%PROJECT%/bin/mri/python:/opt/%PROJECT%/bin/mri/tools:/opt/%PROJECT%/bin/mri/python/react-series-data-viewer:%MINC_TOOLKIT_DIR%/bin:$PATH
+export PERL5LIB=/opt/%PROJECT%/bin/mri/uploadNeuroDB:/opt/%PROJECT%/bin/mri/dicom-archive:$PERL5LIB
 export TMPDIR=/tmp
-export LORIS_CONFIG=/data/%PROJECT%/bin/mri/dicom-archive
+export LORIS_CONFIG=/opt/%PROJECT%/bin/mri/dicom-archive
 
 # for the Python scripts
-export LORIS_MRI=/data/%PROJECT%/bin/mri
-export PYTHONPATH=$PYTHONPATH:/data/%PROJECT%/bin/mri/python:/data/%PROJECT%/bin/mri/python/react-series-data-viewer
-source /data/%PROJECT%/bin/mri/python_virtualenvs/loris-mri-python/bin/activate
+export LORIS_MRI=/opt/%PROJECT%/bin/mri
+export PYTHONPATH=$PYTHONPATH:/opt/%PROJECT%/bin/mri/python:/opt/%PROJECT%/bin/mri/python/react-series-data-viewer
+source /opt/%PROJECT%/bin/mri/python_virtualenvs/loris-mri-python/bin/activate
 
 # for the defacing scripts
 export BEASTLIB=%MINC_TOOLKIT_DIR%/../share/beast-library-1.1


### PR DESCRIPTION
The LORIS-MRI now gets installed in the `/opt` folder to be moved out of the `/data` mounts so that the scripts and the data are in different directories.

While doing so, we forgot to update the paths in the environment file for the install script. This PR updates the paths to point to /opt instead of /data in the environment template file