### PR TITLE
fix the call to make pics from minc_insertion.pl

### DIFF
--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -694,7 +694,7 @@ if ($create_nii) {
 if ($create_minc_pics) {
     print "\nCreating Minc Pics\n" if $verbose;
     NeuroDB::MRI::make_pics(
-        \$file, $data_dir, "$data_dir/pic", $horizontalPics
+        \$file, $data_dir, "$data_dir/pic", $horizontalPics, $db
     );
 }
 


### PR DESCRIPTION
The call to `make_pics` from `minc_insertion.pl` is missing the `$db` argument in the function call leading to an error when creating the pic from `minc_insertion.pl`.


Note: this has been fixed on `main` so the fix will be in the next major release as well.