### PR TITLE
dicomTar.pl - check that the -database option is provided when -mri_upload_update option is set

### DIFF
--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -166,6 +166,10 @@ if (-d $dcm_source && -d $targetlocation) {
     print STDERR "\nERROR: source and target must be existing directories!\n\n";
     exit $NeuroDB::ExitCodes::INVALID_PATH;
 }
+if ($mri_upload_update && !$dbase) {
+    print STDERR "\nERROR: option -database should be provided when -mri_upload_update set!\n\n";
+    exit $NeuroDB::ExitCodes::MISSING_ARG;
+}
 
 # The tar target 
 my $totar = basename($dcm_source);


### PR DESCRIPTION
This adds an extra check at the beginning of `dicomTar.pl` to ensure the `-database` option is provided to the script when `-mri_upload_update` is set.

Resolves #732 