### PR TITLE
Add bids_export_files table to the delete script

### DIFF
--- a/docs/scripts_md/delete_imaging_upload.md
+++ b/docs/scripts_md/delete_imaging_upload.md
@@ -75,8 +75,9 @@ successfully run, this removes all records tied to the upload in the following t
    f) `parameter_file`
    g) `tarchive`
    h) `mri_upload`
-   i) `mri_processing_protocol` if option `-protocol` is used (see below)
-   j) `mri_parameter_form` if option `-form` is used (see below)
+   i) `bids_export_files`
+   j) `mri_processing_protocol` if option `-protocol` is used (see below)
+   k) `mri_parameter_form` if option `-form` is used (see below)
 
 All the deletions and modifications performed in the database are done as part of a single transaction, so they either
 all succeed or a rollback is performed and the database is not modified in any way. The ID of the upload to delete
@@ -339,6 +340,44 @@ RETURNS:
    table, `MincFile` => value of column `MincFile` for the MINC file found in table 
    `MRICandidateErrors` and `FullPath` => absolute path of the MINC file.
 
+### getBidsExportFilesRef($dbh, $filesRef, $dataDirBasePath)
+
+Gets the imaging file records to delete from table bids\_export\_files.
+
+INPUTS:
+  - $dbhr  : database handle reference.
+  - $filesRef: reference on the hash of all files.
+  - $tarchiveID: ID of the DICOM archive.
+  - $dataDirBasePath: config value of setting `dataDirBasePath`.
+  - $scanTypesToDeleteRef: reference to the array that contains the list of scan type names to delete.
+  - $optionsRef: reference on the array of command line options.
+
+RETURNS:
+  - an array of hash references. Each hash has three keys: `BIDSExportedFileID` => ID of the record in the
+   table, `FilePath` => value of column `FilePath` for the BIDS export file found in table
+   `bids_export_files` and `FullPath` => absolute path of the BIDS export file.
+
+### getBidsExportFilesSessionRef($dbh, $filesRef, $dataDirBasePath)
+
+Gets the session level records to delete from table bids\_export\_files (aka scans.tsv and scans.json files).
+
+INPUTS:
+  - $dbhr  : database handle reference.
+  - $filesRef: reference on the hash of all files.
+  - $dataDirBasePath: config value of setting `dataDirBasePath`.
+
+RETURNS:
+  - a hash with scans.tsv full path and a boolean specifying whether the session level scans.tsv file needs to be updated
+
+### updateBidsScansTsvFile()
+
+Modifies the scans.tsv BIDS file if not all files for the session have been deleted. It will remove the
+entries for the files that were deleted from scans.tsv BIDS export file.
+
+INPUTS:
+  - $filesRef: reference to the array that contains the file informations for all the files
+    that are associated to the upload(s) passed on the command line.
+
 ### setFileExistenceStatus($filesRef)
 
 Checks the list of all the files related to the upload(s) that were found in the database and 
@@ -385,7 +424,7 @@ INPUTS:
   - $fileRef: reference to the array that contains the file information for a given file.
   - $scanTypesToDeleteRef: reference to the array that contains the list of scan type names to delete.
   - $keepDefaced: whether the defaced files should be kept or not.
-  - $fileBaseName: value of option -file (or '' if -file was not used).
+  - $fileBaseName: value of option -basename (or '' if -basename was not used).
 
 RETURNS:
   - 0 or 1 depending on whether the file should be deleted or not.
@@ -475,7 +514,7 @@ INPUTS:
     that are associated to the upload(s) passed on the command line.
   - $scanTypesToDeleteRef: reference to the array that contains the list of scan type names to delete.
   - $keepDefaced: whether the defaced files should be kept or not.
-  - $fileBaseName: value of option -file (or '' if option was not used).
+  - $fileBaseName: value of option -basename (or '' if option was not used).
 
 ### getTypesToDelete($dbh, $scanTypeList, $keepDefaced)
 

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -1371,7 +1371,7 @@ sub getBidsExportFilesSessionRef {
     $sth->execute($sessionID);
     my $bids_files_count_hash = $sth->fetchrow_hashref();
     if ($bids_files_count_hash->{'bids_files_count'} == scalar(@{ $filesRef->{'bids_export_files'} })) {
-        push(@$filesRef->{'bids_export_files'}, $sessionFilesRef);
+        push(@{ $filesRef->{'bids_export_files'} }, $sessionFilesRef);
         return {
             'scans_tsv_file_path'        => $scans_tsv_file_path,
             'update_bids_scans_tsv_file' => 0

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -1484,7 +1484,7 @@ sub updateBidsScansTsvFile {
 
     open my $fh, '>', $tsv_to_update;
     foreach my $row (@new_tsv_content) {
-        print $fh $row;
+        print $fh "$row\n";
     }
     close($fh);
 }

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -1608,6 +1608,8 @@ sub backupFiles {
             }
         }
     }
+    # backup the BIDS export scans.tsv file as it will be modified by the delete script so we can regenerate it as it
+    # was when extracting the archive.
     if ($filesRef->{'bids_export_files_scans_tsv'}{'update_bids_scans_tsv_file'}) {
         print $fh "$filesRef->{'bids_export_files_scans_tsv'}{'scans_tsv_file_path'}";
     }

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -516,7 +516,7 @@ my $deleteResultsRef = &deleteUploadsInDatabase($dbh, \%files, \@scanTypesToDele
 
 &gzipBackupFile($options{'BACKUP_PATH'}) if $deleteResultsRef->{'SQL_BACKUP_DONE'};
 
-&updateBidsScansTsvFile(\%files);
+# &updateBidsScansTsvFile(\%files);
 
 #==========================#
 # Print success message    #

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -151,6 +151,7 @@ use warnings;
 
 use Getopt::Tabular;
 use File::Temp qw/tempfile/;
+use File::Basename;
 
 use NeuroDB::DBI;
 use NeuroDB::ExitCodes;

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -1371,7 +1371,7 @@ sub getBidsExportFilesSessionRef {
     $sth->execute($sessionID);
     my $bids_files_count_hash = $sth->fetchrow_hashref();
     if ($bids_files_count_hash->{'bids_files_count'} == scalar(@{ $filesRef->{'bids_export_files'} })) {
-        push(@{ $filesRef->{'bids_export_files'} }, $sessionFilesRef);
+        push(@{ $filesRef->{'bids_export_files'} }, @{ $sessionFilesRef });
         return {
             'scans_tsv_file_path'        => $scans_tsv_file_path,
             'update_bids_scans_tsv_file' => 0

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -1454,7 +1454,12 @@ sub getBidsExportFilesSessionRef {
 
 =head3 updateBidsScansTsvFile()
 
+Modifies the scans.tsv BIDS file if not all files for the session have been deleted. It will remove the
+entries for the files that were deleted from scans.tsv BIDS export file.
 
+INPUTS:
+  - $filesRef: reference to the array that contains the file informations for all the files
+    that are associated to the upload(s) passed on the command line.
 
 =cut
 
@@ -1602,6 +1607,9 @@ sub backupFiles {
                 $nbToBackUp++;
             }
         }
+    }
+    if ($filesRef->{'bids_export_files_scans_tsv'}{'update_bids_scans_tsv_file'}) {
+        print $fh "$filesRef->{'bids_export_files_scans_tsv'}{'scans_tsv_file_path'}";
     }
     close($fh);
     

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -1370,7 +1370,7 @@ sub getBidsExportFilesSessionRef {
     my $sth = $dbh->prepare($query);
     $sth->execute($sessionID);
     my $bids_files_count_hash = $sth->fetchrow_hashref();
-    if ($bids_files_count_hash->{'$bids_files_count'} == scalar($filesRef->{'bids_export_files'})) {
+    if ($bids_files_count_hash->{'bids_files_count'} == scalar(@{ $filesRef->{'bids_export_files'} })) {
         push(@$filesRef->{'bids_export_files'}, $sessionFilesRef);
         return {
             'scans_tsv_file_path'        => $scans_tsv_file_path,

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -1464,7 +1464,10 @@ sub updateBidsScansTsvFile {
         return;
     }
 
-    my @deleted_files_path = grep $_->{'FilePath'} =~ m/\.nii\.gz$/, @$filesRef->{'bids_export_files'};
+    my @deleted_files_basename;
+    foreach (@{ $filesRef->{'bids_export_files'} }) {
+        push @deleted_files_basename, basename($_->{'FilePath'}) if ($_->{'FilePath'} =~ m/\.nii\.gz$/);
+    }
 
     my $tsv_to_update = $filesRef->{'bids_export_files_scans_tsv'}{'scans_tsv_file_path'};
     my @new_tsv_content;
@@ -1473,8 +1476,7 @@ sub updateBidsScansTsvFile {
     close($data);
 
     foreach my $row (@original_content) {
-        foreach my $deleted_file (@deleted_files_path) {
-            my $deleted_file_basename = basename($deleted_file);
+        foreach my $deleted_file_basename (@deleted_files_basename) {
             push @new_tsv_content, $row unless $row =~ m/$deleted_file_basename/;
         }
     }

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -1355,12 +1355,13 @@ sub getBidsExportFilesSessionRef {
     my $sessionID = $filesRef->{'mri_upload'}->[0]->{'SessionID'};
     my $query = 'SELECT BIDSExportedFileID, FilePath FROM bids_export_files WHERE SessionID=?';
     my $sessionFilesRef = $dbh->selectall_arrayref($query, { Slice => {} }, $sessionID);
+    my $scans_tsv_file_path;
     # Set full path of every file
     foreach(@$sessionFilesRef) {
         $_->{'FullPath'} = $_->{'FilePath'} =~ /^\//
             ? $_->{'FilePath'} : "$dataDirBasePath/$_->{'FilePath'}";
+        $scans_tsv_file_path = $_->{'FullPath'} if $_->{'FullPath'} =~ m/scans\.tsv$/;
     }
-    my ($scans_tsv_file_path) = grep $_ =~ m/scans\.tsv$/, @$sessionFilesRef;
 
     # check that the number of BIDS files to be removed matches the number of imaging BIDS
     # files available for the session

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -425,7 +425,7 @@ $files{'mri_violations_log'}          = &getMriViolationsLogFilesRef($dbh, $tarc
 $files{'MRICandidateErrors'}          = &getMRICandidateErrorsFilesRef($dbh, $tarchiveID, $dataDirBasepath, \@scanTypesToDelete, \%options);
 $files{'tarchive'}                    = &getTarchiveFiles($dbh, $tarchiveID, $tarchiveLibraryDir);
 $files{'mri_processing_protocol'}     = &getMriProcessingProtocolFilesRef($dbh, \%files);
-$files{'bids_export_files'}           = &getBidsExportFilesRef($dbh, $tarchiveID, \%files, $dataDirBasepath);
+$files{'bids_export_files'}           = &getBidsExportFilesRef($dbh, $tarchiveID, \%files, $dataDirBasepath, \@scanTypesToDelete, \%options);
 $files{'bids_export_files_scans_tsv'} = &getBidsExportFilesSessionRef($dbh, \%files, $dataDirBasepath);
 
 if(!defined $files{'tarchive'}) {


### PR DESCRIPTION
This allows the deletion of files derived from a `FileID` in the `bids_export_files` when there are BIDS files present for the `FileID` to be deleted.

Resolves #723 