### PR TITLE
Require 0.13.2 of pybids in the requirements.txt python packages as 0.14.0 has bugs at the moment

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 mne
 mne-bids>=0.6
 protobuf>=3.0.0
-pybids>=0.12.1
+pybids=0.13.2
 mysqlclient
 mysql-connector
 pyblake2


### PR DESCRIPTION
The latest version of pybids has a bug where we cannot query the BIDS layout with an `extension` restriction.

So the code here: https://github.com/aces/Loris-MRI/blob/9f2813d45f7e34f0494b6a06f1cd5645cc4d7748/python/lib/eeg.py#L345 does not return any EEG file to insert.

```
    eeg_files = self.bids_layout.get(
            subject   = self.bids_sub_id,
            session   = self.bids_ses_id,
            scope     = 'derivatives' if derivatives else 'raw',
            # datatype  = self.bids_modality,
            suffix    = self.bids_modality,
            extension = ['set', 'edf', 'vhdr', 'vmrk', 'eeg', 'bdf']
        )
```
=> does not return anything when using pybids 0.14.0. Looks like the `extension` parameter is the culprit here. An issue is being created on the pybids repo to let them know. https://github.com/bids-standard/pybids/issues/800 