### PR TITLE
Checks that the UploadID and archivelocation provided to tarchive_validation.pl script refers to the same TarchiveID

### DIFF
--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -148,6 +148,16 @@ INPUTS:
 RETURNS: DICOM/HRRT archive information hash ref if exactly one archive was found. Exits
          when either no match or multiple matches are found.
 
+### createMriUploadArray($uploadID)
+
+Creates the MRI upload information hash ref for the uploadID passed as argument.
+
+INPUTS:
+  - $uploadID: UploadID to query mri\_upload
+
+RETURNS: MRI upload information hash ref if found a row for UploadID in mri\_upload.
+         Exits when either no match is found.
+
 ### determinePSC($tarchiveInfo, $to\_log, $upload\_id)
 
 Determines the PSC based on the DICOM archive information hash ref.
@@ -391,6 +401,12 @@ INPUTS:
   - $tarchiveInfo: DICOM archive information hash ref
   - $upload\_id   : upload ID of the study
 
+### validate\_tarchive\_id\_against\_upload\_id($tarchiveInfoRef, $uploadInfoRef)
+
+INPUTS:
+  - $tarchiveInfoRef: DICOM archive information hash ref
+  - $uploadInfoRef  : MRI upload information reference
+
 ### which\_directory($subjectIDsref, $data\_dir, $hrrt)
 
 Determines where the MINC files to be registered into the database will go.
@@ -486,3 +502,15 @@ License: GPLv3
 
 LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
 Neuroscience
+
+# POD ERRORS
+
+Hey! **The above document had some coding errors, which are explained below:**
+
+- Around line 567:
+
+    &#x3d;cut found outside a pod block.  Skipping to next block.
+
+- Around line 1880:
+
+    &#x3d;cut found outside a pod block.  Skipping to next block.

--- a/docs/scripts_md/MriUploadOB.md
+++ b/docs/scripts_md/MriUploadOB.md
@@ -77,6 +77,22 @@ RETURNS: a reference to an array of array references. If `$isCount` is true, the
          `$returnValue->[x]->[y]` will contain the value of the yth column (in array
          `@MRI_UPLOAD_FIELDS` for the xth record retrieved.
 
+### getWithUploadID($isCount, $uploadID)($isCount, $uploadID)
+
+Fetches the entries in the `mri_upload` table based on an UploadID.
+This method throws a `NeuroDB::objectBroker::ObjectBrokerException`
+if the operation could not be completed successfully.
+
+INPUTS:
+    - boolean indicating if only a count of the records found is needed
+      or the full record properties.
+    - path of the archive location.
+
+RETURNS: a reference to an array of array references. If `$isCount` is true, then
+         `$returnValue->[0]->[0]` will contain the count of records sought. Otherwise
+         `$returnValue->[x]->[y]` will contain the value of the yth column (in array
+         `@MRI_UPLOAD_FIELDS` for the xth record retrieved.
+
 ### insert($valuesRef)
 
 Inserts a new record in the `mri_upload` table with the specified column values.

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1863,7 +1863,7 @@ sub validate_tarchive_id_against_upload_id {
     my ($tarchiveInfoRef, $uploadInfoRef) = @_;
 
     my $upload_id        = $uploadInfoRef->{'UploadID'};
-    my $archive_location = $uploadInfoRef->{'ArchiveLocation'};
+    my $archive_location = $tarchiveInfoRef->{'ArchiveLocation'};
     my $tarchive_id_mu   = $uploadInfoRef->{'TarchiveID'};
     my $tarchive_id_t    = $tarchiveInfoRef->{'TarchiveID'};
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1869,8 +1869,8 @@ sub validate_tarchive_id_against_upload_id {
 
     unless ($tarchiveInfoRef->{'TarchiveID'} == $uploadInfoRef->{'TarchiveID'}) {
         my $message = "\nERROR: UploadID {$upload_id} is associated with TarchiveID {$tarchive_id_mu}"
-                      . "while ArchiveLocation {$archive_location} is associated with TarchiveID {$tarchive_id_t}."
-                      . "Please, ensure the arguments provided to the script refer to the same tarchive\n\n";
+                      . " while ArchiveLocation {$archive_location} is associated with TarchiveID {$tarchive_id_t}."
+                      . " Please, ensure the arguments provided to the script refer to the same tarchive\n\n";
         $this->writeErrorLog($message, $NeuroDB::ExitCodes::CORRUPTED_FILE);
         $this->spool($message, 'Y', $upload_id, $notify_notsummary);
         exit $NeuroDB::ExitCodes::CORRUPTED_FILE;

--- a/uploadNeuroDB/NeuroDB/objectBroker/MriUploadOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriUploadOB.pm
@@ -157,7 +157,7 @@ RETURNS: a reference to an array of array references. If C<$isCount> is true, th
 =cut
 
 sub getWithUploadID {
-    my($self, $isCount, $uploadID) = @_;
+    my($self, $uploadID, $isCount) = @_;
 
     # We must preceed all the MRI upload fields with the table name they are issued from
     # to avoid clashes with fields in table tarchive when building the SQL statement later on

--- a/uploadNeuroDB/NeuroDB/objectBroker/MriUploadOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriUploadOB.pm
@@ -139,6 +139,47 @@ sub getWithTarchive {
 
 =pod
 
+=head3 getWithUploadID($isCount, $uploadID)($isCount, $uploadID)
+
+Fetches the entries in the C<mri_upload> table based on an UploadID.
+This method throws a C<NeuroDB::objectBroker::ObjectBrokerException>
+if the operation could not be completed successfully.
+
+INPUTS:
+    - boolean indicating if only a count of the records found is needed
+      or the full record properties.
+    - path of the archive location.
+
+RETURNS: a reference to an array of array references. If C<$isCount> is true, then
+         C<< $returnValue->[0]->[0] >> will contain the count of records sought. Otherwise
+         C<< $returnValue->[x]->[y] >> will contain the value of the yth column (in array
+         C<@MRI_UPLOAD_FIELDS> for the xth record retrieved.
+=cut
+
+sub getWithUploadID {
+    my($self, $isCount, $uploadID) = @_;
+
+    # We must preceed all the MRI upload fields with the table name they are issued from
+    # to avoid clashes with fields in table tarchive when building the SQL statement later on
+    my $select = $isCount ? 'COUNT(*)' : join(',', (map { "mri_upload.$_" } @MRI_UPLOAD_FIELDS));
+
+    try {
+        return $self->db->pselect(
+            "SELECT $select FROM mri_upload WHERE UploadID = ? ",
+            $uploadID
+        );
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to retrieve mri upload records. Reason:\n%s",
+                $e
+            )
+        );
+    }
+}
+
+=pod
+
 =head3 insert($valuesRef)
 
 Inserts a new record in the C<mri_upload> table with the specified column values.

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -222,8 +222,6 @@ my $tarchiveLibraryDir = $configOB->getTarchiveLibraryDir();
 
 
 
-
-
 ################################################################
 ########## Create the Specific Log File ########################
 ################################################################
@@ -248,6 +246,11 @@ my $utility = NeuroDB::MRIProcessingUtility->new(
                   $db, \$dbh, $debug, $TmpDir, $logfile, $verbose, $profile
               );
 
+#-------------------------------------------------
+# Create mri_upload array
+#-------------------------------------------------
+my %mriUploadInfo = $utility->createMriUploadArray($upload_id);
+
 ################################################################
 ############### Create tarchive array ##########################
 ################################################################
@@ -256,6 +259,12 @@ $tarchiveLibraryDir    =~ s/\/$//g;
 my $ArchiveLocation    = $tarchive;
 $ArchiveLocation       =~ s/$tarchiveLibraryDir\/?//g;
 %tarchiveInfo = $utility->createTarchiveArray($ArchiveLocation);
+
+#-------------------------------------------------
+# Validate that the TarchiveID is the same in %tarchiveInfo and %mriUploadInfo hashes
+#-------------------------------------------------
+$utility->validate_tarchive_id_against_upload_id(\%tarchiveInfo, \%mriUploadInfo);
+
 
 ################################################################
 #### Verify the archive using the checksum from database #######


### PR DESCRIPTION
While testing 24.0, notice that the `tarchive_validation.pl` script does not verify whether the UploadID provided to the script refers to the same `TarchiveID` as the `ArchiveLocation` provided as an argument. If not, returns an error.

Testing instructions: 
- [ ] on main, try running the `tarchive_validation.pl` with an UploadID that do not correspond to an `ArchiveLocation` => no errors and tarchive validated which is clearly wrong
- [ ] on this branch, try running the `tarchive_validation.pl` with an UploadID that do not correspond to an `ArchiveLocation` =>  it will display an error that the UploadID used does not correspond to the ArchiveLocation provided to the script.