### PR TITLE
Move violated files when running minc_insertion.pl

### DIFF
--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -83,10 +83,11 @@ INPUTS:
   - $db             : database object
   - $minc\_location  : location of the MINC files
   - $uploadID       : ID of the upload containing the scan
+  - $data\_dir       : path to the LORIS MRI data directory
 
 RETURNS: textual name of scan type from the `mri_scan_type` table
 
-### insert\_violated\_scans($dbhr, $series\_desc, $minc\_location, $patient\_name, $candid, $pscid, $visit, $tr, $te, $ti, $slice\_thickness, $xstep, $ystep, $zstep, $xspace, $yspace, $zspace, $time, $seriesUID)
+### insert\_violated\_scans($dbhr, $series\_desc, $minc\_location, $patient\_name, $candid, $pscid, $visit, $tr, $te, $ti, $slice\_thickness, $xstep, $ystep, $zstep, $xspace, $yspace, $zspace, $time, $seriesUID, $data\_dir)
 
 Inserts scans that do not correspond to any of the defined protocol from the
 `mri_protocol` table into the `mri_protocol_violated_scans` table of the
@@ -114,6 +115,7 @@ INPUTS:
   - $seriesUID      : `SeriesUID` of the scan
   - $tarchiveID     : `TarchiveID` of the DICOM archive from which this file is derived
   - $image\_type     : the `image_type` header value of the image
+  - $data\_dir       : path to the LORIS MRI data directory
   - $mriProtocolGroupID : ID of the protocol group used to try to identify the scan.
 
 ### scan\_type\_id\_to\_text($typeID, $db)
@@ -377,12 +379,14 @@ RETURNS:
   - %isEcatImage: hash with file path as keys and true or false as values (true
                    if the file is a DICOM image file, false otherwise)
 
-### get\_trashbin\_file\_rel\_path($file)
+### get\_trashbin\_file\_rel\_path($file, $data\_dir, $move\_file)
 
-Determines and returns the relative path of a file moved to trashbin at the end of
-the insertion pipeline.
+Determines and returns the relative path of a file after moving it to trashbin.
 
-INPUT: path to a given file
+INPUT:
+  - $file: path to a given file
+  - $data\_dir: path to the LORIS MRI data directory
+  - $move\_file: bool specifying whether the file should be moved to trashbin
 
 RETURNS: the relative path of the file moved to the trashbin directory
 

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -187,7 +187,7 @@ INPUTS:
 
 RETURNS: 1 if the file is unique, 0 otherwise
 
-### getAcquisitionProtocol($file, $subjectIDsref, $tarchiveInfo, $center\_name, $minc, $acquisitionProtocol, $bypass\_extra\_file\_checks, $upload\_id)
+### getAcquisitionProtocol($file, $subjectIDsref, $tarchiveInfo, $center\_name, $minc, $acquisitionProtocol, $bypass\_extra\_file\_checks, $upload\_id, $data\_dir)
 
 Determines the acquisition protocol and acquisition protocol ID for the MINC
 file. If `$acquisitionProtocol` is not set, it will look for the acquisition
@@ -205,6 +205,7 @@ INPUTS:
   - $acquisitionProtocol     : acquisition protocol if already knows it
   - $bypass\_extra\_file\_checks: boolean, if set bypass the extra checks
   - $upload\_id               : upload ID of the study
+  - $data\_dir                : path to the LORIS MRI data directory
 
 RETURNS:
   - $acquisitionProtocol     : acquisition protocol
@@ -212,7 +213,7 @@ RETURNS:
   - $extra\_validation\_status : extra validation status ("pass", "exclude", "warning") or
                                `undef` if `$bypass_extra_file_checks` is set.
 
-### extra\_file\_checks($scan\_type, $file, $subjectIdsref, $pname)
+### extra\_file\_checks($scan\_type, $file, $subjectIdsref, $pname, $data\_dir)
 
 Returns the list of MRI protocol checks that failed. Can't directly insert
 this information here since the file isn't registered in the database yet.
@@ -222,6 +223,7 @@ INPUTS:
   - $file         : file information hash ref
   - $subjectIdsref: context information for the scan
   - $pname        : patient name found in the scan header
+  - $data\_dir     : path to the LORIS MRI data directory
 
 RETURNS:
   - pass, warn or exclude flag depending on the worst failed check
@@ -259,7 +261,7 @@ INPUTS:
 RETURNS: a hash with all information about the checks for a given scan type
 and severity
 
-### insert\_into\_mri\_violations\_log($valid\_fields, $severity, $pname, $candID, $visit\_label, $file)
+### insert\_into\_mri\_violations\_log($valid\_fields, $severity, $pname, $candID, $visit\_label, $file, $data\_dir)
 
 For a given protocol failure, it will insert into the `mri_violations_log`
 table all the information about the scan and the protocol violation.
@@ -271,6 +273,7 @@ INPUTS:
   - $candID      : `CandID` associated with the scan
   - $visit\_label : visit label associated with the scan
   - $file        : information about the scan
+  - $data\_dir    : path to the LORIS MRI data directory
 
 ### loadAndCreateObjectFile($minc, $upload\_id)
 

--- a/tools/cleanup_paths_of_violation_tables.pl
+++ b/tools/cleanup_paths_of_violation_tables.pl
@@ -9,6 +9,11 @@ use NeuroDB::DBI;
 use NeuroDB::MRI;
 use NeuroDB::ExitCodes;
 
+use NeuroDB::Database;
+use NeuroDB::DatabaseException;
+
+use NeuroDB::objectBroker::ObjectBrokerException;
+use NeuroDB::objectBroker::ConfigOB;
 
 
 my $profile;
@@ -72,6 +77,22 @@ if ( !@Settings::db ) {
 
 my $dbh = &NeuroDB::DBI::connect_to_db(@Settings::db);
 
+# new Moose database connection
+my $db  = NeuroDB::Database->new(
+    databaseName => $Settings::db[0],
+    userName     => $Settings::db[1],
+    password     => $Settings::db[2],
+    hostName     => $Settings::db[3]
+);
+$db->connect();
+
+# ----------------------------------------------------------------
+## Get config setting using ConfigOB
+# ----------------------------------------------------------------
+
+my $configOB = NeuroDB::objectBroker::ConfigOB->new(db => $db);
+
+my $data_dir = $configOB->getDataDirPath();
 
 
 ##################################################
@@ -172,5 +193,5 @@ sub determine_MincPath {
 
     # return the path in the trashbin directory for files not present in the
     # files table
-    return NeuroDB::MRI::get_trashbin_file_rel_path($current_path);
+    return NeuroDB::MRI::get_trashbin_file_rel_path($current_path, $data_dir, 0);
 }

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1659,7 +1659,11 @@ sub get_trashbin_file_rel_path {
                        . "/" . $directories[$#directories-1]
                        . "/" . $directories[$#directories];
 
-    move($file, "$data_dir/$new_rel_path") if (defined $move_file);
+    if (defined $move_file) {
+        my $destination_dir = "$data_dir/trashbin/$directories[$#directories-1]";
+        mkdir $destination_dir unless (-e $destination_dir);
+        move($file, "$data_dir/$new_rel_path");
+    }
 
     return $new_rel_path;
 }

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -517,10 +517,13 @@ if (defined($subjectIDsref->{'CandMismatchError'})) {
     chomp $CandMismatchError;
     $/ = $originalSeparatorValue;
 
+    # move the file into trashbin
+    my $file_rel_path = NeuroDB::MRI::get_trashbin_file_rel_path($minc, $data_dir, 1);
+
     $candlogSth->execute(
         $file->getParameter('series_instance_uid'),
         $studyInfo{'TarchiveID'},
-        NeuroDB::MRI::get_trashbin_file_rel_path($minc),
+        $file_rel_path,
         $studyInfo{'PatientName'},
         $CandMismatchError
     );
@@ -618,7 +621,8 @@ $file->setFileData('Caveat', $caveat);
       $minc,
       $acquisitionProtocol,
       $bypass_extra_file_checks,
-      $upload_id
+      $upload_id,
+      $data_dir
     );
 
 if($acquisitionProtocol =~ /unknown/ && !defined $acquisitionProtocolID) {


### PR DESCRIPTION
This resolves an issue where when running `minc_insertion.pl` on its own, the files that are inserted into the `mri_protocol_violated_scans`, `mri_violations_log (exclude violations only)` and `MRICandidateError` tables, the file is not moved to `trashbin` and the path inserted in those tables are not reliable as there is no files in the file system.

This is not an issue when running the main pipeline as all the files are moved to `trashbin` at the end of `tarchiveLoader` execution. 

This resolves #739 