### PR TITLE
Fixes bug where the tarchive is not moved into the year subfolder anymore when running the pipeline

### DIFF
--- a/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
@@ -73,7 +73,7 @@ use TryCatch;
 my @TARCHIVE_FIELDS = qw(
     TarchiveID ArchiveLocation PatientName PatientID PatientDoB md5sumArchive
     ScannerManufacturer ScannerModel ScannerSerialNumber ScannerSoftwareVersion
-    neurodbCenterName SourceLocation
+    neurodbCenterName SourceLocation DateAcquired
 );
 
 =pod


### PR DESCRIPTION
This fixes a bug where the DICOM archive was not moved anymore in the year subfolder of the `tarchive` folder when run through `tarchiveLoader.pl`. It adds the field `DateAcquired` when querying the `tarchive` table so that the information stored in that field can be used to determine the year subfolder in function `moveAndUpdateTarchive` of `MRIProcessingUtility.pm`.

Note: this bug is not present on 23 releases and specific to 24.


Testing instructions:
- [ ] on main, run the imaging pipeline on a new set of DICOMs and notice that the tarchive file is not moved into the year subfolder
- [ ] on this branch, run the imaging pipeline on a new set of DICOMs and notice that the tarchive file is moved into the year subfolder