### PR TITLE
fix coordinate space not being inserted in the files table when running imaging_non_minc_insertion.pl

### DIFF
--- a/uploadNeuroDB/imaging_non_minc_insertion.pl
+++ b/uploadNeuroDB/imaging_non_minc_insertion.pl
@@ -533,8 +533,9 @@ my ($ss, $mm, $hh, $day, $month, $yy, $zone) = strptime( $date_acquired );
 $date_acquired = sprintf( "%4d-%02d-%02d", $yy+1900, $month+1, $day );
 $file->setParameter( 'acquisition_date', $date_acquired );
 
-# set output type
-$file->setFileData( 'OutputType', $output_type );
+# set output type and coordinate space
+$file->setFileData('OutputType',      $output_type  );
+$file->setFileData('CoordinateSpace', $coordin_space);
 
 
 


### PR DESCRIPTION
This fixes an issue found by a collaborator where the coordinate space provided to the script is not being used when inserting the file into the `files` table.