### PR TITLE
Fix bad requirements for pip install pybids

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 mne
 mne-bids>=0.6
 protobuf>=3.0.0
-pybids=0.14.0
+pybids==0.14.0
 mysqlclient
 mysql-connector
 pyblake2


### PR DESCRIPTION
Fix the following error when install LORIS-MRI:
```
Invalid requirement: 'pybids=0.14.0'
= is not a valid operator. Did you mean == ?
```
Indeed, we meant pybids==0.14.0 :-)