### PR TITLE
Fix insertion pipeline when there is no LabelDescription in annotation.json (optional field)

### DIFF
--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -617,8 +617,9 @@ class Physiological:
             annotation_metadata['Author']
         )
 
-        for label_name, label_desc in annotation_metadata['LabelDescription'].items():
-            self.physiological_annotation_label_obj.insert(annotation_file_id, label_name, label_desc)
+        if annotation_metadata['LabelDescription']:
+            for label_name, label_desc in annotation_metadata['LabelDescription'].items():
+                self.physiological_annotation_label_obj.insert(annotation_file_id, label_name, label_desc)
 
         # insert blake2b hash of annotation file into physiological_parameter_file
         self.insert_physio_parameter_file(


### PR DESCRIPTION
The `LabelDescription` field of the annotation.json file is optional in BIDS. If a dataset does not have this field in the annotation.json file, then bids_import.py fails with NoneType error.

The proposed fix is to check first if the `LabelDescription` field is set in annotation.json, if so, then insert entries in `physiological_annotation_label` with `label` and `description` present in each entry under `LabelDescription`, otherwise, this step is skipped.

