### PR TITLE
Bugfix: Floats returning false on isdecimal() fxn

### DIFF
--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -664,10 +664,10 @@ class Physiological:
                 if field not in row.keys():
                     row[field] = None
 
-            if not row['duration'].isdecimal():
+            if re.match(r'^-?\d+(?:\.\d+)?$', row['duration']) is None:
                 row['duration'] = None
 
-            if not row['onset'].isdecimal():
+            if re.match(r'^-?\d+(?:\.\d+)?$', row['onset']) is None:
                 row['onset'] = None
 
             if row['channels'] and "n/a" in row['channels']:


### PR DESCRIPTION
```
a = '1.23456'
b = '3'

a.isdecimal()
>> False !! this is problematic

b.isdecimal()
>> True
```

Extend support and make sure that strings in float format are accepted. Otherwise a null is inserted in the onset / duration field of annotation instance