### PR TITLE
[EEG-BIDS] Add support for events.json file & HED Tags

### DIFF
--- a/python/lib/database_lib/physiologicaleventarchive.py
+++ b/python/lib/database_lib/physiologicaleventarchive.py
@@ -1,0 +1,57 @@
+"""This class performs database queries for the physiological_event_archive table"""
+
+
+__license__ = "GPLv3"
+
+
+class PhysiologicalEventArchive:
+
+    def __init__(self, db, verbose):
+        """
+        Constructor method for the PhysiologicalEventArchive class.
+
+        :param db                 : Database class object
+         :type db                 : object
+        :param verbose            : whether to be verbose
+         :type verbose            : bool
+        """
+
+        self.db = db
+        self.table = 'physiological_event_archive'
+        self.verbose = verbose
+
+    def grep_from_physiological_file_id(self, physiological_file_id):
+        """
+        Gets rows given a physiological_file_id
+
+        :param physiological_file_id : Physiological file's ID
+         :type physiological_file_id : int
+
+        :return                      : list of dict containing rows data if found or None
+         :rtype                      : list
+        """
+
+        return self.db.pselect(
+            query="SELECT * FROM " + self.table + " WHERE PhysiologicalFileID = %s",
+            args=(physiological_file_id,)
+        )
+
+    def insert(self, physiological_file_id, blake2, archive_path):
+        """
+        Inserts a new entry in the physiological_event_archive table.
+
+        :param physiological_file_id : Physiological file's ID
+         :type physiological_file_id : int
+
+        :param blake2                : blake2b hash
+         :type blake2                : string
+
+        :param archive_path          : Archive's path
+         :type archive_path          : string
+        """
+
+        self.db.insert(
+            table_name   = self.table,
+            column_names = ('PhysiologicalFileID', 'Blake2bHash', 'FilePath'),
+            values       = (physiological_file_id, blake2, archive_path)
+        )

--- a/python/lib/database_lib/physiologicaleventfile.py
+++ b/python/lib/database_lib/physiologicaleventfile.py
@@ -33,8 +33,8 @@ class PhysiologicalEventFile:
         :param event_file       : path of the event file
          :type event_file       : str
 
-        :return                      : id of the row inserted
-         :rtype                      : int
+        :return                  : id of the row inserted
+         :rtype                  : int
         """
 
         return self.db.insert(

--- a/python/lib/database_lib/physiologicaleventfile.py
+++ b/python/lib/database_lib/physiologicaleventfile.py
@@ -63,3 +63,24 @@ class PhysiologicalEventFile:
         )
 
         event_paths = [event_path['FilePath'] for event_path in event_paths]
+
+        return event_paths
+
+    def grep_event_file_id_from_event_path(self, event_file_path):
+        """
+        Gets the EventFileID given a FilePath
+
+        :param event_file_path : FilePath of physiological event file
+         :type event_file_path       : str
+
+        :return                      : id of the file specified
+         :rtype                      : int
+        """
+        event_file_id = self.db.pselect(
+            query = "SELECT EventFileID "
+                    "FROM physiological_event_file "
+                    "WHERE FilePath = %s",
+            args = (event_file_path,)
+        )
+
+        return event_file_id[0]['EventFileID']

--- a/python/lib/database_lib/physiologicaleventfile.py
+++ b/python/lib/database_lib/physiologicaleventfile.py
@@ -82,7 +82,7 @@ class PhysiologicalEventFile:
         event_file_id = self.db.pselect(
             query = "SELECT EventFileID "
                     "FROM physiological_event_file "
-                    "WHERE FilePath = %s
+                    "WHERE FilePath = %s "
                     AND PhysiologicalFileID = %s",
             args = (event_file_path, physio_file_id,)
         )

--- a/python/lib/database_lib/physiologicaleventfile.py
+++ b/python/lib/database_lib/physiologicaleventfile.py
@@ -66,12 +66,15 @@ class PhysiologicalEventFile:
 
         return event_paths
 
-    def grep_event_file_id_from_event_path(self, event_file_path):
+    def grep_event_file_id_from_event_path(self, event_file_path, physio_file_id):
         """
         Gets the EventFileID given a FilePath
 
         :param event_file_path : FilePath of physiological event file
          :type event_file_path       : str
+
+        :param physio_file_id : Physiological file's ID
+         :type physio_file_id       : int
 
         :return                      : id of the file specified
          :rtype                      : int
@@ -79,8 +82,9 @@ class PhysiologicalEventFile:
         event_file_id = self.db.pselect(
             query = "SELECT EventFileID "
                     "FROM physiological_event_file "
-                    "WHERE FilePath = %s",
-            args = (event_file_path,)
+                    "WHERE FilePath = %s
+                    AND PhysiologicalFileID = %s",
+            args = (event_file_path, physio_file_id,)
         )
 
         return event_file_id[0]['EventFileID']

--- a/python/lib/database_lib/physiologicaleventfile.py
+++ b/python/lib/database_lib/physiologicaleventfile.py
@@ -83,7 +83,7 @@ class PhysiologicalEventFile:
             query = "SELECT EventFileID "
                     "FROM physiological_event_file "
                     "WHERE FilePath = %s "
-                    AND PhysiologicalFileID = %s",
+                    "AND PhysiologicalFileID = %s",
             args = (event_file_path, physio_file_id,)
         )
 

--- a/python/lib/database_lib/physiologicaleventfile.py
+++ b/python/lib/database_lib/physiologicaleventfile.py
@@ -1,0 +1,65 @@
+"""This class performs database queries for the physiological_event_file table"""
+
+
+__license__ = "GPLv3"
+
+
+class PhysiologicalEventFile:
+
+    def __init__(self, db, verbose):
+        """
+        Constructor method for the PhysiologicalEventFile class.
+
+        :param db                 : Database class object
+         :type db                 : object
+        :param verbose            : whether to be verbose
+         :type verbose            : bool
+        """
+
+        self.db = db
+        self.table = 'physiological_event_file'
+        self.verbose = verbose
+
+    def insert(self, physiological_file_id, event_file_type, event_file):
+        """
+        Inserts a new entry in the physiological_event_file table.
+
+        :param physiological_file_id : physiological file's ID
+         :type physiological_file_id : int
+
+        :param event_file_type  : type of the event file
+         :type event_file_type  : str
+
+        :param event_file       : path of the event file
+         :type event_file       : str
+
+        :return                      : id of the row inserted
+         :rtype                      : int
+        """
+
+        return self.db.insert(
+            table_name   = self.table,
+            column_names = ('PhysiologicalFileID', 'FileType', 'FilePath'),
+            values       = (physiological_file_id, event_file_type, event_file),
+            get_last_id  = True
+        )
+
+    def grep_event_paths_from_physiological_file_id(self, physiological_file_id):
+        """
+        Gets the FilePath given a physiological_file_id
+
+        :param physiological_file_id : Physiological file's ID
+         :type physiological_file_id : int
+
+        :return                      : list of FilePath if any or None
+         :rtype                      : list
+        """
+
+        event_paths = self.db.pselect(
+            query = "SELECT DISTINCT FilePath "
+                    "FROM physiological_event_file "
+                    "WHERE PhysiologicalFileID = %s",
+            args=(physiological_file_id,)
+        )
+
+        event_paths = [event_path['FilePath'] for event_path in event_paths]

--- a/python/lib/database_lib/physiologicaleventparameter.py
+++ b/python/lib/database_lib/physiologicaleventparameter.py
@@ -48,7 +48,7 @@ class PhysiologicalEventParameter:
 
         self.db.insert(
             table_name   = self.table,
-            column_names = ('EventFileID', 'ParameterName', 'Description', 'LongName', \
-            'Units', 'isCategorical', 'HED'),
+            column_names = ('EventFileID', 'ParameterName', 'Description', 'LongName',
+                'Units', 'isCategorical', 'HED'),
             values       = (event_file_id, parameter_name, description, long_name, units, is_categorical, hed)
         )

--- a/python/lib/database_lib/physiologicaleventparameter.py
+++ b/python/lib/database_lib/physiologicaleventparameter.py
@@ -45,8 +45,8 @@ class PhysiologicalEventParameter:
         :param hed               : Event parameter's HED tag if not categorical
          :type hed               : string
 
-        :return                      : id of the row inserted
-         :rtype                      : int
+        :return                  : id of the row inserted
+         :rtype                  : int
         """
 
         return self.db.insert(

--- a/python/lib/database_lib/physiologicaleventparameter.py
+++ b/python/lib/database_lib/physiologicaleventparameter.py
@@ -1,0 +1,54 @@
+"""This class performs database queries for the physiological_event_parameter table"""
+
+
+__license__ = "GPLv3"
+
+
+class PhysiologicalEventParameter:
+
+    def __init__(self, db, verbose):
+        """
+        Constructor method for the PhysiologicalEventParameter class.
+
+        :param db                 : Database class object
+         :type db                 : object
+        :param verbose            : whether to be verbose
+         :type verbose            : bool
+        """
+
+        self.db = db
+        self.table = 'physiological_event_parameter'
+        self.verbose = verbose
+
+    def insert(self, event_file_id, parameter_name, description, long_name, units, is_categorical, hed):
+        """
+        Inserts a new entry in the physiological_event_parameter table.
+
+        :param event_file_id : event file's ID
+         :type event_file_id : int
+
+        :param parameter_name    : Name of the event parameter
+         :type parameter_name    : string 
+
+        :param description       : Description of the events
+         :type description       : string 
+
+        :param long_name         : Full name of the event parameter
+         :type long_name         : string
+
+        :param units             : Event parameter's units
+         :type units             : string
+        
+        :param is_categorical    : Whether event has categorical levels ('Y' || 'N')
+         :type is_categorical    : string
+
+        :param hed               : Event parameter's HED tag if not categorical
+         :type hed               : string
+        """
+
+        self.db.insert(
+            table_name   = self.table,
+            column_names = ('EventFileID', 'ParameterName', 'Description', 'LongName', \
+            'Units', 'isCategorical', 'HED'),
+            values       = (event_file_id, parameter_name, description, long_name, units, is_categorical, hed)
+        )

--- a/python/lib/database_lib/physiologicaleventparameter.py
+++ b/python/lib/database_lib/physiologicaleventparameter.py
@@ -44,11 +44,15 @@ class PhysiologicalEventParameter:
 
         :param hed               : Event parameter's HED tag if not categorical
          :type hed               : string
+
+        :return                      : id of the row inserted
+         :rtype                      : int
         """
 
-        self.db.insert(
+        return self.db.insert(
             table_name   = self.table,
             column_names = ('EventFileID', 'ParameterName', 'Description', 'LongName',
-                'Units', 'isCategorical', 'HED'),
-            values       = (event_file_id, parameter_name, description, long_name, units, is_categorical, hed)
+                            'Units', 'isCategorical', 'HED'),
+            values       = (event_file_id, parameter_name, description, long_name, units, is_categorical, hed),
+            get_last_id  = True
         )

--- a/python/lib/database_lib/physiologicaleventparametercategorylevel.py
+++ b/python/lib/database_lib/physiologicaleventparametercategorylevel.py
@@ -17,7 +17,7 @@ class PhysiologicalEventParameterCategoryLevel:
         """
 
         self.db = db
-        self.table = 'physiological_event_parameter'
+        self.table = 'physiological_event_parameter_category_level'
         self.verbose = verbose
 
     def insert(self, event_parameter_id, level_name, description, hed):

--- a/python/lib/database_lib/physiologicaleventparametercategorylevel.py
+++ b/python/lib/database_lib/physiologicaleventparametercategorylevel.py
@@ -40,7 +40,7 @@ class PhysiologicalEventParameterCategoryLevel:
         self.db.insert(
             table_name   = self.table,
             column_names = ('EventParameterID', 'LevelName', 'Description', 'HED'),
-            values       = (event_parameter_id, level_name, description, hed)
+            values       = (event_parameter_id, level_name, description, hed),
             get_last_id  = True
         )
 

--- a/python/lib/database_lib/physiologicaleventparametercategorylevel.py
+++ b/python/lib/database_lib/physiologicaleventparametercategorylevel.py
@@ -1,0 +1,67 @@
+"""This class performs database queries for the physiological_event_parameter table"""
+
+
+__license__ = "GPLv3"
+
+
+class PhysiologicalEventParameterCategoryLevel:
+
+    def __init__(self, db, verbose):
+        """
+        Constructor method for the PhysiologicalEventParameter class.
+
+        :param db                 : Database class object
+         :type db                 : object
+        :param verbose            : whether to be verbose
+         :type verbose            : bool
+        """
+
+        self.db = db
+        self.table = 'physiological_event_parameter'
+        self.verbose = verbose
+
+    def insert(self, event_parameter_id, level_name, description, hed):
+        """
+        Inserts a new entry in the physiological_event_parameter table.
+
+        :param event_parameter_id : event parameter's ID
+         :type event_parameter_id : int
+
+        :param level_name         : Name of the event parameter's categorical level
+         :type level_name         : string 
+
+        :param description        : Description of the event parameter's categorical level
+         :type description        : string 
+
+        :param hed                : Event parameter's categorical HED tag
+         :type hed                : string
+        """
+
+        self.db.insert(
+            table_name   = self.table,
+            column_names = ('EventParameterID', 'LevelName', 'Description', 'HED'),
+            values       = (event_parameter_id, level_name, description, hed)
+            get_last_id  = True
+        )
+
+    def grep_id_from_physiological_file_id(self, physiological_file_id):
+        """
+        Gets the EventParameterID given a physiological_file_id
+
+        :param physiological_file_id : Physiological file's ID
+         :type physiological_file_id : int
+
+        :return                      : id of the row if found or None
+         :rtype                      : int
+        """
+
+        paramID = self.db.pselect(
+            query="SELECT EventParameterID "
+            "FROM " + self.table + " p "
+            "JOIN physiological_event_file f ON f.EventFileID = p.EventFileID "
+            "WHERE f.PhysiologicalFileID = %s "
+            "LIMIT 1",
+            args=(physiological_file_id,)
+        )
+
+        return paramID[0]['EventParameterID'] if paramID else None

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -722,7 +722,7 @@ class Eeg:
                     inheritance = True
 
                     if not event_metadata_file:
-                        print('No events.json found')
+                        print(f"WARNING: no events metadata files (event.json) associated with physiological file ID {physiological_file_id}")
                     else:
                         # copy the event file to the LORIS BIDS import directory
                         event_metadata_path = self.copy_file_to_loris_bids_dir(

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -305,7 +305,7 @@ class Eeg:
                         os.path.join(self.data_dir, event_file_path),
                     )
 
-                event_archive_rel_name = os.path.splitext(event_file_path)[0] + ".tgz"
+                event_archive_rel_name = os.path.splitext(event_file_paths[0])[0] + ".tgz"
                 self.create_and_insert_event_archive(
                     event_files_to_archive, event_archive_rel_name, eeg_file_id
                 )
@@ -692,7 +692,7 @@ class Eeg:
                     event_data, event_path, physiological_file_id, blake2
                 )
 
-                event_paths.extend([event_data_file.path])
+                event_paths.extend([event_path])
 
                 # get events.json file and insert
                 # subject-specific metadata
@@ -706,6 +706,7 @@ class Eeg:
                     full_search = False,
                     subject=self.psc_id,
                 )
+                inheritance = False
 
                 if not event_metadata_file:
                     # global events metadata
@@ -718,13 +719,14 @@ class Eeg:
                         all_ = False,
                         full_search = False,
                     )
+                    inheritance = True
 
                     if not event_metadata_file:
                         print('No events.json found')
                     else:
                         # copy the event file to the LORIS BIDS import directory
                         event_metadata_path = self.copy_file_to_loris_bids_dir(
-                            event_metadata_file.path, derivatives
+                            event_metadata_file.path, derivatives, inheritance
                         )
                         # load json data
                         with open(event_metadata_file.path) as metadata_file:
@@ -844,7 +846,7 @@ class Eeg:
 
         return annotation_paths
 
-    def copy_file_to_loris_bids_dir(self, file, derivatives=False):
+    def copy_file_to_loris_bids_dir(self, file, derivatives=False, inheritance=False):
         """
         Wrapper around the utilities.copy_file function that copies the file
         to the LORIS BIDS import directory and returns the relative path of the
@@ -877,7 +879,9 @@ class Eeg:
             )
         else :
             # determine the path of the copied file
-            copy_file = self.loris_bids_eeg_rel_dir
+            copy_file = ""
+            if not inheritance:
+                copy_file = self.loris_bids_eeg_rel_dir
             if self.bids_ses_id:
                 copy_file += os.path.basename(file)
             else:

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -722,7 +722,7 @@ class Eeg:
                     inheritance = True
 
                     if not event_metadata_file:
-                        message = '\nWARNING: no events metadata files (event.json) associated' +
+                        message = '\nWARNING: no events metadata files (event.json) associated' \
                                   'with physiological file ID ' + physiological_file_id
                         print(message)
                     else:

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -737,7 +737,12 @@ class Eeg:
                             event_metadata, event_metadata_path, physiological_file_id, blake2
                         )
 
-                        event_paths.extend([event_metadata_path])                  
+                        event_paths.extend([event_metadata_path])
+
+                        # insert assembled HED annotations
+                        physiological.insert_event_assembled_hed_tags(
+                            self.data_dir, event_path, event_metadata_path
+                        )             
                         
         return event_paths
 

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -722,7 +722,7 @@ class Eeg:
                     inheritance = True
 
                     if not event_metadata_file:
-                        message = '\nWARNING: no events metadata files (event.json) associated' +/
+                        message = '\nWARNING: no events metadata files (event.json) associated' +
                                   'with physiological file ID ' + physiological_file_id
                         print(message)
                     else:

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -298,7 +298,6 @@ class Eeg:
             if event_file_paths:
                 # archive all event files in a tar ball for event download
                 event_files_to_archive = ()
-                print(event_file_paths)
 
                 for event_file_path in event_file_paths:
                     files_to_archive = files_to_archive + (os.path.join(self.data_dir, event_file_path),)

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -722,7 +722,9 @@ class Eeg:
                     inheritance = True
 
                     if not event_metadata_file:
-                        print(f"WARNING: no events metadata files (event.json) associated with physiological file ID {physiological_file_id}")
+                        message = '\nWARNING: no events metadata files (event.json) associated' + /
+                                  'with physiological file ID ' + physiological_file_id
+                        print(message)
                     else:
                         # copy the event file to the LORIS BIDS import directory
                         event_metadata_path = self.copy_file_to_loris_bids_dir(

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -744,7 +744,7 @@ class Eeg:
 
                         # insert assembled HED annotations
                         physiological.insert_event_assembled_hed_tags(
-                            self.data_dir, event_path, event_metadata_path
+                            self.data_dir, event_path, event_metadata_path, physiological_file_id
                         )             
                         
         return event_paths

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -722,7 +722,7 @@ class Eeg:
                     inheritance = True
 
                     if not event_metadata_file:
-                        message = '\nWARNING: no events metadata files (event.json) associated' + /
+                        message = '\nWARNING: no events metadata files (event.json) associated' +/
                                   'with physiological file ID ' + physiological_file_id
                         print(message)
                     else:

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -294,9 +294,9 @@ class Eeg:
             if electrode_file_path:
                 files_to_archive = files_to_archive + (os.path.join(self.data_dir, electrode_file_path),)
             if event_file_paths:
-                files_to_archive = files_to_archive + (os.path.join(self.data_dir, event_file_path),)
                 # archive all event files in a tar ball for event download
                 event_files_to_archive = ()
+                print(event_file_paths)
 
                 for event_file_path in event_file_paths:
                     files_to_archive = files_to_archive + (os.path.join(self.data_dir, event_file_path),)
@@ -689,7 +689,7 @@ class Eeg:
                     event_data, event_path, physiological_file_id, blake2
                 )
 
-                event_paths.extend([event_data_path])
+                event_paths.extend([event_data_file.path])
 
                 # get events.json file and insert
                 # subject-specific metadata
@@ -735,7 +735,7 @@ class Eeg:
 
                         event_paths.extend([event_metadata_path])                  
                         
-        return event_path
+        return event_paths
 
     def fetch_and_insert_annotation_files(
             self, physiological_file_id, original_physiological_file_path, derivatives=False):
@@ -996,7 +996,7 @@ class Eeg:
         blake2 = blake2b(archive_full_path.encode('utf-8')).hexdigest()
         physiological_annotation_archive_obj.insert(eeg_file_id, blake2, archive_rel_name)
 
-def create_and_insert_event_archive(self, files_to_archive, archive_rel_name, eeg_file_id):
+    def create_and_insert_event_archive(self, files_to_archive, archive_rel_name, eeg_file_id):
         """
         Create an archive with all event files associated to a specific recording
 
@@ -1019,7 +1019,7 @@ def create_and_insert_event_archive(self, files_to_archive, archive_rel_name, ee
         # on the filesystem using blake2b hash
         results = self.db.pselect(
             query="SELECT * FROM physiological_event_archive WHERE PhysiologicalFileID = %s",
-            args=(physiological_file_id,)
+            args=(eeg_file_id,)
         )
 
         if results:
@@ -1048,5 +1048,5 @@ def create_and_insert_event_archive(self, files_to_archive, archive_rel_name, ee
         self.db.insert(
             table_name   = 'physiological_event_archive',
             column_names = ('PhysiologicalFileID', 'Blake2bHash', 'FilePath'),
-            values       = (physiological_file_id, blake2, archive_path)
+            values       = (eeg_file_id, blake2, archive_rel_name)
         )

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -68,7 +68,8 @@ class Physiological:
 
         self.physiological_event_file_obj                     = PhysiologicalEventFile(self.db, self.verbose)
         self.physiological_event_parameter_obj                = PhysiologicalEventParameter(self.db, self.verbose)
-        self.physiological_event_parameter_category_level_obj = PhysiologicalEventParameterCategoryLevel(self.db, self.verbose)
+        self.physiological_event_parameter_category_level_obj = \
+            PhysiologicalEventParameterCategoryLevel(self.db, self.verbose)
 
     def determine_file_type(self, file):
         """
@@ -534,8 +535,9 @@ class Physiological:
 
         for parameter in event_metadata:
             parameterName = parameter
-            description = event_metadata[parameter]['Description'] if 'Description' in event_metadata[parameter] \
-            else None
+            description = event_metadata[parameter]['Description'] \
+                if 'Description' in event_metadata[parameter] \
+                else None
             longName = event_metadata[parameter]['LongName'] if 'LongName' in event_metadata[parameter] else None
             units = event_metadata[parameter]['Units'] if 'Units' in event_metadata[parameter] else None
             if 'Levels' in event_metadata[parameter]:
@@ -559,9 +561,11 @@ class Physiological:
                 for level in event_metadata[parameter]['Levels']:
                     levelName = level
                     levelDescription = event_metadata[parameter]['Levels'][level]['Description'] \
-                    if 'Description' in event_metadata[parameter]['Levels'][level] else None
+                        if 'Description' in event_metadata[parameter]['Levels'][level] \
+                        else None
                     levelHED = event_metadata[parameter]['Levels'][level]['HED'] \
-                    if 'HED' in event_metadata[parameter]['Levels'][level] else None
+                        if 'HED' in event_metadata[parameter]['Levels'][level] \
+                        else None
 
                     self.physiological_event_parameter_category_level_obj.insert(
                         str(event_parameter_id),

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -696,8 +696,8 @@ class Physiological:
                 if (float(hedOnset) == float(onset)):
                     assembledHED = hedDict[index]['HED_assembled']
                     updateAssembledHED = "UPDATE physiological_task_event " \
-                                        "SET AssembledHED = %s " \
-                                        "WHERE PhysiologicalTaskEventID = %s"
+                        "SET AssembledHED = %s " \
+                        "WHERE PhysiologicalTaskEventID = %s"
                     self.db.update(query=updateAssembledHED, args=(assembledHED, eventID,))
 
     def insert_annotation_metadata(self, annotation_metadata, annotation_metadata_file, physiological_file_id, blake2):

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -612,6 +612,8 @@ class Physiological:
             values       = (physiological_file_id, 'tsv', event_file),
             get_last_id  = True
         )
+        print('EVENT FILE ID')
+        print(event_file_id)
 
         event_fields = (
             'PhysiologicalFileID', 'EventFileID', 'Onset', 'Duration',   

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -662,7 +662,7 @@ class Physiological:
             physiological_file_id, 'event_file_blake2b_hash', blake2
         )
 
-    def insert_event_assembled_hed_tags(self, data_dir, event_tsv, event_json):
+    def insert_event_assembled_hed_tags(self, data_dir, event_tsv, event_json, physio_file_id):
         """
         Assembles physiological event HED annotations.
 
@@ -671,12 +671,15 @@ class Physiological:
         
         :param event_json           : path to the event metadata file
          :type event_json           : str
+
+        :param physio_file_id : Physiological file's ID
+         :type physio_file_id       : int
         """
         hedDict = utilities.assemble_hed_service(data_dir, event_tsv, event_json)
 
         # get EventFileID from FilePath
         physiological_event_file_obj = PhysiologicalEventFile(self.db, self.verbose)
-        event_file_id = physiological_event_file_obj.grep_event_file_id_from_event_path(event_tsv)
+        event_file_id = physiological_event_file_obj.grep_event_file_id_from_event_path(event_tsv, physio_file_id)
 
         # get all task events for specified EventFileID
         query = "SELECT PhysiologicalTaskEventID as TaskEventID, Onset " \

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -561,11 +561,9 @@ class Physiological:
             if isCategorical == 'Y':
                 for level in event_metadata[parameter]['Levels']:
                     levelName = level
-                    levelDescription = event_metadata[parameter]['Levels'][level]['Description'] \
-                        if 'Description' in event_metadata[parameter]['Levels'][level] \
-                        else None
-                    levelHED = event_metadata[parameter]['Levels'][level]['HED'] \
-                        if 'HED' in event_metadata[parameter]['Levels'][level] \
+                    levelDescription = event_metadata[parameter]['Levels'][level]
+                    levelHED = event_metadata[parameter]['HED'][level] \
+                        if level in event_metadata[parameter]['HED'] \
                         else None
 
                     self.physiological_event_parameter_category_level_obj.insert(

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -604,8 +604,6 @@ class Physiological:
             'tsv',
             event_file
         )
-        print('EVENT FILE ID')
-        print(event_file_id)
 
         event_fields = (
             'PhysiologicalFileID', 'EventFileID', 'Onset', 'Duration',   
@@ -692,6 +690,7 @@ class Physiological:
             eventID = task_event_data[index]['TaskEventID']
             onset = task_event_data[index]['Onset']
             if hedDict[index] and 'onset' in hedDict[index]:
+                print(hedDict[index])
                 hedOnset = '{0:.6f}'.format(float(hedDict[index]['onset']))
                 if (float(hedOnset) == float(onset)):
                     assembledHED = hedDict[index]['HED_assembled']

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -690,7 +690,6 @@ class Physiological:
             eventID = task_event_data[index]['TaskEventID']
             onset = task_event_data[index]['Onset']
             if hedDict[index] and 'onset' in hedDict[index]:
-                print(hedDict[index])
                 hedOnset = '{0:.6f}'.format(float(hedDict[index]['onset']))
                 if (float(hedOnset) == float(onset)):
                     assembledHED = hedDict[index]['HED_assembled']

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -254,8 +254,8 @@ def remove_empty_folders(path_abs):
         if len(os.listdir(path)) == 0:
             os.rmdir(path)
 
+
 def assemble_hed_service(data_dir, event_tsv_path, event_json_path):
-    
     # Using HED Tool Rest Services to assemble the HED Tags
     # https://hed-examples.readthedocs.io/en/latest/HedToolsOnline.html#hed-restful-services
 
@@ -268,9 +268,9 @@ def assemble_hed_service(data_dir, event_tsv_path, event_json_path):
 
     # Define headers for assemble POST request, containing token and cookie
     headers = {
-        "Content-Type": "application/json", 
-        "Accept": "application/json", 
-        "X-CSRFToken": token, 
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "X-CSRFToken": token,
         "Cookie": cookie
     }
 
@@ -291,7 +291,9 @@ def assemble_hed_service(data_dir, event_tsv_path, event_json_path):
 
     # Make the request to assemble
     requestAssembleURL = 'https://hedtools.ucsd.edu/hed/services_submit'
-    assembleResponse = requests.post(requestAssembleURL, headers=headers, json=params)
+    assembleResponse = requests.post(
+        requestAssembleURL, headers=headers, json=params
+    )
 
     # get assembled results as dictionary
     data = assembleResponse.json()['results']['data']

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -14,7 +14,6 @@ import tempfile
 import requests
 import re
 import io
-import json
 
 import lib.exitcode
 
@@ -256,6 +255,7 @@ def remove_empty_folders(path_abs):
             os.rmdir(path)
 
 def assemble_hed_service(data_dir, event_tsv_path, event_json_path):
+    
     # Using HED Tool Rest Services to assemble the HED Tags
     # https://hed-examples.readthedocs.io/en/latest/HedToolsOnline.html#hed-restful-services
 

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -11,6 +11,10 @@ import shutil
 import subprocess
 import tarfile
 import tempfile
+import requests
+import re
+import io
+import json
 
 import lib.exitcode
 
@@ -250,3 +254,47 @@ def remove_empty_folders(path_abs):
     for path, _, _ in walk[::-1]:
         if len(os.listdir(path)) == 0:
             os.rmdir(path)
+
+def assemble_hed_service(data_dir, event_tsv_path, event_json_path):
+    # Using HED Tool Rest Services to assemble the HED Tags
+    # https://hed-examples.readthedocs.io/en/latest/HedToolsOnline.html#hed-restful-services
+
+    # Request CSRF Token & session cookie
+    requestTokenURL = 'https://hedtools.ucsd.edu/hed/services'
+    tokenResponse = requests.get(requestTokenURL)
+
+    cookie = tokenResponse.headers['Set-Cookie']
+    token = re.search('csrf_token" value="(.+?)"', tokenResponse.text).group(1)
+
+    # Define headers for assemble POST request, containing token and cookie
+    headers = {
+        "Content-Type": "application/json", 
+        "Accept": "application/json", 
+        "X-CSRFToken": token, 
+        "Cookie": cookie
+    }
+
+    # Read event files as str
+    eventJsonText = open(data_dir + event_json_path, 'r').read()
+    eventTsvText = open(data_dir + event_tsv_path, 'r').read()
+
+    # Define request parameters
+    params = {
+        'service': 'events_assemble',
+        'schema_version': '8.0.0',
+        'json_string': eventJsonText,
+        'events_string': eventTsvText,
+        'check_for_warnings': 'off',
+        'expand_defs': 'on',
+        'columns_included': ['onset']
+    }
+
+    # Make the request to assemble
+    requestAssembleURL = 'https://hedtools.ucsd.edu/hed/services_submit'
+    assembleResponse = requests.post(requestAssembleURL, headers=headers, json=params)
+
+    # get assembled results as dictionary
+    data = assembleResponse.json()['results']['data']
+    results = list(csv.DictReader(io.StringIO(data), delimiter='\t'))
+
+    return results


### PR DESCRIPTION
### Add support to bids_import for `*events.json` file & HED Tags
#### Scope
This PR refactors how the bids_import handles event files. It adds support for an event.json file in which HED tags can be stored. The PR edits the fetching and inserting of event files and adds an archiving feature similar to the annotation files. 

#### Information
Please reference this documentation for more info on [HED Tags in BIDS](https://bids-specification.readthedocs.io/en/latest/99-appendices/03-hed.html)

#### Testing
1. The SQL patches from https://github.com/aces/Loris/pull/8036 should be sourced before attempting to test these changes.
2. Place the sample [`*events.json` file](https://github.com/aces/Loris-MRI/files/8209484/task-faceO_events.json.zip) at the root of the RB BIDS directory. 
3. Attempt to test the changes in this PR
4. Try putting the `*events.json` file in a subject directory (and renaming) and make sure the import still runs as expected.

