### PR TITLE
Turn off column statistics option when running mysqldump

### DIFF
--- a/docs/scripts_md/ImagingUpload.md
+++ b/docs/scripts_md/ImagingUpload.md
@@ -90,6 +90,12 @@ successfully.
 
 RETURNS: 1 on success, 0 on failure
 
+### runPythonArchiveLoader()
+
+This methods will call `run_dicom_archive_loader.py`
+
+RETURNS: 1 on success, 0 on failure
+
 ### DicomPatientNameMatch($dicom\_file, $expected\_pname\_regex)
 
 This method extracts the patient name field from the DICOM file header using

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -513,7 +513,3 @@ Hey! **The above document had some coding errors, which are explained below:**
 - Around line 567:
 
     &#x3d;cut found outside a pod block.  Skipping to next block.
-
-- Around line 1887:
-
-    &#x3d;cut found outside a pod block.  Skipping to next block.

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -505,11 +505,3 @@ License: GPLv3
 
 LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
 Neuroscience
-
-# POD ERRORS
-
-Hey! **The above document had some coding errors, which are explained below:**
-
-- Around line 567:
-
-    &#x3d;cut found outside a pod block.  Skipping to next block.

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -514,6 +514,6 @@ Hey! **The above document had some coding errors, which are explained below:**
 
     &#x3d;cut found outside a pod block.  Skipping to next block.
 
-- Around line 1880:
+- Around line 1887:
 
     &#x3d;cut found outside a pod block.  Skipping to next block.

--- a/docs/scripts_md/delete_imaging_upload.md
+++ b/docs/scripts_md/delete_imaging_upload.md
@@ -57,8 +57,13 @@ Available options are:
                          upload(s) whose arguments were passed to `-uploadID`, respectively.
 
 \-nosqlbk               : when creating the backup file, do not add to it an SQL file that contains the statements used to restore 
-                         the database to the state it had before the script was invoked. Adding this file, wich will be named
+                         the database to the state it had before the script was invoked. Adding this file, which will be named
                          `imaging_upload_restore.sql`, to the backup file is the default behaviour.
+
+\-dumpOptions           : options to add to the mysqldump command. By default, the following options are used
+                         `--no-create-info --compact --single-transaction --skip-extended-insert --no-tablespaces`.
+                         Example of additional option: `--column-statistics=0` to disable column statistics flag in
+                         mysqldump 8.
 
 # DESCRIPTION
 
@@ -486,7 +491,7 @@ INPUTS:
                 that are associated to the upload(s) passed on the command line.
    - $tmpSQLFile: path of the SQL file that contains the SQL statements used to restore the deleted records.
 
-### deleteMriParameterForm($dbh, $mriUploadsRef, $tmpSQLFile)
+### deleteMriParameterForm($dbh, $mriUploadsRef, $tmpSQLFile, $dump\_opt)
 
 Delete the entries in `mri_parameter_form` (and associated `flag` entry) for the upload(s) passed on the
 command line. The script also adds an SQL statement in the SQL file whose path is passed as argument to 
@@ -499,6 +504,7 @@ INPUTS:
                  in the array. The properties stored for each hash are: `UploadID`, `TarchiveID`, `FullPath`
                  `Inserting`, `InsertionComplete` and `SessionID`.
    - $tmpSQLFile: path of the SQL file that contains the SQL statements used to restore the deleted records.
+   - $dump\_opt: additional options to use for mysqldump
 
 RETURNS:
    - The numbers of records deleted as a result of this operation.
@@ -543,7 +549,7 @@ INPUTS:
 RETURNS:
   - A reference on an array containing the `TarchiveSeriesID` to delete.
 
-### deleteTableData($dbh, $table, $key, $keyValuesRef, $tmpSQLBackupFile)
+### deleteTableData($dbh, $table, $key, $keyValuesRef, $tmpSQLBackupFile, $dump\_opt)
 
 Deletes records from a database table and adds in a file the SQL statements that allow rewriting the
 records back in the table. 
@@ -554,11 +560,12 @@ INPUTS:
   - $key: name of the key used to delete the records.
   - $keyValuesRef: reference on the list of values that field `$key` has for the records to delete.
   - $tmpSQLBackupFile: path of the SQL file that contains the SQL statements used to restore the deleted records.
+  - $dump\_opt: additional options to use for mysqldump
 
 RETURNS:
   - The number of records deleted.
 
-### updateSQLBackupFile($tmpSQLBackupFile, $table, $key, $keyValuesRef)
+### updateSQLBackupFile($tmpSQLBackupFile, $table, $key, $keyValuesRef, $dump\_opt)
 
 Updates the SQL file with the statements to restore the records whose properties are passed as argument.
 The block of statements is written at the beginning of the file.
@@ -568,6 +575,7 @@ INPUTS:
   - $table: name of the database table.
   - $key: name of the key used to delete the records.
   - $keyValuesRef: reference on the list of values that field `$key` has for the records to delete.
+  - $dump\_opt: additional options to use for mysqldump
 
 ### getInvalidDefacedFiles($dbh, $filesRef, $scanTypesToDeleteRef)
 

--- a/docs/scripts_md/get_dicom_files.md
+++ b/docs/scripts_md/get_dicom_files.md
@@ -4,7 +4,7 @@ get\_dicom\_files.pl - extracts DICOM files for specific patient names/scan type
 
 # SYNOPSIS
 
-perl get\_dicom\_files.pl \[-names patient\_name\_patterns\] \[-types scan\_type\_patterns\] \[-outdir tmp\_dir\] \[-outfile tarBasename\] 
+perl get\_dicom\_files.pl \[-name patient\_name\_patterns\] \[-type scan\_type\_patterns\] \[-outdir tmp\_dir\] \[-outfile tarBasename\] 
            \[-id candid|pscid|candid\_pscid|pscid\_candid\] -profile profile
 
 Available options are:

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -2113,7 +2113,7 @@ sub updateSQLBackupFile {
         
     # Run the mysqldump command for the current table and store the
     # result in $tmpSqlBackupFile (overwrite contents)
-    my $mysqldumpOptions = '--no-create-info --compact --single-transaction --skip-extended-insert --no-tablespaces';
+    my $mysqldumpOptions = '--column-statistics=0 --no-create-info --compact --single-transaction --skip-extended-insert --no-tablespaces';
     
     my $warningToIgnore = 'mysqldump: [Warning] Using a password on the command line interface can be insecure.';
     my $cmd = sprintf(

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1884,7 +1884,6 @@ sub validate_tarchive_id_against_upload_id {
     }
 }
 
-=cut
 
 =pod
 

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -564,7 +564,6 @@ sub createMriUploadArray {
     return %{ $mriUploadInfoRef->[0] };
 }
 
-=cut
 
 =pod
 


### PR DESCRIPTION
This resolves the following error I was having on my new sandbox when running mysqldump:

```
mysqldump: Couldn't execute 'SELECT COLUMN_NAME,                       JSON_EXTRACT(HISTOGRAM, '$."number-of-buckets-specified"')                FROM information_schema.COLUMN_STATISTICS                WHERE SCHEMA_NAME = 'cecile_raisin_bread' AND TABLE_NAME = 'psc';': Unknown table 'COLUMN_STATISTICS' in information_schema (1109)
```