### PR TITLE
[bids_import.py] Append to scans.tsv file when it already exists 

### DIFF
--- a/python/lib/scanstsv.py
+++ b/python/lib/scanstsv.py
@@ -83,6 +83,10 @@ class ScansTSV:
                     exit()
             else: 
                 eeg_acq_time = self.acquisition_data['acq_time']
+
+            if eeg_acq_time == 'n/a':
+                return None
+
             try:
                 eeg_acq_time = parse(eeg_acq_time)
             except ValueError as e:
@@ -114,11 +118,16 @@ class ScansTSV:
 
     def copy_scans_tsv_file_to_loris_bids_dir(self, bids_sub_id, loris_bids_root_dir, data_dir):
 
-        file = self.scans_tsv_file
-        copy = loris_bids_root_dir + '/sub-' + bids_sub_id + '/' + os.path.basename(self.scans_tsv_file)
-        utilities.copy_file(file, copy, self.verbose)
+        original_file_path = self.scans_tsv_file
+        final_file_path = loris_bids_root_dir + '/sub-' + bids_sub_id + '/' + os.path.basename(self.scans_tsv_file)
+
+        # copy the scans.tsv file to the new directory
+        if os.path.exists(final_file_path):
+            lib.utilities.append_to_tsv_file(original_file_path, final_file_path, "filename", self.verbose)
+        else:
+            lib.utilities.copy_file(original_file_path, final_file_path, self.verbose)
 
         # determine the relative path and return it
-        relative_path = copy.replace(data_dir, "")
+        relative_path = final_file_path.replace(data_dir, "")
 
         return relative_path

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -58,8 +58,9 @@ def append_to_tsv_file(new_tsv_file, old_tsv_file, key_value_check, verbose):
     # verify that the header rows of the two TSV file are the same
     new_tsv_content = read_tsv_file(new_tsv_file)
     old_tsv_content = read_tsv_file(old_tsv_file)
+    tsv_basename = os.path.basename(new_tsv_file)
     if new_tsv_content[0].keys() != old_tsv_content[0].keys():
-        print(f"ERROR: participants.tsv columns differ between {new_tsv_file} and {old_tsv_file}")
+        print(f"ERROR: {tsv_basename} columns differ between {new_tsv_file} and {old_tsv_file}")
         sys.exit(lib.exitcode.PROGRAM_EXECUTION_FAILURE)
 
     # loop through the rows of the new TSV file and check whether it is already present in the old TSV file


### PR DESCRIPTION
This PR allows to append to `scans.tsv` file if it already exists in the `bids_imports` data directory and a new entry needs to be added.

It also adds support to `n/a` acq_time values if present (this was generated by the BIDS wizard for example)