### PR TITLE
[bids_imports] bugfix - derivative annotation files copied over to raw folders

### DIFF
--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -710,8 +710,8 @@ class Eeg:
             strict = False,
             extension = 'tsv',
             suffix = 'annotations',
-            all_ = True,
-            full_search = True,
+            all_ = False,
+            full_search = False,
             subject=self.psc_id,
         )
 


### PR DESCRIPTION
An issue was reported a few months ago during a LORIS-EEG meeting wherein annotation files from the derivatives folder were being copied into the raw data folders. 

this PR amends this behaviour.