### PR TITLE
[dcm2bids] Adds support for images that do not have an acquisition date

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -541,9 +541,10 @@ class NiftiInsertionPipeline(BasePipeline):
         """
 
         scan_param = self.json_file_dict
-        acquisition_date = datetime.datetime.strptime(
-            scan_param['AcquisitionDateTime'], '%Y-%m-%dT%H:%M:%S.%f'
-        ).strftime("%Y-%m-%d")
+        if "AcquisitionDateTime" in scan_param.keys():
+            acquisition_date = datetime.datetime.strptime(
+                scan_param['AcquisitionDateTime'], '%Y-%m-%dT%H:%M:%S.%f'
+            ).strftime("%Y-%m-%d")
         file_type = self.imaging_obj.determine_file_type(nifti_rel_path)
         if not file_type:
             message = f'Could not determine file type for {nifti_rel_path}. No entry found in ImagingFileTypes table'


### PR DESCRIPTION
# Description

This adds support to insert images with no acquisition dates available. This is particularly pertinent when it comes to manage data supposed to be shared openly where the dates are considered identifying.

With this fix, the `files` table's `AcquisitionDate` field is set to the date available in the JSON if there is one, otherwise, it is set to `NULL`.

