### PR TITLE
[dcm2bids] Get scanner candidate's RegistrationProjectID based on the scanned candidate's visit ProjectID

### DIFF
--- a/python/lib/database_lib/mri_scanner.py
+++ b/python/lib/database_lib/mri_scanner.py
@@ -37,7 +37,7 @@ class MriScanner:
         self.db = db
         self.verbose = verbose
 
-    def determine_scanner_information(self, manufacturer, software_version, serial_number, scanner_model, center_id):
+    def determine_scanner_information(self, manufacturer, software_version, serial_number, scanner_model, center_id, project_id):
         """
         Select a ScannerID based on the scanner information gathered from the headers of the
         DICOM archive. If a ScannerID is not found for the scanner but register_new_scanner
@@ -53,6 +53,8 @@ class MriScanner:
          :type scanner_model: str
         :param center_id: Center ID of the scanner
          :type center_id: int
+        :param project_id: ID of the scanner's project
+         :type project_id: int
 
         :return: scanner ID
          :rtype: int
@@ -72,10 +74,12 @@ class MriScanner:
             return results[0]['ScannerID']
 
         # if could not find a scanner ID, register a new scanner in mri_scanner
-        scanner_id = self.register_new_scanner(manufacturer, software_version, serial_number, scanner_model, center_id)
+        scanner_id = self.register_new_scanner(
+            manufacturer, software_version, serial_number, scanner_model, center_id, project_id
+        )
         return scanner_id
 
-    def register_new_scanner(self, manufacturer, software_version, serial_number, scanner_model, center_id):
+    def register_new_scanner(self, manufacturer, software_version, serial_number, scanner_model, center_id, project_id):
         """
         Inserts a new entry in the mri_scanner table after having created a new candidate to
         associate to that scanner.
@@ -90,6 +94,8 @@ class MriScanner:
          :type scanner_model: str
         :param center_id: Center ID of the scanner
          :type center_id: int
+        :param project_id: ID of the scanner's project
+         :type project_id: int
 
         :return scanner_id: ScannerID of the new entry in the mri_scanner table
          :rtype scanner_id: int
@@ -99,12 +105,12 @@ class MriScanner:
         candidate = Candidate(self.verbose)
         new_cand_id = candidate.generate_cand_id(self.db)
         column_names = (
-            'CandID', 'PSCID',       'RegistrationCenterID', 'Date_active',
-            'UserID', 'Entity_type', 'Date_registered',
+            'CandID', 'PSCID',       'RegistrationCenterID',  'Date_active',
+            'UserID', 'Entity_type', 'RegistrationProjectID', 'Date_registered',
         )
         values = (
-            new_cand_id,  'scanner', center_id,              datetime.datetime.now(),
-            'imaging.py', 'Scanner', datetime.datetime.now()
+            new_cand_id,  'scanner', center_id,  datetime.datetime.now(),
+            'imaging.py', 'Scanner', project_id, datetime.datetime.now()
         )
         self.db.insert(table_name='candidate', column_names=column_names, values=values)
 

--- a/python/lib/database_lib/mri_scanner.py
+++ b/python/lib/database_lib/mri_scanner.py
@@ -37,7 +37,8 @@ class MriScanner:
         self.db = db
         self.verbose = verbose
 
-    def determine_scanner_information(self, manufacturer, software_version, serial_number, scanner_model, center_id, project_id):
+    def determine_scanner_information(self, manufacturer, software_version, serial_number, scanner_model,
+                                      center_id, project_id):
         """
         Select a ScannerID based on the scanner information gathered from the headers of the
         DICOM archive. If a ScannerID is not found for the scanner but register_new_scanner

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -208,7 +208,8 @@ class BasePipeline:
             self.dicom_archive_obj.tarchive_info_dict['ScannerSoftwareVersion'],
             self.dicom_archive_obj.tarchive_info_dict['ScannerSerialNumber'],
             self.dicom_archive_obj.tarchive_info_dict['ScannerModel'],
-            self.site_dict['CenterID']
+            self.site_dict['CenterID'],
+            self.session_obj.session_info_dict['ProjectID']
         )
         message = f"Found Scanner ID: {str(scanner_id)}"
         self.log_info(message, is_error="N", is_verbose="Y")

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -271,7 +271,8 @@ class NiftiInsertionPipeline(BasePipeline):
                 self.json_file_dict['SoftwareVersions'],
                 self.json_file_dict['DeviceSerialNumber'],
                 self.json_file_dict['ManufacturersModelName'],
-                self.site_dict['CenterID']
+                self.site_dict['CenterID'],
+                self.session_obj.session_info_dict['ProjectID']
             )
 
         # get the list of lines in the mri_protocol table that apply to the given scan based on the protocol group

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -751,7 +751,7 @@ class Imaging:
                 'MriProtocolChecksGroupID': hdr_checks_list[0]['MriProtocolChecksGroupID']
             }
 
-    def get_scanner_id(self, manufacturer, software_version, serial_nb, model_name, center_id):
+    def get_scanner_id(self, manufacturer, software_version, serial_nb, model_name, center_id, project_id):
         """
         Get the scanner ID based on the scanner information provided as input.
 
@@ -765,13 +765,16 @@ class Imaging:
          :type model_name: str
         :param center_id: ID of the scanner's center
          :type center_id: int
+        :param project_id: ID of the scanner's project
+         :type project_id: int
         """
         return self.mri_scanner_db_obj.determine_scanner_information(
             manufacturer,
             software_version,
             serial_nb,
             model_name,
-            center_id
+            center_id,
+            project_id
         )
 
     @staticmethod


### PR DESCRIPTION
# Description

This fixes a bug when creating a new entry in `mri_scanner` where the `RegistrationProjectID` of the scanner candidate is missing. This information will be deduced from the `ProjectID` associated to the visit of the imaging session.