### PR TITLE
Reload the mri_upload dictionary before checking if a tarchive has been validated

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -433,11 +433,16 @@ class BasePipeline:
 
         If the DICOM archive was not validated, the pipeline will exit and log the proper error information.
         """
+        # reload the mri_upload object with updated database values
+        self.load_imaging_upload_and_tarchive_dictionaries()
         mu_dict = self.imaging_upload_obj.imaging_upload_dict
         if ("IsTarchiveValidated" not in mu_dict.keys() or not mu_dict["IsTarchiveValidated"]) and not self.force:
             err_msg = f"The DICOM archive validation has failed for UploadID {self.upload_id}. Either run the" \
                       f" validation again and fix the problem or use --force to force the insertion of the NIfTI file."
             self.log_error_and_exit(err_msg, lib.exitcode.INVALID_DICOM, is_error="Y", is_verbose="N")
+
+        print("validated!!!")
+        sys.exit()
 
     def create_dir(self, directory_path):
         """

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -441,9 +441,6 @@ class BasePipeline:
                       f" validation again and fix the problem or use --force to force the insertion of the NIfTI file."
             self.log_error_and_exit(err_msg, lib.exitcode.INVALID_DICOM, is_error="Y", is_verbose="N")
 
-        print("validated!!!")
-        sys.exit()
-
     def create_dir(self, directory_path):
         """
         Create a directory on the file system.


### PR DESCRIPTION
# Description

When a study is run through the whole dcm2bids pipeline, it exits after having run the DICOM validation with message:

```
The DICOM archive validation has failed for UploadID X. Either run the validation again and fix the problem or use --force to force the insertion of the NIfTI file.
```

The correct behaviour is to reload the `mri_upload` dictionary with the latest content for that upload so it reads properly the field `IsTarchiveValidated` and continues processing when that field has been set to 1 in the database.