### PR TITLE
Add PhaseEncodingDirection and EchoNumber to files and mri_violations_log insert statements

### DIFF
--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -476,10 +476,10 @@ INPUTS:
 ### is\_file\_unique($file, $upload\_id)
 
 Queries the `files` and `parameter_file` tables to make sure that no imaging
-datasets with the same `SeriesUID` and `EchoTime` or the same `MD5sum` hash
-can be found in the database already. If there is a match, it will return a
-message with the information about why the file is not unique. If there is no
-match, then it will return undef.
+datasets with the same `SeriesUID`, `EchoTime`, `EchoNumber` and
+`PhaseEncodingDirection` or the same `MD5sum` hash can be found in the database
+already. If there is a match, it will return a message with the information about
+why the file is not unique. If there is no match, then it will return undef.
 
 INPUTS:
   - $file     : the file object from the `NeuroDB::File` package

--- a/python/lib/database_lib/files.py
+++ b/python/lib/database_lib/files.py
@@ -35,7 +35,7 @@ class Files:
         self.db = db
         self.verbose = verbose
 
-    def find_file_with_series_uid_and_echo_time(self, series_uid, echo_time):
+    def find_file_with_series_uid_and_echo_time(self, series_uid, echo_time, phase_enc_dir, echo_number):
         """
         Select files stored in the `files` table with a given `SeriesUID` and `EchoTime`.
 
@@ -43,13 +43,22 @@ class Files:
          :type series_uid: str
         :param echo_time: Echo Time of the file to look for in the files table
          :type echo_time: float
+        :param phase_enc_dir: Phase Encoding Direction of the file to look for
+         :type phase_enc_dir: str
+        :param echo_number: Echo Number of the file to look for
+         :type echo_number: int
 
         :return: entry from the `files` table for the file with SeriesUID and EchoTime
          :rtype: dict
         """
 
-        query = "SELECT * FROM files WHERE SeriesUID = %s and EchoTime = %s "
-        results = self.db.pselect(query=query, args=(series_uid, echo_time))
+        query = "SELECT * FROM files WHERE" \
+                " SeriesUID = %s  AND EchoTime = %s AND " \
+                " EchoNumber = %s AND PhaseEncodingDirection = %s"
+        results = self.db.pselect(
+            query=query,
+            args=(series_uid, echo_time, echo_number, phase_enc_dir)
+        )
 
         return results[0] if results else None
 

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -205,7 +205,7 @@ class NiftiInsertionPipeline(BasePipeline):
             # SeriesInstanceUID and EchoTime have been set in the JSON side car file
             echo_time = self.json_file_dict["EchoTime"]
             series_uid = self.json_file_dict["SeriesInstanceUID"]
-            echo_nb = self.json_file_dict["EchoNumber"] if "EchoNumber" in json_keys() else None
+            echo_nb = self.json_file_dict["EchoNumber"] if "EchoNumber" in json_keys else None
             phase_enc_dir = self.json_file_dict["PhaseEncodingDirection"] \
                 if "PhaseEncodingDirection" in json_keys else None
             match = self.imaging_obj.grep_file_info_from_series_uid_and_echo_time(

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -205,7 +205,11 @@ class NiftiInsertionPipeline(BasePipeline):
             # SeriesInstanceUID and EchoTime have been set in the JSON side car file
             echo_time = self.json_file_dict["EchoTime"]
             series_uid = self.json_file_dict["SeriesInstanceUID"]
-            match = self.imaging_obj.grep_file_info_from_series_uid_and_echo_time(series_uid, echo_time)
+            phase_enc_dir = self.json_file_dict["PhaseEncodingDirection"]
+            echo_number = self.json_file_dict['EchoNumber']
+            match = self.imaging_obj.grep_file_info_from_series_uid_and_echo_time(
+                series_uid, echo_time, phase_enc_dir, echo_number
+            )
             if match:
                 error_msg = f"There is already a file registered in the files table with SeriesUID {series_uid} and" \
                             f" EchoTime {echo_time}. The already registered file is {match['File']}"

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -205,15 +205,16 @@ class NiftiInsertionPipeline(BasePipeline):
             # SeriesInstanceUID and EchoTime have been set in the JSON side car file
             echo_time = self.json_file_dict["EchoTime"]
             series_uid = self.json_file_dict["SeriesInstanceUID"]
-            echo_number = self.json_file_dict["EchoNumber"] if "EchoNumber" in json_keys else None
+            echo_nb = self.json_file_dict["EchoNumber"] if "EchoNumber" in json_keys else None
             phase_enc_dir = self.json_file_dict["PhaseEncodingDirection"] \
                 if "PhaseEncodingDirection" in json_keys else None
             match = self.imaging_obj.grep_file_info_from_series_uid_and_echo_time(
-                series_uid, echo_time, phase_enc_dir, echo_number
+                series_uid, echo_time, phase_enc_dir, echo_nb
             )
             if match:
-                error_msg = f"There is already a file registered in the files table with SeriesUID {series_uid} and" \
-                            f" EchoTime {echo_time}. The already registered file is {match['File']}"
+                error_msg = f"There is already a file registered in the files table with SeriesUID {series_uid}," \
+                            f" EchoTime {echo_time}, EchoNumber {echo_nb} and PhaseEncodingDirection {phase_enc_dir}." \
+                            f" The already registered file is {match['File']}"
 
             # If force option has been used, check that there is no matching SeriesUID/EchoTime entry in tarchive_series
             if self.force:

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -205,8 +205,9 @@ class NiftiInsertionPipeline(BasePipeline):
             # SeriesInstanceUID and EchoTime have been set in the JSON side car file
             echo_time = self.json_file_dict["EchoTime"]
             series_uid = self.json_file_dict["SeriesInstanceUID"]
-            phase_enc_dir = self.json_file_dict["PhaseEncodingDirection"]
-            echo_number = self.json_file_dict['EchoNumber']
+            echo_number = self.json_file_dict["EchoNumber"] if "EchoNumber" in json_keys else None
+            phase_enc_dir = self.json_file_dict["PhaseEncodingDirection"] \
+                if "PhaseEncodingDirection" in json_keys else None
             match = self.imaging_obj.grep_file_info_from_series_uid_and_echo_time(
                 series_uid, echo_time, phase_enc_dir, echo_number
             )

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -205,7 +205,7 @@ class NiftiInsertionPipeline(BasePipeline):
             # SeriesInstanceUID and EchoTime have been set in the JSON side car file
             echo_time = self.json_file_dict["EchoTime"]
             series_uid = self.json_file_dict["SeriesInstanceUID"]
-            echo_nb = self.json_file_dict["EchoNumber"] if "EchoNumber" in json_keys else None
+            echo_nb = self.json_file_dict["EchoNumber"] if "EchoNumber" in json_keys() else None
             phase_enc_dir = self.json_file_dict["PhaseEncodingDirection"] \
                 if "PhaseEncodingDirection" in json_keys else None
             match = self.imaging_obj.grep_file_info_from_series_uid_and_echo_time(
@@ -521,7 +521,7 @@ class NiftiInsertionPipeline(BasePipeline):
          :type file_rel_path: str
         """
         scan_param = self.json_file_dict
-        phase_enc_dir = scan_param['PhaseEncodingDirection'] if 'PhaseEncodingDirection' in scan_param.keys else None
+        phase_enc_dir = scan_param['PhaseEncodingDirection'] if 'PhaseEncodingDirection' in scan_param.keys() else None
         base_info_dict = {
             'TimeRun': datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             'SeriesUID': scan_param['SeriesInstanceUID'] if 'SeriesInstanceUID' in scan_param.keys() else None,
@@ -553,7 +553,7 @@ class NiftiInsertionPipeline(BasePipeline):
 
         scan_param = self.json_file_dict
         acquisition_date = None
-        phase_enc_dir = scan_param['PhaseEncodingDirection'] if 'PhaseEncodingDirection' in scan_param.keys else None
+        phase_enc_dir = scan_param['PhaseEncodingDirection'] if 'PhaseEncodingDirection' in scan_param.keys() else None
         if "AcquisitionDateTime" in scan_param.keys():
             acquisition_date = datetime.datetime.strptime(
                 scan_param['AcquisitionDateTime'], '%Y-%m-%dT%H:%M:%S.%f'

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -521,6 +521,7 @@ class NiftiInsertionPipeline(BasePipeline):
          :type file_rel_path: str
         """
         scan_param = self.json_file_dict
+        phase_enc_dir = scan_param['PhaseEncodingDirection'] if 'PhaseEncodingDirection' in scan_param.keys else None
         base_info_dict = {
             'TimeRun': datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             'SeriesUID': scan_param['SeriesInstanceUID'] if 'SeriesInstanceUID' in scan_param.keys() else None,
@@ -530,6 +531,9 @@ class NiftiInsertionPipeline(BasePipeline):
             'CandID': self.subject_id_dict['CandID'],
             'Visit_label': self.subject_id_dict['visitLabel'],
             'Scan_type': self.scan_type_id,
+            'EchoTime': scan_param['EchoTime'] if 'EchoTime' in scan_param.keys() else None,
+            'EchoNumber': scan_param['EchoNumber'] if 'EchoNumber' in scan_param.keys() else None,
+            'PhaseEncodingDirection': phase_enc_dir,
             'MriProtocolChecksGroupID': self.mri_protocol_group_id
         }
         for violation_dict in violations_list:
@@ -548,6 +552,8 @@ class NiftiInsertionPipeline(BasePipeline):
         """
 
         scan_param = self.json_file_dict
+        acquisition_date = None
+        phase_enc_dir = scan_param['PhaseEncodingDirection'] if 'PhaseEncodingDirection' in scan_param.keys else None
         if "AcquisitionDateTime" in scan_param.keys():
             acquisition_date = datetime.datetime.strptime(
                 scan_param['AcquisitionDateTime'], '%Y-%m-%dT%H:%M:%S.%f'
@@ -561,7 +567,9 @@ class NiftiInsertionPipeline(BasePipeline):
             'SessionID': self.session_obj.session_info_dict['ID'],
             'File': nifti_rel_path,
             'SeriesUID': scan_param['SeriesInstanceUID'] if 'SeriesInstanceUID' in scan_param.keys() else None,
-            'EchoTime': scan_param['EchoTime'],
+            'EchoTime': scan_param['EchoTime'] if 'EchoTime' in scan_param.keys() else None,
+            'EchoNumber': scan_param['EchoNumber'] if 'EchoNumber' in scan_param.keys() else None,
+            'PhaseEncodingDirection': phase_enc_dir,
             'CoordinateSpace': 'native',
             'OutputType': 'native',
             'AcquisitionProtocolID': self.scan_type_id,

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -180,7 +180,7 @@ class Imaging:
 
         pf_entry = self.param_file_db_obj.get_parameter_file_for_file_id_param_type_id(file_id, param_type_id)
         if pf_entry:
-            self.param_file_db_obj.update_parameter_file(value, pf_entry[0]['ParameterFileID'])
+            self.param_file_db_obj.update_parameter_file(value, pf_entry['ParameterFileID'])
         else:
             self.param_file_db_obj.insert_parameter_file(param_file_insert_info_dict)
 

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -108,19 +108,25 @@ class Imaging:
         """
         return self.files_db_obj.find_file_with_hash(hash_string)
 
-    def grep_file_info_from_series_uid_and_echo_time(self, series_uid, echo_time):
+    def grep_file_info_from_series_uid_and_echo_time(self, series_uid, echo_time, phase_enc_dir, echo_number):
         """
         Greps the file ID from the files table. If it cannot be found, the method will return None.
 
         :param series_uid: Series Instance UID of the file to look for
          :type series_uid: str
         :param echo_time: Echo Time of the file to look for
-         :type echo_time: str
+         :type echo_time: float
+        :param phase_enc_dir: Phase Encoding Direction of the file to look for
+         :type phase_enc_dir: str
+        :param echo_number: Echo Number of the file to look for
+         :type echo_number: int
 
         :return: dictionary with files table content of the found file
         :rtype: dict
         """
-        return self.files_db_obj.find_file_with_series_uid_and_echo_time(series_uid, echo_time)
+        return self.files_db_obj.find_file_with_series_uid_and_echo_time(
+            series_uid, echo_time, phase_enc_dir, echo_number
+        )
 
     def insert_imaging_file(self, file_info_dict, parameter_file_data_dict):
         """

--- a/python/lib/mri.py
+++ b/python/lib/mri.py
@@ -3,6 +3,7 @@
 import os
 import json
 import getpass
+import re
 import sys
 from pyblake2 import blake2b
 
@@ -284,15 +285,15 @@ class Mri:
         other_assoc_files = {}
         for assoc_file in associated_files:
             file_info = assoc_file.get_entities()
-            if file_info['extension'] == 'json':
+            if re.search(r'json$', file_info['extension']):
                 json_file = assoc_file.path
-            elif file_info['extension'] == 'bvec':
+            elif re.search(r'bvec$', file_info['extension']):
                 other_assoc_files['bvec_file'] = assoc_file.path
-            elif file_info['extension'] == 'bval':
+            elif re.search(r'bval$', file_info['extension']):
                 other_assoc_files['bval_file'] = assoc_file.path
-            elif file_info['extension'] == 'tsv' and file_info['suffix'] == 'events':
+            elif re.search('tsv$', file_info['extension']) and file_info['suffix'] == 'events':
                 other_assoc_files['task_file'] = assoc_file.path
-            elif file_info['extension'] == 'tsv' and file_info['suffix'] == 'physio':
+            elif re.search('tsv$', file_info['extension']) and file_info['suffix'] == 'physio':
                 other_assoc_files['physio_file'] = assoc_file.path
 
         # read the json file if it exists

--- a/python/lib/mri.py
+++ b/python/lib/mri.py
@@ -380,6 +380,10 @@ class Mri:
             file_path = self.copy_file_to_loris_bids_dir(nifti_file.path)
 
             # insert the file along with its information into files and parameter_file tables
+            echo_time = file_parameters['EchoTime'] if 'EchoTime' in file_parameters.keys() else None
+            echo_nb = file_parameters['EchoNumber'] if 'EchoNumber' in file_parameters.keys() else None
+            phase_enc_dir = file_parameters['PhaseEncodingDirection'] \
+                if 'PhaseEncodingDirection' in file_parameters.keys() else None
             file_info = {
                 'FileType'        : file_type,
                 'File'            : file_path,
@@ -387,6 +391,9 @@ class Mri:
                 'InsertedByUserID': getpass.getuser(),
                 'CoordinateSpace' : coordinate_space,
                 'OutputType'      : output_type,
+                'EchoTime'        : echo_time,
+                'PhaseEncodingDirection': phase_enc_dir,
+                'EchoNumber'      : echo_nb,
                 'SourceFileID'    : None,
                 'AcquisitionProtocolID': scan_type_id
             }

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -774,7 +774,8 @@ sub register_db {
         'FileType',        'InsertedByUserID', 'Caveat',
         'SeriesUID',       'TarchiveSource',   'HrrtArchiveID',
         'SourcePipeline',  'PipelineDate',     'SourceFileID',
-        'ScannerID',       'AcquisitionDate'
+        'ScannerID',       'AcquisitionDate',  'PhaseEncodingDirection',
+        'EchoNumber'
     );
     foreach my $key (@field_array) {
         # add the key=value pair to the query

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1078,20 +1078,22 @@ sub insert_into_mri_violations_log {
 
     # determine the future relative path when the file will be moved to
     # data_dir/trashbin at the end of the script's execution
-    my $file_path     = $file->getFileDatum('File');
-    my $file_rel_path = NeuroDB::MRI::get_trashbin_file_rel_path($file_path, $data_dir, 1);
+    my $file_path        = $file->getFileDatum('File');
+    my $file_rel_path    = NeuroDB::MRI::get_trashbin_file_rel_path($file_path, $data_dir, 1);
+    my $file_ph_enc_dir  = $file->getParameter('phase_encoding_direction');
+    my $file_echo_number = $file->getParameter('echo_numbers');
 
     my $query = "INSERT INTO mri_violations_log"
                     . "("
-                    . "SeriesUID, TarchiveID,  MincFile,   PatientName, "
-                    . " CandID,   Visit_label, Scan_type,  Severity, "
-                    . " Header,   Value,       ValidRange, ValidRegex, "
-                    . " MriProtocolChecksGroupID "
+                    . " SeriesUID,              TarchiveID,  MincFile,           PatientName, "
+                    . " CandID,                 Visit_label, Scan_type,          Severity, "
+                    . " Header,                 Value,       ValidRange,         ValidRegex, "
+                    . " PhaseEncodingDirection, EchoNumber,  MriProtocolChecksGroupID "
                     . ") VALUES ("
                     . " ?,        ?,           ?,          ?, "
                     . " ?,        ?,           ?,          ?, "
                     . " ?,        ?,           ?,          ?, "
-                    . " ?"
+                    . " ?,        ?,           ?"
                     . ")";
     if ($this->{debug}) {
         print $query . "\n";
@@ -1126,6 +1128,8 @@ sub insert_into_mri_violations_log {
             $valid_fields->{$header}{HeaderValue},
             $valid_range_str,
             $valid_regex_str,
+            $file_ph_enc_dir,
+            $file_echo_number,
             $valid_fields->{$header}{MriProtocolChecksGroupID}
         );
     }

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -601,9 +601,11 @@ if ($hrrt) {
     $file->setFileData('HrrtArchiveID', $studyInfo{'HrrtArchiveID'});
     $caveat = 0;
 } else {
-    $file->setFileData('SeriesUID',      $file->getParameter('series_instance_uid'));
-    $file->setFileData('EchoTime',       $file->getParameter('echo_time')          );
-    $file->setFileData('TarchiveSource', $studyInfo{'TarchiveID'}                  );
+    $file->setFileData('SeriesUID',              $file->getParameter('series_instance_uid'));
+    $file->setFileData('EchoTime',               $file->getParameter('echo_time'));
+    $file->setFileData('PhaseEncodingDirection', $file->getParameter('phase_encoding_direction'));
+    $file->setFileData('EchoNumber',             $file->getParameter('echo_numbers'));
+    $file->setFileData('TarchiveSource',         $studyInfo{'TarchiveID'});
     $caveat = $acquisitionProtocol ? 1 : 0;
 }
 $file->setFileData('Caveat', $caveat);


### PR DESCRIPTION
# Description

This PR updates all imaging pipelines to add the PhaseEncodingDirection and EchoNumber information when present in the insertion of new rows into the `files` and `mri_violations_log` tables.

Resolves #784 

# Caveat for existing project

Make sure to source the SQL patches attached to https://github.com/aces/Loris/pull/8152 or source the SQL release patch from 24.0.0 to 24.1.0 releases of LORIS.

