### PR TITLE
Fix regex search in python code to exclude series description provided in Config table

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -230,12 +230,12 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         series_desc = json_data_dict["SeriesDescription"]
 
         if type(self.excluded_series_desc_regex_list) is str:
-            pattern = re.compile(self.excluded_series_desc_regex_list)
-            return True if pattern.match(series_desc) else False
+            pattern = re.compile(self.excluded_series_desc_regex_list, re.IGNORECASE)
+            return True if re.search(pattern, series_desc) else False
         else:
             for regex in self.excluded_series_desc_regex_list:
-                pattern = re.compile(regex)
-                if pattern.match(series_desc):
+                pattern = re.compile(regex, re.IGNORECASE)
+                if re.search(pattern, series_desc):
                     return True
 
     def _loop_through_nifti_files_and_insert(self):


### PR DESCRIPTION
# Description

This fixes the matching of series descriptions provided in the Config table. Previously, only series description starting with the string provided in the Config table were being excluded, instead of any series description matching the string provided in the Config table.

The check also ignore case when matching.