### PR TITLE
Fix return statement in imaging_upload.py

### DIFF
--- a/python/lib/imaging_upload.py
+++ b/python/lib/imaging_upload.py
@@ -50,7 +50,7 @@ class ImagingUpload:
         """
 
         results = self.mri_upload_db_obj.create_mri_upload_dict('UploadID', upload_id)
-        self.imaging_upload_dict = results[0]
+        self.imaging_upload_dict = results[0] if results else None
 
     def create_imaging_upload_dict_from_tarchive_id(self, tarchive_id):
         """


### PR DESCRIPTION
# Description

This fixes the return statement of the `create_imaging_upload_dict_from_upload_id` function of `imaging_upload.py` so that if no rows are found for a given UploadID, then None is being returned instead of failing lamentably.