### PR TITLE
[dcm2bids] Insert into MRICandidateErrors if there is a Candidate PatientName mismatch

### DIFF
--- a/python/lib/database_lib/mri_candidate_errors.py
+++ b/python/lib/database_lib/mri_candidate_errors.py
@@ -1,0 +1,51 @@
+"""This class performs database queries for the MriCandidateErrors table"""
+
+
+__license__ = "GPLv3"
+
+
+class MriCandidateErrors:
+    """
+    This class performs database queries for imaging dataset stored in the MriCandidateErrors table.
+
+    :Example:
+
+        from lib.mri_candidate_errors import MriCandidateErrors
+        from lib.database import Database
+
+        # database connection
+        db = Database(config.mysql, verbose)
+        db.connect()
+
+        mri_cand_error_db_obj = MriCandidateErrors(db, verbose)
+
+        ...
+    """
+
+    def __init__(self, db, verbose):
+        """
+        Constructor method for the MriCandidateErrors class.
+
+        :param db     : Database class object
+         :type db     : object
+        :param verbose: whether to be verbose
+         :type verbose: bool
+        """
+
+        self.db = db
+        self.verbose = verbose
+
+    def insert_mri_candidate_errors(self, field_value_dict):
+        """
+        Inserts a row into the MriCandidateErrors table with information present in the field_value_dict.
+
+        :param field_value_dict: dictionary with table field as keys and values to insert as values
+         :type field_value_dict: dict
+        """
+
+        self.db.insert(
+            table_name="MriCandidateErrors",
+            column_names=field_value_dict.keys(),
+            values=field_value_dict.values(),
+            get_last_id=False
+        )

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -87,7 +87,6 @@ class NiftiInsertionPipeline(BasePipeline):
                 self.subject_id_dict['CandMismatchError'], lib.exitcode.CANDIDATE_MISMATCH, is_error="Y", is_verbose="N"
             )
 
-        sys.exit()
         # ---------------------------------------------------------------------------------------------
         # Verify if the image/NIfTI file was not already registered into the database
         # ---------------------------------------------------------------------------------------------

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -75,7 +75,19 @@ class NiftiInsertionPipeline(BasePipeline):
         else:
             self._determine_subject_ids_based_on_json_patient_name()
         self.validate_subject_ids()
+        if "CandMismatchError" in self.subject_id_dict.keys():
+            self.imaging_obj.insert_mri_candidate_errors(
+                self.dicom_archive_obj.tarchive_info_dict["PatientName"],
+                self.dicom_archive_obj.tarchive_info_dict["TarchiveID"],
+                self.json_file_dict,
+                self.nifti_path,
+                self.subject_id_dict["CandMismatchError"]
+            )
+            self.log_error_and_exit(
+                self.subject_id_dict['CandMismatchError'], lib.exitcode.CANDIDATE_MISMATCH, is_error="Y", is_verbose="N"
+            )
 
+        sys.exit()
         # ---------------------------------------------------------------------------------------------
         # Verify if the image/NIfTI file was not already registered into the database
         # ---------------------------------------------------------------------------------------------
@@ -186,6 +198,13 @@ class NiftiInsertionPipeline(BasePipeline):
         nifti_pname = self.json_file_dict["PatientName"]
         if tarchive_pname != nifti_pname:
             err_msg = "PatientName in DICOM and NIfTI files differ."
+            self.imaging_obj.insert_mri_candidate_errors(
+                nifti_pname,
+                self.dicom_archive_obj.tarchive_info_dict["TarchiveID"],
+                self.json_file_dict,
+                self.nifti_path,
+                err_msg
+            )
             self.log_error_and_exit(err_msg, lib.exitcode.FILENAME_MISMATCH, is_error="Y", is_verbose="N")
 
     def _check_if_nifti_file_was_already_inserted(self):
@@ -502,6 +521,18 @@ class NiftiInsertionPipeline(BasePipeline):
             self.json_file_dict,
             self.trashbin_nifti_rel_path,
             self.mri_protocol_group_id
+        )
+
+    def _register_mri_candidate_errors(self):
+
+        patient_name = None
+        if "PatientName" in self.json_file_dict.keys():
+            patient_name = self.json_file_dict["PatientName"]
+        elif "PatientName" in self.dicom_archive_obj.tarchive_info_dict.keys():
+            patient_name = self.dicom_archive_obj.tarchive_info_dict["PatientName"]
+
+        self.imaging_obj.insert_mri_candidate_errors(
+            patient_name
         )
 
     def _register_violations_log(self, violations_list, file_rel_path):


### PR DESCRIPTION
# Description

This inserts into the MRICandidateErrors table if a NIfTI file has a PatientName that does not correspond to a specific candidate and exits as it is done on the perl side. Otherwise, scans would be inserted anyway to the CandID and it could have attached the scans to a wrong candidate...

