### PR TITLE
Fix case of MRICandidateErrors in the python insert statement that fails on a MariaDB/Linux install

### DIFF
--- a/python/lib/database_lib/mri_candidate_errors.py
+++ b/python/lib/database_lib/mri_candidate_errors.py
@@ -1,4 +1,4 @@
-"""This class performs database queries for the MriCandidateErrors table"""
+"""This class performs database queries for the MRICandidateErrors table"""
 
 
 __license__ = "GPLv3"
@@ -6,25 +6,25 @@ __license__ = "GPLv3"
 
 class MriCandidateErrors:
     """
-    This class performs database queries for imaging dataset stored in the MriCandidateErrors table.
+    This class performs database queries for imaging dataset stored in the MRICandidateErrors table.
 
     :Example:
 
-        from lib.mri_candidate_errors import MriCandidateErrors
+        from lib.mri_candidate_errors import MRICandidateErrors
         from lib.database import Database
 
         # database connection
         db = Database(config.mysql, verbose)
         db.connect()
 
-        mri_cand_error_db_obj = MriCandidateErrors(db, verbose)
+        mri_cand_error_db_obj = MRICandidateErrors(db, verbose)
 
         ...
     """
 
     def __init__(self, db, verbose):
         """
-        Constructor method for the MriCandidateErrors class.
+        Constructor method for the MRICandidateErrors class.
 
         :param db     : Database class object
          :type db     : object
@@ -37,14 +37,14 @@ class MriCandidateErrors:
 
     def insert_mri_candidate_errors(self, field_value_dict):
         """
-        Inserts a row into the MriCandidateErrors table with information present in the field_value_dict.
+        Inserts a row into the MRICandidateErrors table with information present in the field_value_dict.
 
         :param field_value_dict: dictionary with table field as keys and values to insert as values
          :type field_value_dict: dict
         """
 
         self.db.insert(
-            table_name="MriCandidateErrors",
+            table_name="MRICandidateErrors",
             column_names=field_value_dict.keys(),
             values=field_value_dict.values(),
             get_last_id=False


### PR DESCRIPTION
# Description

The table name used in the insert statement to the `MRICandidateErrors` table in the python dcm2bids pipeline failed because the table name appears to be case sensitive on a MariaDB installed on Ubuntu. 