### PR TITLE
Set DICOM dates to undef if the date does not follow proper DICOM standard

### DIFF
--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -1205,7 +1205,11 @@ sub date_format {
         my $diff = &Math::Round::nearest(0.01, ($Y + $M/12.0 + $D/365.0)*1) . " or $Y years, $M months $D days";
 	    return $diff;
     }
-    $first = ($first =~ m/(\d\d\d\d)(\d\d)(\d\d)/ ? s/(\d\d\d\d)(\d\d)(\d\d)/$1-$2-$3/ : undef);
+    # return undef if the date does not follow DICOM Date Value Representation (YYYYMMDD)
+    # note: does not check before as if there is a second argument, the date is expected to
+    # be YYYY-MM-DD, as can be seen in the if statement above
+    return undef unless $first =~ m/(\d\d\d\d)(\d\d)(\d\d)/;
+    $first =~ s/(\d\d\d\d)(\d\d)(\d\d)/$1-$2-$3/;
     return $first;
 }
 

--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -1196,17 +1196,17 @@ sub date_format {
     my $first = $_[0];
     my $second = $_[1];
     return undef unless defined $first;
-    if ($second) {
-	my ($fY, $fM, $fD) = split("-", $first);
-	my ($sY, $sM, $sD) = split("-", $second);
-	my $Y = $sY - $fY;
-	my $M = $sM - $fM;
-	my $D = $sD - $fD;
-	my $diff = &Math::Round::nearest(0.01, ($Y + $M/12.0 + $D/365.0)*1) . " or $Y years, $M months $D days";
-	return $diff;
+    if (defined $second) {
+        my ($fY, $fM, $fD) = split("-", $first);
+        my ($sY, $sM, $sD) = split("-", $second);
+        my $Y = $sY - $fY;
+        my $M = $sM - $fM;
+        my $D = $sD - $fD;
+        my $diff = &Math::Round::nearest(0.01, ($Y + $M/12.0 + $D/365.0)*1) . " or $Y years, $M months $D days";
+	    return $diff;
     }
-    $first =~ s/(....)(..)(..)/$1-$2-$3/; 
-    return $first; 
+    $first = ($first =~ m/(\d\d\d\d)(\d\d)(\d\d)/ ? s/(\d\d\d\d)(\d\d)(\d\d)/$1-$2-$3/ : undef);
+    return $first;
 }
 
 


### PR DESCRIPTION
# Description

PatientBirthDate should follow a string Value Representation (a.k.a `Date (DA)`) which is of the form `YYYYMMDD`. See [Patient's Birth Date Attribute in DICOM standard Browser](https://dicom.innolitics.com/ciods/rt-dose/patient/00100030) and [descriptions of DICOM value representations](https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html).

Sometimes, some deidentifying tools might insert incorrect date format (latest example was 00/00/0000) which leads to database errors when inserting invalid dates to the `tarchive` table for example.

Proposed fix: if the date is not following the original DICOM Value Representation, then it means a tool was run on it to get rid of the date, therefore, the DICOM scripts will set that date to `NULL` in the `tarchive` table.

Discussed during the LORIS HBCD dev meeting call.