### PR TITLE
[DICOMSUM] Set FileNumber to undef if it is '' in the DICOM header

### DIFF
--- a/dicom-archive/DICOM/DCMSUM.pm
+++ b/dicom-archive/DICOM/DCMSUM.pm
@@ -382,6 +382,7 @@ QUERY
         my $filename = $file->[4];
         $filename =~ s/^${dcmdirRoot}\///;
         $file->[2] = undef if($file->[2] eq '');
+        $file->[3] = undef if($file->[3] eq '');
         $select_TarchiveSeriesID->execute($file->[24], $file->[6]); # based on SeriesUID and EchoTime
         my ($TarchiveSeriesID) = $select_TarchiveSeriesID->fetchrow_array();
         my @values;


### PR DESCRIPTION
# Description

When FileNumber is set to '' in DICOM header, the dicomTar.pl pipeline crashes when inserting data into the `tarchive_files` table as FileNumber Int column cannot store empty strings. This PR fixes this by setting empty strings to `undef` for that field.