### PR TITLE
[dcm2bids] Add missing get_scanner_candid function in imaging.py

### DIFF
--- a/python/lib/database_lib/mri_scanner.py
+++ b/python/lib/database_lib/mri_scanner.py
@@ -126,7 +126,15 @@ class MriScanner:
         return scanner_id
 
     def get_scanner_candid(self, scanner_id):
+        """
+        Select a ScannerID CandID based on the scanner ID in mri_scanner.
 
+        :param scanner_id: scanner ID in the mri_scanner table
+         :type scanner_id: int
+
+        :return: scanner CandID
+         :rtype: int
+        """
         query = 'SELECT CandID FROM mri_scanner WHERE ID = %s'
         results = self.db.pselect(query=query, args=(scanner_id,))
         return results[0]['CandID'] if results else None

--- a/python/lib/database_lib/mri_scanner.py
+++ b/python/lib/database_lib/mri_scanner.py
@@ -124,3 +124,9 @@ class MriScanner:
         )
 
         return scanner_id
+
+    def get_scanner_candid(self, scanner_id):
+
+        query = 'SELECT CandID FROM mri_scanner WHERE ID = %s'
+        results = self.db.pselect(query=query, args=(scanner_id,))
+        return results[0]['CandID'] if results else None

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -821,6 +821,15 @@ class Imaging:
         )
 
     def get_scanner_candid(self, scanner_id):
+        """
+        Select a ScannerID CandID based on the scanner ID in mri_scanner.
+
+        :param scanner_id: scanner ID in the mri_scanner table
+         :type scanner_id: int
+
+        :return: scanner CandID
+         :rtype: int
+        """
         return self.mri_scanner_db_obj.get_scanner_candid(scanner_id)
 
     @staticmethod

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -820,6 +820,9 @@ class Imaging:
             project_id
         )
 
+    def get_scanner_candid(self, scanner_id):
+        return self.mri_scanner_db_obj.get_scanner_candid(scanner_id)
+
     @staticmethod
     def extract_files_from_dicom_archive(dicom_archive_path, extract_location_dir):
         """


### PR DESCRIPTION
# Description

The default LORIS `get_subject_ids` function in `database_config.py` calls a `get_scanner_candid` function for phantom datasets that was missing from the `imaging.py` library. This PR adds the missing function.