### PR TITLE
Add required IntendedFor BIDS field in fieldmap JSON files

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -88,6 +88,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         if self.inserted_file_count > 0:
             self._move_and_update_dicom_archive()
             self._compute_snr()
+            self._add_intended_for_to_fieldmap_json_files()
             self._order_modalities_per_acquisition_type()
             self._update_mri_upload()
 
@@ -328,6 +329,14 @@ class DicomArchiveLoaderPipeline(BasePipeline):
     def _compute_snr(self):
         # TODO: to be implemented later on. No clear paths as to how to compute that
         pass
+
+    def _add_intended_for_to_fieldmap_json_files(self):
+
+        fmap_files_dict = self.imaging_obj.determine_intended_for_field_for_fmap_json_files(self.tarchive_id)
+
+        for key in fmap_files_dict.keys():
+            sorted_fmap_files_list = fmap_files_dict[key]
+            self.imaging_obj.modify_fmap_json_file_to_write_intended_for(sorted_fmap_files_list)
 
     def _order_modalities_per_acquisition_type(self):
         """

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -331,6 +331,9 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         pass
 
     def _add_intended_for_to_fieldmap_json_files(self):
+        """
+        Add IntendedFor field in JSON file of fieldmap acquisitions according to BIDS standard for fieldmaps.
+        """
 
         fmap_files_dict = self.imaging_obj.determine_intended_for_field_for_fmap_json_files(self.tarchive_id)
 

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -860,10 +860,11 @@ class Imaging:
                 fmap_acq_time = fmap_dict['acq_time']
                 next_fmap_acq_time = sorted_fmap_files_list[idx + 1]['acq_time'] \
                     if idx + 1 < len(sorted_fmap_files_list) else None
-                sorted_fmap_files_list[idx]['IntendedFor'] = self.get_intended_for_list_of_scans_after_fieldmap_acquisition_based_on_acq_time(
-                    sorted_new_files_list,
-                    fmap_acq_time,
-                    next_fmap_acq_time
+                sorted_fmap_files_list[idx]['IntendedFor'] = \
+                    self.get_intended_for_list_of_scans_after_fieldmap_acquisition_based_on_acq_time(
+                        sorted_new_files_list,
+                        fmap_acq_time,
+                        next_fmap_acq_time
                 )
 
         return sorted_fmap_files_dict
@@ -940,7 +941,7 @@ class Imaging:
          :type files_list: list
 
         :return: the list of files that might need fmap correction sorted by acquisition time.
-         :rtype: dict
+         :rtype: list
         """
 
         # list BIDS dwi, func and perf suffixes to handle

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -2,11 +2,13 @@
 
 import os
 import datetime
+import json
 import nibabel as nib
 import re
 import tarfile
 
 from nilearn import image, plotting
+from pyblake2 import blake2b
 
 from lib.database_lib.config import Config
 from lib.database_lib.files import Files
@@ -19,7 +21,6 @@ from lib.database_lib.mri_scanner import MriScanner
 from lib.database_lib.mri_violations_log import MriViolationsLog
 from lib.database_lib.parameter_file import ParameterFile
 from lib.database_lib.parameter_type import ParameterType
-
 
 __license__ = "GPLv3"
 
@@ -63,6 +64,7 @@ class Imaging:
         self.db = db
         self.verbose = verbose
         self.config_file = config_file
+        self.config_db_obj = Config(self.db, self.verbose)
         self.files_db_obj = Files(db, verbose)
         self.mri_cand_errors_db_obj = MriCandidateErrors(db, verbose)
         self.mri_prot_db_obj = MriProtocol(db, verbose)
@@ -432,7 +434,7 @@ class Imaging:
         """
 
         query = "SELECT CandID " + \
-                " FROM session s " +\
+                " FROM session s " + \
                 " JOIN files f ON (s.ID=f.SessionID) " + \
                 " WHERE FileID = %s"
 
@@ -679,18 +681,18 @@ class Imaging:
         scan_en = scan_param['EchoNumber'] if 'EchoNumber' in scan_param else None
 
         if (self.in_range(scan_param['time'], db_prot['time_min'], db_prot['time_max'])) \
-                and self.in_range(scan_tr,              db_prot['TR_min'],     db_prot['TR_max']) \
-                and self.in_range(scan_te,              db_prot['TE_min'],     db_prot['TE_max']) \
-                and self.in_range(scan_ti,              db_prot['TI_min'],     db_prot['TI_max']) \
-                and self.in_range(scan_param['xstep'],  db_prot['xstep_min'],  db_prot['xstep_max']) \
-                and self.in_range(scan_param['ystep'],  db_prot['ystep_min'],  db_prot['ystep_max']) \
-                and self.in_range(scan_param['zstep'],  db_prot['zstep_min'],  db_prot['zstep_max']) \
+                and self.in_range(scan_tr, db_prot['TR_min'], db_prot['TR_max']) \
+                and self.in_range(scan_te, db_prot['TE_min'], db_prot['TE_max']) \
+                and self.in_range(scan_ti, db_prot['TI_min'], db_prot['TI_max']) \
+                and self.in_range(scan_param['xstep'], db_prot['xstep_min'], db_prot['xstep_max']) \
+                and self.in_range(scan_param['ystep'], db_prot['ystep_min'], db_prot['ystep_max']) \
+                and self.in_range(scan_param['zstep'], db_prot['zstep_min'], db_prot['zstep_max']) \
                 and self.in_range(scan_param['xspace'], db_prot['xspace_min'], db_prot['xspace_max']) \
                 and self.in_range(scan_param['yspace'], db_prot['yspace_min'], db_prot['yspace_max']) \
                 and self.in_range(scan_param['zspace'], db_prot['zspace_min'], db_prot['zspace_max']) \
-                and self.in_range(scan_slice_thick,     db_prot['slice_thickness_min'], db_prot['slice_thickness_max'])\
-                and (not db_prot['PhaseEncodingDirection'] or scan_ped == db_prot['PhaseEncodingDirection'])\
-                and (not db_prot['EchoNumber'] or scan_en == int(db_prot['EchoNumber']))\
+                and self.in_range(scan_slice_thick, db_prot['slice_thickness_min'], db_prot['slice_thickness_max']) \
+                and (not db_prot['PhaseEncodingDirection'] or scan_ped == db_prot['PhaseEncodingDirection']) \
+                and (not db_prot['EchoNumber'] or scan_en == int(db_prot['EchoNumber'])) \
                 and (not db_prot['image_type'] or scan_img_type == db_prot['image_type']):
             return True
 
@@ -831,6 +833,156 @@ class Imaging:
          :rtype: int
         """
         return self.mri_scanner_db_obj.get_scanner_candid(scanner_id)
+
+    def determine_intended_for_field_for_fmap_json_files(self, tarchive_id):
+
+        # get list files from a given tarchive ID
+        files_list = self.files_db_obj.get_files_inserted_for_tarchive_id(tarchive_id)
+
+        # get the list of fmap files for which IntendedFor key will be added in the BIDS JSON file
+        sorted_fmap_files_dict = self.get_list_of_fmap_files_sorted_by_acq_time(files_list)
+
+        # get the list of files sorted by acquisition time
+        sorted_new_files_list = self.get_list_of_files_sorted_by_acq_time(files_list)
+
+        for key in sorted_fmap_files_dict.keys():
+            sorted_fmap_files_list = sorted_fmap_files_dict[key]
+            for idx, fmap_dict in enumerate(sorted_fmap_files_list):
+                fmap_acq_time = fmap_dict['acq_time']
+                next_fmap_acq_time = sorted_fmap_files_list[idx + 1]['acq_time'] \
+                    if idx + 1 < len(sorted_fmap_files_list) else None
+                sorted_fmap_files_list[idx]['IntendedFor'] = self.get_closest_fieldmap_before_scan_based_on_acq_time(
+                    sorted_new_files_list,
+                    fmap_acq_time,
+                    next_fmap_acq_time
+                )
+
+        return sorted_fmap_files_dict
+
+    def get_list_of_fmap_files_sorted_by_acq_time(self, files_list):
+
+        # list BIDS fieldmap suffixes to handle
+        bids_fmap_suffix_list = ['magnitude', 'magnitude1', 'magnitude2',
+                                 'phasediff', 'phase1', 'phase2',
+                                 'fieldmap', 'epi']
+
+        fmap_files_dir_ap = []
+        fmap_files_dir_pa = []
+        fmap_files_no_dir = []
+        for file_dict in files_list:
+            bids_info = self.mri_prot_db_obj.get_bids_info_for_scan_type_id(
+                file_dict['AcquisitionProtocolID']
+            )
+            acq_time = self.param_file_db_obj.get_parameter_file_for_file_id_param_type_id(
+                file_dict['FileID'],
+                self.param_type_db_obj.get_parameter_type_id('acquisition_time')
+            )['Value']
+            if bids_info['BIDSCategoryName'] == 'fmap' and bids_info['BIDSScanType'] in bids_fmap_suffix_list:
+                json_file_path = self.param_file_db_obj.get_parameter_file_for_file_id_param_type_id(
+                    file_dict['FileID'],
+                    self.param_type_db_obj.get_parameter_type_id('bids_json_file')
+                )['Value']
+                file_dict = {
+                    'FileID': file_dict['FileID'],
+                    'FilePath': file_dict['File'],
+                    'bids_suffix': bids_info['BIDSScanType'],
+                    'bids_subcategory': bids_info['BIDSScanTypeSubCategory'],
+                    'json_file_path': json_file_path,
+                    'acq_time': acq_time
+                }
+                if re.match(r'dir-AP', bids_info['BIDSScanTypeSubCategory']):
+                    fmap_files_dir_ap.append(file_dict)
+                elif re.match(r'dir-PA', bids_info['BIDSScanTypeSubCategory']):
+                    fmap_files_dir_pa.append(file_dict)
+                else:
+                    fmap_files_no_dir.append(file_dict)
+
+        fmap_files_dict = {
+            'dir-AP': sorted(fmap_files_dir_ap, key=lambda x: x['acq_time']),
+            'dir-PA': sorted(fmap_files_dir_pa, key=lambda x: x['acq_time']),
+            'no-dir': sorted(fmap_files_no_dir, key=lambda x: x['acq_time']),
+        }
+
+        return fmap_files_dict
+
+    def get_list_of_files_sorted_by_acq_time(self, files_list):
+
+        # list BIDS dwi, func and perf suffixes to handle
+        bids_dwi_suffix_list = ['dwi', 'sbref']
+        bids_func_suffix_list = ['bold', 'sbref']
+        bids_perf_suffix_list = ['asl', 'sbref']
+
+        new_files_list = []
+        for file_dict in files_list:
+            bids_info = self.mri_prot_db_obj.get_bids_info_for_scan_type_id(
+                file_dict['AcquisitionProtocolID']
+            )
+            acq_time = self.param_file_db_obj.get_parameter_file_for_file_id_param_type_id(
+                file_dict['FileID'],
+                self.param_type_db_obj.get_parameter_type_id('acquisition_time')
+            )['Value']
+            require_fmap = False
+            if (bids_info['BIDSCategoryName'] == 'dwi' and bids_info['BIDSScanType'] in bids_dwi_suffix_list) \
+                    or (bids_info['BIDSCategoryName'] == 'func' and bids_info['BIDSScanType'] in bids_func_suffix_list) \
+                    or (bids_info['BIDSCategoryName'] == 'perf' and bids_info['BIDSScanType'] in bids_perf_suffix_list):
+                require_fmap = True
+
+            bids_visit_label = os.path.split(os.path.split(os.path.dirname(file_dict['File']))[0])[1]
+            nii_rel_file_path = os.path.join(
+                bids_visit_label,
+                bids_info['BIDSCategoryName'],
+                os.path.basename(file_dict['File'])
+            )
+
+            new_files_list.append({
+                'FileID': file_dict['FileID'],
+                'BidsFileRelPath': nii_rel_file_path,
+                'bids_suffix': bids_info['BIDSScanType'],
+                'bids_subcategory': bids_info['BIDSScanTypeSubCategory'],
+                'acq_time': acq_time,
+                'need_fmap': require_fmap
+            })
+
+        return sorted(new_files_list, key=lambda x: x['acq_time'])
+
+    def modify_fmap_json_file_to_write_intended_for(self, sorted_fmap_files_list):
+
+        for fmap_dict in sorted_fmap_files_list:
+            json_file_path = os.path.join(self.config_db_obj.get_config('dataDirBasepath'), fmap_dict['json_file_path'])
+            with open(json_file_path) as json_file:
+                json_data = json.load(json_file)
+            json_data['IntendedFor'] = fmap_dict['IntendedFor']
+            with open(json_file_path, 'w') as json_file:
+                json_file.write(json.dumps(json_data, indent=4))
+            json_blake2 = blake2b(json_file_path.encode('utf-8')).hexdigest()
+            param_type_id = self.param_type_db_obj.get_parameter_type_id('bids_json_file_blake2b_hash')
+            param_file_dict = self.param_file_db_obj.get_parameter_file_for_file_id_param_type_id(
+                fmap_dict['FileID'],
+                param_type_id
+            )
+            self.param_file_db_obj.update_parameter_file(json_blake2, param_file_dict['ParameterFileID'])
+
+    @staticmethod
+    def get_closest_fieldmap_before_scan_based_on_acq_time(files_list, current_fmap_acq_time, next_fmap_acq_time):
+
+        # go for acquisitions closest to the acq_time of the fmap before and after the fmap
+
+        intended_for = []
+        for file_dict in files_list:
+            if not file_dict['acq_time']:
+                continue
+            nii_file_acq = file_dict['acq_time']
+            if not file_dict['need_fmap']:
+                continue
+            if nii_file_acq <= current_fmap_acq_time:
+                # ignore if nii acquisition preceded fmap acquisition
+                continue
+            if next_fmap_acq_time and nii_file_acq >= next_fmap_acq_time:
+                # ignore if nii acquisition happened after the next fmap acq
+                continue
+            intended_for.append(file_dict['BidsFileRelPath'])
+
+        return intended_for
 
     @staticmethod
     def extract_files_from_dicom_archive(dicom_archive_path, extract_location_dir):

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -960,7 +960,7 @@ class Imaging:
             )['Value']
             require_fmap = False
             if (bids_info['BIDSCategoryName'] == 'dwi' and bids_info['BIDSScanType'] in bids_dwi_suffix_list) \
-                    or (bids_info['BIDSCategoryName'] == 'func' and bids_info['BIDSScanType'] in bids_func_suffix_list) \
+                    or (bids_info['BIDSCategoryName'] == 'func' and bids_info['BIDSScanType'] in bids_func_suffix_list)\
                     or (bids_info['BIDSCategoryName'] == 'perf' and bids_info['BIDSScanType'] in bids_perf_suffix_list):
                 require_fmap = True
 


### PR DESCRIPTION
# Description

`IntendedFor` is a required field that need to be present in fieldmap's BIDS JSON files. This adds the logic to add this field in the BIDS JSON file to avoid BIDS validator failure.

The adopted logic is the most often used in the BIDS community as far as I can tell: 
IntendedFor content = get the list of files acquired after the fieldmap acquisition but before the next fieldmap acquisition.