### PR TITLE
Fix batch_uploads_tarchive to redirect to dcm2bids pipeline when dcm2niix is set as a converter in the Configs

### DIFF
--- a/batch_uploads_tarchive.pl
+++ b/batch_uploads_tarchive.pl
@@ -258,7 +258,7 @@ foreach my $input (@inputs)
     }
 
     ##if qsub is enabled use it
-    if (defined $is_qsub) {
+    if ($is_qsub) {
 	     open QSUB, "| qsub -V -e $stderr -o $stdout -N process_tarchive_${counter}";
     	 print QSUB $command;
     	 close QSUB;


### PR DESCRIPTION
# Description

This fixes the `batch_uploads_tarchive.pl` file so that when the converter is set to `dcm2niix`, the `dcm2bids` python pipeline (`run_dicom_archive_loader.py`) is launched instead of the `dcm2mnc` `tarchiveLoader.pl` script.