### PR TITLE
[docs] spacing fix so markdown renders properly

### DIFF
--- a/docs/05-PipelineLaunchOptions.md
+++ b/docs/05-PipelineLaunchOptions.md
@@ -154,7 +154,7 @@ The BIDS dataset to import has to:
             "IEEG": "IEEG Atlas"
         }
     }
-}
+  }
   ```
 
 


### PR DESCRIPTION
@cmadjar this is the typo - missing 2 spaces before a bracket, lol.  will make the markdown more readable
I'm committing this so you can add a similar change next time you see fit (on 24 branch or whatnot).  Feel free to delete.