### PR TITLE
[dcm2bids pipeline] Delete temporary directory created by the pipeline once it is done running

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -289,6 +289,7 @@ class BasePipeline:
         if self.upload_id:
             self.imaging_upload_obj.update_mri_upload(upload_id=self.upload_id, fields=("Inserting",), values=("0",))
         print(f"\n{err_msg}\n")
+        self.remove_tmp_dir()
         sys.exit(exit_code)
 
     def log_info(self, message, is_error, is_verbose):
@@ -471,3 +472,8 @@ class BasePipeline:
         if not os.path.exists(new_file_path):
             message = f'Could not move {old_file_path} to {new_file_path}'
             self.log_error_and_exit(message, lib.exitcode.COPY_FAILURE, is_error='Y', is_verbose='N')
+
+    def remove_tmp_dir(self):
+
+        if os.path.exists(self.tmp_dir):
+            shutil.rmtree(self.tmp_dir)

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -474,6 +474,9 @@ class BasePipeline:
             self.log_error_and_exit(message, lib.exitcode.COPY_FAILURE, is_error='Y', is_verbose='N')
 
     def remove_tmp_dir(self):
+        """
+        Removes the temporary directory that was created by the pipeline.
+        """
 
         if os.path.exists(self.tmp_dir):
             shutil.rmtree(self.tmp_dir)

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -93,6 +93,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
             self._update_mri_upload()
 
         self._get_summary_of_insertion()
+        self.remove_tmp_dir()  # remove temporary directory
         sys.exit(lib.exitcode.SUCCESS)
 
     def _run_dicom_archive_validation_pipeline(self):

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_validation_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_validation_pipeline.py
@@ -40,6 +40,7 @@ class DicomValidationPipeline(BasePipeline):
             fields=("isTarchiveValidated", "Inserting",),
             values=("1", "0")
         )
+        self.remove_tmp_dir()  # remove temporary directory
         sys.exit(lib.exitcode.SUCCESS)
 
     def _validate_dicom_archive_md5sum(self):

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -155,6 +155,11 @@ class NiftiInsertionPipeline(BasePipeline):
         self._create_pic_image()
 
         # ---------------------------------------------------------------------------------------------
+        # Remove the tmp directory from the file system
+        # ---------------------------------------------------------------------------------------------
+        self.remove_tmp_dir()
+
+        # ---------------------------------------------------------------------------------------------
         # If we get there, the insertion was complete and successful
         # ---------------------------------------------------------------------------------------------
         sys.exit(lib.exitcode.SUCCESS)


### PR DESCRIPTION
# Description

The temporary directories created by the dcm2bids pipeline were not being deleted. This fixes this issue by deleting temporary directories once the pipeline has finished running.