### PR TITLE
[dcm2bids] Remove hardcoded dcm2niix binary to use the value stored in the `converter` Config setting 

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -143,8 +143,10 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         nifti_tmp_dir = os.path.join(self.tmp_dir, "nifti_files")
         os.makedirs(nifti_tmp_dir)
 
+        converter = self.config_db_obj.get_config("converter")
+
         dcm2niix_process = subprocess.Popen(
-            ["dcm2niix", "-ba", "n", "-z", "y", "-o", nifti_tmp_dir, self.extracted_dicom_dir],
+            [converter, "-ba", "n", "-z", "y", "-o", nifti_tmp_dir, self.extracted_dicom_dir],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT
         )

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -144,6 +144,9 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         os.makedirs(nifti_tmp_dir)
 
         converter = self.config_db_obj.get_config("converter")
+        if not re.search('.*dcm2niix.*', converter, re.IGNORECASE):
+            message = f"{converter} does not appear to be a dcm2niix binary."
+            self.log_error_and_exit(message, lib.exitcode.PROJECT_CUSTOMIZATION_FAILURE, is_error="Y", is_verbose="N")
 
         dcm2niix_process = subprocess.Popen(
             [converter, "-ba", "n", "-z", "y", "-o", nifti_tmp_dir, self.extracted_dicom_dir],


### PR DESCRIPTION
# Description

`dcm2niix` is currently hardcoded in the dcm2bids pipeline. Instead of hardcoding it, the pipeline will fetch the value for the `converter` Config setting and use what has been added there. This allows for naming differently the dcm2niix binary to refer to a specific version (for example: `dcm2niix_dev_2a9fbe82`).

Note: this is already the case for `dcm2mnc` so no need to modify the `dcm2mnc` pipeline.