### PR TITLE
Fix some errors when RepetitionTime is not available in JSON file

### DIFF
--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -672,11 +672,11 @@ class Imaging:
          :rtype: bool
         """
 
-        scan_tr = scan_param['RepetitionTime'] * 1000
-        scan_te = scan_param['EchoTime'] * 1000
+        scan_tr = scan_param['RepetitionTime'] * 1000 if 'RepetitionTime' in scan_param else None
+        scan_te = scan_param['EchoTime'] * 1000 if 'EchoTime' in scan_param else None
         scan_ti = scan_param['InversionTime'] * 1000 if 'InversionTime' in scan_param else None
-        scan_slice_thick = scan_param['SliceThickness']
-        scan_img_type = str(scan_param['ImageType'])
+        scan_slice_thick = scan_param['SliceThickness'] if 'SliceThickness' in scan_param else None
+        scan_img_type = str(scan_param['ImageType']) if 'ImageType' in scan_param else None
         scan_ped = scan_param['PhaseEncodingDirection'] if 'PhaseEncodingDirection' in scan_param else None
         scan_en = scan_param['EchoNumber'] if 'EchoNumber' in scan_param else None
 


### PR DESCRIPTION
# Description

Some NIfTI/JSON file do not have some fields available like RepetitionTime, EchoTime etc... This PR fixes the error encountered when no RepetitionTime was found. Instead of failing miserably, it will continue the protocol checks and if no scan type is found for the acquisition, it will be registered in the `mri_protocol_violated_scans` table as expected.