### PR TITLE
Upload to S3: support object name starting with s3://bucket_name/ for upload

### DIFF
--- a/python/lib/aws_s3.py
+++ b/python/lib/aws_s3.py
@@ -53,9 +53,12 @@ class AwsS3:
         """
 
         # Upload the file
+        s3_prefix = f"s3://{self.bucket_name}/"
+        s3_file_name = object_name[len(s3_prefix):] if object_name.startswith(s3_prefix) else object_name
+
         try:
-            print(f"Uploading {object_name} to {self.aws_endpoint_url}/{self.bucket_name}")
-            self.s3_bucket_obj.upload_file(file_name, object_name)
+            print(f"Uploading {s3_file_name} to {self.aws_endpoint_url}/{self.bucket_name}")
+            self.s3_bucket_obj.upload_file(file_name, s3_file_name)
         except ClientError as err:
             raise Exception(f"{file_name} upload failure - {format(err)}")
 

--- a/python/lib/aws_s3.py
+++ b/python/lib/aws_s3.py
@@ -90,8 +90,6 @@ class AwsS3:
 
         s3_prefix = f"s3://{self.bucket_name}/"
         s3_file_name = s3_object_name[len(s3_prefix):] if s3_object_name.startswith(s3_prefix) else s3_object_name
-        print(s3_file_name)
-
 
         try:
             print(f"Downloading {s3_file_name} from {self.aws_endpoint_url}/{self.bucket_name} to {destination_file}")

--- a/python/lib/aws_s3.py
+++ b/python/lib/aws_s3.py
@@ -77,3 +77,24 @@ class AwsS3:
             return False
 
         return True
+
+    def download_file(self, s3_object_name, destination_file):
+        """
+        Download a file from an S3 bucket
+
+        :param s3_object_name: S3 object name to download from
+         :type s3_object_name: str
+        :param destination_file: Full path where the file should be downloaded
+         :type destination_file: str
+        """
+
+        s3_prefix = f"s3://{self.bucket_name}/"
+        s3_file_name = s3_object_name[len(s3_prefix):] if s3_object_name.startswith(s3_prefix) else s3_object_name
+        print(s3_file_name)
+
+
+        try:
+            print(f"Downloading {s3_file_name} from {self.aws_endpoint_url}/{self.bucket_name} to {destination_file}")
+            self.s3_bucket_obj.download_file(s3_file_name, destination_file)
+        except ClientError as err:
+            raise Exception(f"{s3_object_name} download failure = {format(err)}")


### PR DESCRIPTION
# Description

This modifies the `upload_file` function of `AwsS3` python class to be able to handle objects starting with `s3://bucket_name/` the same way it is handled by `download_file` function of the same class.