### PR TITLE
fix database class pselect documentation for the return type

### DIFF
--- a/python/lib/database.py
+++ b/python/lib/database.py
@@ -129,8 +129,8 @@ class Database:
         :param args: arguments to replace the placeholders with
          :type args: tuple
 
-        :return: dictionary with MySQL column header name
-         :rtype: dict
+        :return: list of dictionaries with MySQL column header name
+         :rtype: list of dict
         """
         if self.verbose:
             print("\nExecuting query:\n\t" + query + "\n")


### PR DESCRIPTION
# Description

The return type document for the `pselect` function of the class `database.py` was wrong in the documentation and this PR fixes the return type of that function