### PR TITLE
map scan type to scan type ID when scan type provided to run_nifti_insertion.pl

### DIFF
--- a/python/lib/database_lib/mri_scan_type.py
+++ b/python/lib/database_lib/mri_scan_type.py
@@ -52,3 +52,21 @@ class MriScanType:
         )
 
         return results[0]['Scan_type'] if results else None
+
+    def get_scan_type_id_from_name(self, scan_type_name):
+        """
+        Get a scan type ID based on a scan type name.
+
+        :param scan_type_name: name of the scan type to look up
+         :type scan_type_name: str
+
+        :return: ID of the scan type queried
+         :rtype: int
+        """
+
+        results = self.db.pselect(
+            query='SELECT ID FROM mri_scan_type WHERE Scan_type = %s',
+            args=(scan_type_name,)
+        )
+
+        return results[0]['ID'] if results else None

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -111,6 +111,14 @@ class NiftiInsertionPipeline(BasePipeline):
                 self.log_error_and_exit(message, lib.exitcode.UNKNOWN_PROTOCOL, is_error="Y", is_verbose="N")
             else:
                 self.scan_type_name = self.imaging_obj.get_scan_type_name_from_id(self.scan_type_id)
+        else:
+            self.scan_type_id = self.imaging_obj.get_scan_type_id_from_scan_type_name(self.loris_scan_type)
+            if not self.scan_type_id:
+                self._move_to_trashbin()
+                self._register_protocol_violated_scan()
+                message = f"{self.nifti_path}'s scan type {self.scan_type_name} provided to run_nifti_insertion.py" \
+                          f" is not a valid scan type in the database."
+                self.log_error_and_exit(message, lib.exitcode.UNKNOWN_PROTOCOL, is_error="Y", is_verbose="N")
 
         # ---------------------------------------------------------------------------------------------
         # Determine BIDS scan type info based on scan_type_id

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -323,6 +323,18 @@ class Imaging:
         """
         return self.mri_scan_type_db_obj.get_scan_type_name_from_id(scan_type_id)
 
+    def get_scan_type_id_from_scan_type_name(self, scan_type_name):
+        """
+        Returns the acquisition protocol ID associated to a scan type name.
+
+        :param scan_type_name: scan type name
+         :type scan_type_name: str
+
+        :return: acquisition protocol ID associated to the scan type name
+         :rtype: int
+        """
+        return self.mri_scan_type_db_obj.get_scan_type_id_from_name(scan_type_name)
+
     def get_bids_to_minc_terms_mapping(self):
         """
         Returns the BIDS to MINC terms mapping queried from parameter_type table.


### PR DESCRIPTION
# Description

The `run_nifti_insertion.pl` pipeline failed when using the option `--scantype` because there was no mapping between a scan type ID and the scan type provided when calling the script. This PR adds this feature.