### PR TITLE
[push to S3 script] Skip violation if not found on filesystem since it means the scan has been rerun and moved

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -143,6 +143,9 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         entries = self.imaging_obj.mri_prot_viol_scan_db_obj.get_protocol_violations_for_tarchive_id(self.tarchive_id)
 
         for entry in entries:
+            if not os.path.exists(entry['minc_location']):
+                # violation has been rerun or moved
+                continue
             self.files_to_push_list.append({
                 "table_name": "mri_protocol_violated_scans",
                 "id_field_name": "ID",
@@ -168,6 +171,9 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         )
 
         for entry in exclude_entries + warning_entries:
+            if not os.path.exists(entry['MincFile']):
+                # violation has been rerun or moved
+                continue
             self.files_to_push_list.append({
                 "table_name": "mri_violations_log",
                 "id_field_name": "LogID",


### PR DESCRIPTION
# Description

If a violation file is not found on the filesystem, will skip pushing to S3 bucket since the file is not there because it has either been rerun or inserted which in both cases mean that the file has been moved to either another trashbin directory (if violation persisted during the rerun) or in assembly_bids (if the files has been inserted into the files table). In both case, the new file (violation or inserted) will be picked by the queries and pushed to S3.