### PR TITLE
Fix logic of determining file run number when previously inserted files are already pushed to S3 and not on filesystem anymore

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -404,7 +404,10 @@ class NiftiInsertionPipeline(BasePipeline):
 
         # determine NIfTI file name
         new_nifti_name = self._construct_nifti_filename(file_bids_entities_dict)
-        while os.path.exists(os.path.join(self.data_dir, new_nifti_rel_dir, new_nifti_name)):
+        already_inserted_filenames = self.imaging_obj.get_list_of_files_already_inserted(
+            self.dicom_archive_obj.tarchive_info_dict["TarchiveID"]
+        )
+        while new_nifti_name in already_inserted_filenames:
             file_bids_entities_dict['run'] += 1
             new_nifti_name = self._construct_nifti_filename(file_bids_entities_dict)
 

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -404,7 +404,7 @@ class NiftiInsertionPipeline(BasePipeline):
 
         # determine NIfTI file name
         new_nifti_name = self._construct_nifti_filename(file_bids_entities_dict)
-        already_inserted_filenames = self.imaging_obj.get_list_of_files_already_inserted(
+        already_inserted_filenames = self.imaging_obj.get_list_of_files_already_inserted_for_tarchive_id(
             self.dicom_archive_obj.tarchive_info_dict["TarchiveID"]
         )
         while new_nifti_name in already_inserted_filenames:

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -884,9 +884,13 @@ class Imaging:
     def get_list_of_files_already_inserted(self, tarchive_id):
 
         # get list files from a given tarchive ID
-        files_list = self.files_db_obj.get_files_inserted_for_tarchive_id(tarchive_id)
+        results = self.files_db_obj.get_files_inserted_for_tarchive_id(tarchive_id)
 
-        return [os.path.basename(i) for i in files_list]
+        files_list = []
+        for entry in results:
+            files_list.append(os.path.basename(entry['File']))
+
+        return files_list
 
     def get_list_of_fmap_files_sorted_by_acq_time(self, files_list):
         """

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -881,6 +881,13 @@ class Imaging:
 
         return sorted_fmap_files_dict
 
+    def get_list_of_files_already_inserted(self, tarchive_id):
+
+        # get list files from a given tarchive ID
+        files_list = self.files_db_obj.get_files_inserted_for_tarchive_id(tarchive_id)
+
+        return [os.path.basename(i) for i in files_list]
+
     def get_list_of_fmap_files_sorted_by_acq_time(self, files_list):
         """
         Get the list of fieldmap acquisitions that requires the IntendedFor field in their JSON file.

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -881,7 +881,16 @@ class Imaging:
 
         return sorted_fmap_files_dict
 
-    def get_list_of_files_already_inserted(self, tarchive_id):
+    def get_list_of_files_already_inserted_for_tarchive_id(self, tarchive_id):
+        """
+        Get the list of filenames already inserted for a given TarchiveID.
+
+        :param tarchive_id: the Tarchive ID to process
+         :type tarchive_id: int
+
+        :return: a list with file names already inserted in the files table for TarchiveID
+         :rtype: list
+        """
 
         # get list files from a given tarchive ID
         results = self.files_db_obj.get_files_inserted_for_tarchive_id(tarchive_id)


### PR DESCRIPTION
# Description

After files are pushed to S3, they are removed from the local file system. When that happens and a new session is uploaded to LORIS, the python pipeline will try to determine the run number based on what is present in the filesystem. That is wrong since the previously inserted file for that session are on S3, it does not check the run number there.

Example: 
- session ID 1 has two tarchives: tarchive ID 1 and tarchive ID 2 acquired on two different days. 
- tarchive ID 1 is converted and T1w NIfTI (`sub-1_ses-V1_run-1_T1w.nii.gz`) file is pushed to S3 and remove from local mount/file system
- tarchive ID 2 is converted and new NIfTI created T1w NIfTI file would be renamed `sub-1_ses-V1_run-1_T1w.nii.gz` and then push to S3, overwriting the tarchive ID 1 file on S3...

This PR fixes the issue by querying the `files` table instead of relying on the file system content to determine run numbers of NIfTI files to be inserted.