### PR TITLE
[dcm2bids] Fix permission denied issue when trying to erase tmp directory after pipeline is done running

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -480,4 +480,7 @@ class BasePipeline:
         """
 
         if os.path.exists(self.tmp_dir):
-            shutil.rmtree(self.tmp_dir)
+            try:
+                shutil.rmtree(self.tmp_dir)
+            except PermissionError as err:
+                self.log_info(f"Could not delete {self.tmp_dir}. Error was: {err}", "N", "Y")


### PR DESCRIPTION
# Description

This adds a try/except around the deletion of the temporary processing directory in case the removal of the tmp directory created by the script dcm2bids pipeline encountered a PermissionError. The script will add a warning in the log and notification spool that the temporary directory could not be deleted and will continue execution instead of failing miserably.