### PR TITLE
Fix two matching protocols' error when matching protocols are actually the same scan type

### DIFF
--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -669,7 +669,7 @@ class Imaging:
             elif self.is_scan_protocol_matching_db_protocol(protocol, scan_param):
                 matching_protocols_list.append(protocol['Scan_type'])
 
-        return matching_protocols_list
+        return list(dict.fromkeys(matching_protocols_list))
 
     def is_scan_protocol_matching_db_protocol(self, db_prot, scan_param):
         """


### PR DESCRIPTION
# Description

When an images matches two protocols referring to the same scan type, an error was triggered to say that more than one protocol was matching the parameters of the image even though, the two protocols referred to the same scan type. This fixes this and make sure that the returned list of matching protocols do not contain any scan type duplicatas.