### PR TITLE
Add download from S3 and reupload to S3 if file provided to run_nifti_insertion was an S3 URL

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -77,7 +77,7 @@ class BasePipeline:
         # ---------------------------------------------------------------------------------------------
         # Create tmp dir and log file (their basename being the name of the script run)
         # ---------------------------------------------------------------------------------------------
-        self.tmp_dir = lib.utilities.create_processing_tmp_dir(script_name)
+        self.tmp_dir = self.loris_getopt_obj.tmp_dir
         self.log_obj = Log(
             self.db, self.data_dir, script_name, os.path.basename(self.tmp_dir), self.options_dict, self.verbose
         )

--- a/python/run_dicom_archive_loader.py
+++ b/python/run_dicom_archive_loader.py
@@ -67,7 +67,7 @@ def main():
     }
 
     # get the options provided by the user
-    loris_getopt_obj = LorisGetOpt(usage, options_dict)
+    loris_getopt_obj = LorisGetOpt(usage, options_dict, os.path.basename(__file__[:-3]))
 
     # input error checking and load config_file file
     input_error_checking(loris_getopt_obj)
@@ -77,8 +77,6 @@ def main():
 
 
 def input_error_checking(loris_getopt_obj):
-    # perform initial checks and load config file (in loris_getopt_obj.config_info)
-    loris_getopt_obj.perform_default_checks_and_load_config()
 
     # check that only one of tarchive_path, upload_id or force has been provided
     loris_getopt_obj.check_tarchive_path_upload_id_or_force_set()

--- a/python/run_dicom_archive_validation.py
+++ b/python/run_dicom_archive_validation.py
@@ -65,10 +65,7 @@ def main():
     }
 
     # get the options provided by the user
-    loris_getopt_obj = LorisGetOpt(usage, options_dict)
-
-    # input error checking and load config_file file
-    loris_getopt_obj.perform_default_checks_and_load_config()
+    loris_getopt_obj = LorisGetOpt(usage, options_dict, os.path.basename(__file__[:-3]))
 
     # validate the DICOM archive
     DicomValidationPipeline(loris_getopt_obj, os.path.basename(__file__[:-3]))

--- a/python/run_nifti_insertion.py
+++ b/python/run_nifti_insertion.py
@@ -97,7 +97,7 @@ def main():
     }
 
     # get the options provided by the user
-    loris_getopt_obj = LorisGetOpt(usage, options_dict)
+    loris_getopt_obj = LorisGetOpt(usage, options_dict, os.path.basename(__file__[:-3]))
 
     # input error checking and load config_file file
     input_error_checking(loris_getopt_obj)
@@ -107,8 +107,6 @@ def main():
 
 
 def input_error_checking(loris_getopt_obj):
-    # perform initial checks and load config file (in loris_getopt_obj.config_info)
-    loris_getopt_obj.perform_default_checks_and_load_config()
 
     # check that only one of tarchive_path, upload_id or force has been provided
     loris_getopt_obj.check_tarchive_path_upload_id_or_force_set()

--- a/python/run_push_imaging_files_to_s3_pipeline.py
+++ b/python/run_push_imaging_files_to_s3_pipeline.py
@@ -55,18 +55,10 @@ def main():
     }
 
     # get the options provided by the user
-    loris_getopt_obj = LorisGetOpt(usage, options_dict)
-
-    # input error checking and load config_file file
-    input_error_checking(loris_getopt_obj)
+    loris_getopt_obj = LorisGetOpt(usage, options_dict, os.path.basename(__file__[:-3]))
 
     # push to S3 pipeline
     PushImagingFilesToS3Pipeline(loris_getopt_obj, os.path.basename(__file__[:-3]))
-
-
-def input_error_checking(loris_getopt_obj):
-    # perform initial checks and load config file (in loris_getopt_obj.config_info)
-    loris_getopt_obj.perform_default_checks_and_load_config()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This modifies the run_nifti_insertion pipeline to download S3 files if an S3 URL is provided to the script for option `-n` before running the insertion logic on the file. At the end of the script, if an S3 URL was provided with option `-n`, the script `run_push_to_s3` will be called to push the newly inserted data to S3.

Resolves https://github.com/aces/HBCD-LORIS-MRI-derivatives/issues/39