### PR TITLE
fix intended for bug when no acq_time available

### DIFF
--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -868,6 +868,11 @@ class Imaging:
         # get the list of files sorted by acquisition time
         sorted_new_files_list = self.get_list_of_files_sorted_by_acq_time(files_list)
 
+        if not sorted_new_files_list or not sorted_fmap_files_dict:
+            # if got empty lists, then there are no files to determine IntendedFor either because acq_time
+            # was not set or because there are no fieldmap data
+            return None
+
         for key in sorted_fmap_files_dict.keys():
             sorted_fmap_files_list = sorted_fmap_files_dict[key]
             for idx, fmap_dict in enumerate(sorted_fmap_files_list):
@@ -959,11 +964,14 @@ class Imaging:
                 else:
                     fmap_files_no_dir.append(file_dict)
 
-        fmap_files_dict = {
-            'dir-AP': sorted(fmap_files_dir_ap, key=lambda x: x['acq_time']),
-            'dir-PA': sorted(fmap_files_dir_pa, key=lambda x: x['acq_time']),
-            'no-dir': sorted(fmap_files_no_dir, key=lambda x: x['acq_time']),
-        }
+        try:
+            fmap_files_dict = {
+                'dir-AP': sorted(fmap_files_dir_ap, key=lambda x: x['acq_time']),
+                'dir-PA': sorted(fmap_files_dir_pa, key=lambda x: x['acq_time']),
+                'no-dir': sorted(fmap_files_no_dir, key=lambda x: x['acq_time']),
+            }
+        except TypeError:
+            return None
 
         return fmap_files_dict
 

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -871,6 +871,8 @@ class Imaging:
         for key in sorted_fmap_files_dict.keys():
             sorted_fmap_files_list = sorted_fmap_files_dict[key]
             for idx, fmap_dict in enumerate(sorted_fmap_files_list):
+                if not fmap_dict['acq_time']:
+                    continue
                 fmap_acq_time = fmap_dict['acq_time']
                 next_fmap_acq_time = sorted_fmap_files_list[idx + 1]['acq_time'] \
                     if idx + 1 < len(sorted_fmap_files_list) else None
@@ -928,13 +930,15 @@ class Imaging:
         fmap_files_dir_pa = []
         fmap_files_no_dir = []
         for file_dict in files_list:
+
             bids_info = self.mri_prot_db_obj.get_bids_info_for_scan_type_id(
                 file_dict['AcquisitionProtocolID']
             )
-            acq_time = self.param_file_db_obj.get_parameter_file_for_file_id_param_type_id(
+            param_file_result = self.param_file_db_obj.get_parameter_file_for_file_id_param_type_id(
                 file_dict['FileID'],
                 self.param_type_db_obj.get_parameter_type_id('acquisition_time')
-            )['Value']
+            )
+            acq_time = param_file_result['Value'] if param_file_result else None
             if bids_info['BIDSCategoryName'] == 'fmap' and bids_info['BIDSScanType'] in bids_fmap_suffix_list:
                 json_file_path = self.param_file_db_obj.get_parameter_file_for_file_id_param_type_id(
                     file_dict['FileID'],
@@ -1025,6 +1029,8 @@ class Imaging:
         """
 
         for fmap_dict in sorted_fmap_files_list:
+            if 'IntendedFor' not in fmap_dict:
+                continue
             json_file_path = os.path.join(self.config_db_obj.get_config('dataDirBasepath'), fmap_dict['json_file_path'])
             with open(json_file_path) as json_file:
                 json_data = json.load(json_file)


### PR DESCRIPTION
# Description

This fixes the following bug occurring when no `acq_time` is available in the image BIDS JSON file:
```
Traceback (most recent call last):\n File "/opt/loris/bin/mri/python/run_dicom_archive_loader.py", line 88, in \n main()\n File "/opt/loris/bin/mri/python/run_dicom_archive_loader.py", line 76, in main\n DicomArchiveLoaderPipeline(loris_getopt_obj, os.path.basename(file[:-3]))\n File "/opt/loris/bin/mri/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py", line 91, in init\n self._add_intended_for_to_fieldmap_json_files()\n File "/opt/loris/bin/mri/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py", line 344, in _add_intended_for_to_fieldmap_json_files\n fmap_files_dict = self.imaging_obj.determine_intended_for_field_for_fmap_json_files(self.tarchive_id)\n File "/opt/loris/bin/mri/python/lib/imaging.py", line 864, in determine_intended_for_field_for_fmap_json_files\n sorted_fmap_files_dict = self.get_list_of_fmap_files_sorted_by_acq_time(files_list)\n File "/opt/loris/bin/mri/python/lib/imaging.py", line 932, in get_list_of_fmap_files_sorted_by_acq_time\n acq_time = self.param_file_db_obj.get_parameter_file_for_file_id_param_type_id(\nTypeError: 'NoneType' object is not subscriptable\n'
```

Resolves https://github.com/aces/HBCD-LORIS-MRI-derivatives/issues/38