### PR TITLE
fix paths when there are not / at the end of the Config

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -140,7 +140,7 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
             if entry['minc_location'].startswith('s3://'):
                 # skip since file already pushed to S3
                 continue
-            if not os.path.exists(self.data_dir + entry['minc_location']):
+            if not os.path.exists(os.path.join(self.data_dir, entry['minc_location'])):
                 # violation has been rerun or moved
                 continue
             self.files_to_push_list.append({
@@ -171,7 +171,7 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
             if entry['MincFile'].startswith('s3://'):
                 # skip since file already pushed to S3
                 continue
-            if not os.path.exists(self.data_dir + entry['MincFile']):
+            if not os.path.exists(os.path.join(self.data_dir, entry['MincFile'])):
                 # violation has been rerun or moved
                 continue
             self.files_to_push_list.append({


### PR DESCRIPTION
# Description

When debugging an instance where the `trashbin` content was not being pushed to the S3 bucket while the content of `assembly_bids` and `pic` were being pushed, we noticed that the reason the files were not pushed to S3 was being the config for the LORIS MRI data was missing a `/` at the end and the code was generating the paths to the files in trashbin using `data_dir + violation_file` instead of using the more robust `os.path.join(data_dir, violation_file)`. This PR fixes the issue so that it does not happen anymore if the user forgot the trailing slash in the config module.