### PR TITLE
Correct NoneType error in dicom_archive_loader_pipeline.py line 346 when fieldmap dictionary is empty

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -342,6 +342,8 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         """
 
         fmap_files_dict = self.imaging_obj.determine_intended_for_field_for_fmap_json_files(self.tarchive_id)
+        if not fmap_files_dict:
+            return
 
         for key in fmap_files_dict.keys():
             sorted_fmap_files_list = fmap_files_dict[key]


### PR DESCRIPTION
# Description

This fixes the following bug:

"/opt/loris/bin/mri/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py", line 346, in _add_intended_for_to_fieldmap_json_files\n    for key in fmap_files_dict.keys():\nAttributeError: \'NoneType\' object has no attribute \'keys\'