### PR TITLE
Properly update `mri_upload` 'Inserting' column when different sections of the pipeline are run

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -119,6 +119,8 @@ class DicomArchiveLoaderPipeline(BasePipeline):
             message = f"run_dicom_archive_validation.py successfully executed for UploadID {self.upload_id} " \
                       f"and ArchiveLocation {self.tarchive_path}"
             self.log_info(message, is_error="N", is_verbose="Y")
+            # reset mri_upload to Inserting as run_dicom_archive_validation.py will set Inserting=0 after execution
+            self.imaging_upload_obj.update_mri_upload(upload_id=self.upload_id, fields=('Inserting',), values=('1',))
         else:
             message = f"run_dicom_archive_validation.py failed validation for UploadID {self.upload_id}" \
                       f"and ArchiveLocation {self.tarchive_path}. Exit code was {validation_process.returncode}."
@@ -297,6 +299,8 @@ class DicomArchiveLoaderPipeline(BasePipeline):
             message = f"run_nifti_insertion.py successfully executed for file {nifti_file_path}"
             self.log_info(message, is_error="N", is_verbose="Y")
             self.inserted_file_count += 1
+            # reset mri_upload to Inserting as run_nifti_insertion.py will set Inserting=0 after execution
+            self.imaging_upload_obj.update_mri_upload(upload_id=self.upload_id, fields=('Inserting',), values=('1',))
         else:
             message = f"run_nifti_insertion.py failed for file {nifti_file_path}.\n{stdout}"
             print(stdout)

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -52,6 +52,11 @@ class NiftiInsertionPipeline(BasePipeline):
         self.bypass_extra_checks = self.options_dict["bypass_extra_checks"]["value"]
 
         # ---------------------------------------------------------------------------------------------
+        # Set 'Inserting' flag to 1 in mri_upload
+        # ---------------------------------------------------------------------------------------------
+        self.imaging_upload_obj.update_mri_upload(upload_id=self.upload_id, fields=('Inserting',), values=('1',))
+
+        # ---------------------------------------------------------------------------------------------
         # Get S3 object from loris_getopt object
         # ---------------------------------------------------------------------------------------------
         self.s3_obj = self.loris_getopt_obj.s3_obj
@@ -194,6 +199,7 @@ class NiftiInsertionPipeline(BasePipeline):
         # ---------------------------------------------------------------------------------------------
         # If we get there, the insertion was complete and successful
         # ---------------------------------------------------------------------------------------------
+        self.imaging_upload_obj.update_mri_upload(upload_id=self.upload_id, fields=('Inserting',), values=('0',))
         sys.exit(lib.exitcode.SUCCESS)
 
     def _load_json_sidecar_file(self):

--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -61,6 +61,7 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
                     os.remove(full_path)
 
         self._clean_up_empty_folders()
+        self.imaging_upload_obj.update_mri_upload(upload_id=self.upload_id, fields=('Inserting',), values=('0',))
         sys.exit(lib.exitcode.SUCCESS)
 
     def _get_files_to_push_list(self):

--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -32,6 +32,11 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         self.tarchive_id = self.dicom_archive_obj.tarchive_info_dict["TarchiveID"]
 
         # ---------------------------------------------------------------------------------------------
+        # Set 'Inserting' flag to 1 in mri_upload
+        # ---------------------------------------------------------------------------------------------
+        self.imaging_upload_obj.update_mri_upload(upload_id=self.upload_id, fields=('Inserting',), values=('1',))
+
+        # ---------------------------------------------------------------------------------------------
         # Get S3 object from loris_getopt object
         # ---------------------------------------------------------------------------------------------
         self.s3_obj = self.loris_getopt_obj.s3_obj


### PR DESCRIPTION
# Description

When running `run_nifti_insertion.py` or `run_push_to_s3.py`, the scripts do not update `Inserting=0` after execution which leads to false lingering 'In Progress' status in the Imaging Upload module.

This PR fixes the logic of update that flag in the database so that the status in Imaging Upload module are correctly set.