### PR TITLE
DICOM Archive broken archive link fix

### DIFF
--- a/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm
@@ -71,7 +71,7 @@ use File::Basename;
 use TryCatch;
 
 my @TARCHIVE_FIELDS = qw(
-    TarchiveID ArchiveLocation PatientName PatientID PatientDoB md5sumArchive
+    DicomArchiveID TarchiveID ArchiveLocation PatientName PatientID PatientDoB md5sumArchive
     ScannerManufacturer ScannerModel ScannerSerialNumber ScannerSoftwareVersion
     neurodbCenterName SourceLocation DateAcquired
 );


### PR DESCRIPTION
Since v24, archive links in the DICOM Archive module are broken.
The regression seems to be linked to this [PR](https://github.com/aces/Loris-MRI/pull/532).

[This query](https://github.com/aces/Loris-MRI/blob/26ca9261ad5c51b26d58f02aee5a4e2007671831/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm#L459) is migrated [here](https://github.com/aces/Loris-MRI/blob/55d10798422818af5eda850c7d5f0abb5f2e253c/uploadNeuroDB/NeuroDB/objectBroker/TarchiveOB.pm#L73) but without the DicomArchiveID field which is used in the update query [here](https://github.com/aces/Loris-MRI/blob/53ae27ecf5bc0ed0f69a8073ce9e72471e78f81d/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm#L1688)