### PR TITLE
Add download from S3 for fmap already pushed to S3 that needs to have IntendedFor written in them

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -59,6 +59,11 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         self.nifti_tmp_dir = self._run_dcm2niix_conversion()
 
         # ---------------------------------------------------------------------------------------------
+        # Get S3 object from loris_getopt object
+        # ---------------------------------------------------------------------------------------------
+        self.s3_obj = self.loris_getopt_obj.s3_obj
+
+        # ---------------------------------------------------------------------------------------------
         # Get the list of NIfTI files to run through NIfTI insertion pipeline
         # ---------------------------------------------------------------------------------------------
         self.excluded_series_desc_regex_list = self.config_db_obj.get_config("excluded_series_description")
@@ -351,7 +356,9 @@ class DicomArchiveLoaderPipeline(BasePipeline):
 
         for key in fmap_files_dict.keys():
             sorted_fmap_files_list = fmap_files_dict[key]
-            self.imaging_obj.modify_fmap_json_file_to_write_intended_for(sorted_fmap_files_list)
+            self.imaging_obj.modify_fmap_json_file_to_write_intended_for(
+                sorted_fmap_files_list, self.s3_obj, self.tmp_dir
+            )
 
     def _order_modalities_per_acquisition_type(self):
         """

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -1055,6 +1055,7 @@ class Imaging:
                     json_file_path = os.path.join(tmp_dir, os.path.basename(fmap_dict['json_file_path']))
                     s3_obj.download_file(fmap_dict['json_file_path'], json_file_path)
                 except Exception as err:
+                    print(err)
                     continue
             else:
                 data_dir = self.config_db_obj.get_config('dataDirBasepath')
@@ -1077,6 +1078,7 @@ class Imaging:
                 try:
                     s3_obj.upload_file(json_file_path, fmap_dict['json_file_path'])
                 except Exception as err:
+                    print(err)
                     continue
 
     @staticmethod

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -1034,18 +1034,32 @@ class Imaging:
         
         return sorted_files_list
 
-    def modify_fmap_json_file_to_write_intended_for(self, sorted_fmap_files_list):
+    def modify_fmap_json_file_to_write_intended_for(self, sorted_fmap_files_list, s3_obj, tmp_dir):
         """
         Function that reads the JSON file and modifies it to add the BIDS IntendedFor field to it.
 
         :param sorted_fmap_files_list: list of dictionary that contains JSON file path info and IntendedFor content
          :type sorted_fmap_files_list: list
+        :param s3_obj: S3 object for downloading and uploading of S3 files
+         :type s3_obj: AWS object
+        :param tmp_dir: temporary directory where to download JSON file if file is on S3
+         :type tmp_dir: str
         """
 
         for fmap_dict in sorted_fmap_files_list:
             if 'IntendedFor' not in fmap_dict:
                 continue
-            json_file_path = os.path.join(self.config_db_obj.get_config('dataDirBasepath'), fmap_dict['json_file_path'])
+            json_file_path = ''
+            if fmap_dict['json_file_path'].startswith('s3://'):
+                try:
+                    json_file_path = os.path.join(tmp_dir, os.path.basename(fmap_dict['json_file_path']))
+                    s3_obj.download_file(fmap_dict['json_file_path'], json_file_path)
+                except Exception as err:
+                    continue
+            else:
+                data_dir = self.config_db_obj.get_config('dataDirBasepath')
+                json_file_path = os.path.join(data_dir, fmap_dict['json_file_path'])
+
             with open(json_file_path) as json_file:
                 json_data = json.load(json_file)
             json_data['IntendedFor'] = fmap_dict['IntendedFor']
@@ -1058,6 +1072,12 @@ class Imaging:
                 param_type_id
             )
             self.param_file_db_obj.update_parameter_file(json_blake2, param_file_dict['ParameterFileID'])
+
+            if fmap_dict['json_file_path'].startswith('s3://'):
+                try:
+                    s3_obj.upload_file(json_file_path, fmap_dict['json_file_path'])
+                except Exception as err:
+                    continue
 
     @staticmethod
     def get_intended_for_list_of_scans_after_fieldmap_acquisition_based_on_acq_time(files_list, current_fmap_acq_time,


### PR DESCRIPTION
# Description

When trying to write the `IntendedFor` field in the JSON file of fmap datasets already pushed to S3, we currently get the following error:
```
Traceback (most recent call last):\n  File "/opt/loris/bin/mri/python/run_dicom_archive_loader.py", line 86, in <module>\n    main()\n  File "/opt/loris/bin/mri/python/run_dicom_archive_loader.py", line 76, in main\n    DicomArchiveLoaderPipeline(loris_getopt_obj, os.path.basename(__file__[:-3]))\n  File "/opt/loris/bin/mri/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py", line 91, in __init__\n    self._add_intended_for_to_fieldmap_json_files()\n  File "/opt/loris/bin/mri/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py", line 354, in _add_intended_for_to_fieldmap_json_files\n    self.imaging_obj.modify_fmap_json_file_to_write_intended_for(sorted_fmap_files_list)\n  File "/opt/loris/bin/mri/python/lib/imaging.py", line 1049, in modify_fmap_json_file_to_write_intended_for\n    with open(json_file_path) as json_file:\nFileNotFoundError: [Errno 2] No such file or directory: \'/data/loris/data/s3://hbcd-pilot/assembly_bids/sub-136240/ses-V02/fmap/sub-136240_ses-V02_dir-AP_run-1_epi.json\'\n'
```

This PR allows the download of S3 fmap JSON files, modifies them in a tmp directory and then reupload the modified version of the fmap JSON files on S3.