### PR TITLE
MATLAB 7.3 HDF5 Workaround

### DIFF
--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -442,54 +442,58 @@ class Eeg:
             result         = physiological.grep_file_id_from_hash(blake2)
             physio_file_id = result['PhysiologicalFileID'] if result else None
             eeg_path       = result['FilePath']            if result else None
-            if not physio_file_id:
-                # grep the modality ID from physiological_modality table
-                modality_id = self.db.grep_id_from_lookup_table(
-                    id_field_name       = 'PhysiologicalModalityID',
-                    table_name          = 'physiological_modality',
-                    where_field_name    = 'PhysiologicalModality',
-                    where_value         = self.bids_modality,
-                    insert_if_not_found = False
-                )
 
-                # copy the eeg_file to the LORIS BIDS import directory
-                eeg_path = self.copy_file_to_loris_bids_dir(
-                    eeg_file.path, derivatives
-                )
-
-                # insert the file along with its information into
-                # physiological_file and physiological_parameter_file tables
-                eeg_file_info = {
-                    'FileType'       : file_type,
-                    'FilePath'       : eeg_path,
-                    'SessionID'      : self.session_id,
-                    'AcquisitionTime': eeg_acq_time,
-                    'InsertedByUser' : getpass.getuser(),
-                    'PhysiologicalOutputTypeID': output_type_id,
-                    'PhysiologicalModalityID'  : modality_id
-                }
-                physio_file_id = physiological.insert_physiological_file(
-                    eeg_file_info, eeg_file_data
-                )
 
             # if the EEG file was a set file, then update the filename for the .set
             # and .fdt files in the .set file so it can find the proper file for
             # visualization and analyses
-            if file_type == 'set':
+            file_paths_updated = file_type != 'set'
+            if not file_paths_updated:
                 set_full_path = os.path.join(self.data_dir, eeg_path)
                 fdt_full_path = eeg_file_data['fdt_file'] if 'fdt_file' in eeg_file_data.keys() else None
 
                 if fdt_full_path:
                     fdt_full_path = os.path.join(self.data_dir, eeg_file_data['fdt_file'])
-                utilities.update_set_file_path_info(set_full_path, fdt_full_path)
+                file_paths_updated = utilities.update_set_file_path_info(set_full_path, fdt_full_path)
 
-            inserted_eegs.append({
-                'file_id': physio_file_id,
-                'file_path': eeg_path,
-                'eegjson_file_path': eegjson_file_path,
-                'fdt_file_path': fdt_file_path,
-                'original_file_data': eeg_file,
-            })
+            if file_paths_updated:
+                if not physio_file_id:
+                    # grep the modality ID from physiological_modality table
+                    modality_id = self.db.grep_id_from_lookup_table(
+                        id_field_name='PhysiologicalModalityID',
+                        table_name='physiological_modality',
+                        where_field_name='PhysiologicalModality',
+                        where_value=self.bids_modality,
+                        insert_if_not_found=False
+                    )
+
+                    # copy the eeg_file to the LORIS BIDS import directory
+                    eeg_path = self.copy_file_to_loris_bids_dir(
+                        eeg_file.path, derivatives
+                    )
+
+                    # insert the file along with its information into
+                    # physiological_file and physiological_parameter_file tables
+                    eeg_file_info = {
+                        'FileType': file_type,
+                        'FilePath': eeg_path,
+                        'SessionID': self.session_id,
+                        'AcquisitionTime': eeg_acq_time,
+                        'InsertedByUser': getpass.getuser(),
+                        'PhysiologicalOutputTypeID': output_type_id,
+                        'PhysiologicalModalityID': modality_id
+                    }
+                    physio_file_id = physiological.insert_physiological_file(
+                        eeg_file_info, eeg_file_data
+                    )
+
+                inserted_eegs.append({
+                    'file_id': physio_file_id,
+                    'file_path': eeg_path,
+                    'eegjson_file_path': eegjson_file_path,
+                    'fdt_file_path': fdt_file_path,
+                    'original_file_data': eeg_file,
+                })
 
         return inserted_eegs
 

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -172,6 +172,8 @@ def update_set_file_path_info(set_file, fdt_file):
 
     # grep the basename without the extension of set_file
     basename = os.path.splitext(os.path.basename(set_file))[0]
+    set_file_name = numpy.array(basename + ".set")
+    fdt_file_name = numpy.array(basename + ".fdt")
 
     try:
         # read the .set EEG file using scipy
@@ -179,14 +181,14 @@ def update_set_file_path_info(set_file, fdt_file):
 
         # update the EEG paths in the .set file
         if 'filename' in dataset.keys():
-            dataset['filename'] = numpy.array(basename + ".set")
+            dataset['filename'] = set_file_name
         if 'setname' in dataset.keys():
             dataset['setname'] = numpy.array(basename)
         if 'EEG' in dataset.keys():
-            dataset['EEG'][0][0][1] = numpy.array(basename + ".set")
+            dataset['EEG'][0][0][1] = set_file_name
         if fdt_file and 'EEG' in dataset.keys():
-            dataset['EEG'][0][0][15] = numpy.array(basename + ".fdt")
-            dataset['EEG'][0][0][40] = numpy.array(basename + ".fdt")
+            dataset['EEG'][0][0][15] = fdt_file_name
+            dataset['EEG'][0][0][40] = fdt_file_name
 
         # write the new .set file with the correct path info
         scipy.io.savemat(set_file, dataset, False)
@@ -195,14 +197,12 @@ def update_set_file_path_info(set_file, fdt_file):
         dataset = mat73.loadmat(set_file, only_include=['filename', 'datfile'])
 
         if 'filename' in dataset.keys():
-            set_file_name = numpy.array(basename + ".set")
             if dataset['filename'] != set_file_name:
                 print('expected filename: {} but read {}'
                       .format(set_file_name, dataset['filename']))
                 return False
 
         if fdt_file and 'datfile' in dataset.keys():
-            fdt_file_name = numpy.array(basename + ".fdt")
             if dataset['datfile'] != fdt_file_name:
                 print('expected datfile: {} but read {}'
                       .format(fdt_file_name, dataset['datfile']))

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -173,22 +173,25 @@ def update_set_file_path_info(set_file, fdt_file):
     # grep the basename without the extension of set_file
     basename = os.path.splitext(os.path.basename(set_file))[0]
 
-    # read the .set EEG file using scipy
-    dataset = scipy.io.loadmat(set_file)
+    try:
+        # read the .set EEG file using scipy
+        dataset = scipy.io.loadmat(set_file)
 
-    # update the EEG paths in the .set file
-    if 'filename' in dataset.keys():
-        dataset['filename'] = numpy.array(basename + ".set")
-    if 'setname' in dataset.keys():
-        dataset['setname'] = numpy.array(basename)
-    if 'EEG' in dataset.keys():
-        dataset['EEG'][0][0][1] = numpy.array(basename + ".set")
-    if fdt_file and 'EEG' in dataset.keys():
-        dataset['EEG'][0][0][15] = numpy.array(basename + ".fdt")
-        dataset['EEG'][0][0][40] = numpy.array(basename + ".fdt")
+        # update the EEG paths in the .set file
+        if 'filename' in dataset.keys():
+            dataset['filename'] = numpy.array(basename + ".set")
+        if 'setname' in dataset.keys():
+            dataset['setname'] = numpy.array(basename)
+        if 'EEG' in dataset.keys():
+            dataset['EEG'][0][0][1] = numpy.array(basename + ".set")
+        if fdt_file and 'EEG' in dataset.keys():
+            dataset['EEG'][0][0][15] = numpy.array(basename + ".fdt")
+            dataset['EEG'][0][0][40] = numpy.array(basename + ".fdt")
 
-    # write the new .set file with the correct path info
-    scipy.io.savemat(set_file, dataset, False)
+        # write the new .set file with the correct path info
+        scipy.io.savemat(set_file, dataset, False)
+    except NotImplementedError:     # Thrown for matlab v7.3 files
+        pass    # Assumes path fields are already set
 
 
 def compute_md5sum(file):

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -196,16 +196,17 @@ def update_set_file_path_info(set_file, fdt_file):
         # read the .set EEG file using skjerns/mat7.3
         dataset = mat73.loadmat(set_file, only_include=['filename', 'datfile'])
 
-        if 'filename' in dataset.keys():
-            if dataset['filename'] != set_file_name:
-                print('expected filename: {} but read {}'
-                      .format(set_file_name, dataset['filename']))
-                return False
+        if 'filename' not in dataset.keys() or \
+                dataset['filename'] != set_file_name:
+            print('Expected `filename` field: {}'
+                  .format(set_file_name))
+            return False
 
-        if fdt_file and 'datfile' in dataset.keys():
-            if dataset['datfile'] != fdt_file_name:
-                print('expected datfile: {} but read {}'
-                      .format(fdt_file_name, dataset['datfile']))
+        if fdt_file:
+            if 'datfile' not in dataset.keys() or \
+                    dataset['datfile'] != fdt_file_name:
+                print('Expected `datfile` field: {}'
+                      .format(fdt_file_name))
                 return False
 
     return True

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -17,3 +17,4 @@ numpy
 scipy
 flake8
 boto3
+mat73


### PR DESCRIPTION
This workaround allows MATLAB 7.3 HDF5 files to work with the pipeline despite not being supported by SciPy.
It assumes that the file path fields are already correctly set.

Related to #841 and in testing by NEMAR team, per MCIN-EEG meeting Jan.27


# Caveat for existing projects

- make sure to install the `mat73` python library using `pip install mat73` after having source the LORIS-MRI `environment` file