### PR TITLE
Fix nii insertion mri protocol group id bug

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -153,6 +153,7 @@ class NiftiInsertionPipeline(BasePipeline):
         # ---------------------------------------------------------------------------------------------
         # Run extra file checks to determine possible protocol violations
         # ---------------------------------------------------------------------------------------------
+        self.violations_summary = {}
         if not self.bypass_extra_checks:
             self.violations_summary = self.imaging_obj.run_extra_file_checks(
                 self.session_obj.session_info_dict['ProjectID'],

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -399,7 +399,7 @@ class NiftiInsertionPipeline(BasePipeline):
         self.log_info(message, is_error='N', is_verbose='Y')
 
         # add an entry in the violations log table if there is a warning violation associated to the file
-        if self.violations_summary['warning']:
+        if 'warning' in self.violations_summary.keys() and self.violations_summary['warning']:
             message = f"Inserting warning violations related to {self.assembly_nifti_rel_path}." \
                       f"  List of violations found: {self.warning_violations_list}"
             self.log_info(message, is_error='N', is_verbose='Y')

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -153,7 +153,8 @@ class NiftiInsertionPipeline(BasePipeline):
         # ---------------------------------------------------------------------------------------------
         # Run extra file checks to determine possible protocol violations
         # ---------------------------------------------------------------------------------------------
-        self.violations_summary = {}
+        self.warning_violations_list = []
+        self.exclude_violations_list = []
         if not self.bypass_extra_checks:
             self.violations_summary = self.imaging_obj.run_extra_file_checks(
                 self.session_obj.session_info_dict['ProjectID'],
@@ -162,8 +163,8 @@ class NiftiInsertionPipeline(BasePipeline):
                 self.scan_type_id,
                 self.json_file_dict
             )
-        self.warning_violations_list = self.violations_summary['warning'] if self.violations_summary else None
-        self.exclude_violations_list = self.violations_summary['exclude'] if self.violations_summary else None
+            self.warning_violations_list = self.violations_summary['warning']
+            self.exclude_violations_list = self.violations_summary['exclude']
 
         # ---------------------------------------------------------------------------------------------
         # Register files in the proper tables

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -399,7 +399,7 @@ class NiftiInsertionPipeline(BasePipeline):
         self.log_info(message, is_error='N', is_verbose='Y')
 
         # add an entry in the violations log table if there is a warning violation associated to the file
-        if 'warning' in self.violations_summary.keys() and self.violations_summary['warning']:
+        if self.warning_violations_list:
             message = f"Inserting warning violations related to {self.assembly_nifti_rel_path}." \
                       f"  List of violations found: {self.warning_violations_list}"
             self.log_info(message, is_error='N', is_verbose='Y')

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -349,13 +349,6 @@ class NiftiInsertionPipeline(BasePipeline):
             self.scanner_id
         )
 
-        if self.loris_scan_type:
-            # if we already know the scan type, get the scan type info directly and return it
-            scan_type_id = self.imaging_obj.get_scan_type_id_from_scan_type_name(self.loris_scan_type)
-            for protocol_info in protocols_list:
-                if protocol_info['Scan_type'] == scan_type_id:
-                    return scan_type_id, protocol_info['mri_protocol_group_id']
-
         protocol_info = self.imaging_obj.get_acquisition_protocol_info(
             protocols_list, nifti_name, scan_param, scan_type
         )

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -350,7 +350,7 @@ class NiftiInsertionPipeline(BasePipeline):
         )
 
         protocol_info = self.imaging_obj.get_acquisition_protocol_info(
-            protocols_list, nifti_name, scan_param, scan_type
+            protocols_list, nifti_name, scan_param, self.loris_scan_type
         )
         self.log_info(protocol_info['error_message'], is_error="N", is_verbose="Y")
 

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -354,7 +354,7 @@ class NiftiInsertionPipeline(BasePipeline):
             scan_type_id = self.imaging_obj.get_scan_type_id_from_scan_type_name(self.loris_scan_type)
             for protocol_info in protocols_list:
                 if protocol_info['Scan_type'] == scan_type_id:
-                    return protocol_info['scan_type_id'], protocol_info['mri_protocol_group_id']
+                    return scan_type_id, protocol_info['mri_protocol_group_id']
 
         protocol_info = self.imaging_obj.get_acquisition_protocol_info(
             protocols_list, nifti_name, scan_param, scan_type

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -153,7 +153,6 @@ class NiftiInsertionPipeline(BasePipeline):
         # ---------------------------------------------------------------------------------------------
         # Run extra file checks to determine possible protocol violations
         # ---------------------------------------------------------------------------------------------
-        self.violations_summary = {}
         if not self.bypass_extra_checks:
             self.violations_summary = self.imaging_obj.run_extra_file_checks(
                 self.session_obj.session_info_dict['ProjectID'],
@@ -162,8 +161,8 @@ class NiftiInsertionPipeline(BasePipeline):
                 self.scan_type_id,
                 self.json_file_dict
             )
-        self.warning_violations_list = self.violations_summary['warning']
-        self.exclude_violations_list = self.violations_summary['exclude']
+        self.warning_violations_list = self.violations_summary['warning'] if self.violations_summary else None
+        self.exclude_violations_list = self.violations_summary['exclude'] if self.violations_summary else None
 
         # ---------------------------------------------------------------------------------------------
         # Register files in the proper tables

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -567,7 +567,7 @@ class Imaging:
 
         return file_parameters
 
-    def get_acquisition_protocol_info(self, protocols_list, nifti_name, scan_param):
+    def get_acquisition_protocol_info(self, protocols_list, nifti_name, scan_param, scan_type=None):
         """
         Get acquisition protocol information (scan_type_id or message to be printed in the log).
         - If the protocols list provided as input is empty, the scan_type_id will be set to None and proper message
@@ -608,7 +608,7 @@ class Imaging:
 
         # look for matching protocols
         mri_protocol_group_id = protocols_list[0]['MriProtocolGroupID']
-        matching_protocols_list = self.look_for_matching_protocols(protocols_list, scan_param)
+        matching_protocols_list = self.look_for_matching_protocols(protocols_list, scan_param, scan_type)
 
         # if more than one protocol matching, return False, otherwise, return the scan type ID
         if not matching_protocols_list:
@@ -648,7 +648,7 @@ class Imaging:
 
         return self.mri_prot_db_obj.get_bids_info_for_scan_type_id(scan_type_id)
 
-    def look_for_matching_protocols(self, protocols_list, scan_param):
+    def look_for_matching_protocols(self, protocols_list, scan_param, scan_type=None):
         """
         Look for matching protocols in protocols_list given scan parameters stored in scan_param.
 
@@ -661,9 +661,13 @@ class Imaging:
          :rtype: list
         """
 
+        scan_type_id = self.get_scan_type_id_from_scan_type_name(scan_type) if scan_type else None
+
         matching_protocols_list = []
         for protocol in protocols_list:
-            if protocol['series_description_regex']:
+            if scan_type_id and protocol['Scan_type'] == scan_type_id:
+                matching_protocols_list.append(protocol['Scan_type'])
+            elif protocol['series_description_regex']:
                 if re.search(
                         rf"{protocol['series_description_regex']}", scan_param['SeriesDescription'], re.IGNORECASE
                 ):


### PR DESCRIPTION
# Description

Resolves the following bug that occurred when setting the scan type option while running `run_nifti_insertion.py`:
```
Traceback (most recent call last):
  File "/opt/loris/bin/mri/python/run_nifti_insertion.py", line 126, in <module>
    main()
  File "/opt/loris/bin/mri/python/run_nifti_insertion.py", line 106, in main
    NiftiInsertionPipeline(loris_getopt_obj, os.path.basename(__file__[:-3]))
  File "/opt/loris/bin/mri/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py", line 173, in __init__
    self._register_violations_log(self.exclude_violations_list, self.trashbin_nifti_rel_path)
  File "/opt/loris/bin/mri/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py", line 625, in _register_violations_log
    'MriProtocolChecksGroupID': self.mri_protocol_group_id
AttributeError: 'NiftiInsertionPipeline' object has no attribute 'mri_protocol_group_id'
```
