### PR TITLE
Keep BIDS multiple electrode coordinate systems

### DIFF
--- a/python/lib/database_lib/physiological_coord_system.py
+++ b/python/lib/database_lib/physiological_coord_system.py
@@ -29,6 +29,23 @@ class PhysiologicalCoordSystem:
         self.db = db
         self.verbose = verbose
 
+    def get_all_coord_system_units(self):
+        """
+        Gets the coord system units.
+        :return : a list of units (name and symbol)
+         :rtype : list
+        """
+        c_units = self.db.pselect(
+            query="SELECT DISTINCT PhysiologicalCoordSystemUnitID, Name, Symbol"
+            "FROM physiological_coord_system_unit",
+            args=[]
+        )
+        return [{
+            'id': u['PhysiologicalCoordSystemUnitID'],
+            'name': u['Name'],
+            'symbol': u['Symbol']
+        } for u in c_units] if c_units else None
+
     def grep_coord_system_name_from_name(self, coord_name: str):
         """
         Gets the coord system name ID given a str name.

--- a/python/lib/database_lib/physiological_coord_system.py
+++ b/python/lib/database_lib/physiological_coord_system.py
@@ -1,0 +1,249 @@
+"""This class performs database queries for several coordinate system tables:
+- physiological_coord_system,
+- physiological_coord_system_name,
+- physiological_coord_system_type,
+- physiological_coord_system_unit,
+- physiological_modality
+- physiological_coord_system_electrode_rel,
+- physiological_coord_system_point_3d_rel
+"""
+
+from typing import Dict, List
+# from lib.point_3d import Point3D
+# from lib.database_lib.point_3d import Point3DDB
+
+__license__ = "GPLv3"
+
+
+class PhysiologicalCoordSystem:
+
+    def __init__(self, db, verbose):
+        """
+        Constructor method for the PhysiologicalCoordSystem class.
+        :param db                 : Database class object
+         :type db                 : object
+        :param verbose            : whether to be verbose
+         :type verbose            : bool
+        """
+
+        self.db = db
+        self.verbose = verbose
+
+    def grep_coord_system_name_from_name(self, coord_name: str):
+        """
+        Gets the coord system name ID given a str name.
+        :param coord_name       : coord system name of the coord file
+         :type coord_name       : str
+        :return                 : id of the coord system name
+         :rtype                 : int
+        """
+        c_name = self.db.pselect(
+            query="SELECT DISTINCT PhysiologicalCoordSystemNameID "
+            "FROM physiological_coord_system_name "
+            "WHERE Name = %s",
+            args=(coord_name,)
+        )
+        return c_name[0]['PhysiologicalCoordSystemNameID'] if c_name else None
+
+    def grep_coord_system_unit_from_symbol(self, coord_unit: str):
+        """
+        Gets the coord system unit ID given a str name.
+        :param coord_unit       : coord system unit name of the coord file (e.g. 'mm')
+         :type coord_unit       : str
+        :return                 : id of the coord system unit
+         :rtype                 : int
+        """
+        c_unit = self.db.pselect(
+            query="SELECT DISTINCT PhysiologicalCoordSystemUnitID "
+            "FROM physiological_coord_system_unit "
+            "WHERE Symbol = %s",
+            args=(coord_unit,)
+        )
+        return c_unit[0]['PhysiologicalCoordSystemUnitID'] if c_unit else None
+
+    def grep_coord_system_type_from_name(self, coord_type: str):
+        """
+        Gets the coord system type ID given a str name.
+        :param coord_type       : coord system type name of the coord file
+         :type coord_type       : str
+        :return                 : id of the coord system type
+         :rtype                 : int
+        """
+        c_type = self.db.pselect(
+            query="SELECT DISTINCT PhysiologicalCoordSystemTypeID "
+            "FROM physiological_coord_system_type "
+            "WHERE Name = %s",
+            args=(coord_type,)
+        )
+        return c_type[0]['PhysiologicalCoordSystemTypeID'] if c_type else None
+
+    def grep_coord_system_modality_from_name(self, coord_modality: str):
+        """
+        Gets the coord system type ID given a str name.
+        :param coord_modality   : coord system modality name of the coord file
+         :type coord_modality   : str
+        :return                 : id of the coord system modality
+         :rtype                 : int
+        """
+        c_mod = self.db.pselect(
+            query="SELECT DISTINCT PhysiologicalModalityID "
+            "FROM physiological_modality "
+            "WHERE PhysiologicalModality = %s",
+            args=(coord_modality,)
+        )
+        return c_mod[0]['PhysiologicalModalityID'] if c_mod else None
+
+    def grep_coord_system(self, coord_mod_id: int, coord_name_id: int = None,
+                          coord_unit_id: int = None, coord_type_id: int = None):
+        """
+        Get a coordinate system by ID.
+        Requires at least the modality.
+        :param name_id     : coord system name id
+         :type name_id     : int
+        :param unit_id     : unit id
+         :type unit_id     : int
+        :param type_id     : type id
+         :type type_id     : int
+        :param mod_id      : modality id
+         :type mod_id      : int
+        :param coord_file  : path of the coord system file
+         :type coord_file  : str
+        :return            : The coordinate system ID or None
+         :rtype            : int | None
+        """
+        q_args = (coord_mod_id,)
+        q_extra = "SELECT DISTINCT PhysiologicalCoordSystemID " \
+                  "FROM physiological_coord_system " \
+                  "WHERE ModalityID = %s"
+        # add name id
+        if coord_name_id is not None:
+            q_args += (coord_name_id,)
+            q_extra += " AND NameID = %s"
+        # add type id
+        if coord_type_id is not None:
+            q_args += (coord_type_id,)
+            q_extra += " AND TypeID = %s"
+        # add unit id
+        if coord_unit_id is not None:
+            q_args += (coord_unit_id,)
+            q_extra += " AND UnitID = %s"
+        # execute query
+        r_query = self.db.pselect(
+            query = q_extra,
+            args = q_args
+        )
+        return r_query[0]['PhysiologicalCoordSystemID'] if r_query else None
+
+    def insert_coord_system(self, name_id: int, unit_id: int, type_id: int,
+                            mod_id: int, coord_file: str):
+        """
+        Inserts a new entry in the physiological_coord_system table.
+        :param name_id     : coord system name id
+         :type name_id     : int
+        :param unit_id     : unit id
+         :type unit_id     : int
+        :param type_id     : type id
+         :type type_id     : int
+        :param mod_id      : modality id
+         :type mod_id      : int
+        :param coord_file  : path of the coord system file
+         :type coord_file  : str
+        :return            : The inserted coordinate system ID or None
+         :rtype            : int
+        """
+        return self.db.insert(
+            table_name='physiological_coord_system',
+            column_names=(
+                'NameID',
+                'UnitID',
+                'TypeID',
+                'ModalityID',
+                'FilePath'
+            ),
+            values=(
+                name_id,
+                unit_id,
+                type_id,
+                mod_id,
+                coord_file
+            ),
+            get_last_id=True
+        )
+
+    def grep_or_insert_coord_system(self, name_id: int, unit_id: int, type_id: int,
+                                    mod_id: int, coord_file: str):
+        """
+        Inserts a new entry in the physiological_coord_system table if it does not exist.
+        :param name_id     : coord system name id
+         :type name_id     : int
+        :param unit_id     : unit id
+         :type unit_id     : int
+        :param type_id     : type id
+         :type type_id     : int
+        :param mod_id      : modality id
+         :type mod_id      : int
+        :param coord_file  : path of the coord system file
+         :type coord_file  : str
+        :return            : The coordinate system ID or None
+         :rtype            : int
+        """
+        coord_system_id = self.grep_coord_system(mod_id, name_id, unit_id, type_id)
+        if coord_system_id is None:
+            coord_system_id = self.insert_coord_system(name_id, unit_id, type_id, mod_id, coord_file)
+        return coord_system_id
+
+    def insert_coord_system_electrodes_relation(self, physiological_file_id: int,
+                                                coord_system_id: int,
+                                                electrode_ids: List[int]):
+        """
+        Inserts new entries in the physiological_coord_system_electrode_rel table.
+        :param physiological_file_id : physiological file ID
+         :type physiological_file_id : int
+        :param coord_system_id       : coordinate system ID
+         :type coord_system_id       : int
+        :param electrode_ids         : list of electrode id associated with the coordinate system ID
+         :type electrode_ids         : List[int]
+        """
+        values_to_insert = [
+            (coord_system_id, eid, physiological_file_id)
+            for eid in electrode_ids
+        ]
+        self.db.insert(
+            table_name='physiological_coord_system_electrode_rel',
+            column_names=(
+                'PhysiologicalCoordSystemID',
+                'PhysiologicalElectrodeID',
+                'PhysiologicalFileID '
+            ),
+            values=values_to_insert
+        )
+
+    def insert_coord_system_point_3d_relation(self, coord_system_id: int,
+                                              point_ids: Dict[str, int]):
+        """
+        Insert new entries in the physiological_coord_system_point_3d_rel table.
+        :param coord_system_id : coordinate system ID
+         :type coord_system_id : int
+        :param point_ids       : dict of (point name,point_3d id) associated with the coordinate system ID
+         :type point_ids       : Dict[str, int]
+        """
+        values_to_insert = []
+        for name, pid in point_ids.items():
+            r = self.db.pselect(
+                query="SELECT * "
+                "FROM physiological_coord_system_point_3d_rel "
+                "WHERE PhysiologicalCoordSystemID = %s "
+                "AND Point3DID = %s ",
+                args=(coord_system_id, pid,)
+            )
+            if not r:
+                values_to_insert.append((coord_system_id, pid, name))
+        self.db.insert(
+            table_name='physiological_coord_system_point_3d_rel',
+            column_names=(
+                'PhysiologicalCoordSystemID',
+                'Point3DID',
+                'Name'
+            ),
+            values=values_to_insert
+        )

--- a/python/lib/database_lib/physiological_coord_system.py
+++ b/python/lib/database_lib/physiological_coord_system.py
@@ -61,6 +61,22 @@ class PhysiologicalCoordSystem:
         )
         return c_unit[0]['PhysiologicalCoordSystemUnitID'] if c_unit else None
 
+    def grep_coord_system_unit_from_name(self, coord_unit_name: str):
+        """
+        Gets the coord system unit ID given a str name.
+        :param coord_unit_name  : coord system unit full name (e.g. 'millimeter')
+         :type coord_unit_name  : str
+        :return                 : id of the coord system unit
+         :rtype                 : int
+        """
+        c_unit = self.db.pselect(
+            query="SELECT DISTINCT PhysiologicalCoordSystemUnitID "
+            "FROM physiological_coord_system_unit "
+            "WHERE Name = %s",
+            args=(coord_unit_name,)
+        )
+        return c_unit[0]['PhysiologicalCoordSystemUnitID'] if c_unit else None
+
     def grep_coord_system_type_from_name(self, coord_type: str):
         """
         Gets the coord system type ID given a str name.

--- a/python/lib/database_lib/physiological_coord_system.py
+++ b/python/lib/database_lib/physiological_coord_system.py
@@ -36,7 +36,7 @@ class PhysiologicalCoordSystem:
          :rtype : list
         """
         c_units = self.db.pselect(
-            query="SELECT DISTINCT PhysiologicalCoordSystemUnitID, Name, Symbol"
+            query="SELECT DISTINCT PhysiologicalCoordSystemUnitID, Name, Symbol "
             "FROM physiological_coord_system_unit",
             args=[]
         )

--- a/python/lib/database_lib/point_3d.py
+++ b/python/lib/database_lib/point_3d.py
@@ -1,0 +1,121 @@
+"""This class performs database queries for point_3d table"""
+
+from lib.point_3d import Point3D
+
+__license__ = "GPLv3"
+
+
+class Point3DDB:
+    def __init__(self, db, verbose):
+        """
+        Constructor method for the PhysiologicalCoordSystem class.
+        :param db                 : Database class object
+         :type db                 : object
+        :param verbose            : whether to be verbose
+         :type verbose            : bool
+        """
+
+        self.db = db
+        self.verbose = verbose
+
+    def grep_point_by_coordinates(self, x: float, y: float, z: float):
+        """
+        Grep a point in db by coordinate if it exists
+        :param x  : x coordinate
+         :type x  : float
+        :param y  : y coordinate
+         :type y  : float
+        :param z  : z coordinate
+         :type z  : float
+        :return: a point or None if it does not exist
+         :rtype: Point3D | None
+        """
+        cp = self.db.pselect(
+            query = "SELECT DISTINCT Point3DID "
+                    "FROM point_3d "
+                    "WHERE X = %s"
+                    " AND Y = %s"
+                    " AND Z = %s",
+            args=(x, y, z,)
+        )
+        return Point3D(cp[0]['Point3DID'], x, y, z) if cp else None
+
+    def grep_point_by_id(self, point_id: int):
+        """
+        Get a point 3d if it exists in db.
+        :param point_id  : a point ID
+         :type point_id  : int
+        :return: a point or None if it does not exist
+         :rtype: Point3D | None
+        """
+        cp = self.db.pselect(
+            query = "SELECT X, Y, Z "
+                    "FROM point_3d "
+                    "WHERE Point3DID = %s",
+            args=(point_id,)
+        )
+        return Point3D(point_id, cp[0]['X'], cp[0]['Y'], cp[0]['Z']) if cp else None
+
+    def insert_point(self, p: Point3D):
+        """
+        Wrapper for insert_point_by_coordinates.
+        :param p  : Point3D object
+         :type p  : Point3D
+        :return   : the id of the inserted point
+         :rtype   : int
+        :return: a point
+         :rtype: Point3D
+        """
+        return self.insert_point_by_coordinates(p.x, p.y, p.z)
+
+    def insert_point_by_coordinates(self, x: float, y: float, z: float):
+        """
+        Insert a point in db by coordinates.
+        :param x  : x coordinate
+         :type x  : float
+        :param y  : y coordinate
+         :type y  : float
+        :param z  : z coordinate
+         :type z  : float
+        :return: a point
+         :rtype: Point3D
+        """
+        pid = self.db.insert(
+            table_name = 'point_3d',
+            column_names = ('X', 'Y', 'Z'),
+            values = (x, y, z),
+            get_last_id = True
+        )
+        return Point3D(pid, x, y, z)
+
+    def grep_or_insert_point(self, point: Point3D):
+        """
+        Wrapper around grep_or_insert_point_by_coordinates.
+        Insert a point in db if it does not already exist.
+        :param x  : x coordinate
+         :type x  : float
+        :param y  : y coordinate
+         :type y  : float
+        :param z  : z coordinate
+         :type z  : float
+        :return: a point
+         :rtype: Point3D
+        """
+        return self.grep_or_insert_point_by_coordinates(point.x, point.y, point.z)
+
+    def grep_or_insert_point_by_coordinates(self, x: float, y: float, z: float):
+        """
+        Insert a point in db by coordinates if it does not already exist.
+        :param x  : x coordinate
+         :type x  : float
+        :param y  : y coordinate
+         :type y  : float
+        :param z  : z coordinate
+         :type z  : float
+        :return: a point
+         :rtype: Point3D
+        """
+        p = self.grep_point_by_coordinates(x, y, z)
+        if p is None:
+            p = self.insert_point_by_coordinates(x, y, z)
+        return p

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -237,6 +237,7 @@ class Eeg:
             - physiological_file
             - physiological_parameter_file
             - physiological_electrode
+            - physiological_coord_system
             - physiological_channel
             - physiological_task_event
             - physiological_annotation_*
@@ -532,40 +533,75 @@ class Eeg:
         # physiological data into the database
         physiological = Physiological(self.db, self.verbose)
 
-        electrode_file = self.bids_layout.get_nearest(
+        electrode_files = self.bids_layout.get_nearest(
             original_physiological_file_path,
             return_type = 'tuple',
             strict = False,
             extension = 'tsv',
             suffix = 'electrodes',
-            all_ = False,
+            all_ = True,  # get all existing electrode files
             full_search = False,
         )
 
-        if not electrode_file:
+        if not electrode_files:
             message = "WARNING: no electrode file associated with " \
                       "physiological file ID " + str(physiological_file_id)
             print(message)
             return None
         else:
-            result = physiological.grep_electrode_from_physiological_file_id(
-                physiological_file_id
-            )
-            electrode_path = result[0]['FilePath'] if result else None
-            electrode_data = utilities.read_tsv_file(electrode_file.path)
-            if not result:
-                # copy the electrode file to the LORIS BIDS import directory
-                electrode_path = self.copy_file_to_loris_bids_dir(
-                    electrode_file.path, derivatives
-                )
-                # get the blake2b hash of the electrode file
-                blake2 = blake2b(electrode_file.path.encode('utf-8')).hexdigest()
-                # insert the electrode data in the database
-                physiological.insert_electrode_file(
-                    electrode_data, electrode_path, physiological_file_id, blake2
+            # maybe several electrode files
+            for electrode_file in electrode_files:
+                result = physiological.grep_electrode_from_physiological_file_id(
+                    physiological_file_id
                 )
 
-        return electrode_path
+                if not result:
+                    electrode_data = utilities.read_tsv_file(electrode_file.path)
+                    # copy the electrode file to the LORIS BIDS import directory
+                    electrode_path = self.copy_file_to_loris_bids_dir(
+                        electrode_file.path, derivatives
+                    )
+                    # get the blake2b hash of the electrode file
+                    blake2 = blake2b(electrode_file.path.encode('utf-8')).hexdigest()
+                    # insert the electrode data in the database
+                    electrode_ids = physiological.insert_electrode_file(
+                        electrode_data, electrode_path, physiological_file_id, blake2
+                    )
+                    # get coordsystem.json file
+                    # subject-specific metadata
+                    coordsystem_metadata_file = self.bids_layout.get_nearest(
+                        electrode_file.path,
+                        return_type = 'tuple',
+                        strict = False,
+                        extension = 'json',
+                        suffix = 'coordsystem',
+                        all_ = False,
+                        full_search = False,
+                        subject=self.psc_id,
+                    )
+                    if not coordsystem_metadata_file:
+                        message = '\nWARNING: no electrode metadata files (coordsystem.json) ' \
+                                  f'associated with physiological file ID {physiological_file_id}'
+                        print(message)
+
+                    else:
+                        # copy the electrode metadata file to the LORIS BIDS import directory
+                        electrode_metadata_path = self.copy_file_to_loris_bids_dir(
+                            coordsystem_metadata_file.path, derivatives
+                        )
+                        # load json data
+                        with open(coordsystem_metadata_file.path) as metadata_file:
+                            electrode_metadata = json.load(metadata_file)
+                        # get the blake2b hash of the json events file
+                        blake2 = blake2b(coordsystem_metadata_file.path.encode('utf-8')).hexdigest()
+                        # insert event metadata in the database
+                        physiological.insert_electrode_metadata(
+                            electrode_metadata,
+                            electrode_metadata_path,
+                            physiological_file_id,
+                            blake2,
+                            electrode_ids
+                        )
 
     def fetch_and_insert_channel_file(
             self, physiological_file_id, original_physiological_file_path, derivatives=False):
@@ -723,7 +759,7 @@ class Eeg:
 
                     if not event_metadata_file:
                         message = '\nWARNING: no events metadata files (event.json) associated' \
-                                  'with physiological file ID ' + physiological_file_id
+                                  'with physiological file ID ' + str(physiological_file_id)
                         print(message)
                     else:
                         # copy the event file to the LORIS BIDS import directory

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -580,7 +580,7 @@ class Physiological:
                 unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_name(unit_symbol)
                 if unit_id is None:
                     print(f"Unit named {unit_symbol} unknown in DB, going default.")
-                    #force default
+                    # force default
                     raise IndexError
         except (IndexError, KeyError):
             unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_name("Not registered")

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -563,15 +563,15 @@ class Physiological:
             for i in range(1, w1_len + 1):
                 for j in range(1, w2_len + 1):
                     if w1[i - 1] == w2[j - 1]:
-                        m[i][j] = m[i-1][j-1]
+                        m[i][j] = m[i - 1][j - 1]
                     else:
                         m[i][j] = 1 + min(
                             # insertion
-                            m[i-1][j],
+                            m[i - 1][j],
                             # deletion
-                            m[i][j-1],
+                            m[i][j - 1],
                             # replacement
-                            m[i-1][j-1]
+                            m[i - 1][j - 1]
                         )
             # return distance from matrix
             return m[w1_len][w2_len]
@@ -590,7 +590,7 @@ class Physiological:
             unit_to_test = unit_to_search
             if unit_to_test.endswith("s"):
                 # remove trailing "s"
-                unit_to_test = unit[:-1]
+                unit_to_test = unit_to_test[:-1]
                 # search without trailing "s" into all units names and symbols
                 for unit in all_units:
                     if levenshtein_distance(unit_to_test, unit['name']) == 0:
@@ -610,13 +610,12 @@ class Physiological:
                     'name': levenshtein_distance(unit_to_test, unit['name']),
                     'symbol': levenshtein_distance(unit_to_test, unit['symbol'])
                 }
-            # take the first that has 1 distance (name or symbol)
+            # take the first that has 1 distance (name only)
+            # symbols are too short to be relevant here
             # e.g. "meter" instead of "metre"
-            for u,d in distance_matrix.items():
+            for u, d in distance_matrix.items():
                 if d['name'] == 1:
                     r = ('name', unit)
-                if d['symbol'] == 1:
-                    r = ('symbol', unit)
             # TODO: try for distance > 1?
             return r if r is not None else None
 

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -571,7 +571,6 @@ class Physiological:
         except (IndexError, KeyError):
             type_id = self.physiological_coord_system_db.grep_coord_system_type_from_name("Not registered")
 
-
         # unit
         try:
             unit_symbol = electrode_metadata[f'{modality}CoordinateUnits']
@@ -585,7 +584,6 @@ class Physiological:
                     raise IndexError
         except (IndexError, KeyError):
             unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_name("Not registered")
-
 
         # name
         try:

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -621,7 +621,6 @@ class Physiological:
             # no ref points
             pass
 
-
         # insert blake2b hash of task event file into physiological_parameter_file
         self.insert_physio_parameter_file(
             physiological_file_id,

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -569,6 +569,7 @@ class Physiological:
                 # force default
                 raise IndexError
         except (IndexError, KeyError):
+            coord_system_type = None
             type_id = self.physiological_coord_system_db.grep_coord_system_type_from_name("Not registered")
 
         # unit
@@ -605,6 +606,8 @@ class Physiological:
         # define coord system referential points (e.g. LPA, RPA) + points
         is_ok_ref_coords = True
         try:
+            if coord_system_type is None:
+                raise KeyError
             ref_coords = electrode_metadata[f'{coord_system_type}Coordinates']
             ref_points = {
                 ref_key : Point3D(None, *ref_val)

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -544,37 +544,58 @@ class Physiological:
         """
 
         # define modality (MEG, iEEG, EEG)
-        modality = [
-            k for k in electrode_metadata.keys()
-            if k.endswith('CoordinateSystem')
-        ][0].rstrip('CoordinateSystem')
-        modality_id = self.physiological_coord_system_db.grep_coord_system_modality_from_name(modality.lower())
-        if modality_id is None:
-            print(f"Modality {modality} unknown in DB")
-            sys.exit(lib.exitcode.SELECT_FAILURE)
+        try:
+            modality = [
+                k for k in electrode_metadata.keys()
+                if k.endswith('CoordinateSystem')
+            ][0].rstrip('CoordinateSystem')
+            modality_id = self.physiological_coord_system_db.grep_coord_system_modality_from_name(modality.lower())
+            if modality_id is None:
+                print(f"Modality {modality} unknown in DB")
+                # force default
+                raise IndexError
+        except (IndexError, KeyError):
+            modality_id = self.physiological_coord_system_db.grep_coord_system_modality_from_name("Not registered")
 
         # type (Fiducials, AnatomicalLandmark, HeadCoil, DigitizedHeapPoints)
-        coord_system_type = [
-            k for k in electrode_metadata.keys()
-            if k.endswith('CoordinateSystem') and not k.startswith(modality)
-        ][0].rstrip('CoordinateSystem')
-        type_id = self.physiological_coord_system_db.grep_coord_system_type_from_name(coord_system_type)
-        if type_id is None:
-            print(f"Type {coord_system_type} unknown in DB")
+        try:
+            coord_system_type = [
+                k for k in electrode_metadata.keys()
+                if k.endswith('CoordinateSystem') and not k.startswith(modality)
+            ][0].rstrip('CoordinateSystem')
+            type_id = self.physiological_coord_system_db.grep_coord_system_type_from_name(coord_system_type)
+            if type_id is None:
+                print(f"Type {coord_system_type} unknown in DB")
+                # force default
+                raise IndexError
+        except (IndexError, KeyError):
             type_id = self.physiological_coord_system_db.grep_coord_system_type_from_name("Not registered")
 
+
         # unit
-        unit_symbol = electrode_metadata[f'{modality}CoordinateUnits']
-        unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_symbol(unit_symbol)
-        if unit_id is None:
-            print(f"Unit {unit_symbol} unknown in DB")
+        try:
+            unit_symbol = electrode_metadata[f'{modality}CoordinateUnits']
+            unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_symbol(unit_symbol)
+            if unit_id is None:
+                print(f"Symbol of unit {unit_symbol} unknown in DB, trying searching by name...")
+                unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_name(unit_symbol)
+                if unit_id is None:
+                    print(f"Unit named {unit_symbol} unknown in DB, going default.")
+                    #force default
+                    raise IndexError
+        except (IndexError, KeyError):
             unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_name("Not registered")
 
+
         # name
-        coord_system_name = electrode_metadata[f'{modality}CoordinateSystem']
-        name_id = self.physiological_coord_system_db.grep_coord_system_name_from_name(coord_system_name)
-        if name_id is None:
-            print(f"Name {coord_system_name} unknown in DB")
+        try:
+            coord_system_name = electrode_metadata[f'{modality}CoordinateSystem']
+            name_id = self.physiological_coord_system_db.grep_coord_system_name_from_name(coord_system_name)
+            if name_id is None:
+                print(f"Name {coord_system_name} unknown in DB")
+                # force default
+                raise IndexError
+        except (IndexError, KeyError):
             name_id = self.physiological_coord_system_db.grep_coord_system_name_from_name("Not registered")
 
         # get or create coord system in db

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -615,7 +615,8 @@ class Physiological:
             # e.g. "meter" instead of "metre"
             for u, d in distance_matrix.items():
                 if d['name'] == 1:
-                    r = ('name', unit)
+                    r = ('name', u)
+                    break
             # TODO: try for distance > 1?
             return r if r is not None else None
 

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -561,21 +561,21 @@ class Physiological:
         type_id = self.physiological_coord_system_db.grep_coord_system_type_from_name(coord_system_type)
         if type_id is None:
             print(f"Type {coord_system_type} unknown in DB")
-            sys.exit(lib.exitcode.SELECT_FAILURE)
+            type_id = self.physiological_coord_system_db.grep_coord_system_type_from_name("Not registered")
 
         # unit
         unit_symbol = electrode_metadata[f'{modality}CoordinateUnits']
         unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_symbol(unit_symbol)
         if unit_id is None:
             print(f"Unit {unit_symbol} unknown in DB")
-            sys.exit(lib.exitcode.SELECT_FAILURE)
+            unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_name("Not registered")
 
         # name
         coord_system_name = electrode_metadata[f'{modality}CoordinateSystem']
         name_id = self.physiological_coord_system_db.grep_coord_system_name_from_name(coord_system_name)
         if name_id is None:
             print(f"Name {coord_system_name} unknown in DB")
-            sys.exit(lib.exitcode.SELECT_FAILURE)
+            name_id = self.physiological_coord_system_db.grep_coord_system_name_from_name("Not registered")
 
         # get or create coord system in db
         coord_system_id = self.physiological_coord_system_db.grep_or_insert_coord_system(

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -13,7 +13,9 @@ from lib.database_lib.physiologicalannotationinstance import PhysiologicalAnnota
 from lib.database_lib.physiologicaleventfile import PhysiologicalEventFile
 from lib.database_lib.physiologicaleventparameter import PhysiologicalEventParameter
 from lib.database_lib.physiologicaleventparametercategorylevel import PhysiologicalEventParameterCategoryLevel
-
+from lib.database_lib.physiological_coord_system import PhysiologicalCoordSystem
+from lib.database_lib.point_3d import Point3DDB
+from lib.point_3d import Point3D
 
 
 __license__ = "GPLv3"
@@ -71,6 +73,8 @@ class Physiological:
         self.physiological_event_parameter_obj                = PhysiologicalEventParameter(self.db, self.verbose)
         self.physiological_event_parameter_category_level_obj = \
             PhysiologicalEventParameterCategoryLevel(self.db, self.verbose)
+        self.physiological_coord_system_db = PhysiologicalCoordSystem(self.db, self.verbose)
+        self.point_3d_db = Point3DDB(self.db, self.verbose)
 
     def determine_file_type(self, file):
         """
@@ -282,8 +286,12 @@ class Physiological:
 
         results = self.db.pselect(
             query = "SELECT * "
-                    " FROM physiological_electrode"
-                    " WHERE PhysiologicalFileID = %s",
+                    "FROM physiological_electrode "
+                    "WHERE PhysiologicalElectrodeID "
+                    "IN ("
+                    "    SELECT PhysiologicalElectrodeID "
+                    "    FROM physiological_coord_system_electrode_rel "
+                    "    WHERE PhysiologicalFileID = %s)",
             args  = (physiological_file_id,)
         )
 
@@ -353,15 +361,17 @@ class Physiological:
 
         # gather values that need to be inserted into physiological_electrode table
         electrode_fields = (
-            'PhysiologicalFileID',              'PhysiologicalElectrodeTypeID',
-            'PhysiologicalElectrodeMaterialID', 'Name',
-            'X',                                'Y',
-            'Z',                                'Impedance',
+            'PhysiologicalElectrodeTypeID',
+            'PhysiologicalElectrodeMaterialID',
+            'Name',
+            'Point3DID',
+            'Impedance',
             'FilePath'
         )
         electrode_values = []
+        electrode_ids = []
+        optional_fields = ('type', 'material', 'impedance')
         for row in electrode_data:
-            optional_fields = ('type', 'material', 'impedance')
             for field in optional_fields:
                 if field not in row.keys():
                     continue
@@ -387,27 +397,33 @@ class Physiological:
             x_value = None if row['x'] == 'n/a' else row['x']
             y_value = None if row['y'] == 'n/a' else row['y']
             z_value = None if row['z'] == 'n/a' else row['z']
+            p = Point3D(None, x_value, y_value, z_value)
+            point = self.point_3d_db.grep_or_insert_point(p)
 
+            # insert into physiological_electrode table
             values_tuple = (
-                str(physiological_file_id), row.get('type_id'),
-                row.get('material_id'),     row['name'],
-                x_value,                    y_value,
-                z_value,                    row.get('impedance'),
+                row.get('type_id'),
+                row.get('material_id'),
+                row['name'],
+                point.id,
+                row.get('impedance'),
                 electrode_file
             )
             electrode_values.append(values_tuple)
 
-        # insert into physiological_electrode table
-        self.db.insert(
-            table_name   = 'physiological_electrode',
-            column_names = electrode_fields,
-            values       = electrode_values
-        )
+            inserted_electrode_id = self.db.insert(
+                table_name   = 'physiological_electrode',
+                column_names = electrode_fields,
+                values       = electrode_values,
+                get_last_id  = True
+            )
+            electrode_ids.append(inserted_electrode_id)
 
         # insert blake2b hash of electrode file into physiological_parameter_file
         self.insert_physio_parameter_file(
             physiological_file_id, 'electrode_file_blake2b_hash', blake2
         )
+        return electrode_ids
 
     def insert_channel_file(self, channel_data, channel_file,
                             physiological_file_id, blake2):
@@ -505,6 +521,92 @@ class Physiological:
         # insert blake2b hash of channel file into physiological_parameter_file
         self.insert_physio_parameter_file(
             physiological_file_id, 'channel_file_blake2b_hash', blake2
+        )
+
+    def insert_electrode_metadata(self, electrode_metadata, electrode_metadata_file,
+                                  physiological_file_id, blake2, electrode_ids):
+        """
+        Inserts the electrode metadata information read from the file *coordsystem.json
+        into the physiological_coord_system, physiological_coord_system_point_3d_rel
+        and physiological_coord_system_electrode_rel tables, linking it to the
+        physiological file ID already inserted in physiological_file.
+        :param electrode_metadata       : dictionaries of electrode metadata to insert
+                                          into the database
+         :type electrode_metadata       : dict
+        :param electrode_metadata_file  : PhysiologicalFileID to link the electrode info to
+         :type electrode_metadata_file  : int
+        :param physiological_file_id    : PhysiologicalFileID to link the electrode info to
+         :type physiological_file_id    : int
+        :param blake2                   : blake2b hash of the event file
+         :type blake2                   : str
+        :param electrode_ids            : blake2b hash of the event file
+         :type electrode_ids            : str
+        """
+
+        # define modality (MEG, iEEG, EEG)
+        modality = [
+            k for k in electrode_metadata.keys()
+            if k.endswith('CoordinateSystem')
+        ][0].rstrip('CoordinateSystem')
+        modality_id = self.physiological_coord_system_db.grep_coord_system_modality_from_name(modality.lower())
+        if modality_id is None:
+            print(f"Modality {modality} unknown in DB")
+            sys.exit(lib.exitcode.SELECT_FAILURE)
+
+        # type (Fiducials, AnatomicalLandmark, HeadCoil, DigitizedHeapPoints)
+        coord_system_type = [
+            k for k in electrode_metadata.keys()
+            if k.endswith('CoordinateSystem') and not k.startswith(modality)
+        ][0].rstrip('CoordinateSystem')
+        type_id = self.physiological_coord_system_db.grep_coord_system_type_from_name(coord_system_type)
+        if type_id is None:
+            print(f"Type {coord_system_type} unknown in DB")
+            sys.exit(lib.exitcode.SELECT_FAILURE)
+
+        # unit
+        unit_symbol = electrode_metadata[f'{modality}CoordinateUnits']
+        unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_symbol(unit_symbol)
+        if unit_id is None:
+            print(f"Unit {unit_symbol} unknown in DB")
+            sys.exit(lib.exitcode.SELECT_FAILURE)
+
+        # name
+        coord_system_name = electrode_metadata[f'{modality}CoordinateSystem']
+        name_id = self.physiological_coord_system_db.grep_coord_system_name_from_name(coord_system_name)
+        if name_id is None:
+            print(f"Name {coord_system_name} unknown in DB")
+            sys.exit(lib.exitcode.SELECT_FAILURE)
+
+        # get or create coord system in db
+        coord_system_id = self.physiological_coord_system_db.grep_or_insert_coord_system(
+            name_id,
+            unit_id,
+            type_id,
+            modality_id,
+            str(electrode_metadata_file)
+        )
+
+        # define coord system referential points (e.g. LPA, RPA) + points
+        ref_coords = electrode_metadata[f'{coord_system_type}Coordinates']
+        ref_points = {
+            ref_key : Point3D(None, *ref_val)
+            for ref_key, ref_val in ref_coords.items()
+        }
+
+        # insert ref points
+        point_ids = {}
+        for rk, rv in ref_points.items():
+            p = self.point_3d_db.grep_or_insert_point(rv)
+            point_ids[rk] = p.id
+
+        # insert ref point/coord system relations
+        self.physiological_coord_system_db.insert_coord_system_point_3d_relation(coord_system_id, point_ids)
+
+        # insert blake2b hash of task event file into physiological_parameter_file
+        self.insert_physio_parameter_file(
+            physiological_file_id,
+            'coordsystem_file_json_blake2b_hash',
+            blake2
         )
 
     def insert_event_metadata(self, event_metadata, event_metadata_file, physiological_file_id, blake2):

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -543,6 +543,83 @@ class Physiological:
          :type electrode_ids            : str
         """
 
+        # in a case of approximate units
+        all_units = self.physiological_coord_system_db.get_all_coord_system_units()
+
+        def levenshtein_distance(w1, w2):
+            """Calculate Levenshtein distance betwee two words"""
+            # lenght
+            w1_len = len(w1)
+            w2_len = len(w2)
+            # create the matrix
+            m = [[0 for i in range(w2_len + 1)] for j in range(w1_len + 1)]
+            # w1_len = 0
+            for j in range(w2_len + 1):
+                m[0][j] = j
+            # When w2_len = 0
+            for i in range(w1_len + 1):
+                m[i][0] = i
+            # All transitions
+            for i in range(1, w1_len + 1):
+                for j in range(1, w2_len + 1):
+                    if w1[i - 1] == w2[j - 1]:
+                        m[i][j] = m[i-1][j-1]
+                    else:
+                        m[i][j] = 1 + min(
+                            # insertion
+                            m[i-1][j],
+                            # deletion
+                            m[i][j-1],
+                            # replacement
+                            m[i-1][j-1]
+                        )
+            # return distance from matrix
+            return m[w1_len][w2_len]
+
+        def search_unit(unit_to_search: str):
+            """
+            Search a unit name using Levenshtein distance
+            into all unit names and symbols in db.
+            Approximation is limited to a distance of 1.
+            Meaning only one modification, deletion, or
+            addition of character is permitted.
+            """
+            r = None
+            # -----
+            # test trailing "s"
+            unit_to_test = unit_to_search
+            if unit_to_test.endswith("s"):
+                # remove trailing "s"
+                unit_to_test = unit[:-1]
+                # search without trailing "s" into all units names and symbols
+                for unit in all_units:
+                    if levenshtein_distance(unit_to_test, unit['name']) == 0:
+                        r = ('name', unit_to_test)
+                        break
+                    if levenshtein_distance(unit_to_test, unit['symbol']) == 0:
+                        r = ('symbol', unit_to_test)
+                        break
+                if r is not None:
+                    return r
+            # -----
+            # if no trailing "s" or removing trailing "s" was not enough
+            # build search matrix
+            distance_matrix = {}
+            for unit in all_units:
+                distance_matrix[unit] = {
+                    'name': levenshtein_distance(unit_to_test, unit['name']),
+                    'symbol': levenshtein_distance(unit_to_test, unit['symbol'])
+                }
+            # take the first that has 1 distance (name or symbol)
+            # e.g. "meter" instead of "metre"
+            for u,d in distance_matrix.items():
+                if d['name'] == 1:
+                    r = ('name', unit)
+                if d['symbol'] == 1:
+                    r = ('symbol', unit)
+            # TODO: try for distance > 1?
+            return r if r is not None else None
+
         # define modality (MEG, iEEG, EEG)
         try:
             modality = [
@@ -573,15 +650,26 @@ class Physiological:
 
         # unit
         try:
-            unit_symbol = electrode_metadata[f'{modality}CoordinateUnits']
-            unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_symbol(unit_symbol)
+            unit_data = electrode_metadata[f'{modality}CoordinateUnits']
+            unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_symbol(unit_data)
             if unit_id is None:
-                print(f"Symbol of unit {unit_symbol} unknown in DB, trying searching by name...")
-                unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_name(unit_symbol)
+                print(f"Symbol of unit {unit_data} unknown in DB, trying searching by name...")
+                unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_name(unit_data)
                 if unit_id is None:
-                    print(f"Unit named {unit_symbol} unknown in DB, going default.")
-                    # force default
-                    raise IndexError
+                    # trying alternative names (meter/metre, meters/meter, ...)
+                    print("Searching for alternative names...")
+                    unit_search_result = search_unit(unit_data)
+                    if unit_search_result is None:
+                        print(f"Unit named {unit_data} unknown in DB, going default.")
+                        # force default
+                        raise IndexError
+                    # unit found with alternate naming, grep it
+                    print(f"Found alternate {unit_search_result[0]} '{unit_search_result[1]}' in DB, using it.")
+                    if unit_search_result[0] == 'name':
+                        grep_method = self.physiological_coord_system_db.grep_coord_system_unit_from_name
+                    else:
+                        grep_method = self.physiological_coord_system_db.grep_coord_system_unit_from_symbol
+                    unit_id = grep_method(unit_search_result[1])
         except (IndexError, KeyError):
             unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_name("Not registered")
 

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -603,20 +603,24 @@ class Physiological:
         )
 
         # define coord system referential points (e.g. LPA, RPA) + points
-        ref_coords = electrode_metadata[f'{coord_system_type}Coordinates']
-        ref_points = {
-            ref_key : Point3D(None, *ref_val)
-            for ref_key, ref_val in ref_coords.items()
-        }
+        try:
+            ref_coords = electrode_metadata[f'{coord_system_type}Coordinates']
+            ref_points = {
+                ref_key : Point3D(None, *ref_val)
+                for ref_key, ref_val in ref_coords.items()
+            }
+            # insert ref points
+            point_ids = {}
+            for rk, rv in ref_points.items():
+                p = self.point_3d_db.grep_or_insert_point(rv)
+                point_ids[rk] = p.id
 
-        # insert ref points
-        point_ids = {}
-        for rk, rv in ref_points.items():
-            p = self.point_3d_db.grep_or_insert_point(rv)
-            point_ids[rk] = p.id
+            # insert ref point/coord system relations
+            self.physiological_coord_system_db.insert_coord_system_point_3d_relation(coord_system_id, point_ids)
+        except (IndexError, KeyError):
+            # no ref points
+            pass
 
-        # insert ref point/coord system relations
-        self.physiological_coord_system_db.insert_coord_system_point_3d_relation(coord_system_id, point_ids)
 
         # insert blake2b hash of task event file into physiological_parameter_file
         self.insert_physio_parameter_file(

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -576,7 +576,7 @@ class Physiological:
             unit_data = electrode_metadata[f'{modality}CoordinateUnits']
             unit_id = self.physiological_coord_system_db.grep_coord_system_unit_from_symbol(unit_data)
             if unit_id is None:
-                print(f"Unit {coord_system_type} unknown in DB")
+                print(f"Unit {unit_data} unknown in DB")
                 # force default
                 raise IndexError
         except (IndexError, KeyError):

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -603,23 +603,25 @@ class Physiological:
         )
 
         # define coord system referential points (e.g. LPA, RPA) + points
+        is_ok_ref_coords = True
         try:
             ref_coords = electrode_metadata[f'{coord_system_type}Coordinates']
             ref_points = {
                 ref_key : Point3D(None, *ref_val)
                 for ref_key, ref_val in ref_coords.items()
             }
+        except (IndexError, KeyError):
+            # no ref points
+            is_ok_ref_coords = False
+        # insert ref points if found 
+        if is_ok_ref_coords:
             # insert ref points
             point_ids = {}
             for rk, rv in ref_points.items():
                 p = self.point_3d_db.grep_or_insert_point(rv)
                 point_ids[rk] = p.id
-
             # insert ref point/coord system relations
             self.physiological_coord_system_db.insert_coord_system_point_3d_relation(coord_system_id, point_ids)
-        except (IndexError, KeyError):
-            # no ref points
-            pass
 
         # insert blake2b hash of task event file into physiological_parameter_file
         self.insert_physio_parameter_file(

--- a/python/lib/point_3d.py
+++ b/python/lib/point_3d.py
@@ -1,0 +1,26 @@
+"""This class represents a Point with 3D coordinates"""
+
+__license__ = "GPLv3"
+
+
+class Point3D:
+    def __init__(self, pid: int, x: float, y: float, z: float):
+        """
+        Create a new point 3D object
+        :param pid  : point ID, can be None
+         :type pid  : int
+        :param x  : x coordinate
+         :type x  : float
+        :param y  : y coordinate
+         :type y  : float
+        :param z  : z coordinate
+         :type z  : float
+        """
+        self.id = pid
+        self.x = x
+        self.y = y
+        self.z = z
+
+    def __str__(self) -> str:
+        """Prints out the point info"""
+        return f"Point [{self.id}] ({self.x}, {self.y}, {self.z})"


### PR DESCRIPTION
Note: rebased from #842 to integrate "subproject" to "cohort" naming change

This PR adds a tracking of all coordinate systems related to electrodes from BIDS archives.
Before that, LORIS-MRI only integrated one coordinate system.
Requires a DB update from [Loris Core 8242](https://github.com/aces/Loris/pull/8242).

