### PR TITLE
Fix incomplete format bug when querying EchoNumber from files table

### DIFF
--- a/python/lib/database_lib/files.py
+++ b/python/lib/database_lib/files.py
@@ -62,7 +62,7 @@ class Files:
             query += " AND PhaseEncodingDirection IS NULL "
 
         if echo_number:
-            query += " AND EchoNumber = % "
+            query += " AND EchoNumber = %s "
             args.append(echo_number)
         else:
             query += " AND EchoNumber IS NULL "


### PR DESCRIPTION
# Description

This fixes a bug in the query to the `files` table when `EchoNumber` should be used to find a file.