### PR TITLE
Add a check before inserting in mri_candidate_errors.py

### DIFF
--- a/python/lib/database_lib/mri_candidate_errors.py
+++ b/python/lib/database_lib/mri_candidate_errors.py
@@ -49,3 +49,18 @@ class MriCandidateErrors:
             values=field_value_dict.values(),
             get_last_id=False
         )
+
+    def get_candidate_errors_for_tarchive_id(self, tarchive_id):
+        """
+        Get the list of MRI candidate errors logged in `MRICandidateErrors` for a given `TarchiveID`.
+
+        :param tarchive_id: `TarchiveID` to restrict the query on
+         :type tarchive_id: int
+
+        :return: list of files inserted into the `MRICandidateErrors` table
+         :rtype: list
+        """
+
+        query = "SELECT * FROM MRICandidateErrors WHERE TarchiveID = %s"
+
+        return self.db.pselect(query=query, args=(tarchive_id,))

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -249,7 +249,7 @@ class Imaging:
         """
 
         series_uid = scan_param["SeriesInstanceUID"] if "SeriesInstanceUID" in scan_param.keys() else None
-        image_type = str(scan_param["ImageType"]) if "ImageType" in scan_param.keys() else None
+        echo_time = str(scan_param["EchoTime"]) if "EchoTime" in scan_param.keys() else None
         echo_number = repr(scan_param["EchoNumber"]) if "EchoNumber" in scan_param.keys() else None
         phase_encoding_dir = scan_param["PhaseEncodingDirection"] \
             if "PhaseEncodingDirection" in scan_param.keys() else None
@@ -259,7 +259,7 @@ class Imaging:
         for row in existing_prot_viol_scans:
             if row['SeriesUID'] == series_uid \
                     and row['PhaseEncodingDirection'] == phase_encoding_dir \
-                    and row['image_type'] == image_type \
+                    and row['TE_range'] == echo_time \
                     and row['EchoNumber'] == echo_number:
                 return
 

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -204,14 +204,26 @@ class Imaging:
          :type reason: str
         """
 
+        series_uid = scan_param["SeriesUID"] if "SeriesUID" in scan_param.keys() else None
+        echo_time = scan_param["EchoTime"] if "EchoTime" in scan_param.keys() else None
+
+        existing_cand_errors = self.mri_cand_errors_db_obj.get_candidate_errors_for_tarchive_id(tarchive_id)
+
+        for row in existing_cand_errors:
+            if str(row['SeriesUID']) == str(series_uid) \
+                    and str(row['EchoTime']) == str(echo_time) \
+                    and str(row['PatientName']) == str(patient_name) \
+                    and str(row['Reason']) == str(reason):
+                return
+
         info_to_insert_dict = {
             "TimeRun": datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-            "SeriesUID": scan_param["SeriesUID"] if "SeriesUID" in scan_param.keys() else None,
+            "SeriesUID": series_uid,
             "TarchiveID": tarchive_id,
             "MincFile": file_rel_path,
             "PatientName": patient_name,
             "Reason": reason,
-            "EchoTime": scan_param["EchoTime"] if "EchoTime" in scan_param.keys() else None
+            "EchoTime": echo_time
         }
         self.mri_cand_errors_db_obj.insert_mri_candidate_errors(info_to_insert_dict)
 


### PR DESCRIPTION
# Description

This PR ensures that no duplicated data are inserted in the `MRICandidateErrors` table using the `SeriesUID`, `EchoTime`, `PatientName` and `Reason` fields.

Related to https://github.com/aces/Loris-MRI/pull/884 and https://github.com/aces/Loris-MRI/issues/890