### PR TITLE
[Perl pipeline] Do not duplicate violation entry if it already exists

### DIFF
--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -94,7 +94,7 @@ Inserts scans that do not correspond to any of the defined protocol from the
 database.
 
 INPUTS:
-  - $dbhr           : database handle reference
+  - $db             : database object
   - $series\_desc    : series description of the scan
   - $minc\_location  : location of the MINC file
   - $patient\_name   : patient name of the scan

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -284,6 +284,7 @@ INPUTS:
   - $visit\_label : visit label associated with the scan
   - $file        : information about the scan
   - $data\_dir    : path to the LORIS MRI data directory
+  - $scan\_type   : scan type associated to the file
 
 ### loadAndCreateObjectFile($minc, $upload\_id)
 

--- a/docs/scripts_md/MriCandidateErrorsOB.md
+++ b/docs/scripts_md/MriCandidateErrorsOB.md
@@ -1,0 +1,106 @@
+# NAME
+
+NeuroDB::objectBroker::MriCandidateErrorsOB -- An object broker for `MriCandidateErrors` records
+
+# SYNOPSIS
+
+    use NeuroDB::Database;
+    use NeuroDB::objectBroker::MriCandidateErrorsOB;
+    use TryCatch;
+
+    my $db = NeuroDB::Database->new(
+        userName     => 'user',
+        databaseName => 'my_db',
+        hostName     => 'my_hostname',
+        password     => 'pwd'
+    );
+
+    try {
+        $db->connect();
+    } catch(NeuroDB::DatabaseException $e) {
+        die sprintf(
+            "User %s failed to connect to %s on %s: %s (error code %d)\n",
+            'user',
+            'my_db',
+            'my_hostname',
+            $e->errorMessage,
+            $e->errorCode
+        );
+    }
+
+    .
+    .
+    .
+
+    my $mriCandidateErrorsOB = NeuroDB::objectBroker::MriCandidateErrorsOB->new(db => $db);
+    my $mriCandidateErrorsRef;
+    try {
+        $mriCandidateErrorsRef = $mriCandidateErrorsOB->getByTarchiveID(
+            [ 'TarchiveID' ], 12
+        );
+    } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+        die sprintf(
+            "Failed to retrieve MriCandidateErrors records: %s",
+            $e->errorMessage
+        );
+    }
+
+# DESCRIPTION
+
+This class provides a set of methods to either fetch records from the `MRICandidateErrors`
+table, insert new entries in it or update existing ones. If an operation cannot
+be executed successfully, a `NeuroDB::objectBroker::ObjectBrokerException` is thrown.
+
+## Methods
+
+### new(db => $db) >> (constructor)
+
+Create a new instance of this class. The only parameter to provide is the
+`Database` object used to access the database.
+
+INPUT: the database object used to read/modify the `MRICandidateErrors` table.
+
+RETURN: new instance of this class.
+
+### getWithTarchiveID($tarchiveID)
+
+Fetches the records from the `MRICandidateErrors` table that have a specific `TarchiveID`.
+
+INPUTS:
+    - ID of the tarchive used during the search.
+
+RETURN: a reference to an array of hash references. Every hash contains the values for a given
+        row returned by the function call: the key/value pairs contain the name of a column
+        (listed in `@MRICANDIDATEERRORS_FIELDS`) and the value it holds, respectively.
+        As an example, suppose array `$r` contains the result of a call to this method with
+        `@$fieldsRef` set to `('TarchiveID', 'MincFile'` one would fetch the `MincFile`
+        of the 4th record returned using `$r-`\[3\]->{'MincFile'}>.
+
+### insert($valuesRef)
+
+Inserts a new record in the `MRICandidateErrors` table with the specified column values.
+This method throws a `NeuroDB::objectBroker::ObjectBrokerException` if the operation
+could not be completed successfully.
+
+INPUT: a reference to a hash of the values to insert. The hash contains the column
+       names and associated record values used during insertion. All the keys of
+       `%$valuesRef` must exist in `@MRICANDIDATEERRORS_FIELDS` or an exception will be thrown.
+
+RETURNS: the index of the MRI upload record inserted.
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# COPYRIGHT AND LICENSE
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience

--- a/docs/scripts_md/MriProtocolViolatedScansOB.md
+++ b/docs/scripts_md/MriProtocolViolatedScansOB.md
@@ -1,0 +1,106 @@
+# NAME
+
+NeuroDB::objectBroker::MriProtocolViolatedScansOB -- An object broker for `mri_protocol_violated_scans` records
+
+# SYNOPSIS
+
+    use NeuroDB::Database;
+    use NeuroDB::objectBroker::MriProtocolViolatedScansOB;
+    use TryCatch;
+
+    my $db = NeuroDB::Database->new(
+        userName     => 'user',
+        databaseName => 'my_db',
+        hostName     => 'my_hostname',
+        password     => 'pwd'
+    );
+
+    try {
+        $db->connect();
+    } catch(NeuroDB::DatabaseException $e) {
+        die sprintf(
+            "User %s failed to connect to %s on %s: %s (error code %d)\n",
+            'user',
+            'my_db',
+            'my_hostname',
+            $e->errorMessage,
+            $e->errorCode
+        );
+    }
+
+    .
+    .
+    .
+
+    my $mriProtocolViolatedScansOB = NeuroDB::objectBroker::MriProtocolViolatedScansOB->new(db => $db);
+    my $mriProtocolViolatedScansOBRef;
+    try {
+        $mriProtocolViolatedScansOBRef = $mriProtocolViolatedScansOB->getByTarchiveID(
+            [ 'TarchiveID' ], 12
+        );
+    } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+        die sprintf(
+            "Failed to retrieve mri_protocol_violated_scans records: %s",
+            $e->errorMessage
+        );
+    }
+
+# DESCRIPTION
+
+This class provides a set of methods to either fetch records from the `mri_protocol_violated_scans`
+table, insert new entries in it or update existing ones. If an operation cannot
+be executed successfully, a `NeuroDB::objectBroker::ObjectBrokerException` is thrown.
+
+## Methods
+
+### new(db => $db) >> (constructor)
+
+Create a new instance of this class. The only parameter to provide is the
+`Database` object used to access the database.
+
+INPUT: the database object used to read/modify the `mri_protocol_violated_scans` table.
+
+RETURN: new instance of this class.
+
+### getWithTarchiveID($tarchiveID)
+
+Fetches the records from the `mri_protocol_violated_scans` table that have a specific `TarchiveID`.
+
+INPUTS:
+    - ID of the tarchive used during the search.
+
+RETURN: a reference to an array of hash references. Every hash contains the values for a given
+        row returned by the function call: the key/value pairs contain the name of a column
+        (listed in `@MRIPROTOCOLVIOLATEDSCANS_FIELDS`) and the value it holds, respectively.
+        As an example, suppose array `$r` contains the result of a call to this method with
+        `@$fieldsRef` set to `('TarchiveID', 'minc_location'` one would fetch the `minc_location`
+        of the 4th record returned using `$r-`\[3\]->{'minc\_location'}>.
+
+### insert($valuesRef)
+
+Inserts a new record in the `mri_protocol_violated_scans` table with the specified column values.
+This method throws a `NeuroDB::objectBroker::ObjectBrokerException` if the operation
+could not be completed successfully.
+
+INPUT: a reference to a hash of the values to insert. The hash contains the column
+       names and associated record values used during insertion. All the keys of
+       `%$valuesRef` must exist in `@MRIPROTOCOLVIOLATEDSCANS_FIELDS` or an exception will be thrown.
+
+RETURNS: the index of the MRI upload record inserted.
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# COPYRIGHT AND LICENSE
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience

--- a/docs/scripts_md/MriViolationsLogOB.md
+++ b/docs/scripts_md/MriViolationsLogOB.md
@@ -1,0 +1,106 @@
+# NAME
+
+NeuroDB::objectBroker::MriViolationsLogOB -- An object broker for `mri_violations_log` records
+
+# SYNOPSIS
+
+    use NeuroDB::Database;
+    use NeuroDB::objectBroker::MriViolationsLogOB;
+    use TryCatch;
+
+    my $db = NeuroDB::Database->new(
+        userName     => 'user',
+        databaseName => 'my_db',
+        hostName     => 'my_hostname',
+        password     => 'pwd'
+    );
+
+    try {
+        $db->connect();
+    } catch(NeuroDB::DatabaseException $e) {
+        die sprintf(
+            "User %s failed to connect to %s on %s: %s (error code %d)\n",
+            'user',
+            'my_db',
+            'my_hostname',
+            $e->errorMessage,
+            $e->errorCode
+        );
+    }
+
+    .
+    .
+    .
+
+    my $mriViolationsLogOB = NeuroDB::objectBroker::MriViolationsLogOB->new(db => $db);
+    my $mriProtocolViolatedScansOBRef;
+    try {
+        $mriViolationsLogOBRef = $mriViolationsLogOB->getByTarchiveID(
+            [ 'TarchiveID' ], 12
+        );
+    } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+        die sprintf(
+            "Failed to retrieve mri_violations_log records: %s",
+            $e->errorMessage
+        );
+    }
+
+# DESCRIPTION
+
+This class provides a set of methods to either fetch records from the `mri_violations_log`
+table, insert new entries in it or update existing ones. If an operation cannot
+be executed successfully, a `NeuroDB::objectBroker::ObjectBrokerException` is thrown.
+
+## Methods
+
+### new(db => $db) >> (constructor)
+
+Create a new instance of this class. The only parameter to provide is the
+`Database` object used to access the database.
+
+INPUT: the database object used to read/modify the `mri_violations_log` table.
+
+RETURN: new instance of this class.
+
+### getWithTarchiveID($tarchiveID)
+
+Fetches the records from the `mri_violations_log` table that have a specific `TarchiveID`.
+
+INPUTS:
+    - ID of the tarchive used during the search.
+
+RETURN: a reference to an array of hash references. Every hash contains the values for a given
+        row returned by the function call: the key/value pairs contain the name of a column
+        (listed in `@MRIVIOLATIONSLOG_FIELDS`) and the value it holds, respectively.
+        As an example, suppose array `$r` contains the result of a call to this method with
+        `@$fieldsRef` set to `('TarchiveID', 'MincFile'` one would fetch the `MincFile`
+        of the 4th record returned using `$r-`\[3\]->{'MincFile'}>.
+
+### insert($valuesRef)
+
+Inserts a new record in the `mri_violations_log` table with the specified column values.
+This method throws a `NeuroDB::objectBroker::ObjectBrokerException` if the operation
+could not be completed successfully.
+
+INPUT: a reference to a hash of the values to insert. The hash contains the column
+       names and associated record values used during insertion. All the keys of
+       `%$valuesRef` must exist in `@MRIVIOLATIONSLOG_FIELDS` or an exception will be thrown.
+
+RETURNS: the index of the MRI upload record inserted.
+
+# TO DO
+
+Nothing planned.
+
+# BUGS
+
+None reported.
+
+# COPYRIGHT AND LICENSE
+
+License: GPLv3
+
+# AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -48,6 +48,7 @@ use FindBin;
 use Encode;
 use DICOM::DICOM;
 
+use NeuroDB::objectBroker::MriProtocolViolatedScansOB;
 use NeuroDB::objectBroker::MriScanTypeOB;
 use NeuroDB::objectBroker::MriScannerOB;
 use NeuroDB::objectBroker::PSCOB;
@@ -517,15 +518,15 @@ sub identify_scan_db {
     }   # if (@rows==0)....else...
 
     # if we got here, we're really clueless: insert scan in mri_protocol_violated_scans
-    # table. Note that $mriProtocolGroupID will be undef unless exactly one protocol 
+    # table. Note that $mriProtocolGroupID will be undef unless exactly one protocol
     # group was used to try to identify the scan
     insert_violated_scans(
-        $dbhr,         $series_description, $minc_location,   $patient_name,
+        $db,           $series_description, $minc_location,   $patient_name,
         $candid,       $pscid,              $tr,              $te,
         $ti,           $slice_thickness,    $xstep,           $ystep,
         $zstep,        $xspace,             $yspace,          $zspace,
         $time,         $seriesUID,          $tarchiveID,      $image_type,
-        $echo_numbers,  $phase_enc_dir,      $data_dir,        $mriProtocolGroupID
+        $echo_numbers, $phase_enc_dir,      $data_dir,        $mriProtocolGroupID
     );
 
     return 'unknown';
@@ -540,7 +541,7 @@ C<mri_protocol> table into the C<mri_protocol_violated_scans> table of the
 database.
 
 INPUTS:
-  - $dbhr           : database handle reference
+  - $db             : database object
   - $series_desc    : series description of the scan
   - $minc_location  : location of the MINC file
   - $patient_name   : patient name of the scan
@@ -570,45 +571,61 @@ INPUTS:
 
 sub insert_violated_scans {
 
-    my ($dbhr,         $series_description, $minc_location, $patient_name,
-        $candid,       $pscid,              $tr,            $te,
-        $ti,           $slice_thickness,    $xstep,         $ystep,
-        $zstep,        $xspace,             $yspace,        $zspace,
-        $time,         $seriesUID,          $tarchiveID,    $image_type,
+    my ($db,          $series_description, $minc_location, $patient_name,
+        $candid,      $pscid,              $tr,            $te,
+        $ti,          $slice_thickness,    $xstep,         $ystep,
+        $zstep,       $xspace,             $yspace,        $zspace,
+        $time,        $seriesUID,          $tarchiveID,    $image_type,
         $echo_number, $phase_enc_dir,  $data_dir,      $mriProtocolGroupID) = @_;
 
     # determine the future relative path when the file will be moved to
     # data_dir/trashbin at the end of the script's execution
     my $file_rel_path = get_trashbin_file_rel_path($minc_location, $data_dir, 1);
 
-    (my $query = <<QUERY) =~ s/\n//gm;
-  INSERT INTO mri_protocol_violated_scans (
-    CandID,                 PSCID,         TarchiveID,            time_run,
-    series_description,     minc_location, PatientName,           TR_range,
-    TE_range,               TI_range,      slice_thickness_range, xspace_range,
-    yspace_range,           zspace_range,  xstep_range,           ystep_range,
-    zstep_range,            time_range,    SeriesUID,             image_type,
-    PhaseEncodingDirection, EchoNumber,   MriProtocolGroupID
-  ) VALUES (
-    ?, ?, ?, now(),
-    ?, ?, ?, ?,
-    ?, ?, ?, ?,
-    ?, ?, ?, ?,
-    ?, ?, ?, ?,
-    ?, ?, ?
-  )
-QUERY
+    # determine time run
+    my ($sec, $min, $hour, $mday, $mon, $year, $wday, $yday, $isdst) = localtime(time);
+    my $time_run = sprintf("%4d-%02d-%02d %02d:%02d:%02d", $year+1900, $mon+1, $mday, $hour, $min, $sec);
 
-    my $sth = $${dbhr}->prepare($query);
-    my $success = $sth->execute(
-        $candid,        $pscid,              $tarchiveID, $series_description,
-        $file_rel_path, $patient_name,       $tr,         $te,
-        $ti,            $slice_thickness,    $xspace,     $yspace,
-        $zspace,        $xstep,              $ystep,      $zstep,
-        $time,          $seriesUID,          $image_type, $phase_enc_dir,
-        $echo_number,   $mriProtocolGroupID
+    my %newMriProtocolViolatedScans = (
+        'CandID'                 => $candid,
+        'PSCID'                  => $pscid,
+        'TarchiveID'             => $tarchiveID,
+        'time_run'               => $time_run,
+        'series_description'     => $series_description,
+        'minc_location'          => $file_rel_path,
+        'PatientName'            => $patient_name,
+        'TR_range'               => $tr,
+        'TE_range'               => $te,
+        'TI_range'               => $ti,
+        'slice_thickness_range'  => $slice_thickness,
+        'xspace_range'           => $xspace,
+        'yspace_range'           => $yspace,
+        'zspace_range'           => $zspace,
+        'xstep_range'            => $xstep,
+        'ystep_range'            => $ystep,
+        'zstep_range'            => $zstep,
+        'time_range'             => $time,
+        'SeriesUID'              => $seriesUID,
+        'image_type'             => $image_type,
+        'PhaseEncodingDirection' => $phase_enc_dir,
+        'EchoNumber'             => $echo_number,
+        'MriProtocolGroupID'     => $mriProtocolGroupID
     );
 
+    my $mriProtocolViolatedScansOB = NeuroDB::objectBroker::MriProtocolViolatedScansOB->new(db => $db);
+    my $mriProtocolViolatedScansRef = $mriProtocolViolatedScansOB->getWithTarchiveID($tarchiveID);
+
+    my $already_inserted = undef;
+    foreach my $dbProtViolScan (@$mriProtocolViolatedScansRef) {
+        if ($dbProtViolScan->{'SeriesUID'} eq $newMriProtocolViolatedScans{'SeriesUID'}
+            && $dbProtViolScan->{'TE_range'} eq $newMriProtocolViolatedScans{'TE_range'}
+            && $dbProtViolScan->{'PhaseEncodingDirection'} eq $newMriProtocolViolatedScans{'PhaseEncodingDirection'}
+            && $dbProtViolScan->{'EchoNumber'} eq $newMriProtocolViolatedScans{'EchoNumber'}
+        ) {
+            $already_inserted = 1;
+        }
+    }
+    $mriProtocolViolatedScansOB->insert(\%newMriProtocolViolatedScans) unless defined $already_inserted;
 }
 
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -623,6 +623,7 @@ sub insert_violated_scans {
             && $dbProtViolScan->{'EchoNumber'} eq $newMriProtocolViolatedScans{'EchoNumber'}
         ) {
             $already_inserted = 1;
+            last;
         }
     }
     $mriProtocolViolatedScansOB->insert(\%newMriProtocolViolatedScans) unless defined $already_inserted;

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1146,6 +1146,7 @@ sub insert_into_mri_violations_log {
                 && $dbViolLog->{'ValidRegex'} eq $newViolationsLog{'ValidRegex'}
             ) {
                 $already_inserted = 1;
+                last;
             }
         }
         $mriViolationsLogOB->insert(\%newViolationsLog) unless defined $already_inserted;

--- a/uploadNeuroDB/NeuroDB/objectBroker/MriCandidateErrorsOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriCandidateErrorsOB.pm
@@ -1,0 +1,201 @@
+package NeuroDB::objectBroker::MriCandidateErrorsOB;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::objectBroker::MriCandidateErrorsOB -- An object broker for C<MriCandidateErrors> records
+
+=head1 SYNOPSIS
+
+  use NeuroDB::Database;
+  use NeuroDB::objectBroker::MriCandidateErrorsOB;
+  use TryCatch;
+
+  my $db = NeuroDB::Database->new(
+      userName     => 'user',
+      databaseName => 'my_db',
+      hostName     => 'my_hostname',
+      password     => 'pwd'
+  );
+
+  try {
+      $db->connect();
+  } catch(NeuroDB::DatabaseException $e) {
+      die sprintf(
+          "User %s failed to connect to %s on %s: %s (error code %d)\n",
+          'user',
+          'my_db',
+          'my_hostname',
+          $e->errorMessage,
+          $e->errorCode
+      );
+  }
+
+  .
+  .
+  .
+
+  my $mriCandidateErrorsOB = NeuroDB::objectBroker::MriCandidateErrorsOB->new(db => $db);
+  my $mriCandidateErrorsRef;
+  try {
+      $mriCandidateErrorsRef = $mriCandidateErrorsOB->getByTarchiveID(
+          [ 'TarchiveID' ], 12
+      );
+  } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+      die sprintf(
+          "Failed to retrieve MriCandidateErrors records: %s",
+          $e->errorMessage
+      );
+  }
+
+=head1 DESCRIPTION
+
+This class provides a set of methods to either fetch records from the C<MRICandidateErrors>
+table, insert new entries in it or update existing ones. If an operation cannot
+be executed successfully, a C<NeuroDB::objectBroker::ObjectBrokerException> is thrown.
+
+=head2 Methods
+
+=cut
+
+use Moose;
+use MooseX::Privacy;
+
+use NeuroDB::Database;
+use NeuroDB::DatabaseException;
+use NeuroDB::objectBroker::ObjectBrokerException;
+
+use File::Basename;
+
+use TryCatch;
+
+my @MRICANDIDATEERRORS_FIELDS = qw(
+    ID TimeRun SeriesUID TarchiveID MincFile PatientName Reason EchoTime
+    PhaseEncodingDirection EchoNumber
+);
+
+=pod
+
+=head3 new(db => $db) >> (constructor)
+
+Create a new instance of this class. The only parameter to provide is the
+C<Database> object used to access the database.
+
+INPUT: the database object used to read/modify the C<MRICandidateErrors> table.
+
+RETURN: new instance of this class.
+
+=cut
+
+has 'db' => (is  => 'rw', isa => 'NeuroDB::Database', required => 1);
+
+=pod
+
+=head3 getWithTarchiveID($tarchiveID)
+
+Fetches the records from the C<MRICandidateErrors> table that have a specific C<TarchiveID>.
+
+INPUTS:
+    - ID of the tarchive used during the search.
+
+RETURN: a reference to an array of hash references. Every hash contains the values for a given
+        row returned by the function call: the key/value pairs contain the name of a column
+        (listed in C<@MRICANDIDATEERRORS_FIELDS>) and the value it holds, respectively.
+        As an example, suppose array C<$r> contains the result of a call to this method with
+        C<@$fieldsRef> set to C<('TarchiveID', 'MincFile'> one would fetch the C<MincFile>
+        of the 4th record returned using C<$r->[3]->{'MincFile'}>.
+=cut
+
+sub getWithTarchiveID {
+    my ($self, $tarchiveID) = @_;
+
+    my $query = sprintf(
+        "SELECT %s FROM MRICandidateErrors WHERE TarchiveID = ? ",
+        join(',', @MRICANDIDATEERRORS_FIELDS)
+    );
+
+    try {
+        return $self->db->pselect(
+            $query, $tarchiveID
+        );
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to get MRICandidateErrors records by tarchive ID. Reason:\n%s",
+                $e
+            )
+        );
+    }
+}
+
+=head3 insert($valuesRef)
+
+Inserts a new record in the C<MRICandidateErrors> table with the specified column values.
+This method throws a C<NeuroDB::objectBroker::ObjectBrokerException> if the operation
+could not be completed successfully.
+
+INPUT: a reference to a hash of the values to insert. The hash contains the column
+       names and associated record values used during insertion. All the keys of
+       C<%$valuesRef> must exist in C<@MRICANDIDATEERRORS_FIELDS> or an exception will be thrown.
+
+RETURNS: the index of the MRI upload record inserted.
+
+=cut
+
+sub insert {
+    my($self, $valuesRef) = @_;
+
+    if(!keys %$valuesRef) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => "MRI candidate errors insertion failed: no values specified"
+        );
+    }
+
+    foreach my $v (keys %$valuesRef) {
+        if(!grep($v eq $_, @MRICANDIDATEERRORS_FIELDS)) {
+            NeuroDB::objectBroker::ObjectBrokerException->throw(
+                errorMessage => "MRI candidate errors insertion failed: invalid field $v"
+            );
+        }
+    }
+
+    try {
+        print($valuesRef);
+        my @results = $self->db->insertOne('MRICandidateErrors', $valuesRef);
+        return $results[0];
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to insert MRICandidateErrors record. Reason:\n%s",
+                $e
+            )
+        );
+    }
+}
+
+1;
+
+__END__
+
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 COPYRIGHT AND LICENSE
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience
+
+=cut

--- a/uploadNeuroDB/NeuroDB/objectBroker/MriProtocolViolatedScansOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriProtocolViolatedScansOB.pm
@@ -1,0 +1,204 @@
+package NeuroDB::objectBroker::MriProtocolViolatedScansOB;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::objectBroker::MriProtocolViolatedScansOB -- An object broker for C<mri_protocol_violated_scans> records
+
+=head1 SYNOPSIS
+
+  use NeuroDB::Database;
+  use NeuroDB::objectBroker::MriProtocolViolatedScansOB;
+  use TryCatch;
+
+  my $db = NeuroDB::Database->new(
+      userName     => 'user',
+      databaseName => 'my_db',
+      hostName     => 'my_hostname',
+      password     => 'pwd'
+  );
+
+  try {
+      $db->connect();
+  } catch(NeuroDB::DatabaseException $e) {
+      die sprintf(
+          "User %s failed to connect to %s on %s: %s (error code %d)\n",
+          'user',
+          'my_db',
+          'my_hostname',
+          $e->errorMessage,
+          $e->errorCode
+      );
+  }
+
+  .
+  .
+  .
+
+  my $mriProtocolViolatedScansOB = NeuroDB::objectBroker::MriProtocolViolatedScansOB->new(db => $db);
+  my $mriProtocolViolatedScansOBRef;
+  try {
+      $mriProtocolViolatedScansOBRef = $mriProtocolViolatedScansOB->getByTarchiveID(
+          [ 'TarchiveID' ], 12
+      );
+  } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+      die sprintf(
+          "Failed to retrieve mri_protocol_violated_scans records: %s",
+          $e->errorMessage
+      );
+  }
+
+=head1 DESCRIPTION
+
+This class provides a set of methods to either fetch records from the C<mri_protocol_violated_scans>
+table, insert new entries in it or update existing ones. If an operation cannot
+be executed successfully, a C<NeuroDB::objectBroker::ObjectBrokerException> is thrown.
+
+=head2 Methods
+
+=cut
+
+use Moose;
+use MooseX::Privacy;
+
+use NeuroDB::Database;
+use NeuroDB::DatabaseException;
+use NeuroDB::objectBroker::ObjectBrokerException;
+
+use File::Basename;
+
+use TryCatch;
+
+my @MRIPROTOCOLVIOLATEDSCANS_FIELDS = qw(
+    ID CandID PSCID TarchiveID time_run series_description minc_location
+    PatientName TR_range TE_range TI_range slice_thickness_range
+    xspace_range yspace_range zspace_range xstep_range ystep_range zstep_range
+    time_range SeriesUID image_type PhaseEncodingDirection EchoNumber
+    MriProtocolGroupID
+);
+
+=pod
+
+=head3 new(db => $db) >> (constructor)
+
+Create a new instance of this class. The only parameter to provide is the
+C<Database> object used to access the database.
+
+INPUT: the database object used to read/modify the C<mri_protocol_violated_scans> table.
+
+RETURN: new instance of this class.
+
+=cut
+
+has 'db' => (is  => 'rw', isa => 'NeuroDB::Database', required => 1);
+
+=pod
+
+=head3 getWithTarchiveID($tarchiveID)
+
+Fetches the records from the C<mri_protocol_violated_scans> table that have a specific C<TarchiveID>.
+
+INPUTS:
+    - ID of the tarchive used during the search.
+
+RETURN: a reference to an array of hash references. Every hash contains the values for a given
+        row returned by the function call: the key/value pairs contain the name of a column
+        (listed in C<@MRIPROTOCOLVIOLATEDSCANS_FIELDS>) and the value it holds, respectively.
+        As an example, suppose array C<$r> contains the result of a call to this method with
+        C<@$fieldsRef> set to C<('TarchiveID', 'minc_location'> one would fetch the C<minc_location>
+        of the 4th record returned using C<$r->[3]->{'minc_location'}>.
+=cut
+
+sub getWithTarchiveID {
+    my ($self, $tarchiveID) = @_;
+
+    my $query = sprintf(
+        "SELECT %s FROM mri_protocol_violated_scans WHERE TarchiveID = ? ",
+        join(',', @MRIPROTOCOLVIOLATEDSCANS_FIELDS)
+    );
+
+    try {
+        return $self->db->pselect(
+            $query, $tarchiveID
+        );
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to get mri_protocol_violated_scans records by tarchive ID. Reason:\n%s",
+                $e
+            )
+        );
+    }
+}
+
+=head3 insert($valuesRef)
+
+Inserts a new record in the C<mri_protocol_violated_scans> table with the specified column values.
+This method throws a C<NeuroDB::objectBroker::ObjectBrokerException> if the operation
+could not be completed successfully.
+
+INPUT: a reference to a hash of the values to insert. The hash contains the column
+       names and associated record values used during insertion. All the keys of
+       C<%$valuesRef> must exist in C<@MRIPROTOCOLVIOLATEDSCANS_FIELDS> or an exception will be thrown.
+
+RETURNS: the index of the MRI upload record inserted.
+
+=cut
+
+sub insert {
+    my($self, $valuesRef) = @_;
+
+    if(!keys %$valuesRef) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => "MRI protocol violated scans insertion failed: no values specified"
+        );
+    }
+
+    foreach my $v (keys %$valuesRef) {
+        if(!grep($v eq $_, @MRIPROTOCOLVIOLATEDSCANS_FIELDS)) {
+            NeuroDB::objectBroker::ObjectBrokerException->throw(
+                errorMessage => "MRI protocol violated scans insertion failed: invalid field $v"
+            );
+        }
+    }
+
+    try {
+        print($valuesRef);
+        my @results = $self->db->insertOne('mri_protocol_violated_scans', $valuesRef);
+        return $results[0];
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to insert mri_protocol_violated_scans record. Reason:\n%s",
+                $e
+            )
+        );
+    }
+}
+
+1;
+
+__END__
+
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 COPYRIGHT AND LICENSE
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience
+
+=cut

--- a/uploadNeuroDB/NeuroDB/objectBroker/MriViolationsLogOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriViolationsLogOB.pm
@@ -1,0 +1,202 @@
+package NeuroDB::objectBroker::MriViolationsLogOB;
+
+=pod
+
+=head1 NAME
+
+NeuroDB::objectBroker::MriViolationsLogOB -- An object broker for C<mri_violations_log> records
+
+=head1 SYNOPSIS
+
+  use NeuroDB::Database;
+  use NeuroDB::objectBroker::MriViolationsLogOB;
+  use TryCatch;
+
+  my $db = NeuroDB::Database->new(
+      userName     => 'user',
+      databaseName => 'my_db',
+      hostName     => 'my_hostname',
+      password     => 'pwd'
+  );
+
+  try {
+      $db->connect();
+  } catch(NeuroDB::DatabaseException $e) {
+      die sprintf(
+          "User %s failed to connect to %s on %s: %s (error code %d)\n",
+          'user',
+          'my_db',
+          'my_hostname',
+          $e->errorMessage,
+          $e->errorCode
+      );
+  }
+
+  .
+  .
+  .
+
+  my $mriViolationsLogOB = NeuroDB::objectBroker::MriViolationsLogOB->new(db => $db);
+  my $mriProtocolViolatedScansOBRef;
+  try {
+      $mriViolationsLogOBRef = $mriViolationsLogOB->getByTarchiveID(
+          [ 'TarchiveID' ], 12
+      );
+  } catch(NeuroDB::objectBroker::ObjectBrokerException $e) {
+      die sprintf(
+          "Failed to retrieve mri_violations_log records: %s",
+          $e->errorMessage
+      );
+  }
+
+=head1 DESCRIPTION
+
+This class provides a set of methods to either fetch records from the C<mri_violations_log>
+table, insert new entries in it or update existing ones. If an operation cannot
+be executed successfully, a C<NeuroDB::objectBroker::ObjectBrokerException> is thrown.
+
+=head2 Methods
+
+=cut
+
+use Moose;
+use MooseX::Privacy;
+
+use NeuroDB::Database;
+use NeuroDB::DatabaseException;
+use NeuroDB::objectBroker::ObjectBrokerException;
+
+use File::Basename;
+
+use TryCatch;
+
+my @MRIVIOLATIONSLOG_FIELDS = qw(
+    LogID TimeRun SeriesUID TarchiveID MincFile PatientName CandID Visit_label
+    CheckID Scan_type Severity Header Value ValidRange ValidRegex
+    EchoTime PhaseEncodingDirection EchoNumber MriProtocolChecksGroupID
+);
+
+=pod
+
+=head3 new(db => $db) >> (constructor)
+
+Create a new instance of this class. The only parameter to provide is the
+C<Database> object used to access the database.
+
+INPUT: the database object used to read/modify the C<mri_violations_log> table.
+
+RETURN: new instance of this class.
+
+=cut
+
+has 'db' => (is  => 'rw', isa => 'NeuroDB::Database', required => 1);
+
+=pod
+
+=head3 getWithTarchiveID($tarchiveID)
+
+Fetches the records from the C<mri_violations_log> table that have a specific C<TarchiveID>.
+
+INPUTS:
+    - ID of the tarchive used during the search.
+
+RETURN: a reference to an array of hash references. Every hash contains the values for a given
+        row returned by the function call: the key/value pairs contain the name of a column
+        (listed in C<@MRIVIOLATIONSLOG_FIELDS>) and the value it holds, respectively.
+        As an example, suppose array C<$r> contains the result of a call to this method with
+        C<@$fieldsRef> set to C<('TarchiveID', 'MincFile'> one would fetch the C<MincFile>
+        of the 4th record returned using C<$r->[3]->{'MincFile'}>.
+=cut
+
+sub getWithTarchiveID {
+    my ($self, $tarchiveID) = @_;
+
+    my $query = sprintf(
+        "SELECT %s FROM mri_violations_log WHERE TarchiveID = ? ",
+        join(',', @MRIVIOLATIONSLOG_FIELDS)
+    );
+
+    try {
+        return $self->db->pselect(
+            $query, $tarchiveID
+        );
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to get mri_violations_log records by tarchive ID. Reason:\n%s",
+                $e
+            )
+        );
+    }
+}
+
+=head3 insert($valuesRef)
+
+Inserts a new record in the C<mri_violations_log> table with the specified column values.
+This method throws a C<NeuroDB::objectBroker::ObjectBrokerException> if the operation
+could not be completed successfully.
+
+INPUT: a reference to a hash of the values to insert. The hash contains the column
+       names and associated record values used during insertion. All the keys of
+       C<%$valuesRef> must exist in C<@MRIVIOLATIONSLOG_FIELDS> or an exception will be thrown.
+
+RETURNS: the index of the MRI upload record inserted.
+
+=cut
+
+sub insert {
+    my($self, $valuesRef) = @_;
+
+    if(!keys %$valuesRef) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => "MRI violations log insertion failed: no values specified"
+        );
+    }
+
+    foreach my $v (keys %$valuesRef) {
+        if(!grep($v eq $_, @MRIVIOLATIONSLOG_FIELDS)) {
+            NeuroDB::objectBroker::ObjectBrokerException->throw(
+                errorMessage => "MRI violations log insertion failed: invalid field $v"
+            );
+        }
+    }
+
+    try {
+        print($valuesRef);
+        my @results = $self->db->insertOne('mri_violations_log', $valuesRef);
+        return $results[0];
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to insert mri_violations_log record. Reason:\n%s",
+                $e
+            )
+        );
+    }
+}
+
+1;
+
+__END__
+
+
+=pod
+
+=head1 TO DO
+
+Nothing planned.
+
+=head1 BUGS
+
+None reported.
+
+=head1 COPYRIGHT AND LICENSE
+
+License: GPLv3
+
+=head1 AUTHORS
+
+LORIS community <loris.info@mcin.ca> and McGill Centre for Integrative
+Neuroscience
+
+=cut

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -542,6 +542,7 @@ if (defined($subjectIDsref->{'CandMismatchError'})) {
             && $dbMriCandError->{'Reason'} eq $newMriCandidateErrors{'Reason'}
         ) {
             $already_inserted = 1;
+            last;
         }
     }
     $mriCandidateErrorsOB->insert(\%newMriCandidateErrors) unless defined $already_inserted;

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -73,6 +73,9 @@ use Data::Dumper;
 use FindBin;
 use Cwd qw/ abs_path /;
 
+use NeuroDB::objectBroker::MriCandidateErrorsOB;
+
+
 # These are the NeuroDB modules to be used
 use lib "$FindBin::Bin";
 use NeuroDB::File;
@@ -503,11 +506,6 @@ if (defined($subjectIDsref->{'CandMismatchError'})) {
     print LOG " -> WARNING: This candidate was invalid. Logging to
               MRICandidateErrors table with reason $CandMismatchError";
 
-    my $logQuery = "INSERT INTO MRICandidateErrors".
-        "(SeriesUID, TarchiveID, MincFile, PatientName, Reason) ".
-        "VALUES (?, ?, ?, ?, ?)";
-    my $candlogSth = $dbh->prepare($logQuery);
-
     # Strip all trailing newlines from the error message. Reason:
     # you cannot search for records in the LORIS MRI violations
     # module that have a message (i.e. a rejection reason) containing
@@ -520,13 +518,33 @@ if (defined($subjectIDsref->{'CandMismatchError'})) {
     # move the file into trashbin
     my $file_rel_path = NeuroDB::MRI::get_trashbin_file_rel_path($minc, $data_dir, 1);
 
-    $candlogSth->execute(
-        $file->getParameter('series_instance_uid'),
-        $studyInfo{'TarchiveID'},
-        $file_rel_path,
-        $studyInfo{'PatientName'},
-        $CandMismatchError
+    my %newMriCandidateErrors = (
+        'TarchiveID'             => $studyInfo{'TarchiveID'},
+        'SeriesUID'              => $file->getParameter('series_instance_uid'),
+        'EchoTime'               => $file->getParameter('echo_time'),
+        'EchoNumber'             => $file->getParameter('echo_numbers'),
+        'PhaseEncodingDirection' => $file->getParameter('phase_encoding_direction'),
+        'MincFile'               => $file_rel_path,
+        'PatientName'            => $studyInfo{'PatientName'},
+        'Reason'                 => $CandMismatchError
     );
+
+    my $mriCandidateErrorsOB = NeuroDB::objectBroker::MriCandidateErrorsOB->new(db => $db);
+    my $mriCandidateErrorsRef = $mriCandidateErrorsOB->getWithTarchiveID($studyInfo{'TarchiveID'});
+
+    my $already_inserted = undef;
+    foreach my $dbMriCandError (@$mriCandidateErrorsRef) {
+        if ($dbMriCandError->{'SeriesUID'} eq $newMriCandidateErrors{'SeriesUID'}
+            && $dbMriCandError->{'EchoTime'} eq $newMriCandidateErrors{'EchoTime'}
+            && $dbMriCandError->{'EchoNumber'} eq $newMriCandidateErrors{'EchoNumber'}
+            && $dbMriCandError->{'PhaseEncodingDirection'} eq $newMriCandidateErrors{'PhaseEncodingDirection'}
+            && $dbMriCandError->{'PatientName'} eq $newMriCandidateErrors{'PatientName'}
+            && $dbMriCandError->{'Reason'} eq $newMriCandidateErrors{'Reason'}
+        ) {
+            $already_inserted = 1;
+        }
+    }
+    $mriCandidateErrorsOB->insert(\%newMriCandidateErrors) unless defined $already_inserted;
 
     $notifier->spool('tarchive validation', $message, 0,
         'minc_insertion.pl', $upload_id, 'Y',


### PR DESCRIPTION
# Description

When the `tarchiveLoader.pl` script is rerun, it checks whether the file has already been registered into the `files` table before inserting a new entry in the `files` table but the pipeline does not check whether a violation has already been registered into the 3 violation tables (`MRICandidateErrors`, `mri_protocol_violated_scans` and `mri_violations_log`) and inserts duplicates of the same violation as many times as `tarchiveLoader.pl` is run on a DICOM archive.

This was fixed on the python side by https://github.com/aces/Loris-MRI/pull/884 and https://github.com/aces/Loris-MRI/pull/891. This PR fixes this for the Perl side as well using the same algorithm.

Reminder: a unique file entry is now determined by the unique combination of `SeriesUID`, `EchoTime`, `PhaseEncodingDirection` and `EchoNumbers`.

Resolves https://github.com/aces/Loris-MRI/issues/890 as this is the only missing piece to close the issue.