### PR TITLE
Keep additional events - rename Task to Property

### DIFF
--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -704,8 +704,8 @@ class Physiological:
                 # table cols
                 add_event_fields = (
                     'PhysiologicalTaskEventID',
-                    'TaskName',
-                    'TaskValue'
+                    'PropertyName',
+                    'PropertyValue'
                 )
                 # each additional fields is a new entry
                 add_event_values = []


### PR DESCRIPTION
Change the `TaskName` and `TaskValue` to `PropertyName` and `PropertyValue` for additional event integration to match BIDS naming.

Linked to [LORIS 8432](https://github.com/aces/Loris/pull/8432) 