### PR TITLE
Fix `image_type` when inserting into mri_protocol_violated_scans

### DIFF
--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -249,6 +249,7 @@ class Imaging:
         """
 
         series_uid = scan_param["SeriesInstanceUID"] if "SeriesInstanceUID" in scan_param.keys() else None
+        image_type = str(scan_param["ImageType"]) if "ImageType" in scan_param.keys() else None
         echo_time = str(scan_param["EchoTime"]) if "EchoTime" in scan_param.keys() else None
         echo_number = repr(scan_param["EchoNumber"]) if "EchoNumber" in scan_param.keys() else None
         phase_encoding_dir = scan_param["PhaseEncodingDirection"] \


### PR DESCRIPTION
# Description

This fixes a `NameError: name \'image_type\' is not defined` bug introduced by https://github.com/aces/Loris-MRI/pull/891.