### PR TITLE
Fix run numbering logic to use SessionID and not TarchiveID to figure out the next number of a run

### DIFF
--- a/python/lib/database_lib/files.py
+++ b/python/lib/database_lib/files.py
@@ -195,7 +195,7 @@ class Files:
 
     def get_files_inserted_for_session_id(self, session_id):
         """
-        Get the list of files that were inserted into the `files` table for a given `TarchiveID`.
+        Get the list of files that were inserted into the `files` table for a given `SessionID`.
 
         :param session_id: `SessionID` to restrict the query on
          :type session_id: int

--- a/python/lib/database_lib/files.py
+++ b/python/lib/database_lib/files.py
@@ -192,3 +192,18 @@ class Files:
         query = "SELECT * FROM files WHERE TarchiveSource = %s"
 
         return self.db.pselect(query=query, args=(tarchive_id,))
+
+    def get_files_inserted_for_session_id(self, session_id):
+        """
+        Get the list of files that were inserted into the `files` table for a given `TarchiveID`.
+
+        :param session_id: `SessionID` to restrict the query on
+         :type session_id: int
+
+        :return: list of relative file path present in the `files` table associated to the `SessionID`
+         :rtype: list
+        """
+
+        query = "SELECT * FROM files WHERE SessionID = %s"
+
+        return self.db.pselect(query=query, args=(session_id,))

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -437,7 +437,7 @@ class NiftiInsertionPipeline(BasePipeline):
         # determine NIfTI file name
         new_nifti_name = self._construct_nifti_filename(file_bids_entities_dict)
         already_inserted_filenames = self.imaging_obj.get_list_of_files_already_inserted_for_tarchive_id(
-            self.dicom_archive_obj.tarchive_info_dict["TarchiveID"]
+            self.dicom_archive_obj.tarchive_info_dict["SessionID"]
         )
         while new_nifti_name in already_inserted_filenames:
             file_bids_entities_dict['run'] += 1

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -436,7 +436,7 @@ class NiftiInsertionPipeline(BasePipeline):
 
         # determine NIfTI file name
         new_nifti_name = self._construct_nifti_filename(file_bids_entities_dict)
-        already_inserted_filenames = self.imaging_obj.get_list_of_files_already_inserted_for_tarchive_id(
+        already_inserted_filenames = self.imaging_obj.get_list_of_files_already_inserted_for_session_id(
             self.dicom_archive_obj.tarchive_info_dict["SessionID"]
         )
         while new_nifti_name in already_inserted_filenames:

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -969,6 +969,26 @@ class Imaging:
 
         return files_list
 
+    def get_list_of_files_already_inserted_for_session_id(self, session_id):
+        """
+        Get the list of filenames already inserted for a given SessionID.
+
+        :param session_id: the Session ID to process
+         :type session_id: int
+
+        :return: a list with file names already inserted in the files table for SessionID
+         :rtype: list
+        """
+
+        # get list files from a given tarchive ID
+        results = self.files_db_obj.get_files_inserted_for_session_id(session_id)
+
+        files_list = []
+        for entry in results:
+            files_list.append(os.path.basename(entry['File']))
+
+        return files_list
+
     def get_list_of_fmap_files_sorted_by_acq_time(self, files_list):
         """
         Get the list of fieldmap acquisitions that requires the IntendedFor field in their JSON file.


### PR DESCRIPTION
# Description

Currently, this fix the querying logic to determine the run number of files by using the `SessionID` instead of the `TarchiveID` to get the list of files already inserted for the session.