### PR TITLE
Add default reason 'not_planned' in the GitHub workflow when auto closing stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,3 +27,4 @@ jobs:
         days-before-issue-close: 90 # ~3 months   
         days-before-pr-stale: 90 # ~3 months
         days-before-pr-close: 45 # ~1.5 month
+        close-issue-reason: 'not_planned'


### PR DESCRIPTION
# Description

This modifies the GitHub workflow to use 'not_planned' as a reason for auto closing stale issues.