### PR TITLE
Get SessionID from the session_obj instead of the tarchive_obj when determining run numbers

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -437,7 +437,7 @@ class NiftiInsertionPipeline(BasePipeline):
         # determine NIfTI file name
         new_nifti_name = self._construct_nifti_filename(file_bids_entities_dict)
         already_inserted_filenames = self.imaging_obj.get_list_of_files_already_inserted_for_session_id(
-            self.dicom_archive_obj.tarchive_info_dict["SessionID"]
+            self.session_obj.session_info_dict['ID']
         )
         while new_nifti_name in already_inserted_filenames:
             file_bids_entities_dict['run'] += 1


### PR DESCRIPTION
# Description

Run numbers were incorrectly determined when a new tarchive was uploaded. This bug fix will fix the issue.