### PR TITLE
DICOM archive validation python crashes when run on inexistant upload ID

### DIFF
--- a/python/lib/bidsreader.py
+++ b/python/lib/bidsreader.py
@@ -129,8 +129,12 @@ class BidsReader:
             else:
                 continue
 
-        self.candidates_list_validation(participants_info)
-
+        if participants_info:
+            self.candidates_list_validation(participants_info)
+        else:
+            bids_subjects = self.bids_layout.get_subjects()
+            participants_info = [{'participant_id': sub_id} for sub_id in bids_subjects]
+        
         if self.verbose:
             print('\t=> List of participants found:')
             for participant in participants_info:

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -159,7 +159,7 @@ class BasePipeline:
             else:
                 err_msg += f"Could not load tarchive dictionary for ArchiveLocation {archive_location}"
 
-        if not success and not self.options_dict["force"]["value"]:
+        if not success and not self.force:
             self.log_error_and_exit(err_msg, lib.exitcode.SELECT_FAILURE, is_error="Y", is_verbose="N")
 
     def determine_study_info(self):


### PR DESCRIPTION
Resolves the following bug when running `dicom_archive_validation.py` with an Upload ID that does not exist in the database.

```
Traceback (most recent call last):
  File "/opt/loris/bin/mri/python/run_dicom_archive_validation.py", line 75, in <module>
    main()
  File "/opt/loris/bin/mri/python/run_dicom_archive_validation.py", line 71, in main
    DicomValidationPipeline(loris_getopt_obj, os.path.basename(__file__[:-3]))
  File "/opt/loris/bin/mri/python/lib/dcm2bids_imaging_pipeline_lib/dicom_validation_pipeline.py", line 29, in __init__
    super().__init__(loris_getopt_obj, script_name)
  File "/opt/loris/bin/mri/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py", line 89, in __init__
    self.load_imaging_upload_and_tarchive_dictionaries()
  File "/opt/loris/bin/mri/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py", line 162, in load_imaging_upload_and_tarchive_dictionaries
    if not success and not self.options_dict["force"]["value"]:
KeyError: 'force'
```

With this fix, the proper message is returned:
```
[ERROR   ] Did not find an entry in mri_upload associated with 'UploadID' 16666
```

Resolves #955