### PR TITLE
Return an error when `run_dicom_archive_validation/py` is run on an incorrect UploadID/tarchivePath combination

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -135,6 +135,15 @@ class BasePipeline:
             if "tarchive_path" in self.options_dict.keys() else None
         success = False
         err_msg = ''
+        if upload_id and tarchive_path:
+            self.imaging_upload_obj.create_imaging_upload_dict_from_upload_id(upload_id)
+            tarchive_id = self.imaging_upload_obj.imaging_upload_dict["TarchiveID"]
+            self.dicom_archive_obj.populate_tarchive_info_dict_from_tarchive_id(tarchive_id=tarchive_id)
+            db_archive_location = self.dicom_archive_obj.tarchive_info_dict['ArchiveLocation']
+            if os.path.join(self.data_dir, 'tarchive', db_archive_location) != tarchive_path:
+                err_msg += f"UploadID {upload_id} and ArchiveLocation {tarchive_path} do not refer to the same upload"
+                self.log_error_and_exit(err_msg, lib.exitcode.SELECT_FAILURE, is_error="Y", is_verbose="N")
+
         if upload_id:
             self.imaging_upload_obj.create_imaging_upload_dict_from_upload_id(upload_id)
             if not self.imaging_upload_obj.imaging_upload_dict:


### PR DESCRIPTION
# Description

When `run_dicom_archive_validation.pl` is provided with an UploadID and an ArchiveLocation that do not refer to the same UploadID as the one provided as input to the script, an error will be printed that: `[ERROR   ] UploadID <UPLOAD ID> and ArchiveLocation <TARCHIVE PATH> do not refer to the same upload`.

This failed silently until now.