### PR TITLE
Better handle bad configuration of S3

### DIFF
--- a/python/lib/aws_s3.py
+++ b/python/lib/aws_s3.py
@@ -2,15 +2,13 @@
 
 import boto3
 import botocore.exceptions
+import lib.exitcode
 import sys
 
 from botocore.exceptions import ClientError
 
 
 __license__ = "GPLv3"
-
-import lib.exitcode
-
 
 class AwsS3:
 

--- a/python/lib/aws_s3.py
+++ b/python/lib/aws_s3.py
@@ -10,6 +10,7 @@ from botocore.exceptions import ClientError
 
 __license__ = "GPLv3"
 
+
 class AwsS3:
 
     def __init__(self, aws_access_key_id, aws_secret_access_key, aws_endpoint_url, bucket_name):

--- a/python/lib/aws_s3.py
+++ b/python/lib/aws_s3.py
@@ -1,11 +1,15 @@
 """This class interacts with S3 Buckets"""
 
 import boto3
+import botocore.exceptions
+import sys
 
 from botocore.exceptions import ClientError
 
 
 __license__ = "GPLv3"
+
+import lib.exitcode
 
 
 class AwsS3:
@@ -34,11 +38,15 @@ class AwsS3:
                 aws_secret_access_key=self.aws_secret_access_key,
                 endpoint_url=self.aws_endpoint_url
             )
-        except ClientError as err:
-            raise Exception("S3 connection failure: " + format(err))
-
-        if s3.Bucket(self.bucket_name) not in s3.buckets.all():
-            raise Exception(f"S3 <{self.bucket_name}> bucket not found in <{self.aws_endpoint_url}>")
+            if s3.Bucket(self.bucket_name) not in s3.buckets.all():
+                print(f"\n[ERROR   ] S3 <{self.bucket_name}> bucket not found in <{self.aws_endpoint_url}>\n")
+                sys.exit(lib.exitcode.S3_SETTINGS_FAILURE)
+        except botocore.exceptions.ClientError as err:
+            print(f'\n[ERROR   ] S3 connection failure: {format(err)}\n')
+            sys.exit(lib.exitcode.S3_SETTINGS_FAILURE)
+        except botocore.exceptions.EndpointConnectionError as err:
+            print(f'[ERROR   ] {format(err)}\n')
+            sys.exit(lib.exitcode.S3_SETTINGS_FAILURE)
 
         return s3
 

--- a/python/lib/aws_s3.py
+++ b/python/lib/aws_s3.py
@@ -2,8 +2,6 @@
 
 import boto3
 import botocore.exceptions
-import lib.exitcode
-import sys
 
 from botocore.exceptions import ClientError
 
@@ -21,7 +19,8 @@ class AwsS3:
         self.bucket_name = bucket_name
 
         self.s3 = self.connect_to_s3_bucket()
-        self.s3_bucket_obj = self.s3.Bucket(self.bucket_name)
+        if self.s3:
+            self.s3_bucket_obj = self.s3.Bucket(self.bucket_name)
 
     def connect_to_s3_bucket(self):
         """
@@ -39,13 +38,13 @@ class AwsS3:
             )
             if s3.Bucket(self.bucket_name) not in s3.buckets.all():
                 print(f"\n[ERROR   ] S3 <{self.bucket_name}> bucket not found in <{self.aws_endpoint_url}>\n")
-                sys.exit(lib.exitcode.S3_SETTINGS_FAILURE)
+                return
         except botocore.exceptions.ClientError as err:
             print(f'\n[ERROR   ] S3 connection failure: {format(err)}\n')
-            sys.exit(lib.exitcode.S3_SETTINGS_FAILURE)
+            return
         except botocore.exceptions.EndpointConnectionError as err:
             print(f'[ERROR   ] {format(err)}\n')
-            sys.exit(lib.exitcode.S3_SETTINGS_FAILURE)
+            return
 
         return s3
 

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -356,6 +356,10 @@ class DicomArchiveLoaderPipeline(BasePipeline):
 
         for key in fmap_files_dict.keys():
             sorted_fmap_files_list = fmap_files_dict[key]
+            for fmap_dict in sorted_fmap_files_list:
+                if fmap_dict['json_file_path'].startswith('s3://') and not self.s3_obj:
+                    message = f"[ERROR   ] S3 configs not configured properly"
+                    self.log_error_and_exit(message, lib.exitcode.S3_SETTINGS_FAILURE, is_error="Y", is_verbose="N")
             self.imaging_obj.modify_fmap_json_file_to_write_intended_for(
                 sorted_fmap_files_list, self.s3_obj, self.tmp_dir
             )

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -358,7 +358,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
             sorted_fmap_files_list = fmap_files_dict[key]
             for fmap_dict in sorted_fmap_files_list:
                 if fmap_dict['json_file_path'].startswith('s3://') and not self.s3_obj:
-                    message = f"[ERROR   ] S3 configs not configured properly"
+                    message = "[ERROR   ] S3 configs not configured properly"
                     self.log_error_and_exit(message, lib.exitcode.S3_SETTINGS_FAILURE, is_error="Y", is_verbose="N")
             self.imaging_obj.modify_fmap_json_file_to_write_intended_for(
                 sorted_fmap_files_list, self.s3_obj, self.tmp_dir

--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -40,6 +40,9 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         # Get S3 object from loris_getopt object
         # ---------------------------------------------------------------------------------------------
         self.s3_obj = self.loris_getopt_obj.s3_obj
+        if not self.s3_obj:
+            message = f"[ERROR   ] S3 configs not configured properly"
+            self.log_error_and_exit(message, lib.exitcode.S3_SETTINGS_FAILURE, is_error="Y", is_verbose="N")
 
         # ---------------------------------------------------------------------------------------------
         # Get all the files from files, parameter_file and violation tables

--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -41,7 +41,7 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         # ---------------------------------------------------------------------------------------------
         self.s3_obj = self.loris_getopt_obj.s3_obj
         if not self.s3_obj:
-            message = f"[ERROR   ] S3 configs not configured properly"
+            message = "[ERROR   ] S3 configs not configured properly"
             self.log_error_and_exit(message, lib.exitcode.S3_SETTINGS_FAILURE, is_error="Y", is_verbose="N")
 
         # ---------------------------------------------------------------------------------------------

--- a/python/lib/exitcode.py
+++ b/python/lib/exitcode.py
@@ -16,6 +16,7 @@ DB_SETTINGS_FAILURE = 4  # if DB settings in profile file are not set
 INVALID_PATH        = 5  # if path to file or folder does not exist
 INVALID_ARG         = 6  # if one of the program argument is invalid
 INVALID_IMPORT      = 7  # if an import statement failed
+S3_SETTINGS_FAILURE = 8  # if S3 settings in profile file are not properly set
 
 
 # -- Common database related failures (exit codes from 20 to 39)

--- a/python/lib/lorisgetopt.py
+++ b/python/lib/lorisgetopt.py
@@ -108,12 +108,14 @@ class LorisGetOpt:
         self.s3_obj = None
         if hasattr(self.config_file, 's3'):
             if not self.config_file.s3["aws_access_key_id"] or not self.config_file.s3["aws_secret_access_key"]:
-                print(f"\n[ERROR   ] missing 'aws_access_key_id' or 'aws_secret_access_key' in config file 's3' object\n")
+                print(
+                    "\n[ERROR   ] missing 'aws_access_key_id' or 'aws_secret_access_key' in config file 's3' object\n"
+                )
                 sys.exit(lib.exitcode.S3_SETTINGS_FAILURE)
             s3_endpoint = s3_endpoint if s3_endpoint else self.config_file.s3["aws_s3_endpoint_url"]
             s3_bucket_name = s3_bucket_name if s3_bucket_name else self.config_file.s3["aws_s3_bucket_name"]
             if not s3_endpoint or not s3_bucket_name:
-                print(f'\n[ERROR   ] missing configuration for S3 endpoint URL or S3 bucket name\n')
+                print('\n[ERROR   ] missing configuration for S3 endpoint URL or S3 bucket name\n')
                 sys.exit(lib.exitcode.S3_SETTINGS_FAILURE)
             self.s3_obj = AwsS3(
                 aws_access_key_id=self.config_file.s3["aws_access_key_id"],


### PR DESCRIPTION
# Description

Scripts `run_nifti_insertion.py`, `run_push_imaging_files_to_s3_pipeline.py` and `run_dicom_archive_loader.py` crashed miserably when the S3 configuration was not set properly. This PR should properly handle errors related to S3 connections.