### PR TITLE
Enforce use of -uploadID in script uploadNeuro/tarchive_validation.pl

### DIFF
--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -170,7 +170,7 @@ USAGE
 # Ensure option -uploadID is used
 if (!defined($upload_id)) {
     print "You have to supply an upload ID on the command line with option -uploadID. Aborting.\n";
-   exit $NeuroDB::ExitCodes::GETOPT_FAILURE;
+    exit $NeuroDB::ExitCodes::GETOPT_FAILURE;
 }
 
 ################################################################

--- a/uploadNeuroDB/tarchive_validation.pl
+++ b/uploadNeuroDB/tarchive_validation.pl
@@ -167,6 +167,12 @@ USAGE
 &Getopt::Tabular::GetOptions(\@opt_table, \@ARGV)
     || exit $NeuroDB::ExitCodes::GETOPT_FAILURE;
 
+# Ensure option -uploadID is used
+if (!defined($upload_id)) {
+    print "You have to supply an upload ID on the command line with option -uploadID. Aborting.\n";
+   exit $NeuroDB::ExitCodes::GETOPT_FAILURE;
+}
+
 ################################################################
 ############### input option error checking ####################
 ################################################################


### PR DESCRIPTION
This PR ensures option `-uploadID` is used on the command line when invoking script `uploadNeuro/tarchive_validation.pl`.


Fixes #975 