### PR TITLE
Change mkdir to make_path in run_defacing_script.pl

### DIFF
--- a/uploadNeuroDB/bin/deface_minipipe.pl
+++ b/uploadNeuroDB/bin/deface_minipipe.pl
@@ -17,6 +17,7 @@
 
 use strict;
 use File::Basename;
+use File::Path qw(make_path);
 use File::Temp qw/ tempfile tempdir /;
 use Getopt::Long;
 
@@ -88,7 +89,7 @@ my @other_scans = grep(! /,/, @ARGV);    # grep the non-multi-contrast, non mp2r
 
 # create the directory where the final outputs will be saved
 unless (-e $output_dir) {
-  mkdir($output_dir) or print "\nCould not create directory '$output_dir'. Error is: '$!'\n";
+  make_path($output_dir) or print "\nCould not create directory '$output_dir'. Error is: '$!'\n";
 }
 
 


### PR DESCRIPTION
# Description

This should fix the issue @zaliqarosli was having when testing `run_defacing_script.pl`. Use `make_path` from `File::Path` instead of mkdir when creating the output directory for the pipeline.