### PR TITLE
[register_processed_data] Project ID is only reported missing when it really is

### DIFF
--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -261,8 +261,10 @@ print LOG "\t -> Set SourceFileID to $sourceFileID.\n";
 
 # ----- STEP 4: Verify project information
 my $projectID = NeuroDB::MRI::getProject($subjectIDsref, \$dbh, $db);
-print LOG "\nERROR: No project found for this candidate \n\n";
-exit $NeuroDB::ExitCodes::SELECT_FAILURE;
+if (!defined($projectID)) {
+    print LOG "\nERROR: No project found for this candidate \n\n";
+    exit $NeuroDB::ExitCodes::SELECT_FAILURE;
+}
 print LOG  "\n==> ProjectID : $projectID\n";
 
 


### PR DESCRIPTION
This PR modifies the checks done in script `register_processed_data` so that the project ID is reported missing only if it really is.


Fixes #988