### PR TITLE
[register_processed_data] Validation of input file ID list

### DIFF
--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -174,7 +174,7 @@ if ($inputFileIDs !~ /^\d+(?:;\d+)*$/) {
     exit $NeuroDB::ExitCodes::INVALID_ARG;
 }
 
-# Make sure all numbers in the input file IDs list are actual fiel IDs that exist
+# Make sure all numbers in the input file IDs list are actual file IDs that exist
 # in the files table
 my %inputFileIDs = map { $_ => 1 } split(';', $inputFileIDs);
 my $query        = "SELECT FileID FROM files WHERE FIND_IN_SET(FileID, ?)";

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -177,10 +177,11 @@ if ($inputFileIDs !~ /^\d+(?:;\d+)*$/) {
 # Make sure all numbers in the input file IDs list are actual file IDs that exist
 # in the files table
 my %inputFileIDs = map { $_ => 1 } split(';', $inputFileIDs);
-my $query        = "SELECT FileID FROM files WHERE FIND_IN_SET(FileID, ?)";
-my $rowsRef = $dbh->selectall_arrayref($query, { Slice => {} }, join(',', keys %inputFileIDs));
+my @ids = keys %inputFileIDs;
+my $query = "SELECT FileID FROM files WHERE FileID IN (?)";
+my $rowsRef = $dbh->selectall_arrayref($query, { Slice => {} }, join(',', @ids));
 my %existingFileIDs = map { $_->{'FileID'} => 1 } @$rowsRef;
-foreach my $fid (keys %inputFileIDs) {
+foreach my $fid (@ids) {
     if (!defined($existingFileIDs{$fid})) {
         print STDERR "Argument to -inputFileIDs contains an invalid file ID: $fid. Aborting.\n";
         exit $NeuroDB::ExitCodes::INVALID_ARG;


### PR DESCRIPTION
This PR adds a validation step in script `register_processed_data.pl` to ensure the argument for option `inputFileIDs` is a list of existing `FileID`s found in the `files` table.


Fixes #990 