### PR TITLE
Control DB parameters initialization

### DIFF
--- a/dicom-archive/profileTemplate.pl
+++ b/dicom-archive/profileTemplate.pl
@@ -20,6 +20,17 @@
 
 @db = ('DBNAME','DBUSER', 'DBPASS', 'DBHOST');
 
+# db parameters empty
+if (!@db)
+{
+    die "Database parameters need intialization in 'prod' file.";
+}
+
+# db parameters != 4
+if (scalar @db ne 4)
+{
+    die "Database intialization need 4 parameters in 'prod' file.";
+}
 
 =pod
 # SECTION II

--- a/dicom-archive/profileTemplate.pl
+++ b/dicom-archive/profileTemplate.pl
@@ -23,13 +23,13 @@
 # db parameters empty
 if (!@db)
 {
-    die "Database parameters need intialization in 'prod' file.";
+    die "Database parameters intialization required.";
 }
 
 # db parameters != 4
 if (scalar @db ne 4)
 {
-    die "Database intialization need 4 parameters in 'prod' file.";
+    die "Database intialization requires 4 parameters.";
 }
 
 =pod


### PR DESCRIPTION
This PR adds controls in the profile template for `@db` initialization.
This will raise an error if the `db` variable is not defined or not well initialized.

Linked to [LORIS Core 8666](https://github.com/aces/Loris/issues/8666)