### PR TITLE
Fix duplicate constant CREATE_CANDIDATES

### DIFF
--- a/uploadNeuroDB/NeuroDB/objectBroker/ConfigOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/ConfigOB.pm
@@ -93,7 +93,6 @@ use constant BIDS_DATASET_AUTHORS        => 'bids_dataset_authors';
 use constant BIDS_ACKNOWLEDGMENTS_TEXT   => 'bids_acknowledgments_text';
 use constant BIDS_README_TEXT            => 'bids_readme_text';
 use constant BIDS_VALIDATOR_OPTIONS_TO_IGNORE => 'bids_validator_options_to_ignore';
-use constant CREATE_CANDIDATES           => 'createCandidates';
 use constant CREATE_VISIT                => 'createVisit';
 use constant DEFAULT_PROJECT             => 'default_project';
 use constant DEFAULT_COHORT              => 'default_cohort';


### PR DESCRIPTION
Fix the error:
```
(loris-mri-python) lorisadmin@cbeaudoin-test-25:/opt/Loris-MRI/bin/mri/dicom-archive$ perl dicomTar.pl /data/Loris-MRI/data/tarchive/2018/ImagingUpload-14-30-gRhCrT /data/Loris-MRI/data/tarchive/2018 -profile prod -database -mri_upload_update Constant subroutine NeuroDB::objectBroker::ConfigOB::CREATE_CANDIDATES redefined at /usr/lib/x86_64-linux-gnu/perl-base/constant.pm line 171.
```