### PR TITLE
[register_processed_data] Fix bug in computation of project ID

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1292,7 +1292,7 @@ sub compute_hash {
     # open the file
     use Digest::MD5;
     my $filename = $file->getFileDatum('File');
-    my $fileType = $file->getFileDatum('FileType');
+    my $fileType = $file->getFileDatum('FileType') // "unknown";
     open FILE, "minctoraw -nonormalize $filename |" if $fileType eq 'mnc';
     open FILE, "<$filename" unless $fileType eq 'mnc';
 


### PR DESCRIPTION
This PR does the following:

1. Fixes a bug in script `register_processed_data.pl` that would prevent the project ID associated to the data to register to ever be computed, this making the script crash.
2. Eliminates some warnings in `MRI.pm` in function `getProject` that occur when the type of the file passed as argument is unknown