### PR TITLE
Error message from file program when the pipeline is run on an empty archive

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1701,6 +1701,8 @@ RETURNS:
 sub isDicomImage {
     my (@files_list) = @_;
 
+    return {} unless @files_list;
+
     # For now, the files list need to be written in a temporary file so that the
     # command does not fail on large amount of files. If doing directly
     # `ls @files_list | xargs file` then the argument list is too long at it does
@@ -1759,6 +1761,8 @@ RETURNS:
 
 sub isEcatImage {
     my (@files_list) = @_;
+
+    return {} unless @files_list;
 
     # For now, the files list need to be written in a temporary file so that the
     # command does not fail on large amount of files. If doing directly


### PR DESCRIPTION
When trying to run the MRI pipeline on an empty archive, I got this error message:
```
Usage: file [-bcEhikLlNnprsvzZ0] [--apple] [--extension] [--mime-encoding] [--mime-type]
            [-e testname] [-F separator] [-f namefile] [-m magicfiles] file ...
       file -C [-m magicfiles]
       file [--help]
```
since the pipeline attempts to run `file` on an empty set of files and consequently builds an invalid Unix command in trying to do so. This PR will first check if the list of files on which `file` should be run is empty before attempting to run the command, thereby getting rid of the error message.


Fixes #1012 