### PR TITLE
Add method to check and skip duplicate content uploads to S3

### DIFF
--- a/python/lib/aws_s3.py
+++ b/python/lib/aws_s3.py
@@ -1,9 +1,9 @@
 """This class interacts with S3 Buckets"""
 
 import boto3
+import lib.utilities
 import os
 from botocore.exceptions import ClientError, EndpointConnectionError
-from hashlib import md5
 
 __license__ = "GPLv3"
 
@@ -70,14 +70,6 @@ class AwsS3:
 
         return s3_client
 
-    def get_md5sum(self, file_path):
-        """
-        Get md5 hash of file content
-
-        :param file_path: Full path to the file to check hash
-         :type file_path: str
-        """
-        return md5(open(file_path,'rb').read()).hexdigest()
 
     def check_object_content_exists(self, file_path, key):
         """
@@ -89,7 +81,7 @@ class AwsS3:
          :type key: str
         """
         try:
-            etag = self.get_md5sum(file_path)
+            etag = lib.utilities.compute_md5_hash(file_path)
             self.s3_client.head_object(Bucket=self.bucket_name, Key=key, IfMatch=etag)
         except ClientError as e:
             """            


### PR DESCRIPTION
# Description

The changes here are intended to check to see if the content of file that would be uploaded to S3 has already been uploaded.  It does this by checking to see if the hash of a file content is already available at the targeted S3 object key location before attempting to upload new content.  If it already exists, it will skip it. 

This helps to resolve an issue where sometimes the same content would be uploaded to an S3 bucket, even if that file already existed.  Normally this would be fine, but in versioning enabled buckets this creates duplicate copies of the files when no changes are needed.

This does not appear to cause any breaking changes.

