### PR TITLE
Aws upload dir subdir fix

### DIFF
--- a/python/extract_eeg_bids_archive.py
+++ b/python/extract_eeg_bids_archive.py
@@ -200,7 +200,7 @@ def main():
                         """
                         If the suject/session/modality BIDS data already exists
                         on the destination folder, delete it first
-                        copying the data
+                        before copying the data
                         """
                         s3_obj.delete_file(s3_data_eeg_modality_path)
 
@@ -222,7 +222,6 @@ def main():
                     copying the data
                     """
                     imaging_io_obj.remove_dir(data_eeg_modality_path)
-
                     imaging_io_obj.copy_file(tmp_eeg_modality_path, data_eeg_modality_path)
 
         # Delete tmp location

--- a/python/lib/aws_s3.py
+++ b/python/lib/aws_s3.py
@@ -80,7 +80,7 @@ class AwsS3:
 
         for (root, dirs, files) in os.walk(dir_name):
             for file in files:
-                s3_prefix = os.path.join(s3_file_name, root.replace(dir_name, ""), file)
+                s3_prefix = os.path.join(s3_file_name, root.replace(dir_name, "").lstrip('/'), file)
                 s3_dest = os.path.join(
                     's3://',
                     s3_bucket_name,


### PR DESCRIPTION
Fix 
==> tmp_path could not be uploaded to the S3 bucket. Error was /subdir/file processing failure, must be a s3 url.

--> Cause: os.path.join() called on a string with leading / will return that string.
--> Solution: remove the leading string. 
