### PR TITLE
Fixes for parameter file value lists

### DIFF
--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -169,7 +169,7 @@ class Imaging:
 
         # convert list values into strings that could be inserted into parameter_file
         if type(value) == list:
-            if type(value[0]) in [float, int]:
+            if value and type(value[0]) in [float, int]:
                 value = [str(f) for f in value]
             value = f"[{', '.join(value)}]"
 

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -171,7 +171,7 @@ class Imaging:
         if type(value) == list:
             if type(value[0]) in [float, int]:
                 value = [str(f) for f in value]
-            value = f"[{', '.join(str(value))}]"
+            value = f"[{', '.join(value)}]"
 
         # Gather column name & values to insert into parameter_file
         param_type_id = self.get_parameter_type_id(parameter_name)


### PR DESCRIPTION
# Description

The changes here are intended to help address two different issues surrounding bids_import and parameter files.  This PR is targeted at the `24.1-release` branch.

- When importing parameter_file values that are a list, do not convert the entire list to a string before join(b8c8e444c883aeff9858986a8329a0af71c0752c).  This ensures that the list is joined correctly instead of creating a list of every character from the original value.
- Check to ensure parameter_file is not empty before attempting to make any changes to int, or float lists(98b0c5fce679aea0d756fd4c2165253ed4354bfe).  This prevents the `bids_import.py` script from failing if a parameter value contains an empty list.