### PR TITLE
[bids_import] Added validSamples to index.json + Self-descriptive renames

### DIFF
--- a/python/react-series-data-viewer/chunking.py
+++ b/python/react-series-data-viewer/chunking.py
@@ -223,8 +223,9 @@ def write_chunk_directory(path, chunk_size, loader, from_channel_index=0, from_c
 
     chunk_dir = chunk_dir_path(path, prefix=prefix, destination=destination)
     channel_chunks_list, time_interval, signal_range, \
-        channel_names, channel_ranges, valid_samples_in_last_chunk = mne_file_to_chunks(path, chunk_size, loader,
-                                                                                        from_channel_name, channel_count)
+        channel_names, channel_ranges, valid_samples_in_last_chunk = \
+        mne_file_to_chunks(path, chunk_size, loader, from_channel_name, channel_count)
+    
     if downsamplings is not None:
         channel_chunks_list = channel_chunks_list[:downsamplings]
     write_index_json(


### PR DESCRIPTION
This PR resolves the data shift issue mentioned in aces/Loris#8892 by adding the number of valid samples in the last chunk to the index.json.

It has a Loris PR counterpart: aces/Loris#8999 to use this value and address the fact that some calculations were being made by multiplying the number of chunks by the number of values per chunk, assuming they were all full.