### PR TITLE
Fix possible typo in close-issue-reason for the github workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,4 +27,4 @@ jobs:
         days-before-issue-close: 90 # ~3 months   
         days-before-pr-stale: 90 # ~3 months
         days-before-pr-close: 45 # ~1.5 month
-        close-issue-reason: 'not_planned'
+        close-issue-reason: 'not-planned'


### PR DESCRIPTION
For some reason, the workflows are not automatically closing the issues with the not planned tag. Trying to fix that with this PR.