### PR TITLE
Use the center ID instead of the center name to identify scans

### DIFF
--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -69,13 +69,13 @@ RETURNS: an array of 2 elements:
     The reference will be `undef` if the session cannot be retrieved/created.
   - An error message (`''` if no errors occured while retrieving/creating the session)
 
-### identify\_scan\_db($psc, $subjectref, $tarchiveInfoRef, $fileref, $dbhr, $db, $minc\_location, $uploadID)
+### identify\_scan\_db($centerID, $subjectref, $tarchiveInfoRef, $fileref, $dbhr, $db, $minc\_location, $uploadID)
 
 Determines the type of the scan described by MINC headers based on
 `mri_protocol` table in the database.
 
 INPUTS:
-  - $psc            : center's name
+  - $centerID       : ID of the center where acquisition was done
   - $subjectref     : reference on the hash that contains the subject information
   - $tarchiveInfoRef: reference on the tarchive
   - $fileref        : file hash ref
@@ -247,16 +247,30 @@ RETURNS: a two element array:
 
 ### getProject($subjectIDsref, $dbhr, $db)
 
-Looks for the project id using the C<session> table C<ProjectID> as
-a first resource, then using the C<candidate> table C<RegistrationProjectID>,
-otherwise, look for the default_project config value, and return C<ProjectID>.
+Looks for the project id using the `session` table `ProjectID` as
+a first resource, then using the `candidate` table `RegistrationProjectID`,
+otherwise, look for the default\_project config value, and return `ProjectID`.
 
 INPUTS:
   - $subjectIDsref: subject's information hash ref
   - $dbhr       : database handle reference
   - $db         : database object
 
-RETURNS: the C<ProjectID> or an error if not found
+RETURNS: the `ProjectID` or an error if not found
+
+### getCohort($subjectIDsref, $projectID, $dbhr, $db)
+
+Looks for the cohort id using the `session` table `ProjectID` as
+a first resource, for the cases where it is created using the front-end,
+otherwise, look for the default\_cohort config value, and return `CohortID`.
+
+INPUTS:
+  - $subjectIDsref: subject's information hash ref
+  - $projectID    : the project ID
+  - $dbhr         : database handle reference
+  - $db           : database object
+
+RETURNS: the `CohortID` or 0
 
 ### compute\_hash($file\_ref)
 

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -131,8 +131,8 @@ INPUTS:
   - $User        : user running the insertion pipeline
   - $centerID    : center ID of the candidate
 
-RETURNS: subject's ID hash ref containing `CandID`, `PSCID`, Visit Label 
-and `CandMismatchError` information
+RETURNS: subject's ID hash ref containing `CandID`, `PSCID`, Visit Label,
+ProjectID, CohortID and `CandMismatchError` information
 
 ### createTarchiveArray($tarchive)
 
@@ -170,6 +170,15 @@ INPUTS:
 
 RETURNS: array of two elements: center name and center ID
 
+### determineProjectID($tarchiveInfo)
+
+Determines the Project.
+
+INPUTS:
+  - $tarchiveInfo: archive information hash ref
+
+RETURNS: project ID
+
 ### determineScannerID($tarchiveInfo, $to\_log, $centerID, $projectID, $upload\_id)
 
 Determines which scanner ID was used for DICOM acquisitions. Note, if 
@@ -179,8 +188,8 @@ in the DICOM headers, then a new scanner will automatically be created.
 INPUTS:
   - $tarchiveInfo: archive information hash ref
   - $to\_log      : whether this step should be logged
-  - $centerID     : center ID
-  - $projectID    : project ID
+  - $centerID    : center ID
+  - $projectID   : project ID
   - $upload\_id   : upload ID of the study
 
 RETURNS: scanner ID
@@ -199,7 +208,7 @@ INPUTS:
 
 RETURNS: 1 if the file is unique, 0 otherwise
 
-### getAcquisitionProtocol($file, $subjectIDsref, $tarchiveInfo, $center\_name, $minc, $acquisitionProtocol, $bypass\_extra\_file\_checks, $upload\_id, $data\_dir)
+### getAcquisitionProtocol($file, $subjectIDsref, $tarchiveInfo, $centerID, $minc, $acquisitionProtocol, $bypass\_extra\_file\_checks, $upload\_id, $data\_dir)
 
 Determines the acquisition protocol and acquisition protocol ID for the MINC
 file. If `$acquisitionProtocol` is not set, it will look for the acquisition
@@ -212,7 +221,7 @@ INPUTS:
   - $file                    : file's information hash ref
   - $subjectIDsref           : subject's information hash ref
   - $tarchiveInfo            : DICOM archive's information hash ref
-  - $center\_name             : center name
+  - $centerID                : ID of the center where the scan was acquired.
   - $minc                    : absolute path to the MINC file
   - $acquisitionProtocol     : acquisition protocol if already knows it
   - $bypass\_extra\_file\_checks: boolean, if set bypass the extra checks

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -284,13 +284,13 @@ sub getSessionInformation {
 
 =pod
 
-=head3 identify_scan_db($psc, $subjectref, $tarchiveInfoRef, $fileref, $dbhr, $db, $minc_location, $uploadID)
+=head3 identify_scan_db($centerID, $subjectref, $tarchiveInfoRef, $fileref, $dbhr, $db, $minc_location, $uploadID)
 
 Determines the type of the scan described by MINC headers based on
 C<mri_protocol> table in the database.
 
 INPUTS:
-  - $psc            : center's name
+  - $centerID       : ID of the center where the scan was acquired
   - $subjectref     : reference on the hash that contains the subject information
   - $tarchiveInfoRef: reference on the tarchive
   - $fileref        : file hash ref
@@ -306,7 +306,7 @@ RETURNS: textual name of scan type from the C<mri_scan_type> table
 
 sub identify_scan_db {
 
-    my  ($psc, $subjectref, $tarchiveInfoRef, $fileref, $dbhr, $db, $minc_location, $uploadID, $data_dir) = @_;
+    my  ($centerID, $subjectref, $tarchiveInfoRef, $fileref, $dbhr, $db, $minc_location, $uploadID, $data_dir) = @_;
 
     my $candid       = ${subjectref}->{'CandID'};
     my $pscid        = ${subjectref}->{'PSCID'};
@@ -396,7 +396,7 @@ sub identify_scan_db {
         
     $query .=  ' ORDER BY CenterID ASC, ScannerID DESC';
 
-    my @bindValues = ($psc, $ScannerID);
+    my @bindValues = ($centerID, $ScannerID);
     push(@bindValues, $projectID)    if defined $projectID;
     push(@bindValues, $cohortID) if defined $cohortID;
     push(@bindValues, $visitLabel)   if defined $visitLabel;

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -788,7 +788,7 @@ sub computeMd5Hash {
 
 =pod
 
-=head3 getAcquisitionProtocol($file, $subjectIDsref, $tarchiveInfo, $center_name, $minc, $acquisitionProtocol, $bypass_extra_file_checks, $upload_id, $data_dir)
+=head3 getAcquisitionProtocol($file, $subjectIDsref, $tarchiveInfo, $centerID, $minc, $acquisitionProtocol, $bypass_extra_file_checks, $upload_id, $data_dir)
 
 Determines the acquisition protocol and acquisition protocol ID for the MINC
 file. If C<$acquisitionProtocol> is not set, it will look for the acquisition
@@ -801,7 +801,7 @@ INPUTS:
   - $file                    : file's information hash ref
   - $subjectIDsref           : subject's information hash ref
   - $tarchiveInfo            : DICOM archive's information hash ref
-  - $center_name             : center name
+  - $centerID                : ID of the center where the scan was acquired.
   - $minc                    : absolute path to the MINC file
   - $acquisitionProtocol     : acquisition protocol if already knows it
   - $bypass_extra_file_checks: boolean, if set bypass the extra checks
@@ -820,7 +820,7 @@ RETURNS:
 sub getAcquisitionProtocol {
    
     my $this = shift;
-    my ($file,$subjectIDsref,$tarchiveInfoRef,$center_name,$minc,
+    my ($file,$subjectIDsref,$tarchiveInfoRef,$centerID,$minc,
         $acquisitionProtocol,$bypass_extra_file_checks, $upload_id, $data_dir) = @_;
     my $message = '';
 
@@ -834,7 +834,7 @@ sub getAcquisitionProtocol {
       $this->spool($message, 'N', $upload_id, $notify_detailed);
 
       $acquisitionProtocol =  &NeuroDB::MRI::identify_scan_db(
-                                   $center_name,
+                                   $centerID,
                                    $subjectIDsref,
                                    $tarchiveInfoRef,
                                    $file, 

--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -639,7 +639,7 @@ $file->setFileData('Caveat', $caveat);
       $file,
       $subjectIDsref,
       \%studyInfo,
-      $center_name,
+      $centerID,
       $minc,
       $acquisitionProtocol,
       $bypass_extra_file_checks,


### PR DESCRIPTION
Function `identify_scan_db` uses an SQL statement that relies on the center ID to identify a scan. This center ID is passed as an _argument_ to this function. Unfortunately, current calls to that function pass the center _name_ instead of the center _ID_...This PR corrects all these invalid calls.

To test: ensure that there's a line in your `mri_protocol` table with a non-null `CenterID` and validate that it's taken into account when identifying a scan.