### PR TITLE
Remove the extra constraint saying that the SourceFileID should not be in InputFileIDs provided to the script

### DIFF
--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -164,15 +164,12 @@ if (@$rowsRef == 0) {
 }
 
 # Make sure all file IDs in the list specified with -inputFileIDs
-# are valid (i.e exist in table files) and are not equal to $sourceFileID
+# are valid (i.e exist in table files)
+# Note: sourceFileID can be listed in the InputFileIDs
 foreach my $fid (split(/;/, $inputFileIDs)) {
     $rowsRef = $dbh->selectall_arrayref($query, { Slice => {} }, $fid);
     if (@$rowsRef == 0) {
         print STDERR "Argument '$fid' for option -inputFileIDs is not an existing file ID. Aborting.\n";
-        exit $NeuroDB::ExitCodes::INVALID_ARG;
-    }
-    if ($rowsRef->[0]->{'FileID'} == $sourceFileID) {
-        print STDERR "Argument to -inputFileIDs cannot contain the source file ID ($sourceFileID). Aborting.\n";
         exit $NeuroDB::ExitCodes::INVALID_ARG;
     }
 }


### PR DESCRIPTION
# Description

This fixes the issue where the defacing script fails because of a constraint that was added at the last release that should not have been added as a `SourceFileID` can be listed in the `InputFileIDs` list provided by the script.

Resolve #1096 