### PR TITLE
Fix project id error when running register processed data

### DIFF
--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -415,9 +415,11 @@ sub getSessionID    {
     my  ($sessionID, %subjectIDsref);
     my  $query  =   "SELECT f.SessionID, " .
                            "s.CandID, " .
+                           "c.PSCID, " .
                            "s.Visit_label " .
                     "FROM files f " .
                     "JOIN session s ON (s.ID=f.SessionID) " .
+                    "JOIN candidate c USING (CandID) " .
                     "WHERE FileID=?";
 
     my  $sth    =   $dbh->prepare($query);

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -164,15 +164,12 @@ if (@$rowsRef == 0) {
 }
 
 # Make sure all file IDs in the list specified with -inputFileIDs
-# are valid (i.e exist in table files) and are not equal to $sourceFileID
+# are valid (i.e exist in table files)
+# Note: sourceFileID can be listed in the InputFileIDs
 foreach my $fid (split(/;/, $inputFileIDs)) {
     $rowsRef = $dbh->selectall_arrayref($query, { Slice => {} }, $fid);
     if (@$rowsRef == 0) {
         print STDERR "Argument '$fid' for option -inputFileIDs is not an existing file ID. Aborting.\n";
-        exit $NeuroDB::ExitCodes::INVALID_ARG;
-    }
-    if ($rowsRef->[0]->{'FileID'} == $sourceFileID) {
-        print STDERR "Argument to -inputFileIDs cannot contain the source file ID ($sourceFileID). Aborting.\n";
         exit $NeuroDB::ExitCodes::INVALID_ARG;
     }
 }

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -428,6 +428,7 @@ sub getSessionID    {
     if  ($sth->rows > 0) {
         my $row                         =   $sth->fetchrow_hashref();
         $sessionID                      =   $row->{'SessionID'};
+        $subjectIDsref{'PSCID'}         =   $row->{'PSCID'};
         $subjectIDsref{'CandID'}        =   $row->{'CandID'};
         $subjectIDsref{'visitLabel'}    =   $row->{'Visit_label'};
     }else{


### PR DESCRIPTION
# Description

In `register_processed_data.pl`, the `subjectIDsRef` used to determine the `ProjectID of the file to register did not populate the `PSCID` field, needed in order to determine the `ProjectID`. This PR fixes this issue.

Resolve #1102
