### PR TITLE
Fix `NoneType` error when S3 configs not set properly

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -40,8 +40,8 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         # Get S3 object from loris_getopt object
         # ---------------------------------------------------------------------------------------------
         self.s3_obj = self.loris_getopt_obj.s3_obj
-        if not self.s3_obj:
-            message = "[ERROR   ] S3 configs not configured properly"
+        if not self.s3_obj.s3:
+            message = "S3 configs not configured properly"
             self.log_error_and_exit(message, lib.exitcode.S3_SETTINGS_FAILURE, is_error="Y", is_verbose="N")
 
         # ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

This fixes the `NoneType` error for `run_push_imaging_files_to_s3_pipeline.py` when incorrect S3 authentication settings are provided. Will now print:

```
[ERROR   ] S3 connection failure: An error occurred (InvalidAccessKeyId) when calling the ListBuckets operation: Unknown

[ERROR   ] S3 configs not configured properly
```