### PR TITLE
[minc_insertion] Improve command line arguments validation

### DIFF
--- a/uploadNeuroDB/minc_insertion.pl
+++ b/uploadNeuroDB/minc_insertion.pl
@@ -337,7 +337,8 @@ if ($upload_id && !$hrrt) {
       IsTarchiveValidated,
       ArchiveLocation
     FROM
-      mri_upload JOIN tarchive USING (TarchiveID)
+      mri_upload
+    LEFT JOIN tarchive USING (TarchiveID)
     WHERE
       UploadID = ?
 QUERY
@@ -345,6 +346,12 @@ QUERY
     my $sth = $dbh->prepare($query);
     $sth->execute($upload_id);
     my @array        = $sth->fetchrow_array;
+
+    die "Upload with ID '$upload_id' does not exist. Aborting.\n" unless @array;
+    if (!defined $array[1]) {
+        die "Upload ID '$upload_id' does not have an associated TarchiveID " .
+            "(dicomTar does not appear to have been successfully run on it...). Aborting.\n";
+    }
     $is_valid        = $array[0];
     $ArchiveLocation = $array[1];
 


### PR DESCRIPTION
This PR improves the validation done on the command line parameters for script `minc_insertion.pl`. More specifically:
- When the argument to `-upload_id` refers to a non-existent upload, the script displays a message indicating that the upload ID is invalid.
- When the upload ID passed on the command line refers to an upload that does not have an associated `tarchive` (i.e value of `TarchiveID` for that upload is `NULL` in table `mri_upload`), an error message to that effect is displayed to the user.