### PR TITLE
[minc_to_bids_converter] Fix json format

### DIFF
--- a/tools/minc_to_bids_converter.pl
+++ b/tools/minc_to_bids_converter.pl
@@ -303,10 +303,10 @@ unless (-e $readme_file_path) {
 my $bids_validator_config_file = $dest_dir . "/.bids-validator-config.json";
 if (!-e $bids_validator_config_file && @validator_ignore_opts) {
     print "\n******* Creating the .bids-validator-config.json file $bids_validator_config_file *******\n";
-    my $validator_ignore_string = join(", ", @validator_ignore_opts);
+    my $validator_ignore_string = join('", "', @validator_ignore_opts);
     my $bids_validator_config_content = <<TEXT;
 {
-  "ignore": [$validator_ignore_string]
+  "ignore": ["$validator_ignore_string"]
 }
 TEXT
     write_BIDS_TEXT_file($bids_validator_config_file, $bids_validator_config_content);


### PR DESCRIPTION
This PR fixes the JSON format in the bids-validator-config.json file generated by minc_to_bids_converter.pl.

Before this PR, there was an error when running the bids validator: 

<img width="1009" alt="image" src="https://github.com/aces/Loris-MRI/assets/51176779/54153558-f79e-4257-bc67-308bc31d15f9">

After this PR, the bids-validator makes a lot more sense:

<img width="1419" alt="image" src="https://github.com/aces/Loris-MRI/assets/51176779/4426bd9b-3c35-4503-a2e1-c1acc507afcc">


