### PR TITLE
Update Python installation

### DIFF
--- a/.github/workflows/flake8_python_linter.yml
+++ b/.github/workflows/flake8_python_linter.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Flake8 Lint
         uses: reviewdog/action-flake8@v3

--- a/.github/workflows/flake8_python_linter.yml
+++ b/.github/workflows/flake8_python_linter.yml
@@ -7,19 +7,19 @@ name: Flake8 Linter
 on: pull_request
 
 jobs:
-  
+
   flake8-lint:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Check out source repository
         uses: actions/checkout@v2
-      
+
       - name: Set up Python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
-      
+          python-version: "3.12"
+
       - name: Flake8 Lint
         uses: reviewdog/action-flake8@v3
         with:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This Readme covers release 26.0.* of the LORIS Imaging Insertion Pipeline for Ub
 This repo accompanies the [LORIS neuroimaging data platform main repo](https://github.com/aces/Loris/releases)</b>, release 24.1.*.<br>
 For documentation and detailed setup information, please see the [LORIS-MRI documentation](docs/) for your installed version</b>.
 
-This repo can be installed on the same VM as the main LORIS codebase, or on a different machine such as a designated fileserver where large imaging filesets are to be stored. 
+This repo can be installed on the same VM as the main LORIS codebase, or on a different machine such as a designated fileserver where large imaging filesets are to be stored.
 
 # System Requirements
 
@@ -13,12 +13,12 @@ This repo can be installed on the same VM as the main LORIS codebase, or on a di
 * DICOM toolkit (step 4 below)
 * tpcclib (for HRRT PET only) (step 5 below)
 
-On <u>Ubuntu</u>, DICOM toolkit will be installed by the imaging install script (step 4 below). This script will _apt-get install dcmtk_.   
+On <u>Ubuntu</u>, DICOM toolkit will be installed by the imaging install script (step 4 below). This script will _apt-get install dcmtk_.
 
 For <u>CentOS</u>: The [LORIS wiki](https://github.com/aces/Loris/wiki/Imaging-Database) Imaging setup page (see Section 1, installing codebase) includes links to older transcripts for [CentOS installation](https://github.com/aces/Loris/wiki/CentOS-Imaging-installation-transcript) and notes on dependencies including [DICOM toolkit](https://github.com/aces/Loris/wiki/CentOS-Imaging-installation-transcript#7-install-dicom-toolkit).
 
 The following installation should be run by the `$lorisadmin` user. `sudo` permission is required.
-See [aces/Loris](https://github.com/aces/loris) README.md for further information. 
+See [aces/Loris](https://github.com/aces/loris) README.md for further information.
 
 # Dependencies
 
@@ -54,21 +54,22 @@ sudo chown -R lorisadmin:lorisadmin /opt/$projectname
 cd /opt/$projectname/bin
 ```
 
-Get the code: Download the latest release from the 
-[releases page](https://github.com/aces/Loris-MRI/releases) 
+Get the code: Download the latest release from the
+[releases page](https://github.com/aces/Loris-MRI/releases)
 and extract it to `/opt/$projectname/bin/mri`
 
 #### 2. Install Python 3 with `pip` and `virtualenv`
 
 ```bash
-sudo apt install python3 
-sudo apt install python3-dev
+sudo apt install software-properties-common
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt update
+sudo apt install python3.12 python3.12-dev python3.12-distutils python3.12-venv
 sudo apt install python3-pip
 sudo apt install libmysqlclient-dev
-sudo apt install virtualenv
 ```
 
-#### 3. Install MINC toolkit from http://bic-mni.github.io/ 
+#### 3. Install MINC toolkit from http://bic-mni.github.io/
 
 - Install MINC dependencies:
 
@@ -82,7 +83,7 @@ sudo apt-get install libgl1-mesa-glx libglu1-mesa
 
 - Download the MINC pre-compiled package for your operating system from http://bic-mni.github.io/.
 
-- Then install the MINC toolkit package: 
+- Then install the MINC toolkit package:
 
 ```bash
 # main minc lib
@@ -112,31 +113,31 @@ sudo dpkg -i beast-library-<version>.deb
 
 #### 4. Run installer to set up directories, configure environment, install Perl libraries and DICOM toolkit:
 
-```bash 
+```bash
 cd /opt/$projectname/bin/mri/install/
 bash ./imaging_install.sh
 ```
 
-You will be asked for the following input: 
+You will be asked for the following input:
 
 * What is the database name? $dbname
 * What is the database host? $dbhost
 * What is the MySQL user? $lorisuser [Use the same mysql user from the Loris installation, i.e. _lorisuser_]
-* What is the MySQL password? 
+* What is the MySQL password?
 * What is the Linux user which the installation will be based on? $lorisadmin
 * What is the project name? $projectname
-* What is your email address? 
+* What is your email address?
 * What prod file name would you like to use? default: prod  [leave blank]
 
-If the imaging install script reports errors in creating directories 
-(due to `/data/` mount permissions), review and manually execute 
-`mkdir/chmod/chown` commands starting at 
+If the imaging install script reports errors in creating directories
+(due to `/data/` mount permissions), review and manually execute
+`mkdir/chmod/chown` commands starting at
 [imaging_install.sh:L97](https://github.com/aces/Loris-MRI/blob/main/install/imaging_install.sh#L97)
 
-Note: The installer will allow Apache to write to the `/data/` and `/opt/` directories by 
-adding user `lorisadmin` to the Apache linux group.  To ensure this change takes 
-effect, log out and log back into your terminal session before running the 
-imaging pipeline. The installer will also set Apache group ownership of certain 
+Note: The installer will allow Apache to write to the `/data/` and `/opt/` directories by
+adding user `lorisadmin` to the Apache linux group.  To ensure this change takes
+effect, log out and log back into your terminal session before running the
+imaging pipeline. The installer will also set Apache group ownership of certain
 `/data/` and `/opt/` subdirectories.
 
 #### 5. HRRT PET
@@ -157,7 +158,7 @@ Then source the `.bashrc` file.
 
 **INSTALLATION COMPLETE!**
 
-Please refer to the [Install](docs/02-Install.md) section in the 
+Please refer to the [Install](docs/02-Install.md) section in the
 [LORIS-MRI documentation](docs/) for your installed version for:
 - customizations and protocol configurations ([Section 2.2](docs/02-Install.md#configuration)).
 - verifying that certain fields were correctly populated by `imaging_install.sh`

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ and extract it to `/opt/$projectname/bin/mri`
 #### 2. Install Python 3 with `pip` and `virtualenv`
 
 ```bash
-sudo apt install python3.11 python3.11-dev python3.11-distutils python3.11-venv
+sudo apt install python3.11 python3.11-dev python3.11-venv
 sudo apt install python3-pip
 sudo apt install libmysqlclient-dev
 ```

--- a/README.md
+++ b/README.md
@@ -61,10 +61,7 @@ and extract it to `/opt/$projectname/bin/mri`
 #### 2. Install Python 3 with `pip` and `virtualenv`
 
 ```bash
-sudo apt install software-properties-common
-sudo add-apt-repository ppa:deadsnakes/ppa
-sudo apt update
-sudo apt install python3.12 python3.12-dev python3.12-distutils python3.12-venv
+sudo apt install python3.11 python3.11-dev python3.11-distutils python3.11-venv
 sudo apt install python3-pip
 sudo apt install libmysqlclient-dev
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo can be installed on the same VM as the main LORIS codebase, or on a di
 # System Requirements
 
 * Perl
-* Python 3 with pip3 and virtualenv (step 2 below)
+* Python 3.11 with pip3 and venv (step 2 below)
 * MINC toolkit (step 3 below)
 * DICOM toolkit (step 4 below)
 * tpcclib (for HRRT PET only) (step 5 below)
@@ -58,7 +58,7 @@ Get the code: Download the latest release from the
 [releases page](https://github.com/aces/Loris-MRI/releases)
 and extract it to `/opt/$projectname/bin/mri`
 
-#### 2. Install Python 3 with `pip` and `virtualenv`
+#### 2. Install Python 3.11 with `pip` and `venv`
 
 ```bash
 sudo apt install python3.11 python3.11-dev python3.11-venv

--- a/install/imaging_install.sh
+++ b/install/imaging_install.sh
@@ -115,7 +115,7 @@ echo
 echo "Creating loris-mri Python virtualenv in $mridir/python_virtualenvs/loris-mri-python/"
 # create a directory in $mridir that will store python 3 virtualenv
 sudo -S su $USER -c "mkdir -m 770 -p $mridir/python_virtualenvs/loris-mri-python"
-virtualenv $mridir/python_virtualenvs/loris-mri-python -p `which python3`
+python3.12 -m venv $mridir/python_virtualenvs/loris-mri-python
 source $mridir/python_virtualenvs/loris-mri-python/bin/activate
 echo "Installing the Python libraries into the loris-mri virtualenv..."
 pip3 install -r "$mridir/python/requirements.txt"

--- a/install/imaging_install.sh
+++ b/install/imaging_install.sh
@@ -115,7 +115,7 @@ echo
 echo "Creating loris-mri Python virtualenv in $mridir/python_virtualenvs/loris-mri-python/"
 # create a directory in $mridir that will store python 3 virtualenv
 sudo -S su $USER -c "mkdir -m 770 -p $mridir/python_virtualenvs/loris-mri-python"
-python3.12 -m venv $mridir/python_virtualenvs/loris-mri-python
+python3.11 -m venv $mridir/python_virtualenvs/loris-mri-python
 source $mridir/python_virtualenvs/loris-mri-python/bin/activate
 echo "Installing the Python libraries into the loris-mri virtualenv..."
 pip3 install -r "$mridir/python/requirements.txt"


### PR DESCRIPTION
As discussed in https://github.com/aces/Loris-MRI/pull/1117#discussion_r1697285437, I believe we should update our Python installation. This PR does that, with a few other improvements to our Python environment.

The Python version used in this PR is Python 3.11, which is a relatively recent stable Python version and is likely the best target imo:
- 3.9 and 3.12 require to add APT repositories
- 3.10 also works but is less recent

More precisely, I did not reinstall a full LORIS-MRI instance during my testing, but I did test the PR changes on my Ubuntu 22 dev VM and Debian 12, by doing the following :
- Install the specific Python version and its dependencies.
- Create our virtual environment.
- Install our package requirements in the environment.

Another change made in this PR is that it installs a fixed Python version, which is not the case in our current setup (for instance, I had Python 3.10 installed on my dev VM although we use 3.8 in our testing).

I advise to ignore whitespace for reviewing (trailing spaces removed with autoformatting).