### PR TITLE
Draft architecture for LORIS API calls within LORIS-MRI Python

### DIFF
--- a/environment
+++ b/environment
@@ -1,5 +1,5 @@
-PROJECT=%PROJECT%
-MINC_TOOLKIT_DIR=%MINC_TOOLKIT_DIR%
+PROJECT=bic
+MINC_TOOLKIT_DIR=/opt/minc/1.9.18
 
 # to source the MINC toolkit
 source ${MINC_TOOLKIT_DIR}/minc-toolkit-config.sh

--- a/python/dicom_upload.py
+++ b/python/dicom_upload.py
@@ -3,6 +3,7 @@
 """Script to import BIDS structure into LORIS."""
 
 import os
+from lib.api.post_candidate_dicom_processes import post_candidate_dicom_processes
 from lib.lorisgetopt import LorisGetOpt
 import lib.api
 from python.lib.api.get_candidate_dicom import get_candidate_dicom
@@ -71,7 +72,8 @@ def main():
     # arg_verbose:   bool       = loris_getopt_obj.options_dict['verbose']['value']
     api = Api.from_credentials('https://mmulder-dev.loris.ca', arg_user, arg_pass)
     # print(get_candidate_dicom(api, 587630, 'V1'))
-    print(post_candidate_dicom(api, 587630, 'DCC090', 'V1', False, arg_dicoms))
+    # print(post_candidate_dicom(api, 587630, 'DCC090', 'V1', False, arg_dicoms))
+    print(post_candidate_dicom_processes(api, 587630, 'V1', 'DCC090_587630_V1.tar', 124))
 
 if __name__ == "__main__":
     main()

--- a/python/dicom_upload.py
+++ b/python/dicom_upload.py
@@ -6,9 +6,9 @@ import os
 from lib.api.post_candidate_dicom_processes import post_candidate_dicom_processes
 from lib.lorisgetopt import LorisGetOpt
 import lib.api
-from python.lib.api.get_candidate_dicom import get_candidate_dicom
-from python.lib.api.post_candidate_dicom import post_candidate_dicom
-from python.lib.dataclass.api import Api
+from lib.api.get_candidate_dicom import get_candidate_dicom
+from lib.api.post_candidate_dicom import post_candidate_dicom
+from lib.dataclass.api import Api
 
 
 def main():
@@ -69,11 +69,11 @@ def main():
     arg_dicoms:    str        = loris_getopt_obj.options_dict['dicoms']['value']
     arg_user:      str        = loris_getopt_obj.options_dict['user']['value']
     arg_pass:      str        = loris_getopt_obj.options_dict['pass']['value']
-    # arg_verbose:   bool       = loris_getopt_obj.options_dict['verbose']['value']
+    arg_verbose:   bool       = loris_getopt_obj.options_dict['verbose']['value']
     api = Api.from_credentials('https://mmulder-dev.loris.ca', arg_user, arg_pass)
-    # print(get_candidate_dicom(api, 587630, 'V1'))
+    # get(post_candidate_dicom(api, 587630, 'V1'))
     # print(post_candidate_dicom(api, 587630, 'DCC090', 'V1', False, arg_dicoms))
-    print(post_candidate_dicom_processes(api, 587630, 'V1', 'DCC090_587630_V1.tar', 124))
+    print(post_candidate_dicom_processes(api, 587630, 'V1', 'DCC090_587630_V1.tar', 126))
 
 if __name__ == "__main__":
     main()

--- a/python/dicom_upload.py
+++ b/python/dicom_upload.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+"""Script to import BIDS structure into LORIS."""
+
+import os
+from lib.lorisgetopt import LorisGetOpt
+import lib.api
+from python.lib.api.get_candidate_dicom import get_candidate_dicom
+from python.lib.api.post_candidate_dicom import post_candidate_dicom
+from python.lib.dataclass.api import Api
+
+
+def main():
+    usage = (
+        "\n"
+
+        "********************************************************************\n"
+        " DICOM UPLOAD SCRIPT\n"
+        "********************************************************************\n"
+        "The program sends a DICOM study to the LORIS API, which will register it in the database\n"
+        "and call back the imaging pipeline scripts to process it adequately."
+
+        "usage  : dicom_upload.py -p <profile> -s <source_dir> -t <target_dir> ...\n\n"
+
+        "options: \n"
+        "\t-p, --profile   : Name of the python database config file in dicom-archive/.loris_mri\n"
+        "\t-d, --dicoms    : Archive containing the DICOMS of the study to upload\n"
+        "\t-u  --user      : Username of the LORIS user responsible for this upload\n"
+        "\t-p  --pass      : Password of the LORIS user responsible for this upload\n"
+        "\t-v, --verbose   : If set, be verbose\n\n"
+
+        "required options are: \n"
+        "\t--profile\n"
+        "\t--dicoms\n"
+        "\t--user\n"
+        "\t--pass\n\n"
+    )
+
+    # NOTE: Some options do not have short options but LorisGetOpt does not support that, so we
+    # repeat the long names.
+    options_dict = {
+        "profile": {
+            "value": None, "required": True, "expect_arg": True, "short_opt": "p", "is_path": False
+        },
+        "dicoms": {
+            "value": None,  "required": True,  "expect_arg": True, "short_opt": "d", "is_path": True,
+        },
+        "user": {
+            "value": None,  "required": True,  "expect_arg": True, "short_opt": "u", "is_path": False,
+        },
+        "pass": {
+            "value": None,  "required": True,  "expect_arg": True, "short_opt": "p", "is_path": False,
+        },
+        "verbose": {
+            "value": False, "required": False, "expect_arg": False, "short_opt": "v", "is_path": False,
+        },
+        "help": {
+            "value": False, "required": False, "expect_arg": False, "short_opt": "h", "is_path": False,
+        },
+    }
+
+    # get the options provided by the user
+    loris_getopt_obj = LorisGetOpt(usage, options_dict, os.path.basename(__file__[:-3]))
+
+    # Typed arguments
+
+    arg_profile:   str | None = loris_getopt_obj.options_dict['profile']['value']
+    arg_dicoms:    str        = loris_getopt_obj.options_dict['dicoms']['value']
+    arg_user:      str        = loris_getopt_obj.options_dict['user']['value']
+    arg_pass:      str        = loris_getopt_obj.options_dict['pass']['value']
+    # arg_verbose:   bool       = loris_getopt_obj.options_dict['verbose']['value']
+    api = Api.from_credentials('https://mmulder-dev.loris.ca', arg_user, arg_pass)
+    # print(get_candidate_dicom(api, 587630, 'V1'))
+    print(post_candidate_dicom(api, 587630, 'DCC090', 'V1', False, arg_dicoms))
+
+if __name__ == "__main__":
+    main()

--- a/python/lib/api.py
+++ b/python/lib/api.py
@@ -41,7 +41,7 @@ class Api:
     ):
         """
         Generic method to call any LORIS API route. This method uses unstructured values as the
-        parameter route and the return value. As such, it should not be used directly into a script
+        parameter route and the return value. As such, it should not be used directly in a script
         but rather used into a wrapper for a specific route that structures both its arguments and
         return value.
         """

--- a/python/lib/api.py
+++ b/python/lib/api.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+import json
+from typing import Literal
+from urllib.request import Request, urlopen
+
+
+@dataclass
+class Api:
+    """
+    Class used to interact with the LORIS API.
+    """
+
+    loris_url: str
+    api_token: str
+
+    @staticmethod
+    def get_api_from_token(loris_url: str, api_token: str):
+        """
+        Create an API object from the LORIS URL and an API token.
+        """
+
+        return Api(loris_url, api_token)
+
+    @staticmethod
+    def get_api_from_credentials(loris_url: str, username: str, password: str):
+        """
+        Create an API object from the LORIS URL and an API token. This function
+        calls the LORIS API using the credentials it is provided with.
+        """
+
+        api_token = get_api_token(loris_url, username, password)
+        return Api(loris_url, api_token)
+
+    def call(
+        self,
+        version: Literal['v0.0.3', 'v0.0.4-dev'],
+        route: str,
+        method: Literal['GET', 'POST'] = 'GET',
+        headers: dict[str, str] = {},
+        data: bytes = None
+    ):
+        """
+        Generic method to call any LORIS API route. This method uses unstructured values as the
+        parameter route and the return value. As such, it should not be used directly into a script
+        but rather used into a wrapper for a specific route that structures both its arguments and
+        return value.
+        """
+
+        request = Request(f'{self.loris_url}/api/{version}/{route}', data, method=method)
+        request.add_header('Authorization', f'Bearer {self.api_token}')
+        for key, value in headers.items():
+            request.add_header(key, value)
+
+        return urlopen(request, data)
+
+
+def get_api_token(loris_url: str, username: str, password: str) -> str:
+    """
+    Call the LORIS API to get an API token for a given user using this user's credentials.
+    """
+
+    args = {
+        'username': username,
+        'password': password,
+    }
+
+    request = Request(
+        f'{loris_url}/api/v0.0.3/login',
+        method='POST',
+        data=json.dumps(args)
+    )
+
+    response = urlopen(request).read()
+    object = json.loads(response)
+    return object['token']

--- a/python/lib/api/get_candidate_dicom.py
+++ b/python/lib/api/get_candidate_dicom.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-import json
 from typing import Any, Literal
 from python.lib.dataclass.api import Api
 
@@ -59,5 +58,5 @@ class GetCandidateDicom:
 
 
 def get_candidate_dicom(api: Api, cand_id: int, visit: str):
-    response = api.call('v0.0.4-dev', f'/candidates/{cand_id}/{visit}/dicoms')
-    return GetCandidateDicom(json.loads(response.read().decode('utf-8')))
+    response = api.get('v0.0.4-dev', f'/candidates/{cand_id}/{visit}/dicoms')
+    return GetCandidateDicom(response.json())

--- a/python/lib/api/get_candidate_dicom.py
+++ b/python/lib/api/get_candidate_dicom.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import Any, Literal
-from python.lib.dataclass.api import Api
+from lib.dataclass.api import Api
 
 
 @dataclass

--- a/python/lib/api/get_candidate_dicom.py
+++ b/python/lib/api/get_candidate_dicom.py
@@ -1,0 +1,57 @@
+from typing import Any, Literal
+from lib.api import Api
+
+
+class GetCandidateDicomMeta:
+    cand_id: int
+    visit: str
+
+    def __init__(self, object: Any):
+        self.cand_id = object['CandID']
+        self.visit   = object['Visit']
+
+
+class GetCandidateDicomTarSeries:
+    series_description: str
+    series_number:      int
+    echo_time:          float
+    repetition_time:    int
+    inversion_time:     int
+    slice_thickness:    int
+    modality:           Literal['MR', 'PT']
+    series_uid:         str
+
+    def __init__(self, object: Any):
+        self.series_description = object['SeriesDescription']
+        self.series_number      = object['SeriesNumber']
+        self.echo_time          = object['EchoTime']
+        self.repetition_time    = object['RepetitionTime']
+        self.inversion_time     = object['InversionTime']
+        self.slice_thickness    = object['SliceThickness']
+        self.modality           = object['Modality']
+        self.series_uid         = object['SeriesUID']
+
+
+class GetCandidateDicomTar:
+    tar_name:     str
+    patient_name: str
+    series:       list[GetCandidateDicomTarSeries]
+
+    def __init__(self, object: Any):
+        self.tar_name     = object['Tarname']
+        self.patient_name = object['Patientname']
+        self.series       = map(GetCandidateDicomTarSeries, object['SeriesInfo'])
+
+
+class GetCandidateDicom:
+    meta: GetCandidateDicomMeta
+    tars: list[GetCandidateDicomTar]
+
+    def __init__(self, object: Any):
+        self.meta = GetCandidateDicomMeta(object['Meta'])
+        self.tars = map(GetCandidateDicomTar, object['DicomTars'])
+
+
+def get_candidate_dicom(api: Api, cand_id: int, visit: str):
+    object = api.call('v0.0.4-dev', f'/candidates/{cand_id}/{visit}/dicoms')
+    return GetCandidateDicom(object)

--- a/python/lib/api/get_candidate_dicom.py
+++ b/python/lib/api/get_candidate_dicom.py
@@ -1,10 +1,10 @@
 from typing import Any, Literal
-from lib.api import Api
+from python.lib.dataclass.api import Api
 
 
 class GetCandidateDicomMeta:
     cand_id: int
-    visit: str
+    visit:   str
 
     def __init__(self, object: Any):
         self.cand_id = object['CandID']

--- a/python/lib/api/get_candidate_dicom_archive.py
+++ b/python/lib/api/get_candidate_dicom_archive.py
@@ -2,5 +2,5 @@ from python.lib.dataclass.api import Api
 
 
 def get_candidate_dicom_archive(api: Api, cand_id: int, visit_label: str, dicom_tar_name: str):
-    api.call('v0.0.4-dev', f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}')
+    api.get('v0.0.4-dev', f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}')
     # TODO: Handle returned file

--- a/python/lib/api/get_candidate_dicom_archive.py
+++ b/python/lib/api/get_candidate_dicom_archive.py
@@ -1,0 +1,6 @@
+from lib.api import Api
+
+
+def get_candidate_dicom_archive(api: Api, cand_id: int, visit_label: str, dicom_tar_name: str):
+    api.call('v0.0.4-dev', f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}')
+    # TODO: Handle returned file

--- a/python/lib/api/get_candidate_dicom_archive.py
+++ b/python/lib/api/get_candidate_dicom_archive.py
@@ -1,4 +1,4 @@
-from python.lib.dataclass.api import Api
+from lib.dataclass.api import Api
 
 
 def get_candidate_dicom_archive(api: Api, cand_id: int, visit_label: str, dicom_tar_name: str):

--- a/python/lib/api/get_candidate_dicom_archive.py
+++ b/python/lib/api/get_candidate_dicom_archive.py
@@ -1,4 +1,4 @@
-from lib.api import Api
+from python.lib.dataclass.api import Api
 
 
 def get_candidate_dicom_archive(api: Api, cand_id: int, visit_label: str, dicom_tar_name: str):

--- a/python/lib/api/get_candidate_dicom_process.py
+++ b/python/lib/api/get_candidate_dicom_process.py
@@ -21,7 +21,7 @@ class GetCandidateDicomProcess:
 
 
 def get_candidate_dicom_process(api: Api, cand_id: int, visit_label: str, dicom_tar_name: str, process_id: int):
-    object = api.call(
+    object = api.get(
         'v0.0.4-dev',
         f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}/processes/{process_id}'
     )

--- a/python/lib/api/get_candidate_dicom_process.py
+++ b/python/lib/api/get_candidate_dicom_process.py
@@ -21,5 +21,9 @@ class GetCandidateDicomProcess:
 
 
 def get_candidate_dicom_process(api: Api, cand_id: int, visit_label: str, dicom_tar_name: str, process_id: int):
-    object = api.call('v0.0.4-dev', f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}/processes/{process_id}')
+    object = api.call(
+        'v0.0.4-dev',
+        f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}/processes/{process_id}'
+    )
+
     return GetCandidateDicomProcess(object)

--- a/python/lib/api/get_candidate_dicom_process.py
+++ b/python/lib/api/get_candidate_dicom_process.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from typing import Any, Literal
+from lib.api import Api
+
+
+class GetCandidateDicomProcess:
+    end_time:  datetime
+    exit_code: int
+    id:        int
+    pid:       int
+    progress:  str
+    state:     Literal['SUCCESS', 'RUNNING', 'ERROR']
+
+    def __init__(self, object: Any):
+        self.end_time  = object['END_TIME']
+        self.exit_code = object['EXIT_CODE']
+        self.id        = object['ID']
+        self.pid       = object['PID']
+        self.progress  = object['PROGRESS']
+        self.state     = object['STATE']
+
+
+def get_candidate_dicom_process(api: Api, cand_id: int, visit_label: str, dicom_tar_name: str, process_id: int):
+    object = api.call('v0.0.4-dev', f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}/processes/{process_id}')
+    return GetCandidateDicomProcess(object)

--- a/python/lib/api/get_candidate_dicom_process.py
+++ b/python/lib/api/get_candidate_dicom_process.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Any, Literal
-from python.lib.dataclass.api import Api
+from lib.dataclass.api import Api
 
 
 class GetCandidateDicomProcess:

--- a/python/lib/api/get_candidate_dicom_process.py
+++ b/python/lib/api/get_candidate_dicom_process.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Any, Literal
-from lib.api import Api
+from python.lib.dataclass.api import Api
 
 
 class GetCandidateDicomProcess:

--- a/python/lib/api/get_candidate_dicom_processes.py
+++ b/python/lib/api/get_candidate_dicom_processes.py
@@ -19,6 +19,7 @@ class GetCandidateDicomProcessesProcess:
         self.progress  = object['PROGRESS']
         self.state     = object['STATE']
 
+
 class GetCandidateDicomProcessesUpload:
     upload_id: int
     processes: list[GetCandidateDicomProcessesProcess]

--- a/python/lib/api/get_candidate_dicom_processes.py
+++ b/python/lib/api/get_candidate_dicom_processes.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Any, Literal
-from lib.api import Api
+from python.lib.dataclass.api import Api
 
 
 class GetCandidateDicomProcessesProcess:

--- a/python/lib/api/get_candidate_dicom_processes.py
+++ b/python/lib/api/get_candidate_dicom_processes.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Any, Literal
-from python.lib.dataclass.api import Api
+from lib.dataclass.api import Api
 
 
 class GetCandidateDicomProcessesProcess:

--- a/python/lib/api/get_candidate_dicom_processes.py
+++ b/python/lib/api/get_candidate_dicom_processes.py
@@ -37,5 +37,5 @@ class GetCandidateDicomProcesses:
 
 
 def get_candidate_dicom_processes(api: Api, cand_id: int, visit_label: str, dicom_tar_name: str):
-    object = api.call('v0.0.4-dev', f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}/processes')
+    object = api.get('v0.0.4-dev', f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}/processes')
     return GetCandidateDicomProcesses(object)

--- a/python/lib/api/get_candidate_dicom_processes.py
+++ b/python/lib/api/get_candidate_dicom_processes.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+from typing import Any, Literal
+from lib.api import Api
+
+
+class GetCandidateDicomProcessesProcess:
+    end_time:  datetime
+    exit_code: int
+    id:        int
+    pid:       int
+    progress:  str
+    state:     Literal['SUCCESS', 'RUNNING', 'ERROR']
+
+    def __init__(self, object: Any):
+        self.end_time  = object['END_TIME']
+        self.exit_code = object['EXIT_CODE']
+        self.id        = object['ID']
+        self.pid       = object['PID']
+        self.progress  = object['PROGRESS']
+        self.state     = object['STATE']
+
+class GetCandidateDicomProcessesUpload:
+    upload_id: int
+    processes: list[GetCandidateDicomProcessesProcess]
+
+    def __init__(self, object: Any):
+        self.upload_id = object['mri_upload_id']
+        self.processes = map(GetCandidateDicomProcessesProcess, object['processes'])
+
+
+class GetCandidateDicomProcesses:
+    mri_uploads: list[GetCandidateDicomProcessesUpload]
+
+    def __init__(self, object: Any):
+        self.mri_uploads = map(GetCandidateDicomProcessesUpload, object['mri_uploads'])
+
+
+def get_candidate_dicom_processes(api: Api, cand_id: int, visit_label: str, dicom_tar_name: str):
+    object = api.call('v0.0.4-dev', f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}/processes')
+    return GetCandidateDicomProcesses(object)

--- a/python/lib/api/post_candidate_dicom.py
+++ b/python/lib/api/post_candidate_dicom.py
@@ -11,7 +11,7 @@ def post_candidate_dicom(
     file_path: str,
     overwrite: bool = False,
 ):
-    data = {
+    json = {
         'CandID':    cand_id,
         'PSCID':     psc_id,
         'Visit':     visit_label,
@@ -23,13 +23,13 @@ def post_candidate_dicom(
     else:
         headers = {}
 
-    response = api.post(
+    response = api.post_file(
         'v0.0.4-dev',
         f'/candidates/{cand_id}/{visit_label}/dicoms',
         headers=headers,
-        data=data,
+        json=json,
         # TODO: Look into https://docs.python.org/3/library/mimetypes.html
-        files={'mriFile': (os.path.basename(file_path), open(file_path, 'rb'), 'application/tar')},
+        files={'MriFile': (os.path.basename(file_path), open(file_path, 'rb'), 'application/tar')},
     )
 
     return response.text

--- a/python/lib/api/post_candidate_dicom.py
+++ b/python/lib/api/post_candidate_dicom.py
@@ -1,8 +1,16 @@
-import json
+import os
 from python.lib.dataclass.api import Api
 
 
-def post_candidate_dicom(api: Api, cand_id: int, psc_id: str, visit_label: str, is_phantom: bool, overwrite: bool = False):
+def post_candidate_dicom(
+    api: Api,
+    cand_id: int,
+    psc_id: str,
+    visit_label: str,
+    is_phantom: bool,
+    file_path: str,
+    overwrite: bool = False,
+):
     data = {
         'CandID':    cand_id,
         'PSCID':     psc_id,
@@ -15,13 +23,14 @@ def post_candidate_dicom(api: Api, cand_id: int, psc_id: str, visit_label: str, 
     else:
         headers = {}
 
-    response = api.call(
+    response = api.post(
         'v0.0.4-dev',
         f'/candidates/{cand_id}/{visit_label}/dicoms',
-        method='POST',
         headers=headers,
-        data=json.dumps(data).encode('utf-8')
+        data=data,
+        # TODO: Look into https://docs.python.org/3/library/mimetypes.html
+        files={'mriFile': (os.path.basename(file_path), open(file_path, 'rb'), 'application/tar')},
     )
 
-    return response.read()
+    return response.text
     # TODO: Handle 303

--- a/python/lib/api/post_candidate_dicom.py
+++ b/python/lib/api/post_candidate_dicom.py
@@ -1,7 +1,8 @@
+import json
 from python.lib.dataclass.api import Api
 
 
-def post_candidate_dicom(api: Api, cand_id: int, psc_id: str, visit_label: str, is_phantom: bool, overwrite: bool):
+def post_candidate_dicom(api: Api, cand_id: int, psc_id: str, visit_label: str, is_phantom: bool, overwrite: bool = False):
     data = {
         'CandID':    cand_id,
         'PSCID':     psc_id,
@@ -14,5 +15,13 @@ def post_candidate_dicom(api: Api, cand_id: int, psc_id: str, visit_label: str, 
     else:
         headers = {}
 
-    api.call('v0.0.4-dev', f'/candidates/{cand_id}/{visit_label}/dicoms', method='POST', headers=headers, data=data)
+    response = api.call(
+        'v0.0.4-dev',
+        f'/candidates/{cand_id}/{visit_label}/dicoms',
+        method='POST',
+        headers=headers,
+        data=json.dumps(data).encode('utf-8')
+    )
+
+    return response.read()
     # TODO: Handle 303

--- a/python/lib/api/post_candidate_dicom.py
+++ b/python/lib/api/post_candidate_dicom.py
@@ -1,0 +1,18 @@
+from lib.api import Api
+
+
+def post_candidate_dicom(api: Api, cand_id: int, psc_id: str, visit_label: str, is_phantom: bool, overwrite: bool):
+    data = {
+        'CandID':    cand_id,
+        'PSCID':     psc_id,
+        'Visit':     visit_label,
+        'IsPhantom': is_phantom,
+    }
+
+    if overwrite:
+        headers = {'LORIS-Overwrite': 'overwrite'}
+    else:
+        headers = {}
+
+    api.call('v0.0.4-dev', f'/candidates/{cand_id}/{visit_label}/dicoms', method='POST', headers=headers, data=data)
+    # TODO: Handle 303

--- a/python/lib/api/post_candidate_dicom.py
+++ b/python/lib/api/post_candidate_dicom.py
@@ -1,4 +1,4 @@
-from lib.api import Api
+from python.lib.dataclass.api import Api
 
 
 def post_candidate_dicom(api: Api, cand_id: int, psc_id: str, visit_label: str, is_phantom: bool, overwrite: bool):

--- a/python/lib/api/post_candidate_dicom.py
+++ b/python/lib/api/post_candidate_dicom.py
@@ -1,5 +1,5 @@
 import os
-from python.lib.dataclass.api import Api
+from lib.dataclass.api import Api
 
 
 def post_candidate_dicom(

--- a/python/lib/api/post_candidate_dicom_processes.py
+++ b/python/lib/api/post_candidate_dicom_processes.py
@@ -1,4 +1,4 @@
-from lib.api import Api
+from python.lib.dataclass.api import Api
 
 
 def post_candidate_dicom_processes(api: Api, cand_id: int, visit_label: str, dicom_tar_name: str, upload_id: int):

--- a/python/lib/api/post_candidate_dicom_processes.py
+++ b/python/lib/api/post_candidate_dicom_processes.py
@@ -1,4 +1,3 @@
-import json
 from python.lib.dataclass.api import Api
 
 
@@ -8,11 +7,10 @@ def post_candidate_dicom_processes(api: Api, cand_id: int, visit_label: str, dic
         'MRIUploadID': upload_id,
     }
 
-    api.call(
+    api.post(
         'v0.0.4-dev',
         f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}/processes',
-        method='POST',
-        data=json.dumps(data).encode('utf-8')
+        data=data,
     )
 
     # TODO: Handle 202

--- a/python/lib/api/post_candidate_dicom_processes.py
+++ b/python/lib/api/post_candidate_dicom_processes.py
@@ -2,7 +2,7 @@ from python.lib.dataclass.api import Api
 
 
 def post_candidate_dicom_processes(api: Api, cand_id: int, visit_label: str, dicom_tar_name: str, upload_id: int):
-    data = {
+    json = {
         'ProcessType': 'mri_upload',
         'MRIUploadID': upload_id,
     }
@@ -10,7 +10,7 @@ def post_candidate_dicom_processes(api: Api, cand_id: int, visit_label: str, dic
     api.post(
         'v0.0.4-dev',
         f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}/processes',
-        data=data,
+        json=json,
     )
 
     # TODO: Handle 202

--- a/python/lib/api/post_candidate_dicom_processes.py
+++ b/python/lib/api/post_candidate_dicom_processes.py
@@ -7,5 +7,11 @@ def post_candidate_dicom_processes(api: Api, cand_id: int, visit_label: str, dic
         'MRIUploadID': upload_id,
     }
 
-    api.call('v0.0.4-dev', f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}/processes', method='POST', data=data)
+    api.call(
+        'v0.0.4-dev',
+        f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}/processes',
+        method='POST',
+        data=data
+    )
+
     # TODO: Handle 202

--- a/python/lib/api/post_candidate_dicom_processes.py
+++ b/python/lib/api/post_candidate_dicom_processes.py
@@ -1,4 +1,4 @@
-from python.lib.dataclass.api import Api
+from lib.dataclass.api import Api
 
 
 def post_candidate_dicom_processes(api: Api, cand_id: int, visit_label: str, dicom_tar_name: str, upload_id: int):

--- a/python/lib/api/post_candidate_dicom_processes.py
+++ b/python/lib/api/post_candidate_dicom_processes.py
@@ -1,0 +1,11 @@
+from lib.api import Api
+
+
+def post_candidate_dicom_processes(api: Api, cand_id: int, visit_label: str, dicom_tar_name: str, upload_id: int):
+    data = {
+        'ProcessType': 'mri_upload',
+        'MRIUploadID': upload_id,
+    }
+
+    api.call('v0.0.4-dev', f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}/processes', method='POST', data=data)
+    # TODO: Handle 202

--- a/python/lib/api/post_candidate_dicom_processes.py
+++ b/python/lib/api/post_candidate_dicom_processes.py
@@ -1,3 +1,4 @@
+import json
 from python.lib.dataclass.api import Api
 
 
@@ -11,7 +12,7 @@ def post_candidate_dicom_processes(api: Api, cand_id: int, visit_label: str, dic
         'v0.0.4-dev',
         f'/candidates/{cand_id}/{visit_label}/dicoms/{dicom_tar_name}/processes',
         method='POST',
-        data=data
+        data=json.dumps(data).encode('utf-8')
     )
 
     # TODO: Handle 202

--- a/python/lib/dataclass/api.py
+++ b/python/lib/dataclass/api.py
@@ -7,7 +7,7 @@ from urllib.request import Request, urlopen
 @dataclass
 class Api:
     """
-    Class used to interact with the LORIS API.
+    Class used to interact with the LORIS API, using the LORIS URL.
     """
 
     loris_url: str
@@ -16,7 +16,8 @@ class Api:
     @staticmethod
     def get_api_from_token(loris_url: str, api_token: str):
         """
-        Create an API object from the LORIS URL and an API token.
+        Create an API object from the LORIS URL and an API token, which will be used for all API
+        calls made using this API object.
         """
 
         return Api(loris_url, api_token)
@@ -24,8 +25,9 @@ class Api:
     @staticmethod
     def get_api_from_credentials(loris_url: str, username: str, password: str):
         """
-        Create an API object from the LORIS URL and an API token. This function
-        calls the LORIS API using the credentials it is provided with.
+        Create an API object from the LORIS URL and some user's credentials. This function calls
+        the LORIS API to get the user's API token, which will be used for all other API calls made
+        using this API object.
         """
 
         api_token = get_api_token(loris_url, username, password)
@@ -44,6 +46,12 @@ class Api:
         parameter route and the return value. As such, it should not be used directly in a script
         but rather used into a wrapper for a specific route that structures both its arguments and
         return value.
+
+        :param version: The version of the API to use for this call
+        :param route:   The API route to call, example: `/candidates/123456`
+        :param method:  The HTTP method to use for the request
+        :param headers: Additional HTTP headers to add to the request
+        :param data:    A body to add to the request
         """
 
         request = Request(f'{self.loris_url}/api/{version}/{route}', data, method=method)
@@ -56,7 +64,7 @@ class Api:
 
 def get_api_token(loris_url: str, username: str, password: str) -> str:
     """
-    Call the LORIS API to get an API token for a given user using this user's credentials.
+    Call the LORIS API to get an API token for a given LORIS user using this user's credentials.
     """
 
     args = {

--- a/python/lib/dataclass/api.py
+++ b/python/lib/dataclass/api.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
-import json
-from typing import Literal
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
+from typing import Any, Literal
+import requests
+from requests.exceptions import HTTPError
+
 
 @dataclass
 class Api:
@@ -14,7 +14,7 @@ class Api:
     api_token: str
 
     @staticmethod
-    def get_api_from_token(loris_url: str, api_token: str):
+    def from_token(loris_url: str, api_token: str):
         """
         Create an API object from the LORIS URL and an API token, which will be used for all API
         calls made using this API object.
@@ -23,7 +23,7 @@ class Api:
         return Api(loris_url, api_token)
 
     @staticmethod
-    def get_api_from_credentials(loris_url: str, username: str, password: str):
+    def from_credentials(loris_url: str, username: str, password: str):
         """
         Create an API object from the LORIS URL and some user's credentials. This function calls
         the LORIS API to get the user's API token, which will be used for all other API calls made
@@ -33,13 +33,12 @@ class Api:
         api_token = get_api_token(loris_url, username, password)
         return Api(loris_url, api_token)
 
-    def call(
+    def get(
         self,
         version: Literal['v0.0.3', 'v0.0.4-dev'],
         route: str,
-        method: Literal['GET', 'POST'] = 'GET',
         headers: dict[str, str] = {},
-        data: bytes | None = None
+        data: dict[str, Any] | None = None,
     ):
         """
         Generic method to call any LORIS API route. This method uses unstructured values as the
@@ -49,23 +48,55 @@ class Api:
 
         :param version: The version of the API to use for this call
         :param route:   The API route to call, example: `/candidates/123456`
-        :param method:  The HTTP method to use for the request
         :param headers: Additional HTTP headers to add to the request
         :param data:    A body to add to the request
         """
 
         print(f'{self.loris_url}/api/{version}/{route}')
 
-        request = Request(f'{self.loris_url}/api/{version}/{route}', data, method=method)
-        request.add_header('Authorization', f'Bearer {self.api_token}')
-        for key, value in headers.items():
-            request.add_header(key, value)
+        headers['Authorization'] = f'Bearer {self.api_token}'
 
         try:
-            return urlopen(request, data)
+            response = requests.get(f'{self.loris_url}/api/{version}/{route}', headers=headers, data=data)
+            response.raise_for_status()
+            return response
         except HTTPError as error:
             # TODO: Better error handling
-            print(error.read())
+            print(error.response.text)
+            exit(0)
+
+    def post(
+        self,
+        version: Literal['v0.0.3', 'v0.0.4-dev'],
+        route: str,
+        headers: dict[str, str] = {},
+        data: dict[str, Any] | None = None,
+        files: dict[str, Any] | None = None,
+    ):
+        """
+        Generic method to call any LORIS API route. This method uses unstructured values as the
+        parameter route and the return value. As such, it should not be used directly in a script
+        but rather used into a wrapper for a specific route that structures both its arguments and
+        return value.
+
+        :param version: The version of the API to use for this call
+        :param route:   The API route to call, example: `/candidates/123456`
+        :param headers: Additional HTTP headers to add to the request
+        :param data:    A body to add to the request
+        """
+
+        print(f'{self.loris_url}/api/{version}/{route}')
+
+        headers['Authorization'] = f'Bearer {self.api_token}'
+
+        try:
+            response = requests.post(f'{self.loris_url}/api/{version}/{route}',headers=headers, data=data, files=files)
+            print(response.status_code)
+            return response
+        except HTTPError as error:
+            # TODO: Better error handling
+            print(error.response.status_code)
+            print(error.response.text)
             exit(0)
 
 
@@ -79,23 +110,17 @@ def get_api_token(loris_url: str, username: str, password: str) -> str:
         'password': password,
     }
 
-    request = Request(
-        f'{loris_url}/api/v0.0.3/login',
-        method='POST',
-        data=json.dumps(credentials).encode('utf-8')
-    )
-
     try:
-        response = urlopen(request).read()
+        response = requests.post(f'{loris_url}/api/v0.0.3/login', json=credentials)
+        response.raise_for_status()
+        return response.json()['token']
     except HTTPError as error:
-        error_description = json.loads(error.read().decode('utf-8'))['error']
+        error_description = error.response.json()['error']
         if error_description == 'Unacceptable JWT key':
-            # TODO: Specialzied exception.
+            # TODO: Specialized exception.
             raise Exception(
                 'Unacceptable LORIS JWT key.\n'
                 'To use the API, please enter a sufficiently complex JWT key in the LORIS configuration module.'
             )
 
         exit(0)
-    object = json.loads(response)
-    return object['token']

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -17,3 +17,4 @@ scipy
 flake8
 boto3
 mat73
+requests


### PR DESCRIPTION
This is a draft architecture to call the LORIS API from within the LORIS-MRI Python code (issue #1147), using the API calls from the DICOM upload API PR ([Loris#9154](https://github.com/aces/Loris/pull/9154)). The code is not fully working yet (TODO: error handling, type conversions), but it presents the broad lines of the architecture:

There is an `Api` class used as the canonical way to make API calls. It stores the LORIS URL and an API token, and can be passed around to any code that needs to make API calls. It has a method `api.call(...)` that allows to call any API route with unstructured values (route as a string, returns the response without parsing it).

There is a `python.lib.api` namespace that contains specialized wrappers for each API route. These wrappers allow to use the API in a structured way, by passing the route arguments directly as function arguments, and by returning structured objects.

Unresolved question, in which namespace to put this `Api` class ?
- `lib.api` (which this PR does, EDIT: this is a bad choice because there is a name clash with the `lib.api` namespace) ?
- `lib.dataclass.api` (EDIT: I prefer this option) ?
- `lib.api.api` ?

Unresolved question, how to structure the objects returned by the API calls ?
- Manually in the classes constructors (which this PR does) ?
- Manually in static methods (examples: `from_object`, `from_json`, `from_dict`) ?
- Automatically using a library (I have heard of `dataclasses-json` and `pydantic`)

Unresolved question, how to structure the API wrapper files ?
- One file per route, with the route function and its types (which this PR does).
- Different files or namespaces for types and routes (examples: `lib.api.routes`, `lib.api.types`) ?
- Something else ?

The *(which this PR does)* mentions are just here as an indication, I am not particularly advocating for these options over others.