### PR TITLE
Fix `BasePipeline.move_file`

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -484,7 +484,7 @@ class BasePipeline:
         """
 
         self.log_info(f'Moving {old_file_path} to {new_file_path}', is_error='N', is_verbose='Y')
-        shutil.move(old_file_path, new_file_path, self.verbose)
+        shutil.move(old_file_path, new_file_path)
         if not os.path.exists(new_file_path):
             message = f'Could not move {old_file_path} to {new_file_path}'
             self.log_error_and_exit(message, lib.exitcode.COPY_FAILURE, is_error='Y', is_verbose='N')


### PR DESCRIPTION
While running `run_dicom_archive_loader`, I got some errors like `[ERRNO: 18] Incorrect link accross file systems something something` and `something something object 'bool' not callable`  (I don't remember exactly I did not write the errors down) that prevented the script from running. The cause of this error is that `shutil.move` was incorrectly called: a boolean was passed as a third parameter whereas an [optional function is expected](https://docs.python.org/3/library/shutil.html#shutil.move). I removed the superfluous argument and the script works as expected.

I'll notice that this error can be caught by typing :eyes:.