### PR TITLE
Update docker Python install

### DIFF
--- a/test/Dockerfile.test.php8
+++ b/test/Dockerfile.test.php8
@@ -25,10 +25,6 @@ RUN apt-get install -y perl && \
 # Update the package list and install required packages
 
 RUN apt-get update && \
-    apt-get install -y \
-    python3 \
-    python3-dev \
-    python3-pip \
+    apt-get install -y python3.11 python3.11-dev python3.11-venv python3-pip \
     libmariadb-dev-compat \
     libmariadb-dev \
-    virtualenv


### PR DESCRIPTION
During the meeting I just noticed that the Python installation in the Dockerfile no longer meets the recommendation in `README.md`. This fixes it.