### PR TITLE
Remove php 8.1 and 8.2 from the LORIS tests to keep only test on PHP 8.3

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -11,7 +11,7 @@ jobs:
         fail-fast: false
         matrix:
             testsuite: ['integration']
-            php: ['8.1','8.2', '8.3']
+            php: ['8.3']
             ci_node_index: [0]
 
             include:

--- a/test/Dockerfile.test.php8
+++ b/test/Dockerfile.test.php8
@@ -1,4 +1,4 @@
-FROM php:8.1
+FROM php:8.3
 
 RUN cat /etc/os-release
 


### PR DESCRIPTION
# Description

We should probably just be testing the latest PHP version tested by LORIS in the LORIS-MRI testing. This PR removes call to PHP 8.1 and 8.2 in the testing and keeps only tests for PHP 8.3.