### PR TITLE
Add leading r for literal regexes

### DIFF
--- a/dicom-archive/database_config_template.py
+++ b/dicom-archive/database_config_template.py
@@ -25,8 +25,8 @@ def get_subject_ids(db, dicom_value=None, scanner_id=None):
 
     imaging = Imaging(db, False)
 
-    phantom_match   = re.search('(pha)|(test)', dicom_value, re.IGNORECASE)
-    candidate_match = re.search('([^_]+)_(\d+)_([^_]+)', dicom_value, re.IGNORECASE)
+    phantom_match   = re.search(r'(pha)|(test)', dicom_value, re.IGNORECASE)
+    candidate_match = re.search(r'([^_]+)_(\d+)_([^_]+)', dicom_value, re.IGNORECASE)
 
     if phantom_match:
         subject_id_dict['isPhantom']  = True

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -151,7 +151,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         os.makedirs(nifti_tmp_dir)
 
         converter = self.config_db_obj.get_config("converter")
-        if not re.search('.*dcm2niix.*', converter, re.IGNORECASE):
+        if not re.search(r'.*dcm2niix.*', converter, re.IGNORECASE):
             message = f"{converter} does not appear to be a dcm2niix binary."
             self.log_error_and_exit(message, lib.exitcode.PROJECT_CUSTOMIZATION_FAILURE, is_error="Y", is_verbose="N")
 

--- a/python/lib/mri.py
+++ b/python/lib/mri.py
@@ -287,9 +287,9 @@ class Mri:
                 other_assoc_files['bvec_file'] = assoc_file.path
             elif re.search(r'bval$', file_info['extension']):
                 other_assoc_files['bval_file'] = assoc_file.path
-            elif re.search('tsv$', file_info['extension']) and file_info['suffix'] == 'events':
+            elif re.search(r'tsv$', file_info['extension']) and file_info['suffix'] == 'events':
                 other_assoc_files['task_file'] = assoc_file.path
-            elif re.search('tsv$', file_info['extension']) and file_info['suffix'] == 'physio':
+            elif re.search(r'tsv$', file_info['extension']) and file_info['suffix'] == 'physio':
                 other_assoc_files['physio_file'] = assoc_file.path
 
         # read the json file if it exists

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -283,7 +283,7 @@ def assemble_hed_service(data_dir, event_tsv_path, event_json_path):
     tokenResponse = requests.get(requestTokenURL)
 
     cookie = tokenResponse.headers['Set-Cookie']
-    token = re.search('csrf_token" value="(.+?)"', tokenResponse.text).group(1)
+    token = re.search(r'csrf_token" value="(.+?)"', tokenResponse.text).group(1)
 
     # Define headers for assemble POST request, containing token and cookie
     headers = {

--- a/python/mass_nifti_pic.py
+++ b/python/mass_nifti_pic.py
@@ -171,7 +171,7 @@ def make_pic(file_id, config_file, force, verbose):
     if not nii_file_path:
         print('WARNING: no file in the database with FileID = ' + str(file_id))
         return
-    if not re.search('.nii.gz$', nii_file_path):
+    if not re.search(r'.nii.gz$', nii_file_path):
         print('WARNING: wrong file type. File ' + nii_file_path + ' is not a .nii.gz file')
         return
     if not os.path.exists(data_dir + nii_file_path):


### PR DESCRIPTION
Following the finding on Slack by @cmadjar. Add leading `r` for literal regexes I found in the Python code (Ctrl + F `re.search` / `re.match`).