### PR TITLE
Factorize get subject session

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ include = [
     "python/lib/config_file.py",
     "python/lib/env.py",
     "python/lib/file_system.py",
+    "python/lib/get_subject_session.py",
     "python/lib/logging.py",
     "python/lib/make_env.py",
     "python/lib/validate_subject_info.py",

--- a/python/lib/database_lib/session_db.py
+++ b/python/lib/database_lib/session_db.py
@@ -1,9 +1,11 @@
 """This class performs session table related database queries and common checks"""
 
+from typing_extensions import deprecated
 
 __license__ = "GPLv3"
 
 
+@deprecated('Use `lib.db.models.session.DbSession` instead')
 class SessionDB:
     """
     This class performs database queries for session table.
@@ -35,6 +37,7 @@ class SessionDB:
         self.db = db
         self.verbose = verbose
 
+    @deprecated('Use `lib.db.queries.try_get_candidate_with_cand_id_visit_label` instead')
     def create_session_dict(self, cand_id, visit_label):
         """
         Queries the session table for a particular candidate ID and visit label and returns a dictionary
@@ -56,6 +59,7 @@ class SessionDB:
 
         return results[0] if results else None
 
+    @deprecated('Use `lib.db.queries.site.try_get_site_with_psc_id_visit_label` instead')
     def get_session_center_info(self, pscid, visit_label):
         """
         Get site information for a given visit.
@@ -77,6 +81,7 @@ class SessionDB:
 
         return results[0] if results else None
 
+    @deprecated('Use `lib.get_subject_session.get_candidate_next_visit_number` instead')
     def determine_next_session_site_id_and_visit_number(self, cand_id):
         """
         Determines the next session site and visit number based on the last session inserted for a given candidate.
@@ -99,6 +104,7 @@ class SessionDB:
 
         return results[0] if results else None
 
+    @deprecated('Use `lib.db.models.session.DbSession` instead')
     def insert_into_session(self, fields, values):
         """
         Insert a new row in the session table using fields list as column names and values as values.

--- a/python/lib/db/models/notification_spool.py
+++ b/python/lib/db/models/notification_spool.py
@@ -25,5 +25,4 @@ class DbNotificationSpool(Base):
     origin       : Mapped[Optional[str]]      = mapped_column('Origin')
     active       : Mapped[bool]               = mapped_column('Active', YNBool)
 
-    type : Mapped['db_notification_type.DbNotificationType'] \
-        = relationship('DbNotificationType')
+    type : Mapped['db_notification_type.DbNotificationType'] = relationship('DbNotificationType')

--- a/python/lib/db/queries/site.py
+++ b/python/lib/db/queries/site.py
@@ -1,7 +1,6 @@
 from sqlalchemy import select
 from sqlalchemy.orm import Session as Database
 
-from lib.db.models.candidate import DbCandidate
 from lib.db.models.session import DbSession
 from lib.db.models.site import DbSite
 
@@ -14,7 +13,6 @@ def try_get_site_with_cand_id_visit_label(db: Database, cand_id: int, visit_labe
 
     return db.execute(select(DbSite)
         .join(DbSession.site)
-        .join(DbSession.candidate)
-        .where(DbCandidate.cand_id == cand_id)
+        .where(DbSession.cand_id == cand_id)
         .where(DbSession.visit_label == visit_label)
     ).scalar_one_or_none()

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -336,7 +336,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         archive_location = self.dicom_archive_obj.tarchive_info_dict["ArchiveLocation"]
 
         fields_to_update = ("SessionID",)
-        values_for_update = (self.session_obj.session_id,)
+        values_for_update = (self.session.id,)
         pattern = re.compile("^[0-9]{4}/")
         if acq_date and not pattern.match(archive_location):
             # move the DICOM archive into a year subfolder
@@ -412,7 +412,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         self.imaging_upload_obj.update_mri_upload(
             upload_id=self.upload_id,
             fields=("Inserting", "InsertionComplete", "number_of_mincInserted", "number_of_mincCreated", "SessionID"),
-            values=("0", "1", len(files_inserted_list), len(self.nifti_files_to_insert), self.session_obj.session_id)
+            values=("0", "1", len(files_inserted_list), len(self.nifti_files_to_insert), self.session.id)
         )
 
     def _get_summary_of_insertion(self):

--- a/python/lib/get_subject_session.py
+++ b/python/lib/get_subject_session.py
@@ -1,0 +1,83 @@
+from typing import cast
+
+import lib.exitcode
+from lib.config_file import SubjectInfo
+from lib.db.models.candidate import DbCandidate
+from lib.db.models.session import DbSession
+from lib.db.queries.candidate import try_get_candidate_with_cand_id
+from lib.db.queries.session import try_get_session_with_cand_id_visit_label
+from lib.db.queries.site import try_get_site_with_cand_id_visit_label
+from lib.env import Env
+from lib.logging import log_error_exit, log_verbose
+
+
+def get_candidate_next_visit_number(candidate: DbCandidate) -> int:
+    """
+    Get the next visit number for a new session for a given candidate.
+    """
+
+    visit_numbers = [session.visit_number for session in candidate.sessions if session.visit_number is not None]
+    return max(*visit_numbers, 0) + 1
+
+
+def get_subject_session(env: Env, subject_info: SubjectInfo) -> DbSession:
+    """
+    Get the imaging session corresponding to a given subject configuration.
+
+    This function first looks for an adequate session in the database, and returns it if one is
+    found. If no session is found, this function creates a new session in the database if the
+    subject configuration allows it, or exits the program otherwise.
+    """
+
+    session = _get_subject_session(env, subject_info)
+    log_verbose(env, f"Session ID for the file to insert is {session.id}")
+    return session
+
+
+def _get_subject_session(env: Env, subject_info: SubjectInfo) -> DbSession:
+    """
+    Implementation of `get_subject_session`.
+    """
+
+    session = try_get_session_with_cand_id_visit_label(env.db, subject_info.cand_id, subject_info.visit_label)
+    if session is not None:
+        return session
+
+    if subject_info.create_visit is None:
+        log_error_exit(
+            env,
+            f"Visit {subject_info.visit_label} for candidate {subject_info.cand_id} does not exist.",
+            lib.exitcode.GET_SESSION_ID_FAILURE,
+        )
+
+    if subject_info.is_phantom:
+        site = try_get_site_with_cand_id_visit_label(env.db, subject_info.cand_id, subject_info.visit_label)
+        visit_number = 1
+    else:
+        candidate = try_get_candidate_with_cand_id(env.db, subject_info.cand_id)
+        # Safe because it has been checked that the candidate exists in `validate_subject_info`
+        candidate = cast(DbCandidate, candidate)
+        site = candidate.registration_site
+        visit_number = get_candidate_next_visit_number(candidate)
+
+    if site is None:
+        log_error_exit(
+            env,
+            f"No center ID found for candidate {subject_info.cand_id}, visit {subject_info.visit_label}"
+        )
+
+    session = DbSession(
+        cand_id       = subject_info.cand_id,
+        site_id       = site.id,
+        visit_number  = visit_number,
+        current_stage = 'Not Started',
+        scan_done     = True,
+        submitted     = False,
+        project_id    = subject_info.create_visit.project_id,
+        cohort_id     = subject_info.create_visit.cohort_id,
+    )
+
+    env.db.add(session)
+    env.db.commit()
+
+    return session

--- a/python/lib/get_subject_session.py
+++ b/python/lib/get_subject_session.py
@@ -66,6 +66,8 @@ def _get_subject_session(env: Env, subject_info: SubjectInfo) -> DbSession:
             f"No center ID found for candidate {subject_info.cand_id}, visit {subject_info.visit_label}"
         )
 
+    log_verbose(env, f"Set newVisitNo = {visit_number} and center ID = {site.id}")
+
     session = DbSession(
         cand_id       = subject_info.cand_id,
         site_id       = site.id,

--- a/python/lib/session.py
+++ b/python/lib/session.py
@@ -1,5 +1,7 @@
 """This class gather functions for session handling."""
 
+from typing_extensions import deprecated
+
 from lib.database_lib.project_cohort_rel import ProjectCohortRel
 from lib.database_lib.session_db import SessionDB
 from lib.database_lib.site import Site
@@ -126,6 +128,7 @@ class Session:
 
         return loris_session_info[0] if loris_session_info else None
 
+    @deprecated('Use `lib.db.queries.site.try_get_site_with_psc_id_visit_label` instead')
     def get_session_center_info(self, pscid, visit_label):
         """
         Get the session center information based on the PSCID and visit label of a session.
@@ -140,6 +143,7 @@ class Session:
         """
         return self.session_db_obj.get_session_center_info(pscid, visit_label)
 
+    @deprecated('Use `lib.db.queries.try_get_candidate_with_cand_id_visit_label` instead')
     def create_session_dict(self, cand_id, visit_label):
         """
         Creates the session information dictionary based on a candidate ID and visit label. This will populate
@@ -159,6 +163,7 @@ class Session:
             self.cohort_id = self.session_info_dict['CohortID']
             self.session_id = self.session_info_dict['ID']
 
+    @deprecated('Use `lib.db.models.session.DbSession` instead')
     def insert_into_session(self, session_info_to_insert_dict):
         """
         Insert a new row in the session table using fields list as column names and values as values.
@@ -176,6 +181,7 @@ class Session:
 
         return self.session_id
 
+    @deprecated('Use `lib.get_subject_session.get_candidate_next_visit_number` instead')
     def get_next_session_site_id_and_visit_number(self, cand_id):
         """
         Determines the next session site and visit number based on the last session inserted for a given candidate.


### PR DESCRIPTION
This PR extracts the "get subject session" operation out of `BasePipeline`, with the goal of making it easily reusable by all scripts, including those that do not use `BasePipeline` (new DICOM archive and eventually BIDS import). It also modernizes the database access by using the new SQLAlchemy abstractions.

Is depended on by:
- #1117 (to implement #1044)
