### PR TITLE
Unify LORIS-MRI logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ include = [
     "python/lib/db",
     "python/lib/exception",
     "python/lib/config_file.py",
+    "python/lib/env.py",
+    "python/lib/file_system.py",
+    "python/lib/logging.py",
+    "python/lib/make_env.py",
     "python/lib/validate_subject_info.py",
 ]
 typeCheckingMode = "strict"

--- a/python/lib/database_lib/notification.py
+++ b/python/lib/database_lib/notification.py
@@ -2,9 +2,12 @@
 
 import datetime
 
+from typing_extensions import deprecated
+
 __license__ = "GPLv3"
 
 
+@deprecated('Use `lib.db.model.notification_spool` instead')
 class Notification:
     """
     This class performs database queries for imaging pipeline notification_spool table.
@@ -46,6 +49,7 @@ class Notification:
         self.notification_origin = notification_origin
         self.process_id = process_id
 
+    @deprecated('Use `lib.logging.register_notification` instead')
     def write_to_notification_spool(self, message, is_error, is_verbose, center_id=None):
         """
         Insert a row in the notification_spool table.

--- a/python/lib/db/connect.py
+++ b/python/lib/db/connect.py
@@ -1,13 +1,11 @@
 from sqlalchemy import URL, create_engine
-from sqlalchemy.orm import Session
 
 from lib.config_file import DatabaseConfig
 
 
-def connect_to_database(config: DatabaseConfig):
+def get_database_engine(config: DatabaseConfig):
     """
-    Connect to the database and get an SQLAlchemy session to interract with it using the provided
-    credentials.
+    Connect to the database and return an SQLAlchemy engine using the provided credentials.
     """
 
     # The SQLAlchemy URL object notably escapes special characters in the configuration attributes
@@ -20,5 +18,4 @@ def connect_to_database(config: DatabaseConfig):
         database   = config.database,
     )
 
-    engine = create_engine(url)
-    return Session(engine)
+    return create_engine(url)

--- a/python/lib/db/query/notification.py
+++ b/python/lib/db/query/notification.py
@@ -4,12 +4,12 @@ from sqlalchemy.orm import Session as Database
 from lib.db.model.notification_type import DbNotificationType
 
 
-def get_notification_type_with_name(db: Database, name: str):
+def try_get_notification_type_with_name(db: Database, name: str):
     """
-    Get a notification type from the database using its configuration setting name, or raise an
-    exception if no notification type is found.
+    Get a notification type from the database using its configuration setting name, or return
+    `None` if no notification type is found.
     """
 
     return db.execute(select(DbNotificationType)
         .where(DbNotificationType.name == name)
-    ).scalar_one()
+    ).scalar_one_or_none()

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_validation_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_validation_pipeline.py
@@ -3,6 +3,7 @@ import sys
 
 import lib.exitcode
 from lib.dcm2bids_imaging_pipeline_lib.base_pipeline import BasePipeline
+from lib.logging import log_error_exit, log_verbose
 
 __license__ = "GPLv3"
 
@@ -33,8 +34,7 @@ class DicomValidationPipeline(BasePipeline):
         # ---------------------------------------------------------------------------------------------
         # If we get here, the tarchive is validated & the script stops running so update mri_upload
         # ---------------------------------------------------------------------------------------------
-        message = f"DICOM archive {self.options_dict['tarchive_path']['value']} is valid!"
-        self.log_info(message, is_error="N", is_verbose="Y")
+        log_verbose(self.env, f"DICOM archive {self.options_dict['tarchive_path']['value']} is valid!")
         self.imaging_upload_obj.update_mri_upload(
             upload_id=self.upload_id,
             fields=("isTarchiveValidated", "Inserting",),
@@ -49,18 +49,18 @@ class DicomValidationPipeline(BasePipeline):
         logged in the <tarchive> table.
         """
 
-        self.log_info(message="Verifying DICOM archive md5sum (checksum)", is_error="N", is_verbose="Y")
+        log_verbose(self.env, "Verifying DICOM archive md5sum (checksum)")
 
         tarchive_path = os.path.join(self.dicom_lib_dir, self.dicom_archive_obj.tarchive_info_dict["ArchiveLocation"])
         result = self.dicom_archive_obj.validate_dicom_archive_md5sum(tarchive_path)
         message = result["message"]
 
         if result['success']:
-            self.log_info(message, is_error="N", is_verbose="Y")
+            log_verbose(self.env, message)
         else:
             self.imaging_upload_obj.update_mri_upload(
                 upload_id=self.upload_id,
                 fields=("isTarchiveValidated", "IsCandidateInfoValidated"),
                 values=("0", "0")
             )
-            self.log_error_and_exit(message, lib.exitcode.CORRUPTED_FILE, is_error="Y", is_verbose="N")
+            log_error_exit(self.env,  message, lib.exitcode.CORRUPTED_FILE)

--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -5,6 +5,7 @@ import sys
 import lib.exitcode
 import lib.utilities
 from lib.dcm2bids_imaging_pipeline_lib.base_pipeline import BasePipeline
+from lib.logging import log_error_exit
 
 __license__ = "GPLv3"
 
@@ -41,8 +42,7 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         # ---------------------------------------------------------------------------------------------
         self.s3_obj = self.loris_getopt_obj.s3_obj
         if not self.s3_obj.s3:
-            message = "S3 configs not configured properly"
-            self.log_error_and_exit(message, lib.exitcode.S3_SETTINGS_FAILURE, is_error="Y", is_verbose="N")
+            log_error_exit(self.env, "S3 configs not configured properly", lib.exitcode.S3_SETTINGS_FAILURE)
 
         # ---------------------------------------------------------------------------------------------
         # Get all the files from files, parameter_file and violation tables

--- a/python/lib/env.py
+++ b/python/lib/env.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+from typing import Callable
+
+from sqlalchemy import Engine
+from sqlalchemy.orm import Session
+
+from lib.db.query.notification import get_notification_type_with_name
+
+
+@dataclass
+class Notifier:
+    """
+    This class wraps information used to send the script logs to the database.
+    """
+
+    # Database session of the notifier, separate from the main database session to not hinder its
+    # transactions
+    db: Session
+    # Notification type ID
+    type_id: int
+    # Notification origin, which is usually the script name
+    origin: str
+    # Process ID, which is usually the MRI upload ID
+    process_id: int
+
+
+@dataclass
+class Env:
+    """
+    This class wraps information about the environmentin which a LORIS-MRI script is executed. It
+    notably stores the database handle and various information used for logging.
+    """
+
+    db_engine: Engine
+    db: Session
+    script_name: str
+    log_file: str
+    verbose: bool
+    cleanups: list[Callable[[], None]]
+    notifier: Notifier | None = None
+
+    def add_cleanup(self, cleanup: Callable[[], None]):
+        """
+        Add a cleanup function to the environment, which will be executed if the program exits
+        early.
+        """
+
+        self.cleanups.append(cleanup)
+
+    def run_cleanups(self):
+        """
+        Run all the cleanup functions of the environment in the reverse insertion order (most
+        recent is ran first). This clears the cleanup functions list.
+        """
+
+        while self.cleanups != []:
+            cleanup = self.cleanups.pop()
+            cleanup()
+
+    def init_notifier(self, process_id: int):
+        """
+        Associate the current script with a given process ID, which notably allows to start logging
+        execution information in the database.
+        """
+
+        notification_session = Session(self.db_engine)
+        notification_type_name = f'PYTHON {self.script_name.replace("_", " ").upper()}'
+        notification_type = get_notification_type_with_name(self.db, notification_type_name)
+        self.notifier = Notifier(
+            notification_session,
+            notification_type.id,
+            f'{self.script_name}.py',
+            process_id,
+        )

--- a/python/lib/file_system.py
+++ b/python/lib/file_system.py
@@ -1,0 +1,47 @@
+import os
+import shutil
+import tarfile
+import tempfile
+from datetime import datetime
+
+import lib.exitcode
+from lib.env import Env
+from lib.logging import log_error_exit, log_verbose, log_warning
+
+
+def extract_archive(env: Env, tar_path: str, prefix: str, dir_path: str):
+    """
+    Extract an archive in a new temporary directory inside the given directory and return
+    the new directory location.
+    """
+
+    date_string = datetime.now().strftime('%Y-%m-%d_%Hh%Mm%Ss')
+    full_prefix = f'{prefix}_DIR_{date_string}_'
+    extract_path = tempfile.mkdtemp(prefix=full_prefix, dir=dir_path)
+    with tarfile.open(tar_path) as tar_file:
+        tar_file.extractall(extract_path)
+
+    return extract_path
+
+
+def remove_directory(env: Env, path: str):
+    """
+    Delete a directory and its content.
+    """
+
+    if os.path.exists(path):
+        try:
+            shutil.rmtree(path)
+        except PermissionError as error:
+            log_warning(env, f"Could not delete {path}. Error was: {error}")
+
+
+def copy_file(env: Env, old_path: str, new_path: str):
+    """
+    Copy a file on the file system.
+    """
+
+    log_verbose(env, f"Moving {old_path} to {new_path}")
+    shutil.copytree(old_path, new_path, dirs_exist_ok=True)
+    if not os.path.exists(new_path):
+        log_error_exit(env, f"Could not copy {old_path} to {new_path}", lib.exitcode.COPY_FAILURE)

--- a/python/lib/imaging_io.py
+++ b/python/lib/imaging_io.py
@@ -5,6 +5,8 @@ import sys
 import tarfile
 import tempfile
 
+from typing_extensions import deprecated
+
 from lib.exitcode import COPY_FAILURE
 
 """Set of io functions."""
@@ -12,11 +14,13 @@ from lib.exitcode import COPY_FAILURE
 __license__ = "GPLv3"
 
 
+@deprecated('Use `lib.logging` and `lib.file_system` instead')
 class ImagingIO:
     def __init__(self, log_obj, verbose):
         self.log_obj = log_obj
         self.verbose = verbose
 
+    @deprecated('Use `lib.file_system.extract_archive` instead')
     def extract_archive(self, location, prefix, tmp_dir):
         """
         Extract Archive in the temporary directory
@@ -33,6 +37,7 @@ class ImagingIO:
         tar_file.close()
         return extract_location
 
+    @deprecated('Use `lib.file_system.remove_directory` instead')
     def remove_dir(self, dir):
         """
         Removes a directory and its content
@@ -44,6 +49,7 @@ class ImagingIO:
             except PermissionError as err:
                 self.log_info(f"Could not delete {dir}. Error was: {err}", is_error=True, is_verbose=False)
 
+    @deprecated('Use `lib.file_system.copy_file` instead')
     def copy_file(self, old_file_path, new_file_path):
         """
         Move a file on the file system.
@@ -60,6 +66,7 @@ class ImagingIO:
             message = f'Could not copy {old_file_path} to {new_file_path}'
             self.log_error_and_exit(message, COPY_FAILURE, is_error=True)
 
+    @deprecated('Use `lib.logging.log_*` instead')
     def log_info(self, message, is_error=False, is_verbose=True, to_file=True, to_table=True):
         """
         Function to log information that need to be logged in the notification_spool table and in the log
@@ -91,6 +98,7 @@ class ImagingIO:
         if self.verbose:
             print(f"{log_msg}\n")
 
+    @deprecated('Use `lib.logging.log_error_exit` instead')
     def log_error_and_exit(self, message, exit_code, callback = None):
         """
         Function to commonly executes all logging information when the script needs to be

--- a/python/lib/log.py
+++ b/python/lib/log.py
@@ -2,11 +2,14 @@
 
 import os
 
+from typing_extensions import deprecated
+
 from lib.database_lib.notification import Notification
 
 __license__ = "GPLv3"
 
 
+@deprecated('Use `lib.logging` instead')
 class Log:
     """
     Class that handles the log edition of the imaging pipeline.
@@ -46,6 +49,7 @@ class Log:
 
         self.create_log_header()
 
+    @deprecated('Use `lib.env.Env.init_notifier` instead')
     def initiate_notification_db_obj(self, upload_id):
         """
         Instantiate the notification_db_obj to be able to write in the notification table. This can only be done

--- a/python/lib/logging.py
+++ b/python/lib/logging.py
@@ -1,0 +1,94 @@
+import sys
+from datetime import datetime
+from typing import Never
+
+from lib.db.model.notification_spool import DbNotificationSpool
+from lib.env import Env
+
+
+def log(env: Env, message: str):
+    """
+    Log a standard message.
+    """
+
+    print(message)
+    write_to_log_file(env, message)
+    register_notification(env, message, False, False)
+
+
+def log_verbose(env: Env, message: str):
+    """
+    Log a verbose message, which is displayed only if the script is running in verbose mode.
+    """
+
+    if env.verbose:
+        print(message)
+
+    write_to_log_file(env, message)
+    register_notification(env, message, False, True)
+
+
+def log_warning(env: Env, message: str):
+    """
+    Log a warning message.
+    """
+
+    full_message = f"WARNING: {message}"
+    print(full_message, file=sys.stderr)
+    write_to_log_file(env, full_message)
+    register_notification(env, full_message, True, False)
+
+
+def log_error(env: Env, message: str):
+    """
+    Log an error message without exiting the program.
+    """
+
+    full_message = f"ERROR: {message}"
+    print(full_message, file=sys.stderr)
+    write_to_log_file(env, full_message)
+    register_notification(env, full_message, True, False)
+
+
+def log_error_exit(env: Env, message: str, exit_code: int = -1) -> Never:
+    """
+    Log an error message and exit the program, executing the cleanup procedures while doing so.
+    """
+
+    log_error(env, message)
+    env.run_cleanups()
+    sys.exit(exit_code)
+
+
+def write_to_log_file(env: Env, message: str):
+    """
+    Write a message to the log file of the environment.
+    """
+
+    with open(env.log_file, 'a') as file:
+        file.write(f"{message}\n")
+
+
+def register_notification(env: Env, message: str, is_error: bool, is_verbose: bool):
+    """
+    Log a message in the database notifications if the notification information of the environment
+    have been initialized.
+    """
+
+    if env.notifier is None:
+        return
+
+    notification = DbNotificationSpool(
+        type_id      = env.notifier.type_id,
+        time_spooled = datetime.now(),
+        message      = message,
+        origin       = env.notifier.origin,
+        process_id   = env.notifier.process_id,
+        error        = is_error,
+        verbose      = is_verbose,
+        sent         = False,
+        active       = True,
+    )
+
+    env.notifier.db.add(notification)
+    env.notifier.db.commit()

--- a/python/lib/lorisgetopt.py
+++ b/python/lib/lorisgetopt.py
@@ -67,6 +67,7 @@ class LorisGetOpt:
         were provided to the script.
         """
         self.usage = usage
+        self.script_name = script_name
         self.options_dict = options_dict
         self.long_options = self.get_long_options()
         self.short_options = self.get_short_options()

--- a/python/lib/make_env.py
+++ b/python/lib/make_env.py
@@ -27,8 +27,8 @@ def make_env(loris_get_opt: LorisGetOpt):
             'Connecting to the database using the following configuration:\n'
             f'  Host: {config.host}\n'
             f'  Port: {config.port}\n'
-            f'  Username: {config.username}\n'
             f'  Database: {config.database}\n'
+            f'  Username: {config.username}\n'
             '  (password hidden)'
         )
 

--- a/python/lib/make_env.py
+++ b/python/lib/make_env.py
@@ -1,0 +1,82 @@
+import os
+from typing import Any, cast
+
+from sqlalchemy.orm import Session
+
+from lib.config_file import DatabaseConfig
+from lib.db.connect import get_database_engine
+from lib.db.query.config import get_config_with_setting_name
+from lib.env import Env
+from lib.logging import log_verbose, write_to_log_file
+from lib.lorisgetopt import LorisGetOpt
+
+
+def make_env(loris_get_opt: LorisGetOpt):
+    """
+    Create a new script environment using the provided LORIS options object.
+    """
+
+    verbose = cast(bool, loris_get_opt.options_dict['verbose']['value'])
+    config = cast(DatabaseConfig, loris_get_opt.config_info.mysql)  # type: ignore
+    script_name = loris_get_opt.script_name
+
+    # Connect to the database
+
+    if verbose:
+        print(
+            'Connecting to the database using the following configuration:\n'
+            f'  Host: {config.host}\n'
+            f'  Port: {config.port}\n'
+            f'  Username: {config.username}\n'
+            f'  Database: {config.database}\n'
+            '  (password hidden)'
+        )
+
+    engine = get_database_engine(config)
+    db = Session(engine)
+
+    # Create the log file
+
+    data_dir = str(get_config_with_setting_name(db, 'dataDirBasepath').value)
+    tmp_dir = os.path.basename(loris_get_opt.tmp_dir)
+    log_dir = os.path.join(data_dir, 'logs', script_name)
+    if not os.path.isdir(log_dir):
+        os.makedirs(log_dir)
+
+    log_file = os.path.join(log_dir, f'{tmp_dir}.log')
+
+    env = Env(
+        engine,
+        db,
+        script_name,
+        log_file,
+        verbose,
+        [],
+    )
+
+    log_file_header = get_log_file_header(env, loris_get_opt.options_dict)
+    write_to_log_file(env, log_file_header)
+
+    log_verbose(env, 'Successfully connected to the database')
+
+    return env
+
+
+def get_log_file_header(env: Env, script_options: dict[str, Any]):
+    run_info = os.path.basename(env.log_file[:-13])
+    title = run_info.replace('_', ' ').upper()
+    message = (
+        "\n"
+        "----------------------------------------------------------------\n"
+        f"  {title}\n"
+        "----------------------------------------------------------------\n"
+        "\n"
+        "Script run with the following options set\n"
+    )
+
+    for key in script_options:
+        if script_options[key]['value']:
+            message += f"  --{key}: {script_options[key]['value']}\n"
+
+    message += "\n"
+    return message

--- a/python/lib/make_env.py
+++ b/python/lib/make_env.py
@@ -18,7 +18,7 @@ def make_env(loris_get_opt: LorisGetOpt):
 
     verbose = cast(bool, loris_get_opt.options_dict['verbose']['value'])
     config = cast(DatabaseConfig, loris_get_opt.config_info.mysql)  # type: ignore
-    script_name = loris_get_opt.script_name
+    script_name = cast(str, loris_get_opt.script_name)
 
     # Connect to the database
 
@@ -54,7 +54,7 @@ def make_env(loris_get_opt: LorisGetOpt):
         [],
     )
 
-    log_file_header = get_log_file_header(env, loris_get_opt.options_dict)
+    log_file_header = get_log_file_header(env, loris_get_opt.options_dict)  # type: ignore
     write_to_log_file(env, log_file_header)
 
     log_verbose(env, 'Successfully connected to the database')

--- a/python/tests/util/database.py
+++ b/python/tests/util/database.py
@@ -1,12 +1,11 @@
 import os
 import sys
-from typing import cast
 
-from sqlalchemy import Engine, create_engine
+from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from lib.db.base import Base
-from lib.db.connect import connect_to_database
+from lib.db.connect import get_database_engine
 
 
 def create_test_database():
@@ -28,5 +27,4 @@ def get_integration_database_engine():
     config_file = os.path.join(os.environ['LORIS_CONFIG'], '.loris_mri', 'database_config.py')
     sys.path.append(os.path.dirname(config_file))
     config = __import__(os.path.basename(config_file[:-3]))
-    session = connect_to_database(config.mysql)
-    return cast(Engine, session.get_bind())
+    return get_database_engine(config.mysql)


### PR DESCRIPTION
# Description of the PR

This PR is a rewrite of the logging and I/O modules of LORIS-MRI.

# Problems of the current architecture

There are several problems with the current logging and I/O architecture of LORIS-MRI:
1. It is fragmented. The core logging class is the `Log` class. The `BasePipeline` and `ImagingIO` classes build on top of `Log` provide better abstractions, with some amount of duplication between those two classes (some scripts simply use `print` but they are not the subject of this PR).
2. The `BasePipeline` class is too coupled with the DCM2BIDS pipeline to be generalized.
3. The `BasePipeline` and `ImagingIO` classes handle both logging and file system operations, which are two different responsibilities.
4. The logging abstractions are verbose, notably because all logging functions require two keyword arguments  `is_error = 'Y' | 'N'` and `is_verbose = 'Y' | 'N'`.
5. The logging functions sometimes uses stdout to print errors, whereas they should use stderr.
6. The code does not integrate the latest LORIS-MRI architecture improvements, namely static typing and the SQLAlchemy integration.

# Description of the new architecture

This PR adds the following:
1. An `lib.env.Env` dataclass that stores generic information about a running script.
2. The `lib.logging` module that handles log operations.
3. The `lib.file_system` module that handles file system operations.
4. The `make_env` function that allows to build an `Env` from a `LorigGetOpt` object (note that the environment does not directly depend on `LorisGetOpt`, it could also be built manually).

Those abstractions aim to replace the `Log` and `ImagingIO` classes, as well as the `BasePipeline` logging methods. They are script-agnostic, remove the existing duplication, are statically typed, use the SQLAlchemy abstractions, and provide more convenient interfaces IMO. They also use simple functions instead of classes, which I think is better for simplicity, reusability and testability.

# Backwards compatibility

This PR is backwards compatible as the old abstractions are not replaced by this PR. They are however annotated as depcreated to let some time for external scripts to move to the old abstractions. All the uses of the old abstractions in LORIS-MRI are replaced by the new abstractions in this PR, so the deprecated files remain only for external scripts compatibility.

Ultimately (once the migration is finished), I would like the new logging module to take the `lib.log` namespace though (the same way I would like the new database module to use the `lib.database` module).

# Final notes

I am not an expert in logging, but I am not a fan of how logging is done in LORIS-MRI (printing AND writing to a log file that does not differentiate stdout and stderr AND inserting into the database on every print). I much prefer how the LORIS process manager does it, which is redirecting stdout and stderr to some files, and saving these files paths in the database. Nevertheless, the current behaviour is conserved in this PR as it is only an architectural change, and I believe this PR is an improvement no matter how LORIS-MRI logging evolves in the future.
