### PR TITLE
Stricter global type checking

### DIFF
--- a/python/lib/scanstsv.py
+++ b/python/lib/scanstsv.py
@@ -73,16 +73,13 @@ class ScansTSV:
             return None
 
         if 'acq_time' in self.acquisition_data:
-            if isinstance(self.tsv_entries, list):
-                acq_time_list = [ele for ele in self.tsv_entries if ele['filename'] in self.acquisition_file]
-                if len(acq_time_list) == 1:
-                    # the variable name could be mri_acq_time, but is eeg originally.
-                    eeg_acq_time = acq_time_list[0]['acq_time']
-                else:
-                    print('More than one or no acquisition time has been found for ', self.acquisition_file)
-                    exit()
+            acq_time_list = [ele for ele in self.tsv_entries if ele['filename'] in self.acquisition_file]
+            if len(acq_time_list) == 1:
+                # the variable name could be mri_acq_time, but is eeg originally.
+                eeg_acq_time = acq_time_list[0]['acq_time']
             else:
-                eeg_acq_time = self.acquisition_data['acq_time']
+                print('More than one or no acquisition time has been found for ', self.acquisition_file)
+                exit()
 
             if eeg_acq_time == 'n/a':
                 return None

--- a/test/pyrightconfig.json
+++ b/test/pyrightconfig.json
@@ -3,5 +3,11 @@
     "exclude": ["../python/react-series-data-viewer"],
     "typeCheckingMode": "off",
     "reportDeprecated": "warning",
-    "reportMissingImports": "error"
+    "reportAbstractUsage": "error",
+    "reportInvalidTypeForm": "error",
+    "reportMissingImports": "error",
+    "reportUnboundVariable": "error",
+    "reportUnnecessaryIsInstance": "error",
+    "reportUnusedExcept": "error",
+    "reportUnusedExpression": "error"
 }


### PR DESCRIPTION
Improve the global type checker by adding rules for a few things that can obviously be checked as errors even without the presence of types (unbound variables, useless type checks, unused expressions...).