### PR TITLE
Fix Pytest unit tests config typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = [
 typeCheckingMode = "strict"
 reportMissingTypeStubs = "none"
 
-[tool.pytest.ini-options]
+[tool.pytest.ini_options]
 # Integration tests are located in `python/tests/integration`, but they should be ran from the
 # appropriate Docker image (usually using GitHub Actions).
 testpaths = ["python/tests/unit"]


### PR DESCRIPTION
Fix a simple typo in the Pytest configuration.

Previously the `pytest` command was ignoring the configuration because of this typo and all tests, including the integration, tests were ran. This is not what we want since integration tests should only be ran in Docker. Now the command `pytest` only runs unit tests (to run integration tests, use `pytest python/tests/integration`).