### PR TITLE
Remove mysql-connector dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/__pycache__/*
 *.pyc
 .loris_mri/
+python_virtualenvs/

--- a/install/INSTALL.Mac.md
+++ b/install/INSTALL.Mac.md
@@ -1,18 +1,18 @@
 # LORIS-MRI Mac Install Guide
 
-### Mac systems are Not supported for LORIS. 
-This guide is offered unofficially on a best-effort basis. 
+### Mac systems are Not supported for LORIS.
+This guide is offered unofficially on a best-effort basis.
 For best results, we recommend installing LORIS on Ubuntu or CentOS.
 
 This file provides guidance on how to install the imaging pipeline on your Mac computer. LORIS must already be installed.
 
-It has been tested for Mac OS X 10.13. 
-Updates and contributions welcome (also see [Contributing Guide](https://github.com/aces/Loris/blob/main/CONTRIBUTING.md)) 
+It has been tested for Mac OS X 10.13.
+Updates and contributions welcome (also see [Contributing Guide](https://github.com/aces/Loris/blob/main/CONTRIBUTING.md))
 
 ## Get the code
 
 Fork the repository to your GitHub user account.
-Then clone this fork on your server as follows (this will create a directory called `mri`) : 
+Then clone this fork on your server as follows (this will create a directory called `mri`) :
 
 ```
 sudo mkdir -p /data/$PROJ/bin
@@ -57,20 +57,20 @@ sudo -S cpanm https://github.com/aces/Loris-MRI/raw/main/install/Digest-BLAKE2-0
 
 ## Install key Python libraries
 
-- Python dependencies to install 
+- Python dependencies to install
 
 ```
 brew install python3
 pip install virtualenv
 ```
 
-- Create the LORIS-MRI virtual python environment 
+- Create the LORIS-MRI virtual python environment
 
 ```
 virtualenv /data/$PROJECT/bin/mri/python_virtualenvs/loris-mri-python
 ```
 
-- Source the `loris-mri-python` virtual environment to install python library dependencies 
+- Source the `loris-mri-python` virtual environment to install python library dependencies
 
 ```
 source /data/$PROJECT/bin/mri/python_virtualenvs/loris-mri-python/bin/activate
@@ -80,7 +80,6 @@ source /data/$PROJECT/bin/mri/python_virtualenvs/loris-mri-python/bin/activate
 
 ```
 pip install mysqlclient
-pip install mysql-connector
 pip install pybids
 pip install pyblake2
 pip install mne
@@ -99,26 +98,26 @@ brew install md5sha1sum
 ```
 
 ## Install GNU `grep`
- 
+
 One of the command run in the insertion pipeline uses a functionality of `grep` that
 can only be found in the GNU version of `grep` for Mac. The default installed version
-of `grep` in a Mac install does not include the possibility to search based on a 
+of `grep` in a Mac install does not include the possibility to search based on a
 perl regular expression (option `-P`).
 ```
 brew install grep
 ```
 
-And add the following to the .bash_profile of the user that will be running the 
-pipeline so that the Linux `grep` is used when running the pipeline instead of 
+And add the following to the .bash_profile of the user that will be running the
+pipeline so that the Linux `grep` is used when running the pipeline instead of
 the Mac `grep`.
 
 ```
-# Add path to linux grep instead of the Mac grep as the Mac one does 
+# Add path to linux grep instead of the Mac grep as the Mac one does
 # not have all the functionatities needed by the LORIS imaging pipeline
 PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"
 ```
 
-## Run install script for Mac: imaging_install_MacOSX.sh 
+## Run install script for Mac: imaging_install_MacOSX.sh
 
 ```
 cd /data/$PROJ/bin/mri/install

--- a/python/lib/db/connect.py
+++ b/python/lib/db/connect.py
@@ -1,4 +1,5 @@
 from typing import Any
+from urllib.parse import quote
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
@@ -9,9 +10,9 @@ default_port = 3306
 def connect_to_db(credentials: dict[str, Any]):
     host     = credentials['host']
     port     = credentials['port']
-    username = credentials['username']
-    password = credentials['passwd']
+    username = quote(credentials['username'])
+    password = quote(credentials['passwd'])
     database = credentials['database']
     port     = int(port) if port else default_port
-    engine = create_engine(f'mariadb+mysqlconnector://{username}:{password}@{host}:{port}/{database}')
+    engine = create_engine(f'mysql+mysqldb://{username}:{password}@{host}:{port}/{database}')
     return Session(engine)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,7 +4,6 @@ mat73
 matplotlib
 mne
 mne-bids>=0.6
-mysql-connector
 mysqlclient
 nilearn
 nibabel


### PR DESCRIPTION
While testing #1150, @cmadjar encountered an issue when connecting to the database through SQLAlchemy. I suspect this is because this connection is using a deprecated version of [`mysql-connector`](https://pypi.org/project/mysql-connector/). This dependency was already present in LORIS-MRI before adding SQLAlchemy although it was unused, and I wrongfully used it for the SQLAlchemy connection not knowing the version we had was deprecated (the non-depecrated version is [`mysql-connector-python`](https://pypi.org/project/mysql-connector-python/).).

Solution: Remove the `mysql-connector` dependency and use `mysqlclient` instead, which is the client we use for the non-SQLAlchemy database connection.

P.S. 1: I manually recreated my virtual environment to make sure the dependency was completely removed, but it was detected by git, so I added the directory the gitignore, I have no idea why it was ignored before.

P.S. 2 : Some whitespace auto-trimming, ignore whitespaces in review.

# Notes for existing projects

- need to remove `mysql-connector` via `pip uninstall mysql-connector`
