### PR TITLE
Remove unused attribute in NIFTI script

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -75,11 +75,6 @@ class NiftiInsertionPipeline(BasePipeline):
         self._add_step_and_space_params_to_json_file_dict()
 
         # ---------------------------------------------------------------------------------------------
-        # Get the mapping dictionary between BIDS and MINC terms
-        # ---------------------------------------------------------------------------------------------
-        self.bids_mapping_dict = self.imaging_obj.get_bids_to_minc_terms_mapping()
-
-        # ---------------------------------------------------------------------------------------------
         # Check that the PatientName in NIfTI and DICOMs are the same and then validate the Subject IDs
         # ---------------------------------------------------------------------------------------------
         if self.dicom_archive_obj.tarchive_info_dict.keys():


### PR DESCRIPTION
The `bids_mapping_dict` attribute in `nifti_insertion_pipeline.py` is unused, and `get_bids_to_minc_terms_mapping` does not mutate its parameters. Hence the attribute and function call can be removed.

The script works by calling `get_bids_to_minc_terms_mapping` later in `imaging.py`.