### PR TITLE
Clean up Docker database scripts

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,11 @@ on:
     - 'main'
     - '*-release'
 
+env:
+  DATABASE_NAME: TestDatabase
+  DATABASE_USERNAME: TestUsername
+  DATABASE_PASSWORD: TestPassword
+
 jobs:
   docker:
     name: Docker
@@ -16,20 +21,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Clone the LORIS core repository
-      run: git clone https://github.com/aces/Loris.git /tmp/Loris
+      run: git clone https://github.com/aces/Loris.git ./test/Loris
 
-    - name: Import database files
-      run: |
-        mkdir -p ./test/database
-        mkdir -p ./test/database/SQL
-        mkdir -p ./test/database/raisinbread/RB_files
-        mkdir -p ./test/database/raisinbread/instruments/instrument_sql
-        mkdir -p ./test/database/test/test_instrument
-        cp -r /tmp/Loris/SQL/* ./test/database/SQL
-        cp -r ./test/RB_SQL/* ./test/database/raisinbread/RB_files
-        cp -r -n /tmp/Loris/raisinbread/RB_files/* ./test/database/raisinbread/RB_files
-        cp -r /tmp/Loris/raisinbread/instruments/instrument_sql/* ./test/database/raisinbread/instruments/instrument_sql
-        cp -r /tmp/Loris/test/test_instrument/testtest.sql ./test/database/test/test_instrument/testtest.sql
+    - name: Overwrite Raisinbread SQL files
+      run: cp -f ./test/RB_SQL/*.sql ./test/Loris/raisinbread/RB_files/
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -39,6 +34,10 @@ jobs:
       with:
         context: .
         file: ./test/db.Dockerfile
+        build-args: |
+          DATABASE_NAME=${{ env.DATABASE_NAME }}
+          DATABASE_USER=${{ env.DATABASE_USERNAME }}
+          DATABASE_PASS=${{ env.DATABASE_PASSWORD }}
         tags: loris-db
         load: true
         cache-from: type=gha,scope=loris-db
@@ -49,6 +48,10 @@ jobs:
       with:
         context: .
         file: ./test/mri.Dockerfile
+        build-args: |
+          DATABASE_NAME=${{ env.DATABASE_NAME }}
+          DATABASE_USERNAME=${{ env.DATABASE_USERNAME }}
+          DATABASE_PASSWORD=${{ env.DATABASE_PASSWORD }}
         tags: loris-mri
         load: true
         cache-from: type=gha,scope=loris-mri

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,8 +50,8 @@ jobs:
         file: ./test/mri.Dockerfile
         build-args: |
           DATABASE_NAME=${{ env.DATABASE_NAME }}
-          DATABASE_USERNAME=${{ env.DATABASE_USERNAME }}
-          DATABASE_PASSWORD=${{ env.DATABASE_PASSWORD }}
+          DATABASE_USER=${{ env.DATABASE_USERNAME }}
+          DATABASE_PASS=${{ env.DATABASE_PASSWORD }}
         tags: loris-mri
         load: true
         cache-from: type=gha,scope=loris-mri

--- a/test/db.Dockerfile
+++ b/test/db.Dockerfile
@@ -1,50 +1,42 @@
 FROM mariadb:latest
 
-COPY test/database/SQL/0000-00-00-schema.sql /0000-00-00-schema.sql
-COPY test/database/SQL/0000-00-01-Modules.sql /0000-00-01-Modules.sql
-COPY test/database/SQL/0000-00-02-Permission.sql /0000-00-02-Permission.sql
-COPY test/database/SQL/0000-00-03-ConfigTables.sql /0000-00-03-ConfigTables.sql
-COPY test/database/SQL/0000-00-04-Help.sql /0000-00-04-Help.sql
-COPY test/database/SQL/0000-00-05-ElectrophysiologyTables.sql /0000-00-05-ElectrophysiologyTables.sql
-COPY test/database/raisinbread/RB_files/*.sql /RB_files/
-COPY test/database/raisinbread/instruments/instrument_sql/aosi.sql  /aosi.sql
-COPY test/database/raisinbread/instruments/instrument_sql/bmi.sql  /bmi.sql
-COPY test/database/raisinbread/instruments/instrument_sql/medical_history.sql  /medical_history.sql
-COPY test/database/raisinbread/instruments/instrument_sql/mri_parameter_form.sql  /mri_parameter_form.sql
-COPY test/database/raisinbread/instruments/instrument_sql/radiology_review.sql  /radiology_review.sql
-COPY test/database/test/test_instrument/testtest.sql /test_instrument.sql
+# Copy the SQL schema files and the Raisinbread data from the main LORIS repository.
+COPY test/Loris/SQL/*.sql .
+COPY test/Loris/raisinbread/instruments/instrument_sql/*.sql ./raisinbread/instruments/
+COPY test/Loris/raisinbread/RB_files/*.sql ./raisinbread/
 
-RUN echo "CREATE DATABASE LorisTest; USE LorisTest;" | cat - \
-    0000-00-00-schema.sql \
-    0000-00-01-Modules.sql \
-    0000-00-02-Permission.sql \
-    0000-00-03-ConfigTables.sql \
-    0000-00-04-Help.sql \
-    0000-00-05-ElectrophysiologyTables.sql \
-    aosi.sql \
-    bmi.sql \
-    medical_history.sql \
-    mri_parameter_form.sql \
-    radiology_review.sql \
-    test_instrument.sql \
-    RB_files/*.sql > /docker-entrypoint-initdb.d/0000-compiled.sql
+# Usually, MariaDB creates the SQL user and database at runtime. Since we want to embed the
+# database in the image, we instead create them manually at build time.
+ARG DATABASE_NAME
+ARG DATABASE_USER
+ARG DATABASE_PASS
 
-RUN echo "CREATE USER 'SQLTestUser'@'%' IDENTIFIED BY 'TestPassword';" >> /docker-entrypoint-initdb.d/0000-compiled.sql
-RUN echo "CREATE USER 'SQLTestUser'@'localhost' IDENTIFIED BY 'TestPassword';" >> /docker-entrypoint-initdb.d/0000-compiled.sql
-RUN echo "GRANT SELECT,INSERT,UPDATE,DELETE,DROP,CREATE TEMPORARY TABLES ON LorisTest.* TO 'SQLTestUser'@'%';" >> /docker-entrypoint-initdb.d/0000-compiled.sql
+# Compile the SQL instructions into a single file that will be sourced by MariaDB.
+RUN ( \
+        echo "CREATE DATABASE $DATABASE_NAME; USE $DATABASE_NAME;" && \
+        echo "CREATE USER '$DATABASE_USER'@'%' IDENTIFIED BY '$DATABASE_PASS';" && \
+        echo "GRANT SELECT,INSERT,UPDATE,DELETE,DROP,CREATE TEMPORARY TABLES ON $DATABASE_NAME.* TO '$DATABASE_USER'@'%';" && \
+        cat \
+        0000-00-00-schema.sql \
+        0000-00-01-Modules.sql \
+        0000-00-02-Permission.sql \
+        0000-00-03-ConfigTables.sql \
+        0000-00-04-Help.sql \
+        0000-00-05-ElectrophysiologyTables.sql \
+        raisinbread/instruments/*.sql \
+        raisinbread/*.sql \
+    ) > source.sql
 
-# Run the LORIS-MRI database installation script
+# Copy the LORIS-MRI database installation script and add it to the compiled SQL file.
 COPY install/install_database.sql /tmp/install_database.sql
-RUN echo "SET @email := 'root@localhost'; SET @project := 'loris'; SET @minc_dir = '/opt/minc/1.9.18';" >> 0000-compiled.sql
-RUN cat /tmp/install_database.sql >> /docker-entrypoint-initdb.d/0000-compiled.sql
+RUN echo "SET @email := 'root@localhost'; SET @project := 'loris'; SET @minc_dir = '/opt/minc/1.9.18';" >> source.sql
+RUN cat /tmp/install_database.sql >> /docker-entrypoint-initdb.d/source.sql
 
-# By default, MariaDB runs the scripts in /docker-entrypoint-initdb.d/ at the time of the first
-# startup to initialize the database. However, we want to populate the database at build time so
-# that the database is part of the final image (and can be cached for CI).
+# By default, MariaDB runs the SQL files provided by the user at the time of the first startup of
+# the image. However, we want to populate the database at build time, we therefore need to manually
+# initialize the database and source the SQL files.
 RUN mariadb-install-db
 RUN docker-entrypoint.sh mariadbd & \
-    sleep 30 && \
-    mariadb < /docker-entrypoint-initdb.d/0000-compiled.sql && \
+    sleep 15 && \
+    mariadb < source.sql && \
     killall mariadbd
-
-CMD ["mariadbd", "--user=root"]

--- a/test/imaging_install_test.sh
+++ b/test/imaging_install_test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-mysqldb="LorisTest"
+mysqldb=$1
 mysqlhost="db"
-mysqluser="SQLTestUser"
-mysqlpass="TestPassword"
+mysqluser=$2
+mysqlpass=$3
 USER="root"
 PROJ="loris"
 prodfilename="prod"

--- a/test/mri.Dockerfile
+++ b/test/mri.Dockerfile
@@ -98,13 +98,13 @@ RUN pip install --no-cache-dir -r ./python/requirements.txt
 
 # Get the database credentials as parameters
 ARG DATABASE_NAME
-ARG DATABASE_USERNAME
-ARG DATABASE_PASSWORD
+ARG DATABASE_USER
+ARG DATABASE_PASS
 
 # Checkout the LORIS-MRI repository
 COPY . /opt/loris/bin/mri
 WORKDIR /opt/loris/bin/mri
-RUN bash ./test/imaging_install_test.sh $DATABASE_NAME $DATABASE_USERNAME $DATABASE_PASSWORD
+RUN bash ./test/imaging_install_test.sh $DATABASE_NAME $DATABASE_USER $DATABASE_PASS
 
 # Setup the LORIS-MRI environment variables
 ENV PROJECT=loris

--- a/test/mri.Dockerfile
+++ b/test/mri.Dockerfile
@@ -96,10 +96,15 @@ RUN cpan install Math::Round && \
 COPY python/requirements.txt ./python/requirements.txt
 RUN pip install --no-cache-dir -r ./python/requirements.txt
 
+# Get the database credentials as parameters
+ARG DATABASE_NAME
+ARG DATABASE_USERNAME
+ARG DATABASE_PASSWORD
+
 # Checkout the LORIS-MRI repository
 COPY . /opt/loris/bin/mri
 WORKDIR /opt/loris/bin/mri
-RUN bash ./test/imaging_install_test.sh
+RUN bash ./test/imaging_install_test.sh $DATABASE_NAME $DATABASE_USERNAME $DATABASE_PASSWORD
 
 # Setup the LORIS-MRI environment variables
 ENV PROJECT=loris


### PR DESCRIPTION
This PR improves the database configuration by doing the following:
1. Store the database name, username, and password in a single place in the GitHub action, removing some duplication.
2. Some minor clean ups.

The main goal of this PR was originally to remove the Raisinbread overwrites but we decided to keep them ultimately, so now it is just a bunch of minor clean ups.