### PR TITLE
Fix Perl dependencies (& CI)

### DIFF
--- a/install/INSTALL.Mac.md
+++ b/install/INSTALL.Mac.md
@@ -35,23 +35,27 @@ sudo ln -s /usr/local/mysql/lib/*.dylib .
 ```
 
 ```
-sudo -S cpan install Math::Round
-sudo -S cpan install Getopt::Tabular
-sudo -S cpan install Time::JulianDay
-sudo -S cpan install Path::Class
-sudo -S cpan install DBI
-sudo -S cpan install DBD::mysql
-sudo -S cpan install Archive::Extract
-sudo -S cpan install Archive::Zip
-sudo -S cpan install Pod::Perldoc
-sudo -S cpan install Pod::Markdown
-sudo -S cpan install Pod::Usage
-sudo -S cpan install JSON
-sudo -S cpan install Moose
-sudo -S cpan install MooseX::Privacy
-sudo -S cpan install TryCatch
-sudo -S cpan install Throwable
-sudo -S cpan install App::cpanminus
+sudo -S cpan App::cpanminus
+sudo -S cpanm Module::Pluggable@5.2
+sudo -S cpanm DBD::mysql@4.052
+sudo -S cpanm Math::Round
+sudo -S cpanm DateTime
+sudo -S cpanm DBI
+sudo -S cpanm Getopt::Tabular
+sudo -S cpanm Time::JulianDay
+sudo -S cpanm Path::Class
+sudo -S cpanm Archive::Extract
+sudo -S cpanm Archive::Zip
+sudo -S cpanm Pod::Perldoc
+sudo -S cpanm Pod::Markdown
+sudo -S cpanm Pod::Usage
+sudo -S cpanm JSON
+sudo -S cpanm Moose
+sudo -S cpanm MooseX::Privacy
+sudo -S cpanm TryCatch
+sudo -S cpanm Throwable
+sudo -S cpanm File::Type
+sudo -S cpanm String::ShellQuote
 sudo -S cpanm https://github.com/aces/Loris-MRI/raw/main/install/Digest-BLAKE2-0.02.tar.gz
 ```
 

--- a/install/imaging_install.sh
+++ b/install/imaging_install.sh
@@ -85,28 +85,29 @@ echo "Successfully connected to database\n"
 #################################################################################################
 echo "Installing the perl libraries...This will take a few minutes..."
 #echo $rootpass | sudo perl -MCPAN -e shell
-sudo -S cpan install Math::Round
 #echo $rootpass | sudo -S cpan install Bundle::CPAN
-sudo -S cpan install DBI
-sudo -S cpan install DBD::mysql
-sudo -S cpan install Getopt::Tabular
-sudo -S cpan install Time::JulianDay
-sudo -S cpan install Path::Class
-sudo -S cpan install Archive::Extract
-sudo -S cpan install Archive::Zip
-sudo -S cpan install Pod::Perldoc
-sudo -S cpan install Pod::Markdown
-sudo -S cpan install Pod::Usage
-sudo -S cpan install JSON
-sudo -S cpan install Moose
-sudo -S cpan install MooseX::Privacy
-sudo -S cpan install TryCatch
-sudo -S cpan install Throwable
-sudo -S cpan install App::cpanminus
+sudo -S cpan App::cpanminus
+sudo -S cpanm Module::Pluggable@5.2
+sudo -S cpanm DBD::mysql@4.052
+sudo -S cpanm Math::Round
+sudo -S cpanm DateTime
+sudo -S cpanm DBI
+sudo -S cpanm Getopt::Tabular
+sudo -S cpanm Time::JulianDay
+sudo -S cpanm Path::Class
+sudo -S cpanm Archive::Extract
+sudo -S cpanm Archive::Zip
+sudo -S cpanm Pod::Perldoc
+sudo -S cpanm Pod::Markdown
+sudo -S cpanm Pod::Usage
+sudo -S cpanm JSON
+sudo -S cpanm Moose
+sudo -S cpanm MooseX::Privacy
+sudo -S cpanm TryCatch
+sudo -S cpanm Throwable
+sudo -S cpanm File::Type
+sudo -S cpanm String::ShellQuote
 sudo -S cpanm https://github.com/aces/Loris-MRI/raw/main/install/Digest-BLAKE2-0.02.tar.gz
-sudo -S cpan install File::Type
-sudo -S cpan install String::ShellQuote
-sudo -S cpan install DateTime
 echo
 
 ################################################################################

--- a/test/mri.Dockerfile
+++ b/test/mri.Dockerfile
@@ -70,26 +70,31 @@ RUN dpkg -i /tmp/bic-mni-models-0.1.1-20120421.deb && \
 RUN apt-get install -y libmariadb-dev libmariadb-dev-compat
 
 # Install the Perl libraries
-RUN cpan install Math::Round && \
-    cpan install DBI && \
-    cpan install DBD::mysql@4.052 && \
-    cpan install Getopt::Tabular && \
-    cpan install Time::JulianDay && \
-    cpan install Path::Class && \
-    cpan install Archive::Extract && \
-    cpan install Archive::Zip && \
-    cpan install Pod::Perldoc && \
-    cpan install Pod::Markdown && \
-    cpan install Pod::Usage && \
-    cpan install JSON && \
-    cpan install Moose && \
-    cpan install MooseX::Privacy && \
-    cpan install TryCatch && \
-    cpan install Throwable && \
-    cpan install App::cpanminus && \
-    cpan install File::Type && \
-    cpan install String::ShellQuote && \
-    cpan install DateTime && \
+# NOTES:
+# - Module::Pluggable is required by other modules. Installation fails for v6.1
+#   (at the time of this writing)
+# - DBD::mysql v5+ is no longer compatible with MariaDB
+RUN cpan App::cpanminus && \
+    cpanm Module::Pluggable@5.2 && \
+    cpanm DBD::mysql@4.052 && \
+    cpanm Math::Round && \
+    cpanm DateTime && \
+    cpanm DBI && \
+    cpanm Getopt::Tabular && \
+    cpanm Time::JulianDay && \
+    cpanm Path::Class && \
+    cpanm Archive::Extract && \
+    cpanm Archive::Zip && \
+    cpanm Pod::Perldoc && \
+    cpanm Pod::Markdown && \
+    cpanm Pod::Usage && \
+    cpanm JSON && \
+    cpanm Moose && \
+    cpanm MooseX::Privacy && \
+    cpanm TryCatch && \
+    cpanm Throwable && \
+    cpanm File::Type && \
+    cpanm String::ShellQuote && \
     cpanm https://github.com/aces/Loris-MRI/raw/main/install/Digest-BLAKE2-0.02.tar.gz
 
 # Install the Python libraries


### PR DESCRIPTION
I noticed the LORIS-MRI Docker image was no longer building in CI for #1191. After some investigation, it appears to be because of an update in [Module::Pluggable](https://metacpan.org/pod/Module::Pluggable) (the first in 9 years !), which some of our required packages depend on (notably [DateTime](https://metacpan.org/dist/DateTime), but also others I think). This PR fixes the issue by pinning the version of Module::Pluggable to version 5.2.

During the investigation of this PR, I also changed our pipeline to use `cpan` instead of `cpanm`, which seems to be [the recommended package installer by the Perl community](https://www.cpan.org/modules/INSTALL.html). It provides both a much clearer output (no longer literal tens of thousands of lines) and is faster by approximately 5 minutes.