### PR TITLE
The return of the Python LORIS API client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length = 120
 preview = true
 
 [tool.ruff.lint]
-ignore = ["E202", "E203", "E221", "E241", "E251", "E272"]
+ignore = ["E202", "E203", "E221", "E241", "E251", "E271","E272"]
 select = ["E", "F", "I", "N", "UP", "W"]
 
 # The strict type checking configuration is used to type check only the modern (typed) modules. An
@@ -15,6 +15,7 @@ select = ["E", "F", "I", "N", "UP", "W"]
 [tool.pyright]
 include = [
     "python/tests",
+    "python/lib/api",
     "python/lib/db",
     "python/lib/exception",
     "python/lib/config_file.py",

--- a/python/lib/api/client.py
+++ b/python/lib/api/client.py
@@ -23,19 +23,19 @@ class ApiClient:
             'Authorization': f'Bearer {self.api_token}',
         }
 
-        print(f'https://{self.loris_url}/api/{version}/{route}')
-
         try:
             response = requests.get(
                 f'https://{self.loris_url}/api/{version}/{route}',
                 headers=headers,
                 json=json,
+                allow_redirects=False,
             )
 
             response.raise_for_status()
             return response
         except HTTPError as error:
             # TODO: Better error handling
+            print(error.response.status_code)
             print(error.response.text)
             exit(0)
 
@@ -58,6 +58,7 @@ class ApiClient:
                 data=data,
                 json=json,
                 files=files,
+                allow_redirects=False,
             )
 
             response.raise_for_status()

--- a/python/lib/api/client.py
+++ b/python/lib/api/client.py
@@ -1,0 +1,99 @@
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import requests
+from requests import HTTPError
+
+# TODO: Turn into a type declaration with Python 3.12
+ApiVersion = Literal['v0.0.3', 'v0.0.4-dev']
+
+
+@dataclass
+class ApiClient:
+    loris_url: str
+    api_token: str
+
+    def get(
+        self,
+        version: ApiVersion,
+        route: str,
+        json: dict[str, Any] | None = None,
+    ):
+        headers = {
+            'Authorization': f'Bearer {self.api_token}',
+        }
+
+        print(f'https://{self.loris_url}/api/{version}/{route}')
+
+        try:
+            response = requests.get(
+                f'https://{self.loris_url}/api/{version}/{route}',
+                headers=headers,
+                json=json,
+            )
+
+            response.raise_for_status()
+            return response
+        except HTTPError as error:
+            # TODO: Better error handling
+            print(error.response.text)
+            exit(0)
+
+    def post(
+        self,
+        version: ApiVersion,
+        route: str,
+        data: dict[str, str] = {},
+        json: dict[str, Any] | None = None,
+        files: dict[str, Any] | None = None,
+    ):
+        headers = {
+            'Authorization': f'Bearer {self.api_token}',
+        }
+
+        try:
+            response = requests.post(
+                f'https://{self.loris_url}/api/{version}/{route}',
+                headers=headers,
+                data=data,
+                json=json,
+                files=files,
+            )
+
+            response.raise_for_status()
+            return response
+        except HTTPError as error:
+            # TODO: Better error handling
+            print(error.response.status_code)
+            print(error.response.text)
+            exit(0)
+
+
+def get_api_token(loris_url: str, username: str, password: str) -> str:
+    """
+    Call the LORIS API to get an API token for a given LORIS user using this user's credentials.
+    """
+
+    credentials = {
+        'username': username,
+        'password': password,
+    }
+
+    try:
+        response = requests.post(f'https://{loris_url}/api/v0.0.4-dev/login', json=credentials)
+        response.raise_for_status()
+        return response.json()['token']
+    except HTTPError as error:
+        error_description = error.response.json()['error']
+        if error_description == 'Unacceptable JWT key':
+            raise Exception(
+                'Unacceptable LORIS JWT key.\n'
+                'To use the API, please enter a sufficiently complex JWT key in the LORIS configuration module.'
+            )
+
+        exit(0)
+
+
+def get_api_client(loris_url: str, username: str, password: str):
+    api_token = get_api_token(loris_url, username, password)
+    return ApiClient(loris_url, api_token)

--- a/python/lib/api/client.py
+++ b/python/lib/api/client.py
@@ -80,19 +80,9 @@ def get_api_token(loris_url: str, username: str, password: str) -> str:
         'password': password,
     }
 
-    try:
-        response = requests.post(f'https://{loris_url}/api/v0.0.4-dev/login', json=credentials)
-        response.raise_for_status()
-        return response.json()['token']
-    except HTTPError as error:
-        error_description = error.response.json()['error']
-        if error_description == 'Unacceptable JWT key':
-            raise Exception(
-                'Unacceptable LORIS JWT key.\n'
-                'To use the API, please enter a sufficiently complex JWT key in the LORIS configuration module.'
-            )
-
-        exit(0)
+    response = requests.post(f'https://{loris_url}/api/v0.0.4-dev/login', json=credentials)
+    response.raise_for_status()
+    return response.json()['token']
 
 
 def get_api_client(loris_url: str, username: str, password: str):

--- a/python/lib/api/client.py
+++ b/python/lib/api/client.py
@@ -3,7 +3,6 @@ from typing import Any, Literal
 
 import requests
 from requests import HTTPError
-from requests_toolbelt import MultipartEncoder
 
 # TODO: Turn into a type declaration with Python 3.12
 ApiVersion = Literal['v0.0.3', 'v0.0.4-dev']
@@ -44,16 +43,13 @@ class ApiClient:
         self,
         version: ApiVersion,
         route: str,
-        data: dict[str, str] | MultipartEncoder = {},
+        data: dict[str, str] = {},
         json: dict[str, Any] | None = None,
         files: dict[str, Any] | None = None,
     ):
         headers = {
             'Authorization': f'Bearer {self.api_token}',
         }
-
-        if isinstance(data, MultipartEncoder):
-            headers['Content-Type'] = data.content_type
 
         try:
             response = requests.post(

--- a/python/lib/api/client.py
+++ b/python/lib/api/client.py
@@ -3,6 +3,7 @@ from typing import Any, Literal
 
 import requests
 from requests import HTTPError
+from requests_toolbelt import MultipartEncoder
 
 # TODO: Turn into a type declaration with Python 3.12
 ApiVersion = Literal['v0.0.3', 'v0.0.4-dev']
@@ -43,13 +44,16 @@ class ApiClient:
         self,
         version: ApiVersion,
         route: str,
-        data: dict[str, str] = {},
+        data: dict[str, str] | MultipartEncoder = {},
         json: dict[str, Any] | None = None,
         files: dict[str, Any] | None = None,
     ):
         headers = {
             'Authorization': f'Bearer {self.api_token}',
         }
+
+        if isinstance(data, MultipartEncoder):
+            headers['Content-Type'] = data.content_type
 
         try:
             response = requests.post(

--- a/python/lib/api/endpoints/candidate.py
+++ b/python/lib/api/endpoints/candidate.py
@@ -1,0 +1,7 @@
+from lib.api.client import ApiClient
+from lib.api.models.candidate import GetCandidate
+
+
+def get_candidate(api: ApiClient, id: int | str):
+    response = api.get('v0.0.4-dev', f'candidates/{id}')
+    return GetCandidate.model_validate(response.json())

--- a/python/lib/api/endpoints/dicom.py
+++ b/python/lib/api/endpoints/dicom.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from lib.api.client import ApiClient
-from lib.api.models.dicom import GetDicom, GetDicomProcess, GetDicomProcesses
+from lib.api.models.dicom import GetDicom, GetDicomProcess, GetDicomProcesses, PostDicomProcesses
 
 
 def get_candidate_dicom(api: ApiClient, cand_id: int, visit_label: str):
@@ -34,7 +34,7 @@ def post_candidate_dicom(
     }
 
     response = api.post('v0.0.4-dev', f'candidates/{cand_id}/{visit_label}/dicoms', data=data, files=files)
-    return response
+    return response.headers['Location']
 
 
 def get_candidate_dicom_archive(api: ApiClient, cand_id: int, visit_label: str, tar_name: str):
@@ -53,11 +53,13 @@ def post_candidate_dicom_processes(api: ApiClient, cand_id: int, visit_label: st
         'MriUploadID': upload_id,
     }
 
-    api.post(
+    response = api.post(
         'v0.0.4-dev',
         f'/candidates/{cand_id}/{visit_label}/dicoms/{tar_name}/processes',
         json=json,
     )
+
+    return PostDicomProcesses.model_validate(response.json())
 
 
 def get_candidate_dicom_process(api: ApiClient, cand_id: int, visit_label: str, tar_name: str, process_id: int):

--- a/python/lib/api/endpoints/dicom.py
+++ b/python/lib/api/endpoints/dicom.py
@@ -1,0 +1,65 @@
+import json
+import os
+
+from lib.api.client import ApiClient
+from lib.api.models.dicom import GetDicom, GetDicomProcess, GetDicomProcesses
+
+
+def get_candidate_dicom(api: ApiClient, cand_id: int, visit_label: str):
+    response = api.get('v0.0.4-dev', f'candidates/{cand_id}/{visit_label}/dicoms')
+    return GetDicom.model_validate(response.json())
+
+
+def post_candidate_dicom(
+    api: ApiClient,
+    cand_id: int,
+    psc_id: str,
+    visit_label: str,
+    is_phantom: bool,
+    overwrite: bool,
+    file_path: str,
+):
+    data = {
+        'Json': json.dumps({
+            'CandID': cand_id,
+            'PSCID': psc_id,
+            'VisitLabel': visit_label,
+            'IsPhantom': is_phantom,
+            'Overwrite': overwrite,
+        }),
+    }
+
+    files = {
+        'File': (os.path.basename(file_path), open(file_path, 'rb'), 'application/x-tar'),
+    }
+
+    response = api.post('v0.0.4-dev', f'candidates/{cand_id}/{visit_label}/dicoms', data=data, files=files)
+    return response
+
+
+def get_candidate_dicom_archive(api: ApiClient, cand_id: int, visit_label: str, tar_name: str):
+    api.get('v0.0.4-dev', f'candidates/{cand_id}/{visit_label}/dicoms/{tar_name}')
+    # TODO: Handle returned file
+
+
+def get_candidate_dicom_processes(api: ApiClient, cand_id: int, visit_label: str, tar_name: str):
+    response = api.get('v0.0.4-dev', f'candidates/{cand_id}/{visit_label}/dicoms/{tar_name}/processes')
+    return GetDicomProcesses.model_validate(response.json())
+
+
+def post_candidate_dicom_processes(api: ApiClient, cand_id: int, visit_label: str, tar_name: str, upload_id: int):
+    json = {
+        'ProcessType': 'mri_upload',
+        'MriUploadID': upload_id,
+    }
+
+    api.post(
+        'v0.0.4-dev',
+        f'/candidates/{cand_id}/{visit_label}/dicoms/{tar_name}/processes',
+        json=json,
+    )
+
+
+def get_candidate_dicom_process(api: ApiClient, cand_id: int, visit_label: str, tar_name: str, process_id: int):
+    response = api.get('v0.0.4-dev', f'candidates/{cand_id}/{visit_label}/dicoms/{tar_name}/processes/{process_id}')
+    return GetDicomProcess.model_validate(response.json())

--- a/python/lib/api/endpoints/dicom.py
+++ b/python/lib/api/endpoints/dicom.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+from requests_toolbelt import MultipartEncoder
+
 from lib.api.client import ApiClient
 from lib.api.models.dicom import GetDicom, GetDicomProcess, GetDicomProcesses, PostDicomProcesses
 
@@ -19,7 +21,7 @@ def post_candidate_dicom(
     overwrite: bool,
     file_path: str,
 ):
-    data = {
+    multipart = MultipartEncoder(fields={
         'Json': json.dumps({
             'CandID': cand_id,
             'PSCID': psc_id,
@@ -27,13 +29,10 @@ def post_candidate_dicom(
             'IsPhantom': is_phantom,
             'Overwrite': overwrite,
         }),
-    }
-
-    files = {
         'File': (os.path.basename(file_path), open(file_path, 'rb'), 'application/x-tar'),
-    }
+    })
 
-    response = api.post('v0.0.4-dev', f'candidates/{cand_id}/{visit_label}/dicoms', data=data, files=files)
+    response = api.post('v0.0.4-dev', f'candidates/{cand_id}/{visit_label}/dicoms', data=multipart)
     return response.headers['Location']
 
 

--- a/python/lib/api/endpoints/dicom.py
+++ b/python/lib/api/endpoints/dicom.py
@@ -1,8 +1,6 @@
 import json
 import os
 
-from requests_toolbelt import MultipartEncoder
-
 from lib.api.client import ApiClient
 from lib.api.models.dicom import GetDicom, GetDicomProcess, GetDicomProcesses, PostDicomProcesses
 
@@ -21,7 +19,7 @@ def post_candidate_dicom(
     overwrite: bool,
     file_path: str,
 ):
-    multipart = MultipartEncoder(fields={
+    data = {
         'Json': json.dumps({
             'CandID': cand_id,
             'PSCID': psc_id,
@@ -29,10 +27,13 @@ def post_candidate_dicom(
             'IsPhantom': is_phantom,
             'Overwrite': overwrite,
         }),
-        'File': (os.path.basename(file_path), open(file_path, 'rb'), 'application/x-tar'),
-    })
+    }
 
-    response = api.post('v0.0.4-dev', f'candidates/{cand_id}/{visit_label}/dicoms', data=multipart)
+    files = {
+        'File': (os.path.basename(file_path), open(file_path, 'rb'), 'application/x-tar'),
+    }
+
+    response = api.post('v0.0.4-dev', f'candidates/{cand_id}/{visit_label}/dicoms', data=data, files=files)
     return response.headers['Location']
 
 

--- a/python/lib/api/models/candidate.py
+++ b/python/lib/api/models/candidate.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, Field
+
+
+class CandidateMeta(BaseModel):
+    cand_id : str  = Field(alias='CandID')
+    psc_id  : str  = Field(alias='PSCID')
+    project : str  = Field(alias='Project')
+    site    : str  = Field(alias='Site')
+    dob     : str  = Field(alias='DoB')
+    sex     : str  = Field(alias='Sex')
+
+
+class GetCandidate(BaseModel):
+    meta         : CandidateMeta = Field(alias='Meta')
+    visit_labels : list[str]     = Field(alias='Visits')

--- a/python/lib/api/models/dicom.py
+++ b/python/lib/api/models/dicom.py
@@ -3,7 +3,7 @@ from typing import Literal, Optional
 from pydantic import BaseModel, Field
 
 
-class GetDicomArchiveSeries(BaseModel):
+class DicomArchiveSeries(BaseModel):
     series_description : str                 = Field(alias='SeriesDescription')
     series_number      : int                 = Field(alias='SeriesNumber')
     echo_time          : Optional[str]       = Field(alias='EchoTime')
@@ -14,35 +14,40 @@ class GetDicomArchiveSeries(BaseModel):
     series_uid         : str                 = Field(alias='SeriesUID')
 
 
-class GetDicomArchive(BaseModel):
+class DicomArchive(BaseModel):
     tar_name     : str                         = Field(alias='Tarname')
     patient_name : str                         = Field(alias='Patientname')
-    series       : list[GetDicomArchiveSeries] = Field(alias='SeriesInfo')
+    series       : list[DicomArchiveSeries] = Field(alias='SeriesInfo')
 
 
-class GetDicomMeta(BaseModel):
+class DicomMeta(BaseModel):
     cand_id     : int = Field(alias='CandID')
     visit_label : str = Field(alias='Visit')
 
 
 class GetDicom(BaseModel):
-    meta : GetDicomMeta          = Field(alias='Meta')
-    tars : list[GetDicomArchive] = Field(alias='DicomTars')
+    meta : DicomMeta          = Field(alias='Meta')
+    tars : list[DicomArchive] = Field(alias='DicomTars')
 
 
 class GetDicomProcess(BaseModel):
-    end_time  : str = Field(alias='END_TIME')
-    exit_code : int = Field(alias='EXIT_CODE')
-    id        : int = Field(alias='ID')
-    pid       : int = Field(alias='PID')
-    progress  : str = Field(alias='PROGRESS')
-    state     : str = Field(alias='STATE')
+    end_time  : Optional[str] = Field(alias='END_TIME')
+    exit_code : Optional[int] = Field(alias='EXIT_CODE')
+    id        : int           = Field(alias='ID')
+    pid       : int           = Field(alias='PID')
+    progress  : str           = Field(alias='PROGRESS')
+    state     : str           = Field(alias='STATE')
 
 
-class GetDicomUpload(BaseModel):
+class DicomUpload(BaseModel):
     upload_id : int                   = Field(alias='MriUploadID')
     processes : list[GetDicomProcess] = Field(alias='Processes')
 
 
+class PostDicomProcesses(BaseModel):
+    link      : str                   = Field(alias='Link')
+    processes : list[GetDicomProcess] = Field(alias='ProcessState')
+
+
 class GetDicomProcesses(BaseModel):
-    uploads : list[GetDicomUpload] = Field(alias='MriUploads')
+    uploads : list[DicomUpload] = Field(alias='MriUploads')

--- a/python/lib/api/models/dicom.py
+++ b/python/lib/api/models/dicom.py
@@ -1,0 +1,48 @@
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class GetDicomArchiveSeries(BaseModel):
+    series_description : str                 = Field(alias='SeriesDescription')
+    series_number      : int                 = Field(alias='SeriesNumber')
+    echo_time          : Optional[str]       = Field(alias='EchoTime')
+    repetition_time    : Optional[str]       = Field(alias='RepetitionTime')
+    inversion_time     : Optional[str]       = Field(alias='InversionTime')
+    slice_thickness    : Optional[str]       = Field(alias='SliceThickness')
+    modality           : Literal['MR', 'PT'] = Field(alias='Modality')
+    series_uid         : str                 = Field(alias='SeriesUID')
+
+
+class GetDicomArchive(BaseModel):
+    tar_name     : str                         = Field(alias='Tarname')
+    patient_name : str                         = Field(alias='Patientname')
+    series       : list[GetDicomArchiveSeries] = Field(alias='SeriesInfo')
+
+
+class GetDicomMeta(BaseModel):
+    cand_id     : int = Field(alias='CandID')
+    visit_label : str = Field(alias='Visit')
+
+
+class GetDicom(BaseModel):
+    meta : GetDicomMeta          = Field(alias='Meta')
+    tars : list[GetDicomArchive] = Field(alias='DicomTars')
+
+
+class GetDicomProcess(BaseModel):
+    end_time  : str = Field(alias='END_TIME')
+    exit_code : int = Field(alias='EXIT_CODE')
+    id        : int = Field(alias='ID')
+    pid       : int = Field(alias='PID')
+    progress  : str = Field(alias='PROGRESS')
+    state     : str = Field(alias='STATE')
+
+
+class GetDicomUpload(BaseModel):
+    upload_id : int                   = Field(alias='MriUploadID')
+    processes : list[GetDicomProcess] = Field(alias='Processes')
+
+
+class GetDicomProcesses(BaseModel):
+    uploads : list[GetDicomUpload] = Field(alias='MriUploads')

--- a/python/lib/api/models/dicom.py
+++ b/python/lib/api/models/dicom.py
@@ -15,8 +15,8 @@ class DicomArchiveSeries(BaseModel):
 
 
 class DicomArchive(BaseModel):
-    tar_name     : str                         = Field(alias='Tarname')
-    patient_name : str                         = Field(alias='Patientname')
+    tar_name     : str                      = Field(alias='Tarname')
+    patient_name : str                      = Field(alias='Patientname')
     series       : list[DicomArchiveSeries] = Field(alias='SeriesInfo')
 
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -16,6 +16,7 @@ pyright
 pytest
 python-dateutil
 requests
+requests_toolbelt
 ruff
 scikit-learn
 scipy

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -11,9 +11,11 @@ nose
 numpy
 protobuf>=3.0.0
 pybids==0.17.0
+pydantic
 pyright
 pytest
 python-dateutil
+requests
 ruff
 scikit-learn
 scipy

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -16,7 +16,6 @@ pyright
 pytest
 python-dateutil
 requests
-requests_toolbelt
 ruff
 scikit-learn
 scipy


### PR DESCRIPTION
Some time ago, I made #1148 which drafts an architecture to call the LORIS API inside LORIS-MRI. However, I closed this PR as the scripts that effectively call the LORIS API will live on the BIC server and not inside of LORIS-MRI. Nevertheless, I think having a library to call the LORIS API in LORIS-MRI is a good thing. It can be used to test the API (which notably came in handy with the API DICOM upload PR), can be re-used by other projects in their scripts, and generally provide a code template to call the LORIS API.

There are a few improvements in this PR compared to the old PR. First, it is updated to fit within the new LORIS-MRI architecture improvements. Second, it uses two very popular Python libraries to improve the code robustness and ergonomy:
- `pydantic`: A library to define, parse and serialize models, which is useful to structure the API results.
- `requests`: A library to make HTTP requests, with better ergonomics than the Python standard library.