### PR TITLE
Migrate "get all sites from the database" to the SQLAlchemy abstraction

### DIFF
--- a/python/lib/database_lib/project_cohort_rel.py
+++ b/python/lib/database_lib/project_cohort_rel.py
@@ -1,9 +1,11 @@
 """This class performs project_cohort_rel table related database queries and common checks"""
 
+from typing_extensions import deprecated
 
 __license__ = "GPLv3"
 
 
+@deprecated('Use `lib.db.models.project_cohort.DbProjectCohort` instead')
 class ProjectCohortRel:
     """
     This class performs database queries for project_cohort_rel table.
@@ -35,6 +37,7 @@ class ProjectCohortRel:
         self.db = db
         self.verbose = verbose
 
+    @deprecated('Use `lib.db.models.project_cohort.DbProjectCohort` instead')
     def create_proj_cohort_rel_dict(self, project_id, cohort_id):
         """
         Get the project/cohort rel information for a given project ID and cohort ID.

--- a/python/lib/database_lib/site.py
+++ b/python/lib/database_lib/site.py
@@ -1,9 +1,11 @@
 """This class performs database queries for the site (psc) table"""
 
+from typing_extensions import deprecated
 
 __license__ = "GPLv3"
 
 
+@deprecated('Use `lib.db.models.site.DbSite` instead')
 class Site:
     """
     This class performs database queries on the psc (site) table.
@@ -35,6 +37,7 @@ class Site:
         self.db = db
         self.verbose = verbose
 
+    @deprecated('Use `lib.db.queries.site.get_all_sites` instead')
     def get_list_of_sites(self):
         """
         Returns a list of dictionaries storing the list of sites present in the psc table.

--- a/python/lib/db/queries/site.py
+++ b/python/lib/db/queries/site.py
@@ -1,3 +1,6 @@
+from collections.abc import Sequence
+from typing import Optional
+
 from sqlalchemy import select
 from sqlalchemy.orm import Session as Database
 
@@ -5,7 +8,7 @@ from lib.db.models.session import DbSession
 from lib.db.models.site import DbSite
 
 
-def try_get_site_with_cand_id_visit_label(db: Database, cand_id: int, visit_label: str):
+def try_get_site_with_cand_id_visit_label(db: Database, cand_id: int, visit_label: str) -> Optional[DbSite]:
     """
     Get a site from the database using a candidate CandID and visit label, or return `None` if no
     site is found.
@@ -16,3 +19,11 @@ def try_get_site_with_cand_id_visit_label(db: Database, cand_id: int, visit_labe
         .where(DbSession.cand_id == cand_id)
         .where(DbSession.visit_label == visit_label)
     ).scalar_one_or_none()
+
+
+def get_all_sites(db: Database) -> Sequence[DbSite]:
+    """
+    Get a sequence of all sites from the database.
+    """
+
+    return db.execute(select(DbSite)).scalars().all()

--- a/python/lib/session.py
+++ b/python/lib/session.py
@@ -194,6 +194,7 @@ class Session:
         """
         return self.session_db_obj.determine_next_session_site_id_and_visit_number(cand_id)
 
+    @deprecated('Use `lib.db.queries.site.get_all_sites` instead')
     def get_list_of_sites(self):
         """
         Get the list of sites available in the psc table.
@@ -204,6 +205,7 @@ class Session:
 
         return self.site_db_obj.get_list_of_sites()
 
+    @deprecated('Use `lib.db.models.project_cohort.DbProjectCohort` instead')
     def create_proj_cohort_rel_info_dict(self, project_id, cohort_id):
         """
         Populate self.proj_cohort_rel_info_dict with the content returned from the database for the ProjectID and


### PR DESCRIPTION
Depends on #1190
Is depended on by #1211

Migrate "get all sites from the database" to the SQLAlchemy abstraction. I'd like to use the same function in the incremental BIDS import. This PR also deprecate a few functions that already have alternatives in the SQLAlchemy abstraction.