### PR TITLE
Migrate DICOM archive files to new database abstraction

### DIFF
--- a/python/lib/database_lib/tarchive.py
+++ b/python/lib/database_lib/tarchive.py
@@ -1,9 +1,11 @@
 """This class performs DICOM archive related database queries and common checks"""
 
+from typing_extensions import deprecated
 
 __license__ = "GPLv3"
 
 
+@deprecated('Use `lib.db.models.dicom_archive.DbDicomArchive` instead')
 class Tarchive:
     """
     This class performs database queries for DICOM archives.
@@ -35,6 +37,7 @@ class Tarchive:
         self.db = db
         self.verbose = verbose
 
+    @deprecated('Use `lib.db.queries.dicom_archive.try_get_dicom_archive_with_*` instead')
     def create_tarchive_dict(self, archive_location=None, tarchive_id=None):
         """
         Create dictionary with DICOM archive information selected from the tarchive table.
@@ -62,6 +65,7 @@ class Tarchive:
 
         return results[0] if results else None
 
+    @deprecated('Use `lib.db.models.dicom_archive.DbDicomArchive` instead')
     def update_tarchive(self, tarchive_id, fields, values):
         """
         Updates the tarchive table for a given TarchiveID.

--- a/python/lib/database_lib/tarchive_series.py
+++ b/python/lib/database_lib/tarchive_series.py
@@ -1,9 +1,11 @@
 """This class performs tarchive_series related database queries and common checks"""
 
+from typing_extensions import deprecated
 
 __license__ = "GPLv3"
 
 
+@deprecated('Use `lib.db.models.dicom_archive_series.DbDicomArchiveSeries` instead')
 class TarchiveSeries:
     """
     This class performs database queries for tarchive_series table.
@@ -35,6 +37,7 @@ class TarchiveSeries:
         self.db = db
         self.verbose = verbose
 
+    @deprecated('Use `lib.db.queries.dicom_archive.try_get_dicom_archive_series_with_series_uid_echo_time` instead')
     def get_tarchive_series_from_series_uid_and_echo_time(self, series_uid, echo_time):
         """
         Create dictionary with DICOM archive information selected from the tarchive table.

--- a/python/lib/db/queries/dicom_archive.py
+++ b/python/lib/db/queries/dicom_archive.py
@@ -8,10 +8,32 @@ from lib.db.models.dicom_archive_file import DbDicomArchiveFile
 from lib.db.models.dicom_archive_series import DbDicomArchiveSeries
 
 
+def try_get_dicom_archive_with_id(db: Database, dicom_archive_id: int) -> Optional[DbDicomArchive]:
+    """
+    Get a DICOM archive from the database using its ID, or return `None` if no DICOM archive is
+    found.
+    """
+
+    return db.execute(select(DbDicomArchive)
+        .where(DbDicomArchive.id == dicom_archive_id)
+    ).scalar_one_or_none()
+
+
+def try_get_dicom_archive_with_archive_location(db: Database, archive_location: str) -> Optional[DbDicomArchive]:
+    """
+    Get a DICOM archive from the database using its archive location, or return `None` if no DICOM
+    archive is found.
+    """
+
+    return db.execute(select(DbDicomArchive)
+        .where(DbDicomArchive.archive_location.like(f'%{archive_location}%'))
+    ).scalar_one_or_none()
+
+
 def try_get_dicom_archive_with_study_uid(db: Database, study_uid: str):
     """
-    Get a DICOM archive from the database using its study UID, or return `None` if no DICOM
-    archive is found.
+    Get a DICOM archive from the database using its study UID, or return `None` if no DICOM archive
+    is found.
     """
 
     query = select(DbDicomArchive).where(DbDicomArchive.study_uid == study_uid)
@@ -39,8 +61,8 @@ def get_dicom_archive_series_with_file_info(
     sequence_name: Optional[str],
 ):
     """
-    Get a DICOM archive series from the database using its file information, or raise an
-    exception if no DICOM archive series is found.
+    Get a DICOM archive series from the database using its file information, or raise an exception
+    if no DICOM archive series is found.
     """
 
     query = select(DbDicomArchiveSeries) \
@@ -50,3 +72,19 @@ def get_dicom_archive_series_with_file_info(
         .where(DbDicomArchiveSeries.sequence_name == sequence_name)
 
     return db.execute(query).scalar_one()
+
+
+def try_get_dicom_archive_series_with_series_uid_echo_time(
+    db: Database,
+    series_uid: str,
+    echo_time: float,
+) -> Optional[DbDicomArchiveSeries]:
+    """
+    Get a DICOM archive series from the database using its series UID and echo time, or return
+    `None` if no DICOM archive series is found.
+    """
+
+    return db.execute(select(DbDicomArchiveSeries)
+        .where(DbDicomArchiveSeries.series_uid == series_uid)
+        .where(DbDicomArchiveSeries.echo_time  == echo_time)
+    ).scalar_one_or_none()

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -170,8 +170,10 @@ class BasePipeline:
             archive_location = tarchive_path.replace(self.dicom_lib_dir, "")
             self.dicom_archive = try_get_dicom_archive_with_archive_location(self.env.db, archive_location)
             if self.dicom_archive is not None:
-                tarchive_id = self.dicom_archive.id
-                success, new_err_msg = self.imaging_upload_obj.create_imaging_upload_dict_from_tarchive_id(tarchive_id)
+                success, new_err_msg = self.imaging_upload_obj.create_imaging_upload_dict_from_tarchive_id(
+                    self.dicom_archive.id
+                )
+
                 if not success:
                     err_msg += new_err_msg
             else:

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -5,9 +5,9 @@ import lib.exitcode
 import lib.utilities
 from lib.database import Database
 from lib.database_lib.config import Config
+from lib.db.queries.dicom_archive import try_get_dicom_archive_with_archive_location, try_get_dicom_archive_with_id
 from lib.db.queries.session import try_get_session_with_cand_id_visit_label
 from lib.db.queries.site import get_all_sites
-from lib.dicom_archive import DicomArchive
 from lib.exception.determine_subject_info_error import DetermineSubjectInfoError
 from lib.exception.validate_subject_info_error import ValidateSubjectInfoError
 from lib.imaging import Imaging
@@ -63,7 +63,6 @@ class BasePipeline:
         # Load the Config, Imaging, ImagingUpload, Tarchive, Session database classes
         # -----------------------------------------------------------------------------------
         self.config_db_obj = Config(self.db, self.verbose)
-        self.dicom_archive_obj = DicomArchive(self.db, self.verbose)
         self.imaging_obj = Imaging(self.db, self.verbose, self.config_file)
         self.imaging_upload_obj = ImagingUpload(self.db, self.verbose)
 
@@ -102,9 +101,9 @@ class BasePipeline:
         # Verify PSC information stored in DICOMs
         # Grep scanner information based on what is in the DICOM headers
         # ---------------------------------------------------------------------------------
-        if self.dicom_archive_obj.tarchive_info_dict.keys():
+        if self.dicom_archive is not None:
             try:
-                self.subject_info = self.imaging_obj.determine_subject_info(self.dicom_archive_obj.tarchive_info_dict)
+                self.subject_info = self.imaging_obj.determine_subject_info(self.dicom_archive)
             except DetermineSubjectInfoError as error:
                 log_error_exit(self.env, error.message, lib.exitcode.PROJECT_CUSTOMIZATION_FAILURE)
 
@@ -144,9 +143,9 @@ class BasePipeline:
                     f"UploadID {upload_id} is not linked to any tarchive in mri_upload.",
                     lib.exitcode.SELECT_FAILURE,
                 )
-            self.dicom_archive_obj.populate_tarchive_info_dict_from_tarchive_id(tarchive_id=tarchive_id)
-            db_archive_location = self.dicom_archive_obj.tarchive_info_dict['ArchiveLocation']
-            if os.path.join(self.data_dir, 'tarchive', db_archive_location) != tarchive_path:
+
+            self.dicom_archive = try_get_dicom_archive_with_id(self.env.db, tarchive_id)
+            if os.path.join(self.data_dir, 'tarchive', self.dicom_archive.archive_location) != tarchive_path:
                 log_error_exit(
                     self.env,
                     f"UploadID {upload_id} and ArchiveLocation {tarchive_path} do not refer to the same upload",
@@ -161,17 +160,17 @@ class BasePipeline:
             else:
                 if self.imaging_upload_obj.imaging_upload_dict["TarchiveID"]:
                     tarchive_id = self.imaging_upload_obj.imaging_upload_dict["TarchiveID"]
-                    self.dicom_archive_obj.populate_tarchive_info_dict_from_tarchive_id(tarchive_id=tarchive_id)
-                    if self.dicom_archive_obj.tarchive_info_dict:
+                    self.dicom_archive = try_get_dicom_archive_with_id(self.env.db, tarchive_id)
+                    if self.dicom_archive is not None:
                         success = True
                     else:
                         err_msg += f"Could not load tarchive dictionary for TarchiveID {tarchive_id}"
 
         elif tarchive_path:
             archive_location = tarchive_path.replace(self.dicom_lib_dir, "")
-            self.dicom_archive_obj.populate_tarchive_info_dict_from_archive_location(archive_location=archive_location)
-            if self.dicom_archive_obj.tarchive_info_dict:
-                tarchive_id = self.dicom_archive_obj.tarchive_info_dict["TarchiveID"]
+            self.dicom_archive = try_get_dicom_archive_with_archive_location(self.env.db, archive_location)
+            if self.dicom_archive is not None:
+                tarchive_id = self.dicom_archive.id
                 success, new_err_msg = self.imaging_upload_obj.create_imaging_upload_dict_from_tarchive_id(tarchive_id)
                 if not success:
                     err_msg += new_err_msg
@@ -222,10 +221,10 @@ class BasePipeline:
         Determine the scanner information found in the database for the uploaded DICOM archive.
         """
         scanner_id = self.imaging_obj.get_scanner_id(
-            self.dicom_archive_obj.tarchive_info_dict['ScannerManufacturer'],
-            self.dicom_archive_obj.tarchive_info_dict['ScannerSoftwareVersion'],
-            self.dicom_archive_obj.tarchive_info_dict['ScannerSerialNumber'],
-            self.dicom_archive_obj.tarchive_info_dict['ScannerModel'],
+            self.dicom_archive.scanner_manufacturer,
+            self.dicom_archive.scanner_software_version,
+            self.dicom_archive.scanner_serial_number,
+            self.dicom_archive.scanner_model,
             self.site_dict['CenterID'],
             self.session.project_id if self.session is not None else None,
         )

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -39,7 +39,6 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         self.tarchive_path = os.path.join(
             self.data_dir, "tarchive", self.dicom_archive.archive_location
         )
-        self.tarchive_id = self.dicom_archive.id
 
         # ---------------------------------------------------------------------------------------------
         # Run the DICOM archive validation script to check if the DICOM archive is valid
@@ -363,7 +362,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         Add IntendedFor field in JSON file of fieldmap acquisitions according to BIDS standard for fieldmaps.
         """
 
-        fmap_files_dict = self.imaging_obj.determine_intended_for_field_for_fmap_json_files(self.tarchive_id)
+        fmap_files_dict = self.imaging_obj.determine_intended_for_field_for_fmap_json_files(self.dicom_archive.id)
         if not fmap_files_dict:
             return
 
@@ -381,13 +380,12 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         Determine the file order based on the modality and populated the `files` table field `AcqOrderPerModality`.
         """
 
-        tarchive_id = self.tarchive_id
         scan_type_id_list = self.imaging_obj.files_db_obj.select_distinct_acquisition_protocol_id_per_tarchive_source(
-            tarchive_id
+            self.dicom_archive.id
         )
         for scan_type_id in scan_type_id_list:
             results = self.imaging_obj.files_db_obj.get_file_ids_and_series_number_per_scan_type_and_tarchive_id(
-                tarchive_id, scan_type_id
+                self.dicom_archive.id, scan_type_id
             )
             file_id_series_nb_ordered_list = sorted(results, key=lambda x: x["SeriesNumber"])
             acq_number = 0
@@ -407,7 +405,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
             - `SessionID`              => `SessionID` associated to the upload
         """
 
-        files_inserted_list = self.imaging_obj.files_db_obj.get_files_inserted_for_tarchive_id(self.tarchive_id)
+        files_inserted_list = self.imaging_obj.files_db_obj.get_files_inserted_for_tarchive_id(self.dicom_archive.id)
         self.imaging_upload_obj.update_mri_upload(
             upload_id=self.upload_id,
             fields=("Inserting", "InsertionComplete", "number_of_mincInserted", "number_of_mincCreated", "SessionID"),
@@ -425,14 +423,14 @@ class DicomArchiveLoaderPipeline(BasePipeline):
             - path to the log file
         """
 
-        files_results = self.imaging_obj.files_db_obj.get_files_inserted_for_tarchive_id(self.tarchive_id)
+        files_results = self.imaging_obj.files_db_obj.get_files_inserted_for_tarchive_id(self.dicom_archive.id)
         files_inserted_list = [v["File"] for v in files_results] if files_results else None
         prot_viol_results = self.imaging_obj.mri_prot_viol_scan_db_obj.get_protocol_violations_for_tarchive_id(
-            self.tarchive_id
+            self.dicom_archive.id
         )
         protocol_violations_list = [v["minc_location"] for v in prot_viol_results] if prot_viol_results else None
         excl_viol_results = self.imaging_obj.mri_viol_log_db_obj.get_violations_for_tarchive_id(
-            self.tarchive_id, "exclude"
+            self.dicom_archive.id, "exclude"
         )
         excluded_violations_list = [v["MincFile"] for v in excl_viol_results] if excl_viol_results else None
 
@@ -446,7 +444,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
 
         summary = f"""
         Finished processing UploadID {self.upload_id}!
-        - DICOM archive info: {self.tarchive_id} => {self.tarchive_path}
+        - DICOM archive info: {self.dicom_archive.id} => {self.tarchive_path}
         - {nb_files_inserted} files were inserted into the files table: {files_list}
         - {nb_prot_violation} files did not match any protocol: {prot_viol_list}
         - {nb_excluded_viol} files were exclusionary violations: {excl_viol_list}

--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -30,7 +30,6 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         """
 
         super().__init__(loris_getopt_obj, script_name)
-        self.tarchive_id = self.dicom_archive.id
 
         # ---------------------------------------------------------------------------------------------
         # Set 'Inserting' flag to 1 in mri_upload
@@ -94,7 +93,7 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         Get the list of files associated to the TarchiveID present in the files table.
         """
 
-        file_entries = self.imaging_obj.files_db_obj.get_files_inserted_for_tarchive_id(self.tarchive_id)
+        file_entries = self.imaging_obj.files_db_obj.get_files_inserted_for_tarchive_id(self.dicom_archive.id)
         for file in file_entries:
             if file['File'].startswith('s3://'):
                 # skip since file already pushed to S3
@@ -144,7 +143,10 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         Will also return the JSON, BVAL and BVEC files associated to protocol violated scan.
         """
 
-        entries = self.imaging_obj.mri_prot_viol_scan_db_obj.get_protocol_violations_for_tarchive_id(self.tarchive_id)
+        entries = self.imaging_obj.mri_prot_viol_scan_db_obj.get_protocol_violations_for_tarchive_id(
+            self.dicom_archive.id
+        )
+
         for entry in entries:
             if entry['minc_location'].startswith('s3://'):
                 # skip since file already pushed to S3
@@ -170,10 +172,10 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         """
 
         exclude_entries = self.imaging_obj.mri_viol_log_db_obj.get_violations_for_tarchive_id(
-            self.tarchive_id, "exclude"
+            self.dicom_archive.id, "exclude"
         )
         warning_entries = self.imaging_obj.mri_viol_log_db_obj.get_violations_for_tarchive_id(
-            self.tarchive_id, "warning"
+            self.dicom_archive.id, "warning"
         )
 
         for entry in exclude_entries + warning_entries:

--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -30,7 +30,7 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         """
 
         super().__init__(loris_getopt_obj, script_name)
-        self.tarchive_id = self.dicom_archive_obj.tarchive_info_dict["TarchiveID"]
+        self.tarchive_id = self.dicom_archive.id
 
         # ---------------------------------------------------------------------------------------------
         # Set 'Inserting' flag to 1 in mri_upload

--- a/python/lib/dicom_archive.py
+++ b/python/lib/dicom_archive.py
@@ -1,5 +1,7 @@
 """This class gather functions for DICOM archive handling."""
 
+from typing_extensions import deprecated
+
 import lib.utilities as utilities
 from lib.database_lib.tarchive import Tarchive
 from lib.database_lib.tarchive_series import TarchiveSeries
@@ -7,6 +9,7 @@ from lib.database_lib.tarchive_series import TarchiveSeries
 __license__ = "GPLv3"
 
 
+@deprecated('Use `lib.db.models.dicom_archive.DbDicomArchive` instead')
 class DicomArchive:
     """
     This class gather functions that interact with the database and allow session
@@ -44,6 +47,7 @@ class DicomArchive:
 
         self.tarchive_info_dict = dict()
 
+    @deprecated('Use `lib.db.queries.dicom_archive.try_get_dicom_archive_with_archive_location` instead')
     def populate_tarchive_info_dict_from_archive_location(self, archive_location):
         """
         Populate the DICOM archive information dictionary (self.tarchive_info_dict) with information found in
@@ -54,6 +58,7 @@ class DicomArchive:
         """
         self.tarchive_info_dict = self.tarchive_db_obj.create_tarchive_dict(archive_location=archive_location)
 
+    @deprecated('Use `lib.db.queries.dicom_archive.try_get_dicom_archive_with_id` instead')
     def populate_tarchive_info_dict_from_tarchive_id(self, tarchive_id):
         """
         Populate the DICOM archive information dictionary (self.tarchive_info_dict) with information found in
@@ -64,6 +69,7 @@ class DicomArchive:
         """
         self.tarchive_info_dict = self.tarchive_db_obj.create_tarchive_dict(tarchive_id=tarchive_id)
 
+    @deprecated('Use `lib.db.queries.dicom_archive.try_get_dicom_archive_series_with_series_uid_echo_time` instead')
     def populate_tarchive_info_dict_from_series_uid_and_echo_time(self, series_uid, echo_time):
         """
         Populate the DICOM archive information dictionary (self.tarchive_info_dict) with information found in
@@ -82,6 +88,9 @@ class DicomArchive:
             tarchive_id = tarchive_series_info_dict["TarchiveID"]
             self.populate_tarchive_info_dict_from_tarchive_id(tarchive_id=tarchive_id)
 
+    @deprecated(
+        'Use `lib.dcm2bids_imaging_pipeline_lib.dicom_validation_pipeline._validate_dicom_archive_md5sum` instead'
+    )
     def validate_dicom_archive_md5sum(self, tarchive_path):
         """
         This function validates that the md5sum of the DICOM archive on the filesystem is the same

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -538,8 +538,10 @@ class Imaging:
             case 'PatientName':
                 subject_name = dicom_archive.patient_name
             case _:
-                print("TODO: ERROR")
-                exit(-1)
+                raise DetermineSubjectInfoError(
+                    "Unexpected 'lookupCenterNameUsing' configuration setting, expected 'PatientName' or 'PatientID'"
+                    f" but found '{dicom_header}'."
+                )
 
         try:
             subject_info = self.config_file.get_subject_info(self.db, subject_name, scanner_id)

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -23,6 +23,7 @@ from lib.database_lib.mri_scanner import MriScanner
 from lib.database_lib.mri_violations_log import MriViolationsLog
 from lib.database_lib.parameter_file import ParameterFile
 from lib.database_lib.parameter_type import ParameterType
+from lib.db.models.dicom_archive import DbDicomArchive
 from lib.exception.determine_subject_info_error import DetermineSubjectInfoError
 
 __license__ = "GPLv3"
@@ -513,7 +514,7 @@ class Imaging:
         # return the result
         return results[0]['CandID'] if results else None
 
-    def determine_subject_info(self, tarchive_info_dict, scanner_id: Optional[int] = None) -> SubjectInfo:
+    def determine_subject_info(self, dicom_archive: DbDicomArchive, scanner_id: Optional[int] = None) -> SubjectInfo:
         """
         Determine subject IDs based on the DICOM header specified by the lookupCenterNameUsing
         config setting. This function will call a function in the configuration file that can be
@@ -531,7 +532,14 @@ class Imaging:
 
         config_obj = Config(self.db, self.verbose)
         dicom_header = config_obj.get_config('lookupCenterNameUsing')
-        subject_name = tarchive_info_dict[dicom_header]
+        match dicom_header:
+            case 'PatientID':
+                subject_name = dicom_archive.patient_id
+            case 'PatientName':
+                subject_name = dicom_archive.patient_name
+            case _:
+                print("TODO: ERROR")
+                exit(-1)
 
         try:
             subject_info = self.config_file.get_subject_info(self.db, subject_name, scanner_id)


### PR DESCRIPTION
Migrate `lib.dicom_archive`, `lib.database_lib.tarchive` and `lib.database_lib.tarchive_series` to the new database abstraction.