### PR TITLE
Migrate `mri_scanner` to the new database abstraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ include = [
     "python/lib/get_subject_session.py",
     "python/lib/logging.py",
     "python/lib/make_env.py",
+    "python/lib/scanner.py",
     "python/lib/validate_subject_info.py",
 ]
 typeCheckingMode = "strict"

--- a/python/lib/database_lib/mri_scanner.py
+++ b/python/lib/database_lib/mri_scanner.py
@@ -2,11 +2,14 @@
 
 import datetime
 
+from typing_extensions import deprecated
+
 from lib.candidate import Candidate
 
 __license__ = "GPLv3"
 
 
+@deprecated('Use `lib.scanner` instead')
 class MriScanner:
     """
     This class performs database queries for imaging dataset stored in the mri_scanner table.
@@ -38,6 +41,7 @@ class MriScanner:
         self.db = db
         self.verbose = verbose
 
+    @deprecated('Use `lib.scanner.get_or_create_scanner` instead')
     def determine_scanner_information(self, manufacturer, software_version, serial_number, scanner_model,
                                       center_id, project_id):
         """
@@ -81,6 +85,7 @@ class MriScanner:
         )
         return scanner_id
 
+    @deprecated('Use `lib.scanner.get_or_create_scanner` instead')
     def register_new_scanner(self, manufacturer, software_version, serial_number, scanner_model, center_id, project_id):
         """
         Inserts a new entry in the mri_scanner table after having created a new candidate to
@@ -132,6 +137,7 @@ class MriScanner:
 
         return scanner_id
 
+    @deprecated('Use `lib.db.models.mri_scanner.DbMriScanner.candidate` instead')
     def get_scanner_candid(self, scanner_id):
         """
         Select a ScannerID CandID based on the scanner ID in mri_scanner.

--- a/python/lib/db/queries/mri_scanner.py
+++ b/python/lib/db/queries/mri_scanner.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session as Database
+
+from lib.db.models.mri_scanner import DbMriScanner
+
+
+def try_get_scanner_with_info(
+    db: Database,
+    manufacturer: str,
+    software_version: str,
+    serial_number: str,
+    model: str,
+) -> Optional[DbMriScanner]:
+    """
+    Get an MRI scanner from the database using the provided information, or return `None` if no
+    scanner is found.
+    """
+
+    return db.execute(select(DbMriScanner)
+        .where(DbMriScanner.manufacturer     == manufacturer)
+        .where(DbMriScanner.model            == model)
+        .where(DbMriScanner.serial_number    == serial_number)
+        .where(DbMriScanner.software_version == software_version)
+    ).scalar_one_or_none()

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import nibabel as nib
 from nilearn import image, plotting
+from typing_extensions import deprecated
 
 import lib.utilities as utilities
 from lib.config_file import SubjectInfo
@@ -832,6 +833,7 @@ class Imaging:
                 'MriProtocolChecksGroupID': hdr_checks_list[0]['MriProtocolChecksGroupID']
             }
 
+    @deprecated('Use `lib.scanner.get_or_create_scanner` instead')
     def get_scanner_id(self, manufacturer, software_version, serial_nb, model_name, center_id, project_id):
         """
         Get the scanner ID based on the scanner information provided as input.
@@ -858,6 +860,7 @@ class Imaging:
             project_id
         )
 
+    @deprecated('Use `lib.db.models.DbScanner.candidate` instead')
     def get_scanner_candid(self, scanner_id):
         """
         Select a ScannerID CandID based on the scanner ID in mri_scanner.

--- a/python/lib/scanner.py
+++ b/python/lib/scanner.py
@@ -1,0 +1,74 @@
+import random
+from datetime import datetime
+
+from sqlalchemy.orm import Session as Database
+
+from lib.db.models.candidate import DbCandidate
+from lib.db.models.mri_scanner import DbMriScanner
+from lib.db.queries.candidate import try_get_candidate_with_cand_id
+from lib.db.queries.mri_scanner import try_get_scanner_with_info
+from lib.env import Env
+
+
+def get_or_create_scanner(
+    env: Env,
+    manufacturer: str,
+    model: str,
+    serial_number: str,
+    software_version: str,
+    site_id: int,
+    project_id: int,
+) -> DbMriScanner:
+    """
+    Get an MRI scanner from the database using the provided information, or create it if it does
+    not already exist.
+    """
+
+    mri_scanner = try_get_scanner_with_info(env.db, manufacturer, model, serial_number, software_version)
+
+    if mri_scanner is not None:
+        return mri_scanner
+
+    cand_id = generate_new_cand_id(env.db)
+    now = datetime.now()
+
+    candidate = DbCandidate(
+        cand_id                 = cand_id,
+        psc_id                  = 'scanner',
+        registration_site_id    = site_id,
+        registration_project_id = project_id,
+        user_id                 = 'imaging.py',
+        entity_type             = 'Scanner',
+        date_active             = now,
+        date_registered         = now,
+        active                  = True,
+    )
+
+    env.db.add(candidate)
+    env.db.commit()
+
+    mri_scanner = DbMriScanner(
+        manufacturer     = manufacturer,
+        model            = model,
+        serial_number    = serial_number,
+        software_version = software_version,
+        candidate_id     = candidate.id,
+    )
+
+    env.db.add(mri_scanner)
+    env.db.commit()
+
+    return mri_scanner
+
+
+# TODO: Move this function to a more appropriate place.
+def generate_new_cand_id(db: Database) -> int:
+    """
+    Generate a new random CandID that is not already in the database.
+    """
+
+    while True:
+        cand_id = random.randint(100000, 999999)
+        candidate = try_get_candidate_with_cand_id(db, cand_id)
+        if candidate is None:
+            return cand_id


### PR DESCRIPTION
Builds on top of #1224. This PR migrates `lib.database_lib.mri_scanner` to the new database abstraction, and migrates the existing code that uses it to the new abstraction.

This PR does not migrate the configuration file that still indirectly uses this code, but this can be done in a follow-up PR (or this PR if wanted).
