### PR TITLE
More ORM definitions

### DIFF
--- a/python/lib/db/models/cohort.py
+++ b/python/lib/db/models/cohort.py
@@ -1,0 +1,13 @@
+from sqlalchemy.orm import Mapped, mapped_column
+
+from lib.db.base import Base
+
+
+class DbCohort(Base):
+    __tablename__ = 'cohort'
+
+    id                 : Mapped[int]         = mapped_column('CohortID', primary_key=True)
+    name               : Mapped[str]         = mapped_column('title')
+    use_edc            : Mapped[bool | None] = mapped_column('useEDC')
+    window_difference  : Mapped[str | None]  = mapped_column('WindowDifference')
+    recruitment_target : Mapped[int | None]  = mapped_column('RecruitmentTarget')

--- a/python/lib/db/models/config.py
+++ b/python/lib/db/models/config.py
@@ -1,4 +1,3 @@
-
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 

--- a/python/lib/db/models/config_setting.py
+++ b/python/lib/db/models/config_setting.py
@@ -1,4 +1,3 @@
-
 from sqlalchemy.orm import Mapped, mapped_column
 
 from lib.db.base import Base

--- a/python/lib/db/models/dicom_archive_series.py
+++ b/python/lib/db/models/dicom_archive_series.py
@@ -1,4 +1,3 @@
-
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 

--- a/python/lib/db/models/mri_scanner.py
+++ b/python/lib/db/models/mri_scanner.py
@@ -1,4 +1,3 @@
-
 from sqlalchemy.orm import Mapped, mapped_column
 
 from lib.db.base import Base

--- a/python/lib/db/models/notification_type.py
+++ b/python/lib/db/models/notification_type.py
@@ -1,4 +1,3 @@
-
 from sqlalchemy.orm import Mapped, mapped_column
 
 from lib.db.base import Base

--- a/python/lib/db/models/parameter_file.py
+++ b/python/lib/db/models/parameter_file.py
@@ -1,4 +1,3 @@
-
 from sqlalchemy.orm import Mapped, mapped_column
 
 from lib.db.base import Base

--- a/python/lib/db/models/project.py
+++ b/python/lib/db/models/project.py
@@ -1,4 +1,3 @@
-
 from sqlalchemy.orm import Mapped, mapped_column
 
 from lib.db.base import Base

--- a/python/lib/db/models/site.py
+++ b/python/lib/db/models/site.py
@@ -1,4 +1,3 @@
-
 from sqlalchemy.orm import Mapped, mapped_column
 
 from lib.db.base import Base

--- a/python/lib/db/models/visit.py
+++ b/python/lib/db/models/visit.py
@@ -1,0 +1,11 @@
+from sqlalchemy.orm import Mapped, mapped_column
+
+from lib.db.base import Base
+
+
+class DbVisit(Base):
+    __tablename__  = 'visit'
+
+    id    : Mapped[int] = mapped_column('VisitID', primary_key=True)
+    name  : Mapped[str] = mapped_column('VisitName')
+    label : Mapped[str] = mapped_column('VisitLabel')

--- a/python/lib/db/models/visit_window.py
+++ b/python/lib/db/models/visit_window.py
@@ -1,4 +1,3 @@
-
 from sqlalchemy.orm import Mapped, mapped_column
 
 from lib.db.base import Base

--- a/python/lib/db/queries/candidate.py
+++ b/python/lib/db/queries/candidate.py
@@ -4,11 +4,22 @@ from sqlalchemy.orm import Session as Database
 from lib.db.models.candidate import DbCandidate
 
 
-def try_get_candidate_with_cand_id(db: Database, cand_id: int):
+def try_get_candidate_with_cand_id(db: Database, cand_id: int) -> DbCandidate | None:
     """
     Get a candidate from the database using its CandID, or return `None` if no candidate is
     found.
     """
 
-    query = select(DbCandidate).where(DbCandidate.cand_id == cand_id)
-    return db.execute(query).scalar_one_or_none()
+    return db.execute(select(DbCandidate)
+        .where(DbCandidate.cand_id == cand_id)
+    ).scalar_one_or_none()
+
+
+def try_get_candidate_with_psc_id(db: Database, psc_id: str) -> DbCandidate | None:
+    """
+    Get a candidate from the database using its PSCID, or return `None` if no candidate is found.
+    """
+
+    return db.execute(select(DbCandidate)
+        .where(DbCandidate.psc_id == psc_id)
+    ).scalar_one_or_none()

--- a/python/lib/db/queries/cohort.py
+++ b/python/lib/db/queries/cohort.py
@@ -1,0 +1,24 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session as Database
+
+from lib.db.models.cohort import DbCohort
+
+
+def try_get_cohort_with_id(db: Database, id: int) -> DbCohort | None:
+    """
+    Try to get a cohort from the database using its ID, or return `None` if no cohort is found.
+    """
+
+    return db.execute(select(DbCohort)
+        .where(DbCohort.id == id)
+    ).scalar_one_or_none()
+
+
+def try_get_cohort_with_name(db: Database, name: str) -> DbCohort | None:
+    """
+    Try to get a cohort from the database using its name, or return `None` if no cohort is found.
+    """
+
+    return db.execute(select(DbCohort)
+        .where(DbCohort.name == name)
+    ).scalar_one_or_none()

--- a/python/lib/db/queries/config.py
+++ b/python/lib/db/queries/config.py
@@ -5,7 +5,7 @@ from lib.db.models.config import DbConfig
 from lib.db.models.config_setting import DbConfigSetting
 
 
-def get_config_with_setting_name(db: Database, name: str):
+def get_config_with_setting_name(db: Database, name: str) -> DbConfig:
     """
     Get a single configuration entry from the database using its configuration setting name, or
     raise an exception if no entry or several entries are found.

--- a/python/lib/db/queries/dicom_archive.py
+++ b/python/lib/db/queries/dicom_archive.py
@@ -29,14 +29,15 @@ def try_get_dicom_archive_with_archive_location(db: Database, archive_location: 
     ).scalar_one_or_none()
 
 
-def try_get_dicom_archive_with_study_uid(db: Database, study_uid: str):
+def try_get_dicom_archive_with_study_uid(db: Database, study_uid: str) -> DbDicomArchive | None:
     """
     Get a DICOM archive from the database using its study UID, or return `None` if no DICOM archive
     is found.
     """
 
-    query = select(DbDicomArchive).where(DbDicomArchive.study_uid == study_uid)
-    return db.execute(query).scalar_one_or_none()
+    return db.execute(select(DbDicomArchive)
+        .where(DbDicomArchive.study_uid == study_uid)
+    ).scalar_one_or_none()
 
 
 def delete_dicom_archive_file_series(db: Database, dicom_archive: DbDicomArchive):

--- a/python/lib/db/queries/mri_upload.py
+++ b/python/lib/db/queries/mri_upload.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session as Database
 from lib.db.models.mri_upload import DbMriUpload
 
 
-def try_get_mri_upload_with_id(db: Database, id: int):
+def try_get_mri_upload_with_id(db: Database, id: int) -> DbMriUpload | None:
     """
     Get an MRI upload from the database using its ID, or return `None` if no MRI upload is found.
     """
@@ -14,7 +14,7 @@ def try_get_mri_upload_with_id(db: Database, id: int):
     ).scalar_one_or_none()
 
 
-def get_mri_upload_with_patient_name(db: Database, patient_name: str):
+def get_mri_upload_with_patient_name(db: Database, patient_name: str) -> DbMriUpload:
     """
     Get an MRI upload from the database using its patient name, or throw an exception if no MRI
     upload is found.

--- a/python/lib/db/queries/notification.py
+++ b/python/lib/db/queries/notification.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session as Database
 from lib.db.models.notification_type import DbNotificationType
 
 
-def try_get_notification_type_with_name(db: Database, name: str):
+def try_get_notification_type_with_name(db: Database, name: str) -> DbNotificationType | None:
     """
     Get a notification type from the database using its configuration setting name, or return
     `None` if no notification type is found.

--- a/python/lib/db/queries/project.py
+++ b/python/lib/db/queries/project.py
@@ -1,10 +1,35 @@
 from sqlalchemy import select
 from sqlalchemy.orm import Session as Database
 
+from lib.db.models.project import DbProject
 from lib.db.models.project_cohort import DbProjectCohort
 
 
-def try_get_project_cohort_with_project_id_cohort_id(db: Database, project_id: int, cohort_id: int):
+def try_get_project_with_id(db: Database, id: int) -> DbProject | None:
+    """
+    Try to get a project from the database using its ID, or return `None` if no project is found.
+    """
+
+    return db.execute(select(DbProject)
+        .where(DbProject.id == id)
+    ).scalar_one_or_none()
+
+
+def try_get_project_with_name(db: Database, name: str) -> DbProject | None:
+    """
+    Try to get a project from the database using its name, or return `None` if no project is found.
+    """
+
+    return db.execute(select(DbProject)
+        .where(DbProject.name == name)
+    ).scalar_one_or_none()
+
+
+def try_get_project_cohort_with_project_id_cohort_id(
+    db: Database,
+    project_id: int,
+    cohort_id: int,
+) -> DbProjectCohort | None:
     """
     Get a project cohort relation from the database using its project ID and candidate ID, or
     return `None` if no relation is found.

--- a/python/lib/db/queries/session.py
+++ b/python/lib/db/queries/session.py
@@ -6,7 +6,7 @@ from lib.db.models.candidate import DbCandidate
 from lib.db.models.session import DbSession
 
 
-def try_get_session_with_cand_id_visit_label(db: Database, cand_id: int, visit_label: str):
+def try_get_session_with_cand_id_visit_label(db: Database, cand_id: int, visit_label: str) -> DbSession | None:
     """
     Get a session from the database using its candidate CandID and visit label, or return `None`
     if no session is found.

--- a/python/lib/db/queries/site.py
+++ b/python/lib/db/queries/site.py
@@ -8,6 +8,36 @@ from lib.db.models.session import DbSession
 from lib.db.models.site import DbSite
 
 
+def try_get_site_with_id(db: Database, id: int) -> DbSite | None:
+    """
+    Get a site from the database using its ID, or return `None` if no site is found.
+    """
+
+    return db.execute(select(DbSite)
+        .where(DbSite.id == id)
+    ).scalar_one_or_none()
+
+
+def try_get_site_with_name(db: Database, name: str) -> DbSite | None:
+    """
+    Get a site from the database using its name, or return `None` if no site is found.
+    """
+
+    return db.execute(select(DbSite)
+        .where(DbSite.name == name)
+    ).scalar_one_or_none()
+
+
+def get_all_sites(db: Database) -> Sequence[DbSite]:
+    """
+    Get a sequence of all sites from the database.
+    """
+
+    return db.execute(select(DbSite)).scalars().all()
+
+
+# TODO: This function should be deleted soon in favor of using `try_get_session_with_cand_id_visit_label`.
+# and `session.site`.
 def try_get_site_with_cand_id_visit_label(db: Database, cand_id: int, visit_label: str) -> DbSite | None:
     """
     Get a site from the database using a candidate CandID and visit label, or return `None` if no
@@ -20,11 +50,3 @@ def try_get_site_with_cand_id_visit_label(db: Database, cand_id: int, visit_labe
         .where(DbSession.visit_label == visit_label)
         .where(DbCandidate.cand_id == cand_id)
     ).scalar_one_or_none()
-
-
-def get_all_sites(db: Database) -> Sequence[DbSite]:
-    """
-    Get a sequence of all sites from the database.
-    """
-
-    return db.execute(select(DbSite)).scalars().all()

--- a/python/lib/db/queries/visit.py
+++ b/python/lib/db/queries/visit.py
@@ -1,14 +1,26 @@
 from sqlalchemy import select
 from sqlalchemy.orm import Session as Database
 
+from lib.db.models.visit import DbVisit
 from lib.db.models.visit_window import DbVisitWindow
 
 
-def try_get_visit_window_with_visit_label(db: Database, visit_label: str):
+def try_get_visit_with_visit_label(db: Database, visit_label: str) -> DbVisit | None:
+    """
+    Get a visit from the database using its visit label, or return `None` if no visit is found.
+    """
+
+    return db.execute(select(DbVisit)
+        .where(DbVisit.label == visit_label)
+    ).scalar_one_or_none()
+
+
+def try_get_visit_window_with_visit_label(db: Database, visit_label: str) -> DbVisitWindow | None:
     """
     Get a visit window from the database using its visit label, or return `None` if no visit
     window is found.
     """
 
-    query = select(DbVisitWindow).where(DbVisitWindow.visit_label == visit_label)
-    return db.execute(query).scalar_one_or_none()
+    return db.execute(select(DbVisitWindow)
+        .where(DbVisitWindow.visit_label == visit_label)
+    ).scalar_one_or_none()


### PR DESCRIPTION
Extracted a few changes from my other WIP PRs (refactor `get_subject_info` and incremental BIDS importer) here.

List of changes:
* Add ORM models for `cohort` and `visit`.
* Add some common queries of the shape `try_get_x_with_id` and `try_get_x_with_name`.
* Remove some unwanted newlines that Ruff introduced when removing `Optional` imports.
* Add explicit return types for all queries (NGL I liked inferred return type at first, but now I prefer to have them explicit).
* Use (properly formatted) nested function calls instead of an intermediate `query` variable.