### PR TITLE
small test type improvement

### DIFF
--- a/python/tests/integration/scripts/test_run_dicom_archive_loader.py
+++ b/python/tests/integration/scripts/test_run_dicom_archive_loader.py
@@ -106,13 +106,14 @@ def test_successful_run_on_valid_tarchive_path():
     assert mri_upload.is_dicom_archive_validated is True
     # check session has been linked to tarchive and mri_upload
     assert mri_upload.session is not None
-    assert mri_upload.dicom_archive is not None and mri_upload.dicom_archive.session_id is not None
+    assert mri_upload.dicom_archive is not None
+    assert mri_upload.dicom_archive.session is not None
     # check that archive location has been updated
-    assert mri_upload.dicom_archive is not None and mri_upload.dicom_archive.archive_location == archive_new_path
+    assert mri_upload.dicom_archive.archive_location == archive_new_path
     # check series/files counts
     # notes: - tarchive_series should have 2 series for this upload (localizer + T1W)
     #        - localizer is skipped from conversion because of config settings `excluded_series_description`
-    assert mri_upload.dicom_archive is not None and len(mri_upload.dicom_archive.series) == 2
+    assert len(mri_upload.dicom_archive.series) == 2
     assert mri_upload.number_of_minc_inserted == 1
     assert mri_upload.number_of_minc_created == 1
     assert len(mri_upload.session.files) == 1


### PR DESCRIPTION
Just noticed something that I missed during review. We checked `mri_upload.dicom_archive is not None` several times, but we only need to check it once ! The type checker is smart enough to remember that information in the following statements. I also changed a `dicom_archive.session_id` to a `dicom_archive.session` because I like it.
@cmadjar 