### PR TITLE
Update of the PERL pipeline following the refactor of the foreign keys on table candidate in LORIS

### DIFF
--- a/docs/scripts_md/MriScannerOB.md
+++ b/docs/scripts_md/MriScannerOB.md
@@ -93,3 +93,13 @@ Gets the column names for table mri\_scanner.
 INPUT: None
 
 RETURN: Column names for table mri\_scanner.
+
+### getScannerCandID($scannerID)
+
+Fetches the CandID for the record in the `mri_scanner` table that has a given scanner ID.
+
+INPUTS:
+    - value of column `ID` for the scanner record.
+
+RETURN: the CandID in table `candidate` for the record with a given ID in table `mri_scanner`
+        (or `undef` if none can be found).

--- a/tools/get_dicom_files.pl
+++ b/tools/get_dicom_files.pl
@@ -220,7 +220,7 @@ my $tmpExtractDir = tempdir("$0.XXXX", DIR => $tmpExtractBaseDir, CLEANUP => 1);
 my $query = "SELECT c.PSCID, c.CandID, s.Visit_label, t.DateAcquired, t.ArchiveLocation, t.TarchiveID, t.PatientName "
           . "FROM tarchive t "
           . "JOIN session s ON (t.SessionID=s.ID) "
-          . "JOIN candidate c ON (c.CandID=s.CandID) "
+          . "JOIN candidate c ON (c.ID=s.CandidateID) "
           . "WHERE 1=1";
 
 # Add patient name clause (if any)

--- a/tools/minc_to_bids_converter.pl
+++ b/tools/minc_to_bids_converter.pl
@@ -439,7 +439,7 @@ SELECT
   mst.MriScanTypeName AS LorisScanType
 FROM files f
 JOIN session s         ON (s.ID        = f.SessionID)
-JOIN candidate c       ON (c.CandID    = s.CandID)
+JOIN candidate c       ON (c.ID        = s.CandidateID)
 JOIN mri_scan_type mst ON (mst.MriScanTypeID = f.MriScanTypeID)
 JOIN tarchive t        ON (t.SessionID = s.ID)
 LEFT JOIN parameter_file pf_echonb    ON (f.FileID=pf_echonb.FileID)    AND pf_echonb.ParameterTypeID    = ?
@@ -1123,7 +1123,7 @@ SELECT
   TIMESTAMPDIFF(MONTH, DoB, Date_visit)
 FROM
   candidate
-  JOIN session USING (CandID)
+  JOIN session ON (session.CandidateID=candidate.ID)
 WHERE
   CandID = ? AND Visit_label = ?;
 QUERY

--- a/tools/run_defacing_script.pl
+++ b/tools/run_defacing_script.pl
@@ -406,7 +406,10 @@ RETURNS: the candidate's C<CandID> and the session visit label
 sub grep_candID_visit_from_SessionID {
     my ($session_id) = @_;
 
-    my $query  = "SELECT CandID, Visit_label FROM session WHERE ID = ?";
+    my $query  = "SELECT candidate.CandID, session.Visit_label "
+               . "FROM session "
+               . "JOIN candidate ON (session.CandidateID=candidate.ID) "
+               . "WHERE session.ID = ?";
     my $result = $dbh->selectrow_hashref($query, undef, $session_id);
 
     my $cand_id     = $result->{'CandID'     };

--- a/uploadNeuroDB/NeuroDB/objectBroker/MriScannerOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriScannerOB.pm
@@ -95,7 +95,7 @@ use TryCatch;
 
 my $TABLE_NAME = "mri_scanner";
 
-my @COLUMN_NAMES = qw(ID Manufacturer Model Serial_number Software CandID);
+my @COLUMN_NAMES = qw(ID Manufacturer Model Serial_number Software CandidateID);
 
 =pod
 
@@ -127,6 +127,43 @@ RETURN: Column names for table mri_scanner.
 
 sub getColumnNames {
 	return @COLUMN_NAMES;
+}
+
+
+=pod
+
+=head3 getScannerCandID($scannerID)
+
+Fetches the CandID for the record in the C<mri_scanner> table that has a given scanner ID.
+
+INPUTS:
+    - value of column C<ID> for the scanner record.
+
+RETURN: the CandID in table C<candidate> for the record with a given ID in table C<mri_scanner>
+        (or C<undef> if none can be found).
+=cut
+
+sub getScannerCandID {
+    my($self, $scannerID) = @_;
+
+    my $query = "SELECT CandID "
+              . "FROM candidate c JOIN mri_scanner m ON (m.CandidateID=c.ID) "
+              . "WHERE m.ID=?";
+
+    try {
+        my $resultRef = $self->db->pselect(
+            $query,
+            ($scannerID)
+        );
+        return @$resultRef ? $resultRef->[0]->{'CandID'} : undef;
+    } catch(NeuroDB::DatabaseException $e) {
+        NeuroDB::objectBroker::ObjectBrokerException->throw(
+            errorMessage => sprintf(
+                "Failed to get CandID for scanner $scannerID. Reason:\n%s",
+                $e
+            )
+        );
+    }
 }
 
 1;

--- a/uploadNeuroDB/register_processed_data.pl
+++ b/uploadNeuroDB/register_processed_data.pl
@@ -414,12 +414,12 @@ sub getSessionID    {
     # get sessionID using sourceFileID
     my  ($sessionID, %subjectIDsref);
     my  $query  =   "SELECT f.SessionID, " .
-                           "s.CandID, " .
+                           "c.CandID, " .
                            "c.PSCID, " .
                            "s.Visit_label " .
                     "FROM files f " .
                     "JOIN session s ON (s.ID=f.SessionID) " .
-                    "JOIN candidate c USING (CandID) " .
+                    "JOIN candidate c ON (c.ID=s.CandidateID) " .
                     "WHERE FileID=?";
 
     my  $sth    =   $dbh->prepare($query);


### PR DESCRIPTION
This PR updates the LORIS-MRI codebase following these modifications done in LORIS:

- Addition of new column `ID` in table `candidate`
- Modification of all FK constraints on table `candidate`: the FK is now tied to the above column.