### PR TITLE
Improve and adopt more the new `lib.config` module

### DIFF
--- a/python/lib/config.py
+++ b/python/lib/config.py
@@ -1,26 +1,100 @@
+import os
 from typing import Literal
 
-from lib.db.queries.config import get_config_with_setting_name
+from lib.db.queries.config import try_get_config_with_setting_name
 from lib.env import Env
 from lib.logging import log_error_exit
 
 
 def get_patient_id_dicom_header_config(env: Env) -> Literal['PatientID', 'PatientName']:
     """
-    Get the DICOM header in which to look for the patient ID from the database configuration.
+    Get the DICOM header in which to look for the patient ID from the in-database configuration, or
+    exit the program with an error if that configuration value does not exist or is incorrect.
     """
 
-    config_value = get_config_with_setting_name(env.db, 'lookupCenterNameUsing').value
-    match config_value:
-        case 'PatientID':
-            return 'PatientID'
-        case 'PatientName':
-            return 'PatientName'
-        case _:
-            log_error_exit(
-                env,
-                (
-                    "Unexpected 'lookupCenterNameUsing' configuration setting, expected 'PatientID' or 'PatientName'"
-                    f" but found '{config_value}'."
-                )
+    patient_id_dicom_header = _get_config_value(env, 'lookupCenterNameUsing')
+
+    if patient_id_dicom_header not in ('PatientID', 'PatientName'):
+        log_error_exit(
+            env,
+            (
+                "Unexpected patient ID DICOM header configuration value, expected 'PatientID' or 'PatientName' but"
+                f" found '{patient_id_dicom_header}'."
             )
+        )
+
+    return patient_id_dicom_header
+
+
+def get_data_dir_path_config(env: Env) -> str:
+    """
+    Get the LORIS base data directory path from the in-database configuration, or exit the program
+    with an error if that configuration value does not exist or is incorrect.
+    """
+
+    data_dir_path = os.path.normpath(_get_config_value(env, 'dataDirBasepath'))
+
+    if not os.path.isdir(data_dir_path):
+        log_error_exit(
+            env,
+            (
+                f"The LORIS base data directory path configuration value '{data_dir_path}' does not refer to an"
+                " existing directory."
+            )
+        )
+
+    if not os.access(data_dir_path, os.R_OK) or not os.access(data_dir_path, os.W_OK):
+        log_error_exit(
+            env,
+            f"Missing read or write permission on the LORIS base data directory '{data_dir_path}'.",
+        )
+
+    return data_dir_path
+
+
+def get_dicom_archive_dir_path_config(env: Env) -> str:
+    """
+    Get the LORIS DICOM archive directory path from the in-database configuration, or exit the
+    program with an error if that configuration value does not exist or is incorrect.
+    """
+
+    dicom_archive_dir_path = os.path.normpath(_get_config_value(env, 'tarchiveLibraryDir'))
+
+    if not os.path.isdir(dicom_archive_dir_path):
+        log_error_exit(
+            env,
+            (
+                f"The LORIS DICOM archive directory path configuration value '{dicom_archive_dir_path}' does not refer"
+                " to an existing diretory."
+            ),
+        )
+
+    if not os.access(dicom_archive_dir_path, os.R_OK) or not os.access(dicom_archive_dir_path, os.W_OK):
+        log_error_exit(
+            env,
+            f"Missing read or write permission on the LORIS DICOM archive directory '{dicom_archive_dir_path}'.",
+        )
+
+    return dicom_archive_dir_path
+
+
+def _get_config_value(env: Env, setting_name: str) -> str:
+    """
+    Get a configuration value from the database using a configuration setting name, or exit the
+    program with an error that value does not exist or is not a string.
+    """
+
+    config = try_get_config_with_setting_name(env.db, setting_name)
+    if config is None:
+        log_error_exit(
+            env,
+            f"No configuration value found in the database for setting '{setting_name}'."
+        )
+
+    if config.value is None:
+        log_error_exit(
+            env,
+            f"Found a configuration value in the database for setting '{setting_name}' but that value is NULL."
+        )
+
+    return config.value

--- a/python/lib/db/queries/config.py
+++ b/python/lib/db/queries/config.py
@@ -5,16 +5,16 @@ from lib.db.models.config import DbConfig
 from lib.db.models.config_setting import DbConfigSetting
 
 
-def get_config_with_setting_name(db: Database, name: str) -> DbConfig:
+def try_get_config_with_setting_name(db: Database, name: str) -> DbConfig | None:
     """
-    Get a single configuration entry from the database using its configuration setting name, or
-    raise an exception if no entry or several entries are found.
+    Try to get a single configuration entry from the database using its configuration setting name,
+    or return `None` if no configuration setting is found.
     """
 
     return db.execute(select(DbConfig)
         .join(DbConfig.setting)
         .where(DbConfigSetting.name == name)
-    ).scalar_one()
+    ).scalar_one_or_none()
 
 
 def set_config_with_setting_name(db: Database, name: str, value: str):

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -175,7 +175,7 @@ class BasePipeline:
             self.dicom_archive = self.mri_upload.dicom_archive
 
         elif tarchive_path:
-            archive_location = tarchive_path.replace(self.dicom_lib_dir, "")
+            archive_location = os.path.relpath(tarchive_path, self.dicom_lib_dir)
             dicom_archive = try_get_dicom_archive_with_archive_location(self.env.db, archive_location)
             if dicom_archive is None:
                 log_error_exit(

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -3,8 +3,8 @@ import shutil
 
 import lib.exitcode
 import lib.utilities
+from lib.config import get_data_dir_path_config, get_dicom_archive_dir_path_config
 from lib.database import Database
-from lib.database_lib.config import Config
 from lib.db.queries.dicom_archive import try_get_dicom_archive_with_archive_location
 from lib.db.queries.mri_upload import try_get_mri_upload_with_id
 from lib.get_session_info import SessionConfigError, get_dicom_archive_session_info
@@ -54,16 +54,9 @@ class BasePipeline:
         self.db.connect()
 
         # -----------------------------------------------------------------------------------
-        # Load the Config, Imaging, ImagingUpload, Tarchive, Session database classes
+        # Load the Imaging database class
         # -----------------------------------------------------------------------------------
-        self.config_db_obj = Config(self.db, self.verbose)
         self.imaging_obj = Imaging(self.db, self.verbose, self.config_file)
-
-        # ---------------------------------------------------------------------------------------------
-        # Grep config settings from the Config module
-        # ---------------------------------------------------------------------------------------------
-        self.data_dir = self.config_db_obj.get_config("dataDirBasepath")
-        self.dicom_lib_dir = self.config_db_obj.get_config('tarchiveLibraryDir')
 
         # ---------------------------------------------------------------------------------------------
         # Create tmp dir and log file (their basename being the name of the script run)
@@ -71,6 +64,12 @@ class BasePipeline:
         self.tmp_dir = self.loris_getopt_obj.tmp_dir
         self.env = make_env(self.loris_getopt_obj)
         self.env.add_cleanup(self.remove_tmp_dir)
+
+        # ---------------------------------------------------------------------------------------------
+        # Grep config settings from the config module
+        # ---------------------------------------------------------------------------------------------
+        self.data_dir = get_data_dir_path_config(self.env)
+        self.dicom_lib_dir = get_dicom_archive_dir_path_config(self.env)
 
         # ---------------------------------------------------------------------------------------------
         # Load imaging_upload and tarchive dictionary

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -5,6 +5,7 @@ import lib.exitcode
 import lib.utilities
 from lib.config import get_data_dir_path_config, get_dicom_archive_dir_path_config
 from lib.database import Database
+from lib.database_lib.config import Config
 from lib.db.queries.dicom_archive import try_get_dicom_archive_with_archive_location
 from lib.db.queries.mri_upload import try_get_mri_upload_with_id
 from lib.get_session_info import SessionConfigError, get_dicom_archive_session_info
@@ -57,6 +58,7 @@ class BasePipeline:
         # Load the Imaging database class
         # -----------------------------------------------------------------------------------
         self.imaging_obj = Imaging(self.db, self.verbose, self.config_file)
+        self.config_db_obj = Config(self.db, self.verbose)
 
         # ---------------------------------------------------------------------------------------------
         # Create tmp dir and log file (their basename being the name of the script run)

--- a/python/scripts/import_dicom_study.py
+++ b/python/scripts/import_dicom_study.py
@@ -9,8 +9,8 @@ from typing import Any, cast
 
 import lib.exitcode
 import lib.import_dicom_study.text
+from lib.config import get_dicom_archive_dir_path_config
 from lib.db.models.dicom_archive import DbDicomArchive
-from lib.db.queries.config import get_config_with_setting_name
 from lib.db.queries.dicom_archive import try_get_dicom_archive_with_study_uid
 from lib.get_session_info import SessionConfigError
 from lib.import_dicom_study.dicom_database import insert_dicom_archive, update_dicom_archive
@@ -137,6 +137,10 @@ def main() -> None:
             lib.exitcode.INVALID_ARG,
         )
 
+    # Load configuration values.
+
+    dicom_archive_dir_path = get_dicom_archive_dir_path_config(env)
+
     # Utility variables.
 
     dicom_study_name = os.path.basename(args.source)
@@ -187,11 +191,6 @@ def main() -> None:
         session = session_info.session
 
     log(env, 'Checking DICOM scan date...')
-
-    # TODO: Factorize this into a `lib.config` module and add some checks (directory exists, permissions).
-    dicom_archive_dir_path = get_config_with_setting_name(env.db, 'tarchiveLibraryDir').value
-    if dicom_archive_dir_path is None:
-        log_error_exit(env, "No value found for configuration setting 'tarchiveLibraryDir'.")
 
     if dicom_summary.info.scan_date is None:
         log_warning(env, "No DICOM scan date found in the DICOM files.")


### PR DESCRIPTION
Title. Improve the new `lib.config` module that was introduced in #1250, and adopt it for some configurations in the new DICOM study importer and the DICOM to BIDS pipeline.

The goal of this module is to centralize/factorize access to the in-database LORIS configuration, and to to provide robust validation and error reporting if these configuration values are missing or incorrect.