### PR TITLE
Finish to adopt `lib.util.crypto`

### DIFF
--- a/python/lib/aws_s3.py
+++ b/python/lib/aws_s3.py
@@ -5,7 +5,7 @@ import os
 import boto3
 from botocore.exceptions import ClientError, EndpointConnectionError
 
-import lib.utilities
+from lib.util.crypto import compute_file_md5_hash
 
 __license__ = "GPLv3"
 
@@ -81,7 +81,7 @@ class AwsS3:
          :type key: str
         """
         try:
-            etag = lib.utilities.compute_md5_hash(file_path)
+            etag = compute_file_md5_hash(file_path)
             self.s3_client.head_object(Bucket=self.bucket_name, Key=key, IfMatch=etag)
         except ClientError:
             """

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_validation_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_validation_pipeline.py
@@ -2,11 +2,11 @@ import os
 import sys
 
 import lib.exitcode
-import lib.utilities as utilities
 from lib.db.models.dicom_archive import DbDicomArchive
 from lib.dcm2bids_imaging_pipeline_lib.base_pipeline import BasePipeline
 from lib.env import Env
 from lib.logging import log_error_exit, log_verbose
+from lib.util.crypto import compute_file_md5_hash
 
 __license__ = "GPLv3"
 
@@ -79,7 +79,7 @@ def _validate_dicom_archive_md5sum(env: Env, dicom_archive: DbDicomArchive, dico
     """
 
     # compute the md5sum of the tarchive file
-    dicom_archive_file_md5_sum = utilities.compute_md5_hash(dicom_archive_path)
+    dicom_archive_file_md5_sum = compute_file_md5_hash(dicom_archive_path)
 
     # grep the md5sum stored in the database
     dicom_archive_db_md5_sum = dicom_archive.md5_sum_archive.split()[0]

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -7,12 +7,12 @@ import subprocess
 import sys
 
 import lib.exitcode
-import lib.utilities as utilities
 from lib.bids import get_bids_json_session_info
 from lib.db.queries.dicom_archive import try_get_dicom_archive_series_with_series_uid_echo_time
 from lib.dcm2bids_imaging_pipeline_lib.base_pipeline import BasePipeline
 from lib.get_session_info import SessionConfigError, get_dicom_archive_session_info
 from lib.logging import log_error_exit, log_verbose
+from lib.util.crypto import compute_file_blake2b_hash, compute_file_md5_hash
 
 __license__ = "GPLv3"
 
@@ -42,15 +42,15 @@ class NiftiInsertionPipeline(BasePipeline):
         self.nifti_path = self.options_dict["nifti_path"]["value"]
         self.nifti_s3_url = self.options_dict["nifti_path"]["s3_url"] \
             if 's3_url' in self.options_dict["nifti_path"].keys() else None
-        self.nifti_blake2 = utilities.compute_blake2b_hash(self.nifti_path)
-        self.nifti_md5 = utilities.compute_md5_hash(self.nifti_path)
+        self.nifti_blake2 = compute_file_blake2b_hash(self.nifti_path)
+        self.nifti_md5 = compute_file_md5_hash(self.nifti_path)
         self.json_path = self.options_dict["json_path"]["value"]
-        self.json_blake2 = utilities.compute_blake2b_hash(self.json_path) if self.json_path else None
+        self.json_blake2 = compute_file_blake2b_hash(self.json_path) if self.json_path else None
+        self.json_md5 = compute_file_md5_hash(self.json_path) if self.json_path else None
         self.bval_path = self.options_dict["bval_path"]["value"]
-        self.bval_blake2 = utilities.compute_blake2b_hash(self.bval_path) if self.bval_path else None
+        self.bval_blake2 = compute_file_blake2b_hash(self.bval_path) if self.bval_path else None
         self.bvec_path = self.options_dict["bvec_path"]["value"]
-        self.bvec_blake2 = utilities.compute_blake2b_hash(self.bvec_path) if self.bval_path else None
-        self.json_md5 = utilities.compute_md5_hash(self.json_path)
+        self.bvec_blake2 = compute_file_blake2b_hash(self.bvec_path) if self.bval_path else None
         self.loris_scan_type = self.options_dict["loris_scan_type"]["value"]
         self.bypass_extra_checks = self.options_dict["bypass_extra_checks"]["value"]
 

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -16,6 +16,7 @@ from lib.database_lib.physiological_output_type import PhysiologicalOutputType
 from lib.physiological import Physiological
 from lib.scanstsv import ScansTSV
 from lib.session import Session
+from lib.util.crypto import compute_file_blake2b_hash
 
 __license__ = "GPLv3"
 
@@ -427,7 +428,7 @@ class Eeg:
                     )
 
                 eeg_file_data['eegjson_file'] = eegjson_file_path
-                json_blake2 = utilities.compute_blake2b_hash(eegjson_file.path)
+                json_blake2 = compute_file_blake2b_hash(eegjson_file.path)
                 eeg_file_data['physiological_json_file_blake2b_hash'] = json_blake2
 
             # greps the file type from the ImagingFileTypes table
@@ -452,7 +453,7 @@ class Eeg:
                     )
 
                 eeg_file_data['scans_tsv_file'] = scans_path
-                scans_blake2 = utilities.compute_blake2b_hash(self.scans_file)
+                scans_blake2 = compute_file_blake2b_hash(self.scans_file)
                 eeg_file_data['physiological_scans_tsv_file_bake2hash'] = scans_blake2
 
             # if file type is set and fdt file exists, append fdt path to the
@@ -467,11 +468,11 @@ class Eeg:
                     )
 
                 eeg_file_data['fdt_file'] = fdt_file_path
-                fdt_blake2 = utilities.compute_blake2b_hash(fdt_file.path)
+                fdt_blake2 = compute_file_blake2b_hash(fdt_file.path)
                 eeg_file_data['physiological_fdt_file_blake2b_hash'] = fdt_blake2
 
             # append the blake2b to the eeg_file_data dictionary
-            blake2 = utilities.compute_blake2b_hash(eeg_file.path)
+            blake2 = compute_file_blake2b_hash(eeg_file.path)
             eeg_file_data['physiological_file_blake2b_hash'] = blake2
 
             # check that the file using blake2b is not already inserted before
@@ -587,7 +588,7 @@ class Eeg:
                             electrode_file.path, derivatives
                         )
                     # get the blake2b hash of the electrode file
-                    blake2 = utilities.compute_blake2b_hash(electrode_file.path)
+                    blake2 = compute_file_blake2b_hash(electrode_file.path)
 
                     # insert the electrode data in the database
                     electrode_ids = physiological.insert_electrode_file(
@@ -630,7 +631,7 @@ class Eeg:
                         with open(coordsystem_metadata_file.path) as metadata_file:
                             electrode_metadata = json.load(metadata_file)
                         # get the blake2b hash of the json events file
-                        blake2 = utilities.compute_blake2b_hash(coordsystem_metadata_file.path)
+                        blake2 = compute_file_blake2b_hash(coordsystem_metadata_file.path)
                         # insert event metadata in the database
                         physiological.insert_electrode_metadata(
                             electrode_metadata,
@@ -696,7 +697,7 @@ class Eeg:
                         channel_file.path, derivatives
                     )
                 # get the blake2b hash of the channel file
-                blake2 = utilities.compute_blake2b_hash(channel_file.path)
+                blake2 = compute_file_blake2b_hash(channel_file.path)
                 # insert the channel data in the database
                 physiological.insert_channel_file(
                     channel_data, channel_path, physiological_file_id, blake2
@@ -784,7 +785,7 @@ class Eeg:
                     with open(event_metadata_file.path) as metadata_file:
                         event_metadata = json.load(metadata_file)
                     # get the blake2b hash of the json events file
-                    blake2 = utilities.compute_blake2b_hash(event_metadata_file.path)
+                    blake2 = compute_file_blake2b_hash(event_metadata_file.path)
                     # insert event metadata in the database
                     _, file_tag_dict = physiological.insert_event_metadata(
                         event_metadata=event_metadata,
@@ -806,7 +807,7 @@ class Eeg:
                     event_data_file.path, derivatives
                 )
             # get the blake2b hash of the task events file
-            blake2 = utilities.compute_blake2b_hash(event_data_file.path)
+            blake2 = compute_file_blake2b_hash(event_data_file.path)
 
             # insert event data in the database
             physiological.insert_event_file(
@@ -901,9 +902,10 @@ class Eeg:
 
         # check if archive is on the filesystem
         (archive_rel_name, archive_full_path) = self.get_archive_paths(archive_rel_name)
-        blake2            = None
         if os.path.isfile(archive_full_path):
-            blake2 = utilities.compute_blake2b_hash(archive_full_path)
+            blake2 = compute_file_blake2b_hash(archive_full_path)
+        else:
+            blake2 = None
 
         # check if archive already inserted in database and matches the one
         # on the filesystem using blake2b hash
@@ -929,7 +931,7 @@ class Eeg:
         utilities.create_archive(files_to_archive, archive_full_path)
 
         # insert the archive file in physiological_archive
-        blake2 = utilities.compute_blake2b_hash(archive_full_path)
+        blake2 = compute_file_blake2b_hash(archive_full_path)
         archive_info = {
             'PhysiologicalFileID': eeg_file_id,
             'Blake2bHash'        : blake2,
@@ -952,9 +954,10 @@ class Eeg:
 
         # check if archive is on the filesystem
         (archive_rel_name, archive_full_path) = self.get_archive_paths(archive_rel_name)
-        blake2            = None
         if os.path.isfile(archive_full_path):
-            blake2 = utilities.compute_blake2b_hash(archive_full_path)
+            blake2 = compute_file_blake2b_hash(archive_full_path)
+        else:
+            blake2 = None
 
         # check if archive already inserted in database and matches the one
         # on the filesystem using blake2b hash
@@ -983,7 +986,7 @@ class Eeg:
         utilities.create_archive(files_to_archive, archive_full_path)
 
         # insert the archive into the physiological_annotation_archive table
-        blake2 = utilities.compute_blake2b_hash(archive_full_path)
+        blake2 = compute_file_blake2b_hash(archive_full_path)
         physiological_event_archive_obj.insert(eeg_file_id, blake2, archive_rel_name)
 
     def get_archive_paths(self, archive_rel_name):

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -10,7 +10,6 @@ import nibabel as nib
 from nilearn import image, plotting
 from typing_extensions import deprecated
 
-import lib.utilities as utilities
 from lib.database_lib.candidate_db import CandidateDB
 from lib.database_lib.config import Config
 from lib.database_lib.files import Files
@@ -23,6 +22,7 @@ from lib.database_lib.mri_scanner import MriScanner
 from lib.database_lib.mri_violations_log import MriViolationsLog
 from lib.database_lib.parameter_file import ParameterFile
 from lib.database_lib.parameter_type import ParameterType
+from lib.util.crypto import compute_file_blake2b_hash
 
 __license__ = "GPLv3"
 
@@ -1065,7 +1065,7 @@ class Imaging:
             json_data['IntendedFor'] = fmap_dict['IntendedFor']
             with open(json_file_path, 'w') as json_file:
                 json_file.write(json.dumps(json_data, indent=4))
-            json_blake2 = utilities.compute_blake2b_hash(json_file_path)
+            json_blake2 = compute_file_blake2b_hash(json_file_path)
             param_type_id = self.param_type_db_obj.get_parameter_type_id('bids_json_file_blake2b_hash')
             param_file_dict = self.param_file_db_obj.get_parameter_file_for_file_id_param_type_id(
                 fmap_dict['FileID'],

--- a/python/lib/mri.py
+++ b/python/lib/mri.py
@@ -12,6 +12,7 @@ from lib.candidate import Candidate
 from lib.imaging import Imaging
 from lib.scanstsv import ScansTSV
 from lib.session import Session
+from lib.util.crypto import compute_file_blake2b_hash
 
 __license__ = "GPLv3"
 
@@ -300,7 +301,7 @@ class Mri:
             # copy the JSON file to the LORIS BIDS import directory
             json_path = self.copy_file_to_loris_bids_dir(json_file)
             file_parameters['bids_json_file'] = json_path
-            json_blake2 = utilities.compute_blake2b_hash(json_file)
+            json_blake2 = compute_file_blake2b_hash(json_file)
             file_parameters['bids_json_file_blake2b_hash'] = json_blake2
 
         # grep the file type from the ImagingFileTypes table
@@ -326,7 +327,7 @@ class Mri:
                 self.bids_sub_id, self.loris_bids_root_dir, self.data_dir
             )
             file_parameters['scans_tsv_file'] = scans_path
-            scans_blake2 = utilities.compute_blake2b_hash(self.scans_file)
+            scans_blake2 = compute_file_blake2b_hash(self.scans_file)
             file_parameters['scans_tsv_file_bake2hash'] = scans_blake2
 
         # grep voxel step from the NIfTI file header
@@ -349,12 +350,12 @@ class Mri:
             copied_path = self.copy_file_to_loris_bids_dir(original_file_path)
             file_param_name = 'bids_' + type
             file_parameters[file_param_name] = copied_path
-            file_blake2 = utilities.compute_blake2b_hash(original_file_path)
+            file_blake2 = compute_file_blake2b_hash(original_file_path)
             hash_param_name = file_param_name + '_blake2b_hash'
             file_parameters[hash_param_name] = file_blake2
 
         # append the blake2b to the MRI file parameters dictionary
-        blake2 = utilities.compute_blake2b_hash(nifti_file.path)
+        blake2 = compute_file_blake2b_hash(nifti_file.path)
         file_parameters['file_blake2b_hash'] = blake2
 
         # check that the file is not already inserted before inserting it

--- a/python/scripts/bids_import.py
+++ b/python/scripts/bids_import.py
@@ -18,6 +18,7 @@ from lib.database_lib.config import Config
 from lib.eeg import Eeg
 from lib.mri import Mri
 from lib.session import Session
+from lib.util.crypto import compute_file_blake2b_hash
 
 __license__ = "GPLv3"
 
@@ -325,7 +326,7 @@ def read_and_insert_bids(
         # load json data
         with open(root_event_metadata_file.path) as metadata_file:
             event_metadata = json.load(metadata_file)
-        blake2 = lib.utilities.compute_blake2b_hash(root_event_metadata_file.path)
+        blake2 = compute_file_blake2b_hash(root_event_metadata_file.path)
         physio = lib.physiological.Physiological(db, verbose)
         _, dataset_tag_dict = physio.insert_event_metadata(
             event_metadata=event_metadata,


### PR DESCRIPTION
Some other PR created `lib.util.crypto` to have typed hash functions for the DICOM study importer, but these functions were not adopted in the rest of the codebase. This PR adopts them. A small difference is that the new functions raise an exception if the file does not exist, whereas the old ones return `None`, so I had to check whether there was a possibility that the files do not exist while replacing the old function calls.

This reduces the number of depreciation warnings in CI and makes it possible to delete the untyped functions after LORIS-MRI 27.