### PR TITLE
Adopt new DICOM study importer in the MRI pipeline

### DIFF
--- a/dicom-archive/dicomTar.pl
+++ b/dicom-archive/dicomTar.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 # J-Sebastian Muehlboeck 2006
 # sebas@bic.mni.mcgill.ca
-# Archive your dicom data using DICOM::DCMSUM 
+# Archive your dicom data using DICOM::DCMSUM
 # Tar and gzip dicom files and retar them with pertaining summary and creation log
 # @VERSION : $Id: dicomTar.pl 9 2007-12-18 22:26:00Z jharlap $
 
@@ -133,6 +133,10 @@ my @arg_table =
      exit."],
      );
 
+print STDERR "WARNING: `dicomTar.pl` is deprecated and may eventually be removed. Please use the"
+             . " new `import_dicom_study.py` script instead, which also comes with new features"
+             . " like support for enhanced DICOMs, multi-echo series, and more.\n\n";
+
 GetOptions(\@arg_table, \@ARGV) ||  exit $NeuroDB::ExitCodes::GETOPT_FAILURE;
 
 if ($version) { print "Version: $versionInfo\n"; exit; }
@@ -171,7 +175,7 @@ if ($mri_upload_update && !$dbase) {
     exit $NeuroDB::ExitCodes::MISSING_ARG;
 }
 
-# The tar target 
+# The tar target
 my $totar = basename($dcm_source);
 print "Source: ". $dcm_source . "\nTarget: ".  $targetlocation . "\n\n"
     if $verbose;
@@ -187,7 +191,7 @@ if ($dbase) {
     print "Database is available.\n\n" if $verbose;
 }
 
-# ***************************************    main    *************************************** 
+# ***************************************    main    ***************************************
 #### get some info about who created the archive and where and when
 my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)=localtime(time);
 my $date            = sprintf("%4d-%02d-%02d %02d:%02d:%02d\n",
@@ -217,7 +221,7 @@ my $sumTypeVersion = $summary->{'sumTypeVersion'};
 # get the unique study ID
 my $studyUnique = $summary->{'studyuid'};
 my $creator         = $summary->{user};
-my $sumTypeVersion  = $summary->{sumTypeVersion}; 
+my $sumTypeVersion  = $summary->{sumTypeVersion};
 
 # check if the study is already uploaded in the tarchive tables
 if ($dbase) {
@@ -246,7 +250,7 @@ if (-e $finalTarget && !$clobber) {
     exit $NeuroDB::ExitCodes::TARGET_EXISTS_NO_CLOBBER;
 }
 
-# read acquisition metadata into variable 
+# read acquisition metadata into variable
 my $metafile = "$targetlocation/$metaname.meta";
 open META, ">$metafile";
 META->autoflush(1);
@@ -260,7 +264,7 @@ select(STDOUT);
 # get rid of newline
 chomp($hostname,$system);
 
-#### create tar from rigt above the source 
+#### create tar from rigt above the source
 chdir(dirname($dcm_source));
 print "You will archive the dir\t\t: $totar\n" if $verbose;
 # tar contents into tarball
@@ -283,7 +287,7 @@ select(TARINFO);
 &archive_head;
 close TARINFO;
 select(STDOUT);
-my $tarinfo = &read_file("$totar.log"); 
+my $tarinfo = &read_file("$totar.log");
 
 my $retar = "tar cvf DCM\_$byDate\_$totar.tar $totar.meta $totar.log $totar.tar.gz";
 `$retar`;
@@ -295,7 +299,7 @@ select(TARINFO);
 &archive_head;
 close TARINFO;
 select(STDOUT);
-$tarinfo = &read_file("$totar.log"); 
+$tarinfo = &read_file("$totar.log");
 print  $tarinfo if $verbose;
 
 
@@ -343,7 +347,7 @@ if ($mri_upload_update) {
 
 exit $NeuroDB::ExitCodes::SUCCESS;
 
-=pod 
+=pod
 
 =head3 archive_head()
 
@@ -363,11 +367,11 @@ format FORMAT_HEADER =
 * Archive target location          :    @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                                       $finalTarget,
 * Name of creating host            :    @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                                      $hostname,                                
+                                      $hostname,
 * Name of host OS                  :    @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                                       $system,
 * Created by user                  :    @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                                      $creator,                                
+                                      $creator,
 * Archived on                      :    @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                                       $date,
 * dicomSummary version             :    @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -382,7 +386,7 @@ format FORMAT_HEADER =
                                       $ARCHIVEmd5sum,
 .
 
-=pod 
+=pod
 
 =head3 read_file($file)
 

--- a/docs/scripts_md/ConfigOB.md
+++ b/docs/scripts_md/ConfigOB.md
@@ -61,7 +61,7 @@ RETURN: new instance of this class.
 
 ### &$getConfigSettingRef($setting)
 
-Private method. This method fetches setting `$setting` from the LORIS table 
+Private method. This method fetches setting `$setting` from the LORIS table
 Config. It will throw a `NeuroDB::objectBroker::ObjectBrokerException` if either
 the database transaction failed for some reason or it succeeded but returned no
 results (i.e. setting `$setting` does not exist).
@@ -261,6 +261,13 @@ Get the bids\_validator\_options\_to\_ignore Config setting
 
 RETURN: an array of the BIDS validator options to ignore
 to use when creating a BIDS dataset
+
+### getUseLegacyDicomStudyImporter()
+
+Get the use\_legacy\_dicom\_study\_importer Config setting
+
+RETURN: (boolean) 1 if use\_legacy\_dicom\_study\_importer is set to Yes in the Config module, 0
+otherwise
 
 # TO DO
 

--- a/docs/scripts_md/GetRole.md
+++ b/docs/scripts_md/GetRole.md
@@ -108,7 +108,6 @@ INPUTS:
        Field3 => undef
      }
 
-
 RETURNS:
    - a reference to an array of hash references. Every hash contains the values
      for a given row returned by the method call: the key/value pairs contain
@@ -134,7 +133,6 @@ INPUTS:
        Field2 => { NOT => 3 },
        Field3 => undef
      }
-
 
 RETURNS:
    - the number of records found.

--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -56,10 +56,10 @@ exists, the method will try to create it using the supplied parameters.
 INPUTS:
   - $subjectIDref: hash reference of subject IDs
   - $studyDate   : study date
-  - $dbh         : database handle 
+  - $dbh         : database handle
   - $db          : database object
 
-RETURNS: an array of 2 elements: 
+RETURNS: an array of 2 elements:
   - A reference to a hash containing the session properties:
     `ID` => session ID.
     `ProjectID` => project ID for the session.
@@ -429,7 +429,6 @@ that could not be deleted.
 INPUTS:
 
     - @files: list of files to delete.
-    
 
 # TO DO
 

--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -45,7 +45,7 @@ Creates a new instance of this class. The parameter `$dbhr` is a reference
 to a `DBI` database handle, used to set the object's database handle, so that
 all the DB-driven methods will work.
 
-INPUT: 
+INPUT:
   - $db      : database object
   - $dbhr    : DBI database handle reference
   - $debug   : degug flag (1 for debug, 0 otherwise)
@@ -117,9 +117,9 @@ RETURNS:
 
 This function does:
 1) Determine subject's ID based on scanner ID and DICOM archive information.
-2) Call the `CreateMRICandidate` function (will create the candidate if it does 
+2) Call the `CreateMRICandidate` function (will create the candidate if it does
 not exists and `createCandidates` config option is set to yes)
-3) Call the `validateCandidate` to validate the candidate information 
+3) Call the `validateCandidate` to validate the candidate information
 (it will return a `CandMismatchError` if there is one)
 
 INPUTS:
@@ -181,7 +181,7 @@ RETURNS: project ID
 
 ### determineScannerID($tarchiveInfo, $to\_log, $centerID, $projectID, $upload\_id)
 
-Determines which scanner ID was used for DICOM acquisitions. Note, if 
+Determines which scanner ID was used for DICOM acquisitions. Note, if
 a scanner ID is not already associated to the scanner information found
 in the DICOM headers, then a new scanner will automatically be created.
 
@@ -391,7 +391,7 @@ Registers a new candidate in the `candidate` table.
 
 Note: before doing so, the following checks will be performed:
 1) check that the `createCandidates` config option was set to yes
-2) check that the `PSCID` given in `$subjectIDsref` is not already associated 
+2) check that the `PSCID` given in `$subjectIDsref` is not already associated
 to an existing candidate
 3) check that the `CandID` given in `$subjectIDsref` is not already associated
 to an existing candidate
@@ -438,8 +438,8 @@ RETURNS: the final directory in which the registered MINC files will go
 
 Check that the candidate's information derived from the patient name field of
 the DICOM files is valid (`CandID` and `PSCID` of the candidate should
-correspond to the same subject in the database). It will also check that the 
-Visit Label of `$subjectIDsref` is a valid Visit Label present in the 
+correspond to the same subject in the database). It will also check that the
+Visit Label of `$subjectIDsref` is a valid Visit Label present in the
 `Visit_Windows` table.
 
 INPUT: subject's ID information hash ref

--- a/docs/scripts_md/batch_uploads_tarchive.md
+++ b/docs/scripts_md/batch_uploads_tarchive.md
@@ -10,11 +10,11 @@ batch\_uploads\_tarchive - upload a batch of DICOM archives using script
 # DESCRIPTION
 
 This script uploads a list of DICOM archives to the database by calling script
-`tarchiveLoader.pl` on each file in succession. The list of files to process is read 
+`tarchiveLoader.pl` on each file in succession. The list of files to process is read
 from `STDIN`, one file name per line. Each file name is assumed to be a path
 relative to `tarchiveLibraryDir` (see below).
 
-The following settings of file `$ENV{LORIS_CONFIG}/.loris-mri/prod` affect the 
+The following settings of file `$ENV{LORIS_CONFIG}/.loris-mri/prod` affect the
 behvaviour of `batch_uploads_tarchive` (where `$ENV{LORIS_CONFIG}` is the
 value of the Unix environment variable `LORIS_CONFIG`):
 

--- a/docs/scripts_md/delete_imaging_upload.md
+++ b/docs/scripts_md/delete_imaging_upload.md
@@ -14,7 +14,7 @@ Available options are:
 
 \-ignore                : ignore files whose paths exist in the database but do not exist on the file system.
                          Default is to abort if such a file is found, irrespective of whether a backup file will
-                         be created by the script (see `-nofilesbk` and `-nosqlbk`). If this option is used, a 
+                         be created by the script (see `-nofilesbk` and `-nosqlbk`). If this option is used, a
                          warning is issued and program execution continues.
 
 \-nofilesbk             : when creating the backup file for the deleted upload(s), do not backup the files produced by
@@ -24,17 +24,17 @@ Available options are:
                          script will delete, both on the file system and in the database (but see `-nofilesbk` and
                          `-nosqlbk`). The extension `.tar.gz` will be added to this base name to build the name of the final
                          backup file. If a file with this resulting name already exists, an error message is shown and the script
-                         will abort. Note that `path` can be an absolute path or a path relative to the current directory. A 
+                         will abort. Note that `path` can be an absolute path or a path relative to the current directory. A
                          backup file is always created unless options `-nofilesbk` and `-nosqlbk` are both used. By default, the
-                         backup file name is `imaging_upload_backup.tar.gz` and is written in the current directory. Option 
+                         backup file name is `imaging_upload_backup.tar.gz` and is written in the current directory. Option
                          `-backup_path` cannot be used if `-nofilesbk` and `-nosqlbk` are also used.
 
-\-basename fileBaseName : basename of the file to delete. The file is assumed to either exist in table `files` or table 
+\-basename fileBaseName : basename of the file to delete. The file is assumed to either exist in table `files` or table
                          `parameter_file`. This option should be used when targeting a specific (unique) file for deletion.
-                         Note that the file will be deleted from both the database and the filesystem. This option cannot be 
+                         Note that the file will be deleted from both the database and the filesystem. This option cannot be
                          used with options `-defaced` and `-form`.
 
-\-uploadID              : comma-separated list of upload IDs (found in table `mri_upload`) to delete. The program will 
+\-uploadID              : comma-separated list of upload IDs (found in table `mri_upload`) to delete. The program will
                          abort if the list contains an upload ID that does not exist. Also, all upload IDs must
                          have the same `tarchive` ID (which can be `NULL`).
 
@@ -53,10 +53,10 @@ Available options are:
 
 \-defaced               : fetch the scan types listed in config setting `modalities_to_delete` and perform a deletion of these scan
                          types as if their names were used with option `-type`. Once all deletions are done, set the `SourceFileID`
-                         and `TarchiveSource` of all the defaced files in table &lt;files> to `NULL` and to the tarchive ID of the 
+                         and `TarchiveSource` of all the defaced files in table &lt;files> to `NULL` and to the tarchive ID of the
                          upload(s) whose arguments were passed to `-uploadID`, respectively.
 
-\-nosqlbk               : when creating the backup file, do not add to it an SQL file that contains the statements used to restore 
+\-nosqlbk               : when creating the backup file, do not add to it an SQL file that contains the statements used to restore
                          the database to the state it had before the script was invoked. Adding this file, which will be named
                          `imaging_upload_restore.sql`, to the backup file is the default behaviour.
 
@@ -85,7 +85,7 @@ successfully run, this removes all records tied to the upload in the following t
    b) `files`
    c) `tarchive_series` and `tarchive_files`
    d) `mri_protocol_violated_scans`, `MRICandidateErrors` and `mri_violations_log`
-   e) `files_intermediary`. 
+   e) `files_intermediary`.
    f) `parameter_file`
    g) `tarchive`
    h) `mri_upload`
@@ -95,29 +95,29 @@ successfully run, this removes all records tied to the upload in the following t
 
 All the deletions and modifications performed in the database are done as part of a single transaction, so they either
 all succeed or a rollback is performed and the database is not modified in any way. The ID of the upload to delete
-is specified via option `-uploadID`. More than one upload can be deleted if they all have the same `TarchiveID` 
+is specified via option `-uploadID`. More than one upload can be deleted if they all have the same `TarchiveID`
 in table `mri_upload`: option `-uploadID` can take as argument a comma-separated list of upload IDs for this case.
 If an upload that is deleted is the only one that was associated to a given session, the script will set the `Scan_done`
-value for that session to 'N'. If option `-form` is used, the `mri_parameter_form` and its associated `flag` record 
-are also deleted, for each deleted upload. If option `-protocol` is used and if there is a record in table 
+value for that session to 'N'. If option `-form` is used, the `mri_parameter_form` and its associated `flag` record
+are also deleted, for each deleted upload. If option `-protocol` is used and if there is a record in table
 `mri_processing_protocol` that is tied only to the deleted upload(s), then that record is also deleted.
 
 `delete_imaging_upload.pl` cannot be used to delete an upload that has an associated MINC file that has been QCed.
-In other words, if there is a MINC file tied to the upload that is targeted for deletion and if that MINC file has 
+In other words, if there is a MINC file tied to the upload that is targeted for deletion and if that MINC file has
 an associated record in table `files_qcstatus` or `feedback_mri_comments`, the script will issue an error message
 and exit.
 
-Before deleting any records in the database, the script will verify that all the records in tables a) through j) that 
+Before deleting any records in the database, the script will verify that all the records in tables a) through j) that
 represent file names (e.g. a record in `files`, a protocol file in `mri_processing_protocol`, etc...) refer to files
-that actually exist on the file system. If it finds a record that does not meet that criterion, the script issues an 
+that actually exist on the file system. If it finds a record that does not meet that criterion, the script issues an
 error message and exits, leaving the database untouched. To avoid this check, use option `-ignore`. Each time a file
-record is deleted, the file it refers to on the file system is also deleted. A backup will be created by 
-`delete_imaging_upload.pl` of all the files that were deleted during execution. Option `-nofilesbk` can be used to 
+record is deleted, the file it refers to on the file system is also deleted. A backup will be created by
+`delete_imaging_upload.pl` of all the files that were deleted during execution. Option `-nofilesbk` can be used to
 prevent this. If created, the backup file will be named `imaging_upload_backup.tar.gz`. This name can be changed with
 option `-backup_path`. Note that the file paths inside this backup archive are absolute. To restore the files in the archive,
 one must use `tar` with option `--absolute-names`.
 
-The script will also create a file that contains a backup of all the information that was deleted or modified from the 
+The script will also create a file that contains a backup of all the information that was deleted or modified from the
 database tables. This backup is created using `mysqldump` and contains an `INSERT` statement for every record erased.
 When running `mysqldump` the script uses the database credentials in file `~/.my.cnf` to connect to the database. Option
 `-extra_mysqlcnf` has to be used to specify an alternate credentials file when the default credential file does not exist
@@ -127,11 +127,11 @@ If sourced back into the database with `mysql`, it should allow the database to 
 `delete_imaging_upload.pl` was invoked, provided the database was not modified in the meantime. The SQL backup file will
 be named `imaging_upload_restore.sql`.
 
-2\. Delete specific scan types from an archive. The behaviour of the script is identical to the one described above, except 
+2\. Delete specific scan types from an archive. The behaviour of the script is identical to the one described above, except
    that:
     a) the deletions are limited to MINC files of a specific scan type: use option `-type` with a comma-separated list
        of scan type names to specify which ones.
-    b) everything associated to the MINC files deleted in a) is also deleted: this includes the processed files in 
+    b) everything associated to the MINC files deleted in a) is also deleted: this includes the processed files in
        `files_intermediary` and the records in `mri_violations_log`.
     c) if `-protocol` is used and there is an entry in table `mri_processing_protocol` that is tied only to the files
        deleted in a), then that record is also deleted.
@@ -139,35 +139,35 @@ be named `imaging_upload_restore.sql`.
        and `mri_parameter_form` are never modified.
    Note that option `-type` cannot be used in conjunction with either option `-form` or option `-defaced`.
 
-3\. Replace MINC files with their defaced counterparts. This is the behaviour obtained when option `-defaced` is used. As far as 
-   deletions go, the behaviour of the script in this case is identical to the one described in 2), except that the list of 
+3\. Replace MINC files with their defaced counterparts. This is the behaviour obtained when option `-defaced` is used. As far as
+   deletions go, the behaviour of the script in this case is identical to the one described in 2), except that the list of
    scan types to delete is fetched from the config setting `modalities_to_deface`. Use of option `-defaced` is not permitted
-   in conjunction with option `-type` or option `-form`. Once all deletions are made, the script will change the `SourceFileID` 
-   of all defaced files to `NULL` and set the `TarchiveSource` of all defaced files to the `TarchiveID` of the upload(s). 
-   This effectively "replaces" the original MINC files with their corresponding defaced versions. Note that the script will issue 
+   in conjunction with option `-type` or option `-form`. Once all deletions are made, the script will change the `SourceFileID`
+   of all defaced files to `NULL` and set the `TarchiveSource` of all defaced files to the `TarchiveID` of the upload(s).
+   This effectively "replaces" the original MINC files with their corresponding defaced versions. Note that the script will issue
    an error message and abort, leaving the database and file system untouched, if:
        a) A MINC file should have a corresponding defaced file but does not.
        b) A MINC file that has been defaced has an associated file that is not a defaced file.
 
 4\. Delete a specific file that exists in table `files` or table `parameter_file` (in which case it will be associated to parameter
    `check_pic_filename`, `check_nii_filename`, `check_bval_filename` or `check_bvec_filename`). Note that once a file is
-   deleted, all the files that have been derived/built using this deleted file will also be deleted. Use option `-basename fileBaseName`, 
+   deleted, all the files that have been derived/built using this deleted file will also be deleted. Use option `-basename fileBaseName`,
    where `fileBaseName` is the basename of the file to delete, along with option `-uploadID` to use the script this way.
 
 ## Methods
 
 ### printExitMessage($filesRef, $scanTypesToDeleteRef, $deleteResultsRef)
 
-Prints an appropriate message before exiting. 
+Prints an appropriate message before exiting.
 
 INPUTS:
   - $filesRef: reference to the array that contains the file information for all the files
     that are associated to the upload(s) passed on the command line.
   - $scanTypesToDeleteRef: reference to the array that contains the list of scan type names to delete.
   - $deleteResultsRef: reference on the hash that contains the result of the deletion of the records in the
-    database. 
+    database.
 
-### prettyListPrint($listRef, $andOr) 
+### prettyListPrint($listRef, $andOr)
 
 Pretty prints a list in string form (e.g "1, 2, 3 and 4" or "7, 8 or 9").
 
@@ -201,7 +201,7 @@ RETURNS:
   - a reference on an array that contains the `tarchive` associated to the upload ID(s) passed on the command line.
     This array can contain one element (if the uploads are all tied to the same `tarchive`) or be empty (if all the
     uploads have a `TarchiveID` set to `NULL`). If the `ArchiveLocation` for the `tarchive` is a relative path and
-    if config setting `tarchiveLibraryDir`is not defined, the return value is `undef`, indicating that something is 
+    if config setting `tarchiveLibraryDir`is not defined, the return value is `undef`, indicating that something is
     wrong.
 
 ### validateMriUploads($mriUploadsRef, $optionsRef, $scanTypeList)
@@ -220,7 +220,7 @@ INPUTS:
 ### getMriProcessingProtocolFilesRef($dbh, $filesRef)
 
 Finds the list of `ProcessingProtocolID`s to delete, namely those in table
-`mri_processing_protocol` associated to the files to delete, and \*only\* to 
+`mri_processing_protocol` associated to the files to delete, and \*only\* to
 those files that are going to be deleted.
 
 INPUTS:
@@ -230,14 +230,14 @@ INPUTS:
 
 RETURNS:
   - reference on an array that contains the `ProcessProtocolID` in table `mri_processing_protocol`
-    associated to the files to delete. This array has two keys: `ProcessProtocolID` => the protocol 
+    associated to the files to delete. This array has two keys: `ProcessProtocolID` => the protocol
     process ID found in table `mri_processing_protocol` and `FullPath` => the value of `ProtocolFile`
     in the same table.
 
 ### hasQcOrComment($dbh, $mriUploadsRef)
 
-Determines if any of the MINC files associated to the `tarchive` have QC 
-information associated to them by looking at the contents of tables 
+Determines if any of the MINC files associated to the `tarchive` have QC
+information associated to them by looking at the contents of tables
 `files_qcstatus` and `feedback_mri_comments`.
 
 INPUTS:
@@ -252,7 +252,7 @@ RETURNS:
 
 ### getFilesRef($dbh, $tarchiveID, $dataDirBasePath, $scanTypesToDeleteRef, $optionsRef)
 
-Get the absolute paths of all the files associated to a DICOM archive that are listed in 
+Get the absolute paths of all the files associated to a DICOM archive that are listed in
 table `files`.
 
 INPUTS:
@@ -262,14 +262,14 @@ INPUTS:
   - $scanTypesToDeleteRef: reference to the array that contains the list of names of scan types to delete.
   - $optionsRef: reference on the array of command line options.
 
-RETURNS: 
+RETURNS:
  - an array of hash references. Each hash has three keys: `FileID` => ID of a file in table `files`,
    `File` => value of column `File` for the file with the given ID and `FullPath` => absolute path
    for the file with the given ID.
 
 ### getIntermediaryFilesRef($dbh, $filesRef, $tarchiveID, $dataDirBasePath, $scanTypesToDeleteRef, $optionsRef)
 
-Get the absolute paths of all the intermediary files associated to an archive 
+Get the absolute paths of all the intermediary files associated to an archive
 that are listed in table `files_intermediary`.
 
 INPUTS:
@@ -280,12 +280,12 @@ INPUTS:
   - $scanTypesToDeleteRef: reference to the array that contains the list of scan type names to delete.
   - $optionsRef: reference on the array of command line options.
 
-RETURNS: 
-  - an array of hash references. Each hash has seven keys: `IntermedID` => ID of a file in 
-    table `files_intermediary`, `Input_FileID` => ID of the file that was used as input to create 
-    the intermediary file, `Output_FileID` ID of the output file, `FileID` => ID of this file in 
-    table `files`, `File` => value of column `File` in table `files` for the file with the given 
-    ID, `SourceFileID` value of column `SourceFileID` for the intermediary file and 
+RETURNS:
+  - an array of hash references. Each hash has seven keys: `IntermedID` => ID of a file in
+    table `files_intermediary`, `Input_FileID` => ID of the file that was used as input to create
+    the intermediary file, `Output_FileID` ID of the output file, `FileID` => ID of this file in
+    table `files`, `File` => value of column `File` in table `files` for the file with the given
+    ID, `SourceFileID` value of column `SourceFileID` for the intermediary file and
     `FullPath` => absolute path of the file with the given ID.
 
 ### getParameterFilesRef($dbh, $filesRef, $tarchiveID, $dataDirBasePath, $scanTypesToDeleteRef, $optionsRef)
@@ -300,15 +300,15 @@ INPUTS:
   - $scanTypesToDeleteRef: reference to the array that contains the list of scan type names to delete.
   - $optionsRef: reference on the array of command line options.
 
-RETURNS: 
-  - an array of hash references. Each hash has four keys: `FileID` => FileID of a file 
+RETURNS:
+  - an array of hash references. Each hash has four keys: `FileID` => FileID of a file
     in table `parameter_file`, `Value` => value of column `Value` in table `parameter_file`
     for the file with the given ID, `Name` => name of the parameter and `FullPath` => absolute
     path of the file with the given ID.
 
 ### getMriProtocolViolatedScansFilesRef($dbh, $tarchiveID, $dataDirBasePath, $scanTypesToDeleteRef, $optionsRef)
 
-Get the absolute paths of all the files associated to a DICOM archive that are listed in 
+Get the absolute paths of all the files associated to a DICOM archive that are listed in
 table `mri_protocol_violated_scans`.
 
 INPUTS:
@@ -318,15 +318,15 @@ INPUTS:
   - $scanTypesToDeleteRef: reference to the array that contains the list of scan type names to delete.
   - $optionsRef: reference on the array of command line options.
 
-RETURNS: 
+RETURNS:
  - an array of hash references. Each hash has three keys: `ID` => ID of the record in table
-   `mri_protocol_violated_scans`, `minc_location` => value of column `minc_location` in table 
+   `mri_protocol_violated_scans`, `minc_location` => value of column `minc_location` in table
    `mri_protocol_violated_scans` for the MINC file found and `FullPath` => absolute path of the MINC
    file found.
 
 ### getMriViolationsLogFilesRef($dbh, $tarchiveID, $dataDirBasePath, $scanTypesToDeleteRef, $optionsRef)
 
-Get the absolute paths of all the files associated to an archive that are listed in 
+Get the absolute paths of all the files associated to an archive that are listed in
 table `mri_violations_log`.
 
 INPUTS:
@@ -336,14 +336,14 @@ INPUTS:
   - $scanTypesToDeleteRef: reference to the array that contains the list of scan type names to delete.
   - $optionsRef: reference on the array of command line options.
 
-RETURNS: 
- an array of hash references. Each hash has three keys: `LogID` => ID of the record in table 
+RETURNS:
+ an array of hash references. Each hash has three keys: `LogID` => ID of the record in table
  `mri_violations_log`, `MincFile` => value of column `MincFile` for the MINC file found in table
  `mri_violations_log` and `FullPath` => absolute path of the MINC file.
 
 ### getMRICandidateErrorsFilesRef($dbh, $tarchiveID, $dataDirBasePath, $scanTypeToDeleteRef, $optionsRef)
 
-Get the absolute paths of all the files associated to a DICOM archive that are listed in 
+Get the absolute paths of all the files associated to a DICOM archive that are listed in
 table `MRICandidateErrors`.
 
 INPUTS:
@@ -353,9 +353,9 @@ INPUTS:
   - $scanTypesToDeleteRef: reference to the array that contains the list of scan type names to delete.
   - $optionsRef: reference on the array of command line options.
 
-RETURNS: 
- - an array of hash references. Each hash has three keys: `ID` => ID of the record in the 
-   table, `MincFile` => value of column `MincFile` for the MINC file found in table 
+RETURNS:
+ - an array of hash references. Each hash has three keys: `ID` => ID of the record in the
+   table, `MincFile` => value of column `MincFile` for the MINC file found in table
    `MRICandidateErrors` and `FullPath` => absolute path of the MINC file.
 
 ### getBidsExportFilesRef($dbh, $filesRef, $dataDirBasePath)
@@ -398,7 +398,7 @@ INPUTS:
 
 ### setFileExistenceStatus($filesRef)
 
-Checks the list of all the files related to the upload(s) that were found in the database and 
+Checks the list of all the files related to the upload(s) that were found in the database and
 determine whether they exist or not on the file system.
 
 INPUTS:
@@ -449,12 +449,12 @@ RETURNS:
 
 ### deleteUploadsInDatabase($dbh, $filesRef, $scanTypesToDeleteRef, $optionsRef)
 
-This method deletes all information in the database associated to the given upload(s)/scan type combination. 
+This method deletes all information in the database associated to the given upload(s)/scan type combination.
 More specifically, it deletes records from tables `notification_spool`, `tarchive_files`, `tarchive_series`
 `files_intermediary`, `parameter_file`, `files`, `mri_protocol_violated_scans`, `mri_violations_log`
-`MRICandidateErrors`, `mri_upload`, `tarchive`, `mri_processing_protocol` and `mri_parameter_form` 
+`MRICandidateErrors`, `mri_upload`, `tarchive`, `mri_processing_protocol` and `mri_parameter_form`
 (the later is done only if requested). It will also set the `Scan_done` value of the scan's session to 'N' for
-each upload that is the last upload tied to that session. All the delete/update operations are done inside a single 
+each upload that is the last upload tied to that session. All the delete/update operations are done inside a single
 transaction so either they all succeed or they all fail (and a rollback is performed).
 
 INPUTS:
@@ -495,7 +495,7 @@ INPUTS:
 ### updateFilesIntermediaryTable($dbh, $filesRef, $tmpSQLFile)
 
 Sets the `TarchiveSource` and `SourceFileID` columns of all the defaced files to `$tarchiveID` and `NULL`
-respectively. The script also adds an SQL statement in the SQL file whose path is passed as argument to 
+respectively. The script also adds an SQL statement in the SQL file whose path is passed as argument to
 restore the state that the defaced files in the `files` table had before the deletions.
 
 INPUTS:
@@ -507,7 +507,7 @@ INPUTS:
 ### deleteMriParameterForm($dbh, $mriUploadsRef, $tmpSQLFile, $optionsRef)
 
 Delete the entries in `mri_parameter_form` (and associated `flag` entry) for the upload(s) passed on the
-command line. The script also adds an SQL statement in the SQL file whose path is passed as argument to 
+command line. The script also adds an SQL statement in the SQL file whose path is passed as argument to
 restore the state that the `mri_parameter_form` and `flag` tables had before the deletions.
 
 INPUTS:
@@ -565,7 +565,7 @@ RETURNS:
 ### deleteTableData($dbh, $table, $key, $keyValuesRef, $tmpSQLBackupFile, $optionsRef)
 
 Deletes records from a database table and adds in a file the SQL statements that allow rewriting the
-records back in the table. 
+records back in the table.
 
 INPUTS:
   - $dbh: database handle.

--- a/docs/scripts_md/get_dicom_files.md
+++ b/docs/scripts_md/get_dicom_files.md
@@ -4,7 +4,7 @@ get\_dicom\_files.pl - extracts DICOM files for specific patient names/scan type
 
 # SYNOPSIS
 
-perl get\_dicom\_files.pl \[-name patient\_name\_patterns\] \[-type scan\_type\_patterns\] \[-outdir tmp\_dir\] \[-outfile tarBasename\] 
+perl get\_dicom\_files.pl \[-name patient\_name\_patterns\] \[-type scan\_type\_patterns\] \[-outdir tmp\_dir\] \[-outfile tarBasename\]
            \[-id candid|pscid|candid\_pscid|pscid\_candid\] -profile profile
 
 Available options are:
@@ -12,8 +12,8 @@ Available options are:
 \-profile : name of the config file in `../dicom-archive/.loris_mri` (typically `prod`)
 
 \-name    : comma separated list of MySQL patterns for the patient names that a DICOM file
-           has to have in order to be extracted. A DICOM file only has to match one of the 
-           patterns to be extracted. If no pattern is specified, then the patient name is 
+           has to have in order to be extracted. A DICOM file only has to match one of the
+           patterns to be extracted. If no pattern is specified, then the patient name is
            not used to determine which DICOM files to extract. This option must be used if
            no scan type patterns were specified with `-type` (see below).
 
@@ -34,7 +34,7 @@ Available options are:
            `get_dicom_files.pl` failing. Note that this argument has no impact on the location of the
            final `.tar.gz` file. Use option `-outfile` to control that.
 
-\-outfile : basename of the final `tar.gz` file to produce, in the current directory (defaults to 
+\-outfile : basename of the final `tar.gz` file to produce, in the current directory (defaults to
            `dicoms.tar.gz`).
 
 \-id      : how to name the subdirectory identifying the candidate to which the DICOM files belong:
@@ -44,16 +44,16 @@ Available options are:
 
 This script first connects to the database to build the list of DICOM archives for which
 the patient names match the list of patterns specified as argument, or all DICOM archives if
-no patterns were specified. The script will then examine these DICOM archives and look for the 
-MINC files whose scan types (acquisition protocol names) match the list of patterns passed as 
+no patterns were specified. The script will then examine these DICOM archives and look for the
+MINC files whose scan types (acquisition protocol names) match the list of patterns passed as
 argument, or all MINC files for that archive if `-type` was not used. It then extracts the DICOM files
-associated to each MINC file and writes them in the extraction directory (see `-outdir` option), in a 
+associated to each MINC file and writes them in the extraction directory (see `-outdir` option), in a
 subdirectory with name
 
 `<dccid>/<visit_label>/<acquisition_date>/<protocol>_<minc_index>_<series_description`
 
-where `<minc_index>` is the index number of the MINC file to which the DICOMs are associated: 
-e.g. for file `loris_300001_V4_DtiSA_002.mnc`, the MINC index is 2 (i.e. the second MINC file with 
+where `<minc_index>` is the index number of the MINC file to which the DICOMs are associated:
+e.g. for file `loris_300001_V4_DtiSA_002.mnc`, the MINC index is 2 (i.e. the second MINC file with
 scan type `DtiSA`). Note that the `dccid` subdirectory in the file path can be changed to another
 identifier with option `-id`. Finally, a `.tar.gz` that contains all the DICOM files that were extracted
 is created.

--- a/docs/scripts_md/register_processed_data.md
+++ b/docs/scripts_md/register_processed_data.md
@@ -72,7 +72,7 @@ RETURNS: scanner ID
 ### getAcqProtID($scanType, $dbh)
 
 This function returns the `MriScanTypeID` of the file to register in
-the database based on `scanType` in the `mri_scan_type` table.
+the database based on `ScanType` in the `mri_scan_type` table.
 
 INPUTS:
   - $scanType: scan type

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -398,17 +398,15 @@ sub runDicomTar {
     # ----------------------------------------------------------------
     ## Get config settings using ConfigOB
     # ----------------------------------------------------------------
-    my $configOB             = $this->{configOB};
-    my $tarchive_location    = $configOB->getTarchiveLibraryDir();
-
+    my $configOB      = $this->{configOB};
+    my $python_config = $configOB->getPythonConfigFile();
 
     my $command = sprintf(
-        "dicomTar.pl %s %s -database -profile %s",
+        "import_dicom_study.py --profile %s --insert --source %s",
+        quotemeta($python_config),
         quotemeta($this->{'uploaded_temp_folder'}),
-        quotemeta($tarchive_location),
-        $this->{'profile'}
     );
-    $command .= " -verbose" if $this->{verbose};
+    $command .= " --verbose" if $this->{verbose};
     my $output = $this->runCommandWithExitCode($command);
 
     if ( $output == 0 ) {

--- a/uploadNeuroDB/NeuroDB/ImagingUpload.pm
+++ b/uploadNeuroDB/NeuroDB/ImagingUpload.pm
@@ -398,15 +398,32 @@ sub runDicomTar {
     # ----------------------------------------------------------------
     ## Get config settings using ConfigOB
     # ----------------------------------------------------------------
-    my $configOB      = $this->{configOB};
-    my $python_config = $configOB->getPythonConfigFile();
+    my $configOB = $this->{configOB};
+    my $use_legacy_dicom_study_importer = $configOB->getUseLegacyDicomStudyImporter();
 
-    my $command = sprintf(
-        "import_dicom_study.py --profile %s --insert --source %s",
-        quotemeta($python_config),
-        quotemeta($this->{'uploaded_temp_folder'}),
-    );
-    $command .= " --verbose" if $this->{verbose};
+    if ($use_legacy_dicom_study_importer) {
+        my $tarchive_location = $configOB->getTarchiveLibraryDir();
+
+        my $command = sprintf(
+            "dicomTar.pl %s %s -database -profile %s",
+            quotemeta($this->{'uploaded_temp_folder'}),
+            quotemeta($tarchive_location),
+            $this->{'profile'}
+        );
+
+        $command .= " -verbose" if $this->{verbose};
+    } else {
+        my $python_config = $configOB->getPythonConfigFile();
+
+        my $command = sprintf(
+            "import_dicom_study.py --profile %s --insert --source %s",
+            quotemeta($python_config),
+            quotemeta($this->{'uploaded_temp_folder'}),
+        );
+
+        $command .= " --verbose" if $this->{verbose};
+    }
+
     my $output = $this->runCommandWithExitCode($command);
 
     if ( $output == 0 ) {

--- a/uploadNeuroDB/NeuroDB/objectBroker/ConfigOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/ConfigOB.pm
@@ -96,6 +96,7 @@ use constant BIDS_VALIDATOR_OPTIONS_TO_IGNORE => 'bids_validator_options_to_igno
 use constant CREATE_VISIT                => 'createVisit';
 use constant DEFAULT_PROJECT             => 'default_project';
 use constant DEFAULT_COHORT              => 'default_cohort';
+use constant USE_LEGACY_DICOM_STUDY_IMPORTER => 'use_legacy_dicom_study_importer';
 
 =pod
 
@@ -115,7 +116,7 @@ has 'db'     => (is  => 'rw', isa => 'NeuroDB::Database', required => 1);
 
 =head3 &$getConfigSettingRef($setting)
 
-Private method. This method fetches setting C<$setting> from the LORIS table 
+Private method. This method fetches setting C<$setting> from the LORIS table
 Config. It will throw a C<NeuroDB::objectBroker::ObjectBrokerException> if either
 the database transaction failed for some reason or it succeeded but returned no
 results (i.e. setting C<$setting> does not exist).
@@ -159,7 +160,7 @@ my $getConfigSettingRef = sub {
             ? ()
             : map { $_->{'value'} } @$result;
     }
-    
+
     return $result->[0]->{'value'};
 };
 
@@ -610,6 +611,21 @@ sub getBidsValidatorOptionsToIgnore {
 1;
 
 
+=head3 getUseLegacyDicomStudyImporter()
+
+Get the use_legacy_dicom_study_importer Config setting
+
+RETURN: (boolean) 1 if use_legacy_dicom_study_importer is set to Yes in the Config module, 0
+otherwise
+
+=cut
+sub getUseLegacyDicomStudyImporter {
+    my $self = shift;
+
+    my $value = &$getConfigSettingRef($self, USE_LEGACY_DICOM_STUDY_IMPORTER);
+
+    return $getBooleanRef->($value);
+}
 
 
 __END__


### PR DESCRIPTION
Title. Replace the uses of `dicomTar.pl` by `import_dicom_study.py` in the LORIS MRI pipeline. I would prefer to have this merged for LORIS-MRI 27, but if someone has problems with it 28 is ok too.

Succesfully tested on my local LORIS VM.