### PR TITLE
Add Date::Parse to the set of required Perl libraries

### DIFF
--- a/install/requirements/cpanfile
+++ b/install/requirements/cpanfile
@@ -6,6 +6,7 @@ requires 'Module::Pluggable', '== 5.2';
 requires 'DBD::mysql', '== 4.052';
 requires 'Math::Round';
 requires 'DateTime';
+requires 'Date::Parse';
 requires 'DBI';
 requires 'Getopt::Tabular';
 requires 'Time::JulianDay';


### PR DESCRIPTION
This PR adds `Date::Parse` to the list of libraries in `install/requirements/cpanfile`.


Fixes #1268