### PR TITLE
Improve ORM definitions

### DIFF
--- a/python/lib/db/models/file.py
+++ b/python/lib/db/models/file.py
@@ -35,6 +35,7 @@ class DbFile(Base):
     acquisition_order_per_modality : Mapped[int | None]   = mapped_column('AcqOrderPerModality')
     acquisition_date               : Mapped[date | None]  = mapped_column('AcquisitionDate')
 
-    session   : Mapped['db_session.DbSession'] = relationship('DbSession', back_populates='files')
-    parameters: Mapped[list['db_parameter_file.DbParameterFile']] \
+    session    : Mapped['db_session.DbSession'] \
+        = relationship('DbSession', back_populates='files')
+    parameters : Mapped[list['db_parameter_file.DbParameterFile']] \
         = relationship('DbParameterFile', back_populates='file')

--- a/python/lib/db/models/imaging_file_type.py
+++ b/python/lib/db/models/imaging_file_type.py
@@ -1,0 +1,10 @@
+from sqlalchemy.orm import Mapped, mapped_column
+
+from lib.db.base import Base
+
+
+class DbImagingFileType(Base):
+    __tablename__ = 'ImagingFileTypes'
+
+    type        : Mapped[str]        = mapped_column('type', primary_key=True)
+    description : Mapped[str | None] = mapped_column('description')

--- a/python/lib/db/models/mri_violation_log.py
+++ b/python/lib/db/models/mri_violation_log.py
@@ -43,5 +43,5 @@ class DbMriViolationLog(Base):
         = relationship('DbCandidate', back_populates='violations_log')
     scan_type            : Mapped[Optional['db_mri_scan_type.DbMriScanType']] \
         = relationship('DbMriScanType', back_populates='violations_log')
-    protocol_check_group: Mapped[Optional['db_mri_protocol_check_group.DbMriProtocolCheckGroup']] \
+    protocol_check_group : Mapped[Optional['db_mri_protocol_check_group.DbMriProtocolCheckGroup']] \
         = relationship('DbMriProtocolCheckGroup', back_populates='violations_log')

--- a/python/lib/db/models/parameter_file.py
+++ b/python/lib/db/models/parameter_file.py
@@ -15,5 +15,7 @@ class DbParameterFile(Base):
     value       : Mapped[str | None] = mapped_column('Value')
     insert_time : Mapped[int]        = mapped_column('InsertTime')
 
-    file: Mapped[list['db_file.DbFile']]              = relationship('DbFile', back_populates='parameters')
-    type: Mapped['db_parameter_type.DbParameterType'] = relationship('DbParameterType', back_populates='parameter_file')
+    file: Mapped['db_file.DbFile'] \
+        = relationship('DbFile', back_populates='parameters')
+    type: Mapped['db_parameter_type.DbParameterType'] \
+        = relationship('DbParameterType', back_populates='parameter_files')

--- a/python/lib/db/models/parameter_type.py
+++ b/python/lib/db/models/parameter_type.py
@@ -20,5 +20,5 @@ class DbParameterType(Base):
     queryable        : Mapped[bool | None]  = mapped_column('Queryable')
     is_file          : Mapped[bool | None]  = mapped_column('IsFile')
 
-    parameter_file: Mapped[list['db_parameter_file.DbParameterFile']] \
+    parameter_files: Mapped[list['db_parameter_file.DbParameterFile']] \
         = relationship('DbParameterFile', back_populates='type')

--- a/python/lib/db/queries/candidate.py
+++ b/python/lib/db/queries/candidate.py
@@ -6,8 +6,7 @@ from lib.db.models.candidate import DbCandidate
 
 def try_get_candidate_with_cand_id(db: Database, cand_id: int) -> DbCandidate | None:
     """
-    Get a candidate from the database using its CandID, or return `None` if no candidate is
-    found.
+    Get a candidate from the database using its CandID, or return `None` if no candidate is found.
     """
 
     return db.execute(select(DbCandidate)

--- a/python/lib/db/queries/file.py
+++ b/python/lib/db/queries/file.py
@@ -40,3 +40,17 @@ def try_get_parameter_value_with_file_id_parameter_name(
         .where(DbParameterType.name == parameter_name)
         .where(DbParameterFile.file_id == file_id)
     ).scalar_one_or_none()
+
+
+def try_get_file_with_hash(db: Database, file_hash: str) -> DbFile | None:
+    """
+    Get an imaging file from the database using its BLAKE2b or MD5 hash, or return `None` if no
+    imaging file is found.
+    """
+
+    return db.execute(select(DbFile)
+        .join(DbFile.parameters)
+        .join(DbParameterFile.type)
+        .where(DbParameterType.name.in_(['file_blake2b_hash', 'md5hash']))
+        .where(DbParameterFile.value == file_hash)
+    ).scalar_one_or_none()

--- a/python/lib/db/queries/imaging_file_type.py
+++ b/python/lib/db/queries/imaging_file_type.py
@@ -1,0 +1,14 @@
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session as Database
+
+from lib.db.models.imaging_file_type import DbImagingFileType
+
+
+def get_all_imaging_file_types(db: Database) -> Sequence[DbImagingFileType]:
+    """
+    Get a sequence of all imaging file types from the database.
+    """
+
+    return db.execute(select(DbImagingFileType)).scalars().all()

--- a/python/lib/db/queries/mri_scan_type.py
+++ b/python/lib/db/queries/mri_scan_type.py
@@ -1,0 +1,15 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session as Database
+
+from lib.db.models.mri_scan_type import DbMriScanType
+
+
+def try_get_mri_scan_type_with_name(db: Database, name: str) -> DbMriScanType | None:
+    """
+    Get an MRI scan type from the database using its name, or return `None` if no scan type is
+    found.
+    """
+
+    return db.execute(select(DbMriScanType)
+        .where(DbMriScanType.name == name)
+    ).scalar_one_or_none()

--- a/python/lib/db/queries/parameter_type.py
+++ b/python/lib/db/queries/parameter_type.py
@@ -1,0 +1,14 @@
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session as Database
+
+from lib.db.models.parameter_type import DbParameterType
+
+
+def get_all_parameter_types(db: Database) -> Sequence[DbParameterType]:
+    """
+    Get a sequence of all parameter types from the database.
+    """
+
+    return db.execute(select(DbParameterType)).scalars().all()


### PR DESCRIPTION
Just a sync of the ORM definitions I have on my fork and the main LORIS-MRI repo after #1257. This PR includes a few stylistic changes (whitespaces), a few renamings (0-to-n relations being put in plural form), a relationship fix (due to a bad review of mine :grimacing:), a new model and a few new queries (unused in LORIS-MRI main for now).