### PR TITLE
Fix ingest_eeg_bids_datasets.py

### DIFF
--- a/python/scripts/ingest_eeg_bids_datasets.py
+++ b/python/scripts/ingest_eeg_bids_datasets.py
@@ -127,7 +127,7 @@ def main():
         if os.path.isdir(
             os.path.join(assembly_bids_path, 'sub-' + str(candid))
         ):
-            subjectid = 'sub-{}'.format(candid)
+            subjectid = f'sub-{candid}'
 
         # Try the pscid, case insensitive
         if not subjectid:

--- a/python/scripts/ingest_eeg_bids_datasets.py
+++ b/python/scripts/ingest_eeg_bids_datasets.py
@@ -127,13 +127,13 @@ def main():
         if os.path.isdir(
             os.path.join(assembly_bids_path, 'sub-' + str(candid))
         ):
-            subjectid = str(candid)
+            subjectid = 'sub-{}'.format(candid)
 
         # Try the pscid, case insensitive
         if not subjectid:
             gen = (
                 dir for dir in os.listdir(assembly_bids_path)
-                if dir.lower() == 'sub-' + pscid.lower()
+                if dir.lower() == ('sub-' + pscid.lower())
             )
             subjectid = next(gen, None)
 
@@ -143,7 +143,8 @@ def main():
             continue
 
         # Visit
-        path = os.path.join(assembly_bids_path, 'sub-' + subjectid, 'ses-' + visit)
+        path = os.path.join(assembly_bids_path, subjectid, 'ses-' + visit)
+
         if not os.path.isdir(path):
             print(f'No BIDS dataset matching visit {visit} for candidate {pscid} {candid} found.')
             continue
@@ -174,7 +175,7 @@ def main():
 
             if result.returncode == 0:
                 db.update(
-                    "UPDATE electrophysiology_uploader SET Status = 'Ingested' WHERE UploadID = %s",
+                    "UPDATE electrophysiology_uploader SET Status = 'Complete' WHERE UploadID = %s",
                     (uploadid,)
                 )
                 print('EEG Dataset with uploadID ' + uploadid + ' successfully ingested')
@@ -185,7 +186,7 @@ def main():
             print('ERROR: error while executing bids_import.py')
 
         db.update(
-            "UPDATE electrophysiology_uploader SET Status = 'Failed Ingestion' WHERE UploadID = %s",
+            "UPDATE electrophysiology_uploader SET Status = 'Failed' WHERE UploadID = %s",
             (uploadid,)
         )
 


### PR DESCRIPTION
Fixed bugs found in v27 testing (no issue opened)

This PR fixes the subject ID used, so that it's uniform and works both when derived from CandID and PSCID (failed test with PSCID)

It also changes the `UPDATE  electrophysiology_uploader` query to `SET Status` to values part of its `enum('Not Started','Extracted','Failed Extraction','In Progress','Complete','Failed','Archived')`
 