### PR TITLE
Update MriViolationsLogOB.pm following the refactor of the CandID references

### DIFF
--- a/uploadNeuroDB/NeuroDB/objectBroker/MriViolationsLogOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/MriViolationsLogOB.pm
@@ -71,7 +71,7 @@ use File::Basename;
 use TryCatch;
 
 my @MRIVIOLATIONSLOG_FIELDS = qw(
-    LogID TimeRun SeriesUID TarchiveID MincFile PatientName CandID Visit_label
+    LogID TimeRun SeriesUID TarchiveID MincFile PatientName CandidateID Visit_label
     CheckID MriScanTypeID Severity Header Value ValidRange ValidRegex
     EchoTime PhaseEncodingDirection EchoNumber MriProtocolChecksGroupID
 );


### PR DESCRIPTION
This PR updates `MriViolationsLogOB` to take into account the renaming of column `CandID` into `CandidateID` in table `mri_violations_log`.
