### PR TITLE
Fix bug when trying to create a session via the dcm2bids pipeline

### DIFF
--- a/python/lib/database_lib/session_db.py
+++ b/python/lib/database_lib/session_db.py
@@ -115,7 +115,7 @@ class SessionDB:
         session_id = self.db.insert(
             table_name="session",
             column_names=tuple(fields),
-            values=values,
+            values=[tuple(values)],
             get_last_id=True
         )
 

--- a/python/lib/database_lib/session_db.py
+++ b/python/lib/database_lib/session_db.py
@@ -114,7 +114,7 @@ class SessionDB:
 
         session_id = self.db.insert(
             table_name="session",
-            column_names=fields,
+            column_names=tuple(fields),
             values=values,
             get_last_id=True
         )

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -366,10 +366,7 @@ class BasePipeline:
             self.log_error_and_exit(message, lib.exitcode.CREATE_SESSION_FAILURE, is_error="Y", is_verbose="N")
 
         # check that the project ID and cohort ID refers to an existing row in project_cohort_rel table
-        print(project_id)
-        print(cohort_id)
         self.session_obj.create_proj_cohort_rel_info_dict(project_id, cohort_id)
-        print(self.session_obj.proj_cohort_rel_info_dict)
         if not self.session_obj.proj_cohort_rel_info_dict.keys():
             message = f"Cannot create visit with project ID {project_id} and cohort ID {cohort_id}:" \
                       f" no such association in table project_cohort_rel"

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -389,13 +389,13 @@ class BasePipeline:
             {
                 'CandID': cand_id,
                 'Visit_label': visit_label,
-                'CenterID': str(center_id),
-                'VisitNo': str(visit_nb),
+                'CenterID': center_id,
+                'VisitNo': visit_nb,
                 'Current_stage': 'Not Started',
                 'Scan_done': 'Y',
                 'Submitted': 'N',
-                'CohortID': str(cohort_id),
-                'ProjectID': str(project_id)
+                'CohortID': cohort_id,
+                'ProjectID': project_id
             }
         )
         if session_id:

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -389,13 +389,13 @@ class BasePipeline:
             {
                 'CandID': cand_id,
                 'Visit_label': visit_label,
-                'CenterID': center_id,
-                'VisitNo': visit_nb,
+                'CenterID': str(center_id),
+                'VisitNo': str(visit_nb),
                 'Current_stage': 'Not Started',
                 'Scan_done': 'Y',
                 'Submitted': 'N',
-                'CohortID': cohort_id,
-                'ProjectID': project_id
+                'CohortID': str(cohort_id),
+                'ProjectID': str(project_id)
             }
         )
         if session_id:

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -366,7 +366,10 @@ class BasePipeline:
             self.log_error_and_exit(message, lib.exitcode.CREATE_SESSION_FAILURE, is_error="Y", is_verbose="N")
 
         # check that the project ID and cohort ID refers to an existing row in project_cohort_rel table
+        print(project_id)
+        print(cohort_id)
         self.session_obj.create_proj_cohort_rel_info_dict(project_id, cohort_id)
+        print(self.session_obj.proj_cohort_rel_info_dict)
         if not self.session_obj.proj_cohort_rel_info_dict.keys():
             message = f"Cannot create visit with project ID {project_id} and cohort ID {cohort_id}:" \
                       f" no such association in table project_cohort_rel"


### PR DESCRIPTION
# Description

This fixes a current bug in 26.0 where the creation of a session via the python MRI pipeline failed due to incorrect type being provided to a function.

Note: this will be obsolete for 27.0 since that logic has been rewritten in different library.