### PR TITLE
Fix incorrect uses of `re.match`

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -397,7 +397,7 @@ class NiftiInsertionPipeline(BasePipeline):
 
         # add TaskName to the JSON file if the file's BIDS scan type subcategory contains task-*
         bids_subcategories = self.bids_categories_dict['BIDSScanTypeSubCategory']
-        if self.json_path and bids_subcategories and re.match(r'task-', bids_subcategories):
+        if self.json_path and bids_subcategories and re.search(r'task-', bids_subcategories):
             with open(self.json_path) as json_file:
                 json_data = json.load(json_file)
             json_data['TaskName'] = re.search(r'task-([a-zA-Z0-9]*)', bids_subcategories).group(1)

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -772,7 +772,7 @@ class Imaging:
             True for v in valid_ranges if self.in_range(scan_param, v[0], v[1])]
         )) if valid_ranges else True
         passes_regex_check = bool(len([
-            True for r in valid_regexs if re.match(r, scan_param, re.IGNORECASE)
+            True for r in valid_regexs if re.search(r, scan_param, re.IGNORECASE)
         ])) if valid_regexs else True
 
         if passes_regex_check and passes_range_check:
@@ -956,9 +956,9 @@ class Imaging:
                     'json_file_path': json_file_path,
                     'acq_time': acq_time
                 }
-                if re.match(r'dir-AP', bids_info['BIDSScanTypeSubCategory']):
+                if re.search(r'dir-AP', bids_info['BIDSScanTypeSubCategory']):
                     fmap_files_dir_ap.append(file_dict)
-                elif re.match(r'dir-PA', bids_info['BIDSScanTypeSubCategory']):
+                elif re.search(r'dir-PA', bids_info['BIDSScanTypeSubCategory']):
                     fmap_files_dir_pa.append(file_dict)
                 else:
                     fmap_files_no_dir.append(file_dict)


### PR DESCRIPTION
Replace incorrect uses of `re.match` (which only matches regexs at the beginning of a string) with `re.search`, as per what was found with #1292.