### PR TITLE
set boto3 to install version 1.35.99, last version before boto3 breaking change

### DIFF
--- a/install/requirements/requirements.txt
+++ b/install/requirements/requirements.txt
@@ -1,4 +1,4 @@
-boto3
+boto3==1.35.99
 google
 mat73
 matplotlib


### PR DESCRIPTION
# Description

boto3 introduced a breaking change in their 1.36 release. No time for now to work on fixing this so blocking the version of boto3 to 1.35.99, last working version of boto3 with our current code.

A bug fix will be issued later on so that our pipeline works with latest version of boto3 as well.