### PR TITLE
Remove shebang from the Python configuration file.

### DIFF
--- a/install/templates/database_config_template.py
+++ b/install/templates/database_config_template.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import re
 
 from sqlalchemy.orm import Session as Database


### PR DESCRIPTION
## Description

The Python file is not executable, therefore there is no reason for it to have a shebang.

## Changelog

- Remove the shebang from the Python configuration file.