### PR TITLE
Fix call to plotting to work with latest version of nilearn

### DIFF
--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -1260,9 +1260,9 @@ class Imaging:
             anat_img=volume,
             output_file=os.path.join(file_info['data_dir_path'], 'pic', pic_rel_path),
             display_mode='ortho',
-            black_bg=1,
-            draw_cross=0,
-            annotate=0
+            black_bg=True,
+            draw_cross=False,
+            annotate=False
         )
 
         return pic_rel_path


### PR DESCRIPTION
# Description

Latest version of nilearn (0.12) removed support to provide `int` to the `plotting` function parameters in favour of using `bool` data type for those. This fixes the LORIS-MRI code accordingly so that the pic creation is not broken when using latest version of the package.

Code tested on nilearn version 0.10 and above which should be the version used by most projects at this point.