### PR TITLE
Setup DB connection so that DB errors raise exceptions

### DIFF
--- a/uploadNeuroDB/NeuroDB/DBI.pm
+++ b/uploadNeuroDB/NeuroDB/DBI.pm
@@ -64,7 +64,8 @@ sub connect_to_db
     $db_user = ""    unless $db_user;       # user name (fill in as appropriate)
     $db_pass = ""    unless $db_pass;       # password (ditto)
 
-    my $dbh = DBI->connect($db_dsn, $db_user, $db_pass) or die
+    my $connectOptionsRef = { PrintError => 0, RaiseError => 1, AutoCommit => 1 };
+    my $dbh = DBI->connect($db_dsn, $db_user, $db_pass, $connectOptionsRef) or die
         "DB connection failed\nDBI Error: ". $DBI::errstr."\n";
       
     $dbh->{mysql_auto_reconnect} = 1;


### PR DESCRIPTION
This PR changes the call to the `connect` method in class `NeuroDB::DBI` so that when a DB error occurs, it raises an exception (which in most cases halts script execution immediately).