### PR TITLE
Remove unused imports to fix CI

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -2,7 +2,6 @@ import os
 import shutil
 
 import lib.exitcode
-import lib.utilities
 from lib.config import get_data_dir_path_config, get_dicom_archive_dir_path_config
 from lib.database import Database
 from lib.database_lib.config import Config

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 
 import lib.exitcode
-import lib.utilities
 from lib.dcm2bids_imaging_pipeline_lib.base_pipeline import BasePipeline
 from lib.logging import log_error_exit, log_verbose
 

--- a/python/scripts/run_nifti_insertion.py
+++ b/python/scripts/run_nifti_insertion.py
@@ -6,7 +6,6 @@ import os
 import sys
 
 import lib.exitcode
-import lib.utilities
 from lib.dcm2bids_imaging_pipeline_lib.nifti_insertion_pipeline import NiftiInsertionPipeline
 from lib.lorisgetopt import LorisGetOpt
 


### PR DESCRIPTION
Ruff got updated and more precise regarding unused imports, which is cool but breaks CI. This PR removes unused imports and makes CI green again.