### PR TITLE
Differentiate between pyright errors and warnings in GitHub output

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -45,12 +45,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-      # Like in the other Pyright run, the `jq` arcane is used to translate the errors from JSON to
-      # the GitHub actions format
     - name: Run Pyright
       run: |
-        pyright --outputjson | jq -r '.generalDiagnostics[] | "::error file=\(.file),line=\(.range.start.line),col=\(.range.start.character)::\(.message)"'
-        (exit ${PIPESTATUS[0]})
+        pyright --outputjson | test/pyright_to_github.sh
 
   pyrigh-global:
     name: Global type checks
@@ -70,10 +67,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Run Pyright
-      run: |
-        cd test
-        pyright --outputjson | jq -r '.generalDiagnostics[] | "::error file=\(.file),line=\(.range.start.line),col=\(.range.start.character)::\(.message)"'
-        (exit ${PIPESTATUS[0]})
+      run: pyright --project test --outputjson | test/pyright_to_github.sh
 
   pytest:
     name: Unit tests

--- a/test/pyright_to_github.sh
+++ b/test/pyright_to_github.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Script to convert Pyright JSON output to GitHub annotation format.
+# Usage: pyright --outputjson | .pyright_to_github.sh
+
+set -euo pipefail
+
+# Read JSON input from standard input.
+pyright_json=$(cat)
+
+# Convert Pyright's JSON to GitHub annotations.
+echo "$pyright_json" | jq -r '
+.generalDiagnostics[]? |
+"::\(.severity |
+    if . == "error" then "error"
+    elif . == "warning" then "warning"
+    else "notice" end) file=\(.file),line=\(.range.start.line + 1),col=\(.range.start.character + 1),title=Pyright \(.rule // "diagnostic")::\(.message)"'
+
+# Exit with Pyright's return code.
+exit ${PIPESTATUS[0]}


### PR DESCRIPTION
## Description

Currently, our Pyright-based type checking CI does not differentiate between errors and warnings in the GitHub output. As a result, although warnings do not make CI fail, they appear as errors when browsing the PRs' code in GitHub, which is confusing.

This PR fixes that by introducing a small `pyright_to_github.sh` utility script in the `test` directory.
