### PR TITLE
Remove useless script code

### DIFF
--- a/python/scripts/bids_import.py
+++ b/python/scripts/bids_import.py
@@ -21,11 +21,6 @@ from lib.mri import Mri
 from lib.session import Session
 from lib.util.crypto import compute_file_blake2b_hash
 
-sys.path.append('/home/user/python')
-
-
-# to limit the traceback when raising exceptions.
-# sys.tracebacklimit = 0
 
 def main():
     bids_dir         = ''

--- a/python/scripts/extract_eeg_bids_archive.py
+++ b/python/scripts/extract_eeg_bids_archive.py
@@ -15,8 +15,6 @@ from lib.lorisgetopt import LorisGetOpt
 from lib.make_env import make_env
 from lib.util.fs import copy_file, extract_archive, remove_directory
 
-sys.path.append('/home/user/python')
-
 
 def main():
     usage = (

--- a/python/scripts/ingest_eeg_bids_datasets.py
+++ b/python/scripts/ingest_eeg_bids_datasets.py
@@ -12,8 +12,6 @@ from lib.exitcode import INVALID_ARG, SUCCESS
 from lib.lorisgetopt import LorisGetOpt
 from scripts.delete_physiological_file import delete_physiological_file_in_db
 
-sys.path.append('/home/user/python')
-
 
 def main():
     usage = (

--- a/python/scripts/mass_electrophysiology_chunking.py
+++ b/python/scripts/mass_electrophysiology_chunking.py
@@ -11,11 +11,6 @@ from lib.database import Database
 from lib.database_lib.config import Config
 from lib.physiological import Physiological
 
-sys.path.append('/home/user/python')
-
-
-# to limit the traceback when raising exceptions.
-# sys.tracebacklimit = 0
 
 def main():
     profile     = None

--- a/python/scripts/mass_nifti_pic.py
+++ b/python/scripts/mass_nifti_pic.py
@@ -13,11 +13,6 @@ from lib.database import Database
 from lib.database_lib.config import Config
 from lib.imaging import Imaging
 
-sys.path.append('/home/user/python')
-
-
-# to limit the traceback when raising exceptions.
-# sys.tracebacklimit = 0
 
 def main():
     profile     = None

--- a/python/scripts/run_dicom_archive_loader.py
+++ b/python/scripts/run_dicom_archive_loader.py
@@ -3,16 +3,10 @@
 """Script that loads a DICOM archive and generate BIDS files to be inserted into the database"""
 
 import os
-import sys
 
 from lib.dcm2bids_imaging_pipeline_lib.dicom_archive_loader_pipeline import DicomArchiveLoaderPipeline
 from lib.lorisgetopt import LorisGetOpt
 
-sys.path.append('/home/user/python')
-
-
-# to limit the traceback when raising exceptions.
-# sys.tracebacklimit = 0
 
 def main():
     usage = (

--- a/python/scripts/run_dicom_archive_validation.py
+++ b/python/scripts/run_dicom_archive_validation.py
@@ -3,15 +3,9 @@
 """Script to validate a DICOM archive from the filesystem against the one stored in the database"""
 
 import os
-import sys
 
 from lib.dcm2bids_imaging_pipeline_lib.dicom_validation_pipeline import DicomValidationPipeline
 from lib.lorisgetopt import LorisGetOpt
-
-sys.path.append('/home/user/python')
-
-# to limit the traceback when raising exceptions.
-# sys.tracebacklimit = 0
 
 
 def main():

--- a/python/scripts/run_nifti_insertion.py
+++ b/python/scripts/run_nifti_insertion.py
@@ -9,12 +9,6 @@ import lib.exitcode
 from lib.dcm2bids_imaging_pipeline_lib.nifti_insertion_pipeline import NiftiInsertionPipeline
 from lib.lorisgetopt import LorisGetOpt
 
-sys.path.append('/home/user/python')
-
-
-# to limit the traceback when raising exceptions.
-# sys.tracebacklimit = 0
-
 
 def main():
     usage = (

--- a/python/scripts/run_push_imaging_files_to_s3_pipeline.py
+++ b/python/scripts/run_push_imaging_files_to_s3_pipeline.py
@@ -3,16 +3,10 @@
 """Script that takes file paths in the database and push them to an S3 bucket"""
 
 import os
-import sys
 
 from lib.dcm2bids_imaging_pipeline_lib.push_imaging_files_to_s3_pipeline import PushImagingFilesToS3Pipeline
 from lib.lorisgetopt import LorisGetOpt
 
-sys.path.append('/home/user/python')
-
-
-# to limit the traceback when raising exceptions.
-# sys.tracebacklimit = 0
 
 def main():
     usage = (


### PR DESCRIPTION
(sorry for the rude title I could not think of a better one haha)

## Description

Remove the following code that is found in most LORIS-MRI scripts:
- `sys.path.append('/home/loris/python')`: Not sure what this directory is referring to. It for sure only works if the user is called `user`, which is obviously often not the case. Moreover, LORIS-MRI scripts should always be executed in the LORIS-MRI Python virtual environment, which already contains a Python interpreter and the LORIS-MRI dependencies, so there should be no need to add anything.
- `# sys.tracebacklimit = 0`: This commented code gives information on how to control exception depth while debugging, but I think copying this comment in each script is not a practical solution. This kind of information would probably live better in a `docs/python/Debugging.md` file.