### PR TITLE
Rename the main Python package

### DIFF
--- a/install/imaging_install.sh
+++ b/install/imaging_install.sh
@@ -99,7 +99,7 @@ echo
 echo "Creating loris-mri Python virtualenv in $mridir/.venv/"
 # create a directory in $mridir that will store python 3 virtualenv
 sudo -S su $USER -c "mkdir -m 770 -p $mridir/.venv"
-python3.11 -m venv $mridir/.venv --prompt loris-python
+python3.11 -m venv $mridir/.venv --prompt loris
 source $mridir/.venv/bin/activate
 echo "Installing the Python libraries into the loris-mri virtualenv..."
 pip3 install $mridir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "loris-mri"
+name = "loris"
 version = "27.0.0"
-description = "The LORIS Python scripts"
+description = "The LORIS Python package"
 readme = "README.md"
 license = "GPL-3.0-or-later"
 license-files = ["LICENSE"]


### PR DESCRIPTION
`loris-mri` is a pretty terrible name for a package that handles more than just MRI, let's just rename it to `loris` (as in, the LORIS Python package).

Let's also rename the virtual environment from `loris-python` to just `loris`, of course it's in Python, it's a Python virtual environment!