### PR TITLE
Fix EEG chunks path bug with `EEGChunksPath` in EEG BIDS import

### DIFF
--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -1223,12 +1223,13 @@ class Physiological:
 
             chunk_root_dir_config = self.config_db_obj.get_config("EEGChunksPath")
             chunk_root_dir = chunk_root_dir_config
-            if not chunk_root_dir:
-                # the bids_rel_dir is the first two directories in file_path (
-                # bids_imports/BIDS_dataset_name_BIDSVersion)
-                file_path_components = Path(file_path).parts
-                bids_rel_dir   = os.path.join(file_path_components[0], file_path_components[1])
-                chunk_root_dir = os.path.join(data_dir, f'{bids_rel_dir}_chunks')
+            file_path_parts = Path(file_path).parts
+            if chunk_root_dir_config:
+                chunk_root_dir = chunk_root_dir_config
+            else:
+                chunk_root_dir = os.path.join(data_dir, file_path_parts[0])
+
+            chunk_root_dir = os.path.join(chunk_root_dir, f'{file_path_parts[1]}_chunks')
 
             full_file_path = os.path.join(data_dir, file_path)
 
@@ -1260,6 +1261,5 @@ class Physiological:
                 self.insert_physio_parameter_file(
                     physiological_file_id = physio_file_id,
                     parameter_name = 'electrophysiology_chunked_dataset_path',
-                    value = os.path.relpath(chunk_path, chunk_root_dir_config) if chunk_root_dir_config
-                        else os.path.relpath(chunk_path, data_dir)
+                    value = os.path.relpath(chunk_path, data_dir)
                 )


### PR DESCRIPTION
During testing of #1338, @jeffersoncasimir  found a bug where the EEG chunks path is incorrectly set in the database if the configuration variable `EEGChunksPath` is used.

After investigation, I also managed to reproduce this bug both on the PR branch and on the `27-release` branch (see the screen below). This PR fixes the bug in the main branch by making the code works for both whether `EEGChunksPath` is set or not. This PR will also need to be backported to `27-release`.

<img width="2626" height="1581" alt="image" src="https://github.com/user-attachments/assets/e553e7a8-25d4-406a-a03a-af6c622a0c2f" />
