### PR TITLE
Migrate ORM to `pathlib.Path` (path PR 2)

### DIFF
--- a/python/lib/db/decorators/string_path.py
+++ b/python/lib/db/decorators/string_path.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from sqlalchemy import String
+from sqlalchemy.engine import Dialect
+from sqlalchemy.types import TypeDecorator
+
+
+class StringPath(TypeDecorator[Path]):
+    """
+    Decorator for a database path type.
+    In SQL, the type will appear as a string.
+    In Python, the type will appear as a path object.
+    """
+
+    impl = String
+    cache_ok = True
+
+    def process_bind_param(self, value: Path | None, dialect: Dialect) -> str | None:
+        if value is None:
+            return None
+
+        return str(value)
+
+    def process_result_value(self, value: str | None, dialect: Dialect) -> Path | None:
+        if value is None:
+            return None
+
+        return Path(value)

--- a/python/lib/db/models/dicom_archive.py
+++ b/python/lib/db/models/dicom_archive.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+from pathlib import Path
 from typing import Optional
 
 from sqlalchemy import ForeignKey
@@ -12,6 +13,7 @@ import lib.db.models.mri_violation_log as db_mri_violation_log
 import lib.db.models.session as db_session
 from lib.db.base import Base
 from lib.db.decorators.int_bool import IntBool
+from lib.db.decorators.string_path import StringPath
 
 
 class DbDicomArchive(Base):
@@ -37,8 +39,8 @@ class DbDicomArchive(Base):
     creating_user            : Mapped[str]             = mapped_column('CreatingUser')
     sum_type_version         : Mapped[int]             = mapped_column('sumTypeVersion')
     tar_type_version         : Mapped[int | None]      = mapped_column('tarTypeVersion')
-    source_location          : Mapped[str]             = mapped_column('SourceLocation')
-    archive_location         : Mapped[str | None]      = mapped_column('ArchiveLocation')
+    source_path              : Mapped[Path]            = mapped_column('SourceLocation', StringPath)
+    archive_path             : Mapped[Path | None]     = mapped_column('ArchiveLocation', StringPath)
     scanner_manufacturer     : Mapped[str]             = mapped_column('ScannerManufacturer')
     scanner_model            : Mapped[str]             = mapped_column('ScannerModel')
     scanner_serial_number    : Mapped[str]             = mapped_column('ScannerSerialNumber')

--- a/python/lib/db/models/file.py
+++ b/python/lib/db/models/file.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+from pathlib import Path
 
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -8,6 +9,7 @@ import lib.db.models.session as db_session
 from lib.db.base import Base
 from lib.db.decorators.int_bool import IntBool
 from lib.db.decorators.int_datetime import IntDatetime
+from lib.db.decorators.string_path import StringPath
 
 
 class DbFile(Base):
@@ -15,7 +17,7 @@ class DbFile(Base):
 
     id                             : Mapped[int]          = mapped_column('FileID', primary_key=True)
     session_id                     : Mapped[int]          = mapped_column('SessionID', ForeignKey('session.ID'))
-    rel_path                       : Mapped[str]          = mapped_column('File')
+    path                           : Mapped[Path]         = mapped_column('File', StringPath)
     series_uid                     : Mapped[str | None]   = mapped_column('SeriesUID')
     echo_time                      : Mapped[float | None] = mapped_column('EchoTime')
     phase_encoding_direction       : Mapped[str | None]   = mapped_column('PhaseEncodingDirection')

--- a/python/lib/db/models/mri_protocol_violated_scan.py
+++ b/python/lib/db/models/mri_protocol_violated_scan.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
 from sqlalchemy import ForeignKey
@@ -8,6 +9,7 @@ import lib.db.models.candidate as db_candidate
 import lib.db.models.dicom_archive as db_dicom_archive
 import lib.db.models.mri_protocol_group as db_mri_protocol_group
 from lib.db.base import Base
+from lib.db.decorators.string_path import StringPath
 
 
 class DbMriProtocolViolatedScan(Base):
@@ -19,7 +21,7 @@ class DbMriProtocolViolatedScan(Base):
     dicom_archive_id         : Mapped[int | None]      = mapped_column('TarchiveID', ForeignKey('tarchive.TarchiveID'))
     time_run                 : Mapped[datetime | None] = mapped_column('time_run')
     series_description       : Mapped[str | None]      = mapped_column('series_description')
-    file_rel_path            : Mapped[str | None]      = mapped_column('minc_location')
+    file_path                : Mapped[Path | None]     = mapped_column('minc_location', StringPath)
     patient_name             : Mapped[str | None]      = mapped_column('PatientName')
     tr_range                 : Mapped[str | None]      = mapped_column('TR_range')
     te_range                 : Mapped[str | None]      = mapped_column('TE_range')

--- a/python/lib/db/models/mri_upload.py
+++ b/python/lib/db/models/mri_upload.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
 from sqlalchemy import ForeignKey
@@ -8,6 +9,7 @@ import lib.db.models.dicom_archive as db_dicom_archive
 import lib.db.models.session as db_session
 from lib.db.base import Base
 from lib.db.decorators.int_bool import IntBool
+from lib.db.decorators.string_path import StringPath
 from lib.db.decorators.y_n_bool import YNBool
 
 
@@ -17,8 +19,8 @@ class DbMriUpload(Base):
     id                          : Mapped[int]             = mapped_column('UploadID', primary_key=True)
     uploaded_by                 : Mapped[str]             = mapped_column('UploadedBy')
     upload_date                 : Mapped[datetime | None] = mapped_column('UploadDate')
-    upload_location             : Mapped[str]             = mapped_column('UploadLocation')
-    decompressed_location       : Mapped[str]             = mapped_column('DecompressedLocation')
+    upload_path                 : Mapped[Path]            = mapped_column('UploadLocation', StringPath)
+    decompressed_path           : Mapped[Path]            = mapped_column('DecompressedLocation', StringPath)
     insertion_complete          : Mapped[bool]            = mapped_column('InsertionComplete', IntBool)
     inserting                   : Mapped[bool | None]     = mapped_column('Inserting', IntBool)
     patient_name                : Mapped[str]             = mapped_column('PatientName')

--- a/python/lib/db/models/mri_violation_log.py
+++ b/python/lib/db/models/mri_violation_log.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
 from sqlalchemy import ForeignKey
@@ -9,6 +10,7 @@ import lib.db.models.dicom_archive as db_dicom_archive
 import lib.db.models.mri_protocol_check_group as db_mri_protocol_check_group
 import lib.db.models.mri_scan_type as db_mri_scan_type
 from lib.db.base import Base
+from lib.db.decorators.string_path import StringPath
 
 
 class DbMriViolationLog(Base):
@@ -19,7 +21,7 @@ class DbMriViolationLog(Base):
     series_uid              : Mapped[str | None]       = mapped_column('SeriesUID')
     dicom_archive_id        : Mapped[int | None]       \
         = mapped_column('TarchiveID', ForeignKey('tarchive.TarchiveID'))
-    file_rel_path           : Mapped[str | None]       = mapped_column('MincFile')
+    file_path               : Mapped[Path | None]      = mapped_column('MincFile', StringPath)
     patient_name            : Mapped[str | None]       = mapped_column('PatientName')
     candidate_id            : Mapped[int | None]       = mapped_column('CandidateID', ForeignKey('candidate.ID'))
     visit_label             : Mapped[str | None]       = mapped_column('Visit_label')

--- a/python/lib/db/models/physio_channel.py
+++ b/python/lib/db/models/physio_channel.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from decimal import Decimal
+from pathlib import Path
 
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -8,6 +9,7 @@ import lib.db.models.physio_channel_type as db_physio_channel_type
 import lib.db.models.physio_file as db_physio_file
 import lib.db.models.physio_status_type as db_physio_status_type
 from lib.db.base import Base
+from lib.db.decorators.string_path import StringPath
 
 
 class DbPhysioChannel(Base):
@@ -28,7 +30,7 @@ class DbPhysioChannel(Base):
     reference          : Mapped[str | None]     = mapped_column('Reference')
     status_description : Mapped[str | None]     = mapped_column('StatusDescription')
     unit               : Mapped[str | None]     = mapped_column('Unit')
-    file_path          : Mapped[str | None]     = mapped_column('FilePath')
+    file_path          : Mapped[Path | None]    = mapped_column('FilePath', StringPath)
 
     physio_file  : Mapped['db_physio_file.DbPhysioFile']                = relationship('DbPhysioFile', back_populates='channels')
     channel_type : Mapped['db_physio_channel_type.DbPhysioChannelType'] = relationship('DbPhysioChannelType')

--- a/python/lib/db/models/physio_coord_system.py
+++ b/python/lib/db/models/physio_coord_system.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -6,17 +8,18 @@ import lib.db.models.physio_coord_system_type as db_physio_coord_system_type
 import lib.db.models.physio_coord_system_unit as db_physio_coord_system_unit
 import lib.db.models.physio_modality as db_physio_modality
 from lib.db.base import Base
+from lib.db.decorators.string_path import StringPath
 
 
 class DbPhysioCoordSystem(Base):
     __tablename__ = 'physiological_coord_system'
 
-    id          : Mapped[int]        = mapped_column('PhysiologicalCoordSystemID', primary_key=True)
-    name_id     : Mapped[int]        = mapped_column('NameID', ForeignKey('physiological_coord_system_name.PhysiologicalCoordSystemNameID'))
-    type_id     : Mapped[int]        = mapped_column('TypeID', ForeignKey('physiological_coord_system_type.PhysiologicalCoordSystemTypeID'))
-    unit_id     : Mapped[int]        = mapped_column('UnitID', ForeignKey('physiological_coord_system_unit.PhysiologicalCoordSystemUnitID'))
-    modality_id : Mapped[int]        = mapped_column('ModalityID', ForeignKey('physiological_modality.PhysiologicalModalityID'))
-    file_path   : Mapped[str | None] = mapped_column('FilePath')
+    id          : Mapped[int]         = mapped_column('PhysiologicalCoordSystemID', primary_key=True)
+    name_id     : Mapped[int]         = mapped_column('NameID', ForeignKey('physiological_coord_system_name.PhysiologicalCoordSystemNameID'))
+    type_id     : Mapped[int]         = mapped_column('TypeID', ForeignKey('physiological_coord_system_type.PhysiologicalCoordSystemTypeID'))
+    unit_id     : Mapped[int]         = mapped_column('UnitID', ForeignKey('physiological_coord_system_unit.PhysiologicalCoordSystemUnitID'))
+    modality_id : Mapped[int]         = mapped_column('ModalityID', ForeignKey('physiological_modality.PhysiologicalModalityID'))
+    file_path   : Mapped[Path | None] = mapped_column('FilePath', StringPath)
 
     name     : Mapped['db_physio_coord_system_name.DbPhysioCoordSystemName'] = relationship('DbPhysioCoordSystemName')
     type     : Mapped['db_physio_coord_system_type.DbPhysioCoordSystemType'] = relationship('DbPhysioCoordSystemType')

--- a/python/lib/db/models/physio_event_file.py
+++ b/python/lib/db/models/physio_event_file.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -9,18 +10,19 @@ import lib.db.models.physio_file as db_physio_file
 import lib.db.models.physio_task_event as db_physio_task_event
 import lib.db.models.project as db_project
 from lib.db.base import Base
+from lib.db.decorators.string_path import StringPath
 
 
 class DbPhysioEventFile(Base):
     __tablename__ = 'physiological_event_file'
 
-    id             : Mapped[int]        = mapped_column('EventFileID', primary_key=True)
-    physio_file_id : Mapped[int | None] = mapped_column('PhysiologicalFileID', ForeignKey('physiological_file.PhysiologicalFileID'))
-    project_id     : Mapped[int | None] = mapped_column('ProjectID', ForeignKey('Project.ProjectID'))
-    file_type      : Mapped[str]        = mapped_column('FileType', ForeignKey('ImagingFileTypes.type'))
-    file_path      : Mapped[str | None] = mapped_column('FilePath')
-    last_update    : Mapped[datetime]   = mapped_column('LastUpdate')
-    last_written   : Mapped[datetime]   = mapped_column('LastWritten')
+    id             : Mapped[int]         = mapped_column('EventFileID', primary_key=True)
+    physio_file_id : Mapped[int | None]  = mapped_column('PhysiologicalFileID', ForeignKey('physiological_file.PhysiologicalFileID'))
+    project_id     : Mapped[int | None]  = mapped_column('ProjectID', ForeignKey('Project.ProjectID'))
+    file_type      : Mapped[str]         = mapped_column('FileType', ForeignKey('ImagingFileTypes.type'))
+    file_path      : Mapped[Path | None] = mapped_column('FilePath', StringPath)
+    last_update    : Mapped[datetime]    = mapped_column('LastUpdate')
+    last_written   : Mapped[datetime]    = mapped_column('LastWritten')
 
     physio_file       : Mapped['db_physio_file.DbPhysioFile | None']                     = relationship('PhysiologicalFile')
     project           : Mapped['db_project.DbProject | None']                            = relationship('Project')

--- a/python/lib/db/models/physio_file.py
+++ b/python/lib/db/models/physio_file.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -7,6 +8,7 @@ import lib.db.models.physio_file_parameter as db_phyiso_file_parameter
 import lib.db.models.physio_modality as db_physio_modality
 import lib.db.models.physio_output_type as db_physio_output_type
 from lib.db.base import Base
+from lib.db.decorators.string_path import StringPath
 
 
 class DbPhysioFile(Base):
@@ -20,7 +22,7 @@ class DbPhysioFile(Base):
     file_type        : Mapped[str | None]      = mapped_column('FileType')
     acquisition_time : Mapped[datetime | None] = mapped_column('AcquisitionTime')
     inserted_by_user : Mapped[str]             = mapped_column('InsertedByUser')
-    path             : Mapped[str]             = mapped_column('FilePath')
+    path             : Mapped[Path]            = mapped_column('FilePath', StringPath)
     index            : Mapped[int | None]      = mapped_column('Index')
     parent_id        : Mapped[int | None]      = mapped_column('ParentID')
 

--- a/python/lib/db/queries/dicom_archive.py
+++ b/python/lib/db/queries/dicom_archive.py
@@ -1,4 +1,6 @@
 
+from pathlib import Path
+
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session as Database
 
@@ -29,14 +31,14 @@ def try_get_dicom_archive_with_patient_name(db: Database, patient_name: str) -> 
     ).scalar_one_or_none()
 
 
-def try_get_dicom_archive_with_archive_location(db: Database, archive_location: str) -> DbDicomArchive | None:
+def try_get_dicom_archive_with_archive_path(db: Database, archive_path: Path) -> DbDicomArchive | None:
     """
-    Get a DICOM archive from the database using its archive location, or return `None` if no DICOM
+    Get a DICOM archive from the database using its archive path, or return `None` if no DICOM
     archive is found.
     """
 
     return db.execute(select(DbDicomArchive)
-        .where(DbDicomArchive.archive_location.like(f'%{archive_location}%'))
+        .where(DbDicomArchive.archive_path.like(f'%{archive_path}%'))
     ).scalar_one_or_none()
 
 

--- a/python/lib/db/queries/file.py
+++ b/python/lib/db/queries/file.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session as Database
 
@@ -26,14 +28,14 @@ def try_get_file_with_unique_combination(
     ).scalar_one_or_none()
 
 
-def try_get_file_with_rel_path(db: Database, rel_path: str) -> DbFile | None:
+def try_get_file_with_path(db: Database, path: Path) -> DbFile | None:
     """
-    Get an imaging file from the database using its relative path, or return `None` if no imaging
-    file is found.
+    Get an imaging file from the database using its path, or return `None` if no imaging file is
+    found.
     """
 
     return db.execute(select(DbFile)
-        .where(DbFile.rel_path == rel_path)
+        .where(DbFile.path == path)
     ).scalar_one_or_none()
 
 

--- a/python/lib/db/queries/physio_file.py
+++ b/python/lib/db/queries/physio_file.py
@@ -1,10 +1,12 @@
+from pathlib import Path
+
 from sqlalchemy import select
 from sqlalchemy.orm import Session as Database
 
 from lib.db.models.physio_file import DbPhysioFile
 
 
-def try_get_physio_file_with_path(db: Database, path: str) -> DbPhysioFile | None:
+def try_get_physio_file_with_path(db: Database, path: Path) -> DbPhysioFile | None:
     """
     Get a physiological file from the database using its path, or return `None` if no file was
     found.

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -1,11 +1,12 @@
 import os
 import shutil
+from pathlib import Path
 
 import lib.exitcode
 from lib.config import get_data_dir_path_config, get_dicom_archive_dir_path_config
 from lib.database import Database
 from lib.database_lib.config import Config
-from lib.db.queries.dicom_archive import try_get_dicom_archive_with_archive_location
+from lib.db.queries.dicom_archive import try_get_dicom_archive_with_archive_path
 from lib.db.queries.mri_upload import try_get_mri_upload_with_id
 from lib.get_session_info import SessionConfigError, get_dicom_archive_session_info
 from lib.imaging import Imaging
@@ -149,7 +150,7 @@ class BasePipeline:
                 )
 
             self.dicom_archive = self.mri_upload.dicom_archive
-            if os.path.join(self.data_dir, 'tarchive', self.dicom_archive.archive_location) != tarchive_path:
+            if os.path.join(self.data_dir, 'tarchive', self.dicom_archive.archive_path) != tarchive_path:
                 log_error_exit(
                     self.env,
                     f"UploadID {upload_id} and ArchiveLocation {tarchive_path} do not refer to the same upload",
@@ -177,7 +178,7 @@ class BasePipeline:
 
         elif tarchive_path:
             archive_location = os.path.relpath(tarchive_path, self.dicom_lib_dir)
-            dicom_archive = try_get_dicom_archive_with_archive_location(self.env.db, archive_location)
+            dicom_archive = try_get_dicom_archive_with_archive_path(self.env.db, Path(archive_location))
             if dicom_archive is None:
                 log_error_exit(
                     self.env,

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import sys
+from pathlib import Path
 
 import lib.exitcode
 from lib.dcm2bids_imaging_pipeline_lib.base_pipeline import BasePipeline
@@ -35,7 +36,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         self.init_session_info()
         self.series_uid = self.options_dict["series_uid"]["value"]
         self.tarchive_path = os.path.join(
-            self.data_dir, "tarchive", self.dicom_archive.archive_location
+            self.data_dir, "tarchive", self.dicom_archive.archive_path
         )
 
         # ---------------------------------------------------------------------------------------------
@@ -47,7 +48,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         # Extract DICOM files from the tarchive
         # ---------------------------------------------------------------------------------------------
         self.extracted_dicom_dir = self.imaging_obj.extract_files_from_dicom_archive(
-            os.path.join(self.data_dir, 'tarchive', self.dicom_archive.archive_location),
+            os.path.join(self.data_dir, 'tarchive', self.dicom_archive.archive_path),
             self.tmp_dir
         )
 
@@ -334,7 +335,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         """
 
         acq_date = self.dicom_archive.date_acquired
-        archive_location = self.dicom_archive.archive_location
+        archive_location = str(self.dicom_archive.archive_path)
 
         pattern = re.compile(r"^[0-9]{4}/")
         if acq_date and not pattern.match(archive_location):
@@ -349,7 +350,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
             os.replace(self.tarchive_path, new_tarchive_path)
             self.tarchive_path = new_tarchive_path
             # add the new archive location to the list of fields to update in the tarchive table
-            self.dicom_archive.archive_location = new_archive_location
+            self.dicom_archive.archive_path = Path(new_archive_location)
 
         self.dicom_archive.session = self.session
 

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_validation_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_validation_pipeline.py
@@ -53,7 +53,7 @@ class DicomValidationPipeline(BasePipeline):
 
         log_verbose(self.env, "Verifying DICOM archive md5sum (checksum)")
 
-        dicom_archive_path = os.path.join(self.dicom_lib_dir, self.dicom_archive.archive_location)
+        dicom_archive_path = os.path.join(self.dicom_lib_dir, self.dicom_archive.archive_path)
         result = _validate_dicom_archive_md5sum(self.env, self.dicom_archive, dicom_archive_path)
         if not result:
             # Update the MRI upload.

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -328,7 +328,7 @@ class NiftiInsertionPipeline(BasePipeline):
                     error_msg = f"Found a DICOM archive containing DICOM files with the same SeriesUID ({series_uid})" \
                                 f" and EchoTime ({tar_echo_time}) as the one present in the JSON side car file. " \
                                 f" The DICOM archive location containing those DICOM files is " \
-                                f" {self.dicom_archive.archive_location}. Please, rerun " \
+                                f" {self.dicom_archive.archive_path}. Please, rerun " \
                                 f" <run_nifti_insertion.py> with either --upload_id or --tarchive_path option."
 
         # verify that a file with the same MD5 or blake2b hash has not already been inserted

--- a/python/lib/import_dicom_study/dicom_database.py
+++ b/python/lib/import_dicom_study/dicom_database.py
@@ -84,8 +84,8 @@ def populate_dicom_archive(
     dicom_archive.creating_user            = dicom_import_log.creator_name
     dicom_archive.sum_type_version         = dicom_import_log.summary_version
     dicom_archive.tar_type_version         = dicom_import_log.archive_version
-    dicom_archive.source_location          = str(dicom_import_log.source_path)
-    dicom_archive.archive_location         = str(archive_path)
+    dicom_archive.source_path              = dicom_import_log.source_path
+    dicom_archive.archive_path             = archive_path
     dicom_archive.scanner_manufacturer     = dicom_summary.info.scanner.manufacturer or ''
     dicom_archive.scanner_model            = dicom_summary.info.scanner.model or ''
     dicom_archive.scanner_serial_number    = dicom_summary.info.scanner.serial_number or ''

--- a/python/tests/integration/scripts/test_import_bids_dataset.py
+++ b/python/tests/integration/scripts/test_import_bids_dataset.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from lib.db.queries.candidate import try_get_candidate_with_psc_id
 from lib.db.queries.config import set_config_with_setting_name
 from lib.db.queries.physio_file import try_get_physio_file_with_path
@@ -33,7 +35,7 @@ def test_import_eeg_bids_dataset():
     # Check that the physiological file has been inserted in the database.
     file = try_get_physio_file_with_path(
         db,
-        'bids_imports/Face13_BIDSVersion_1.1.0/sub-OTT166/ses-V1/eeg/sub-OTT166_ses-V1_task-faceO_eeg.edf',
+        Path('bids_imports/Face13_BIDSVersion_1.1.0/sub-OTT166/ses-V1/eeg/sub-OTT166_ses-V1_task-faceO_eeg.edf'),
     )
     assert file is not None
 

--- a/python/tests/integration/scripts/test_mass_nifti_pic.py
+++ b/python/tests/integration/scripts/test_mass_nifti_pic.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+from pathlib import Path
 
 from lib.db.models.file import DbFile
 from lib.db.queries.file import delete_file
@@ -163,7 +164,7 @@ def test_running_on_a_text_file():
 
     # insert fake text file
     file = DbFile(
-        rel_path            = 'test.txt',
+        path                = Path('test.txt'),
         file_type           = 'txt',
         session_id          = 564,
         output_type         = 'native',

--- a/python/tests/integration/scripts/test_run_dicom_archive_loader.py
+++ b/python/tests/integration/scripts/test_run_dicom_archive_loader.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from lib.db.queries.config import set_config_with_setting_name
 from lib.db.queries.mri_upload import get_mri_upload_with_patient_name
 from lib.exitcode import GETOPT_FAILURE, INVALID_PATH, SELECT_FAILURE, SUCCESS
@@ -85,7 +87,7 @@ def test_successful_run_on_valid_tarchive_path():
     })
 
     # Check that the expected data has been inserted in the database
-    archive_new_path = '2015/DCM_2015-07-07_MTL001_300001_V2_localizer_t1w.tar'
+    archive_new_path = Path('2015/DCM_2015-07-07_MTL001_300001_V2_localizer_t1w.tar')
     mri_upload = get_mri_upload_with_patient_name(db, 'MTL001_300001_V2')
     # check mri_upload flags
     assert mri_upload.inserting is False
@@ -97,7 +99,7 @@ def test_successful_run_on_valid_tarchive_path():
     assert mri_upload.dicom_archive is not None
     assert mri_upload.dicom_archive.session is not None
     # check that archive location has been updated
-    assert mri_upload.dicom_archive.archive_location == archive_new_path
+    assert mri_upload.dicom_archive.archive_path == archive_new_path
     # check series/files counts
     # notes: - tarchive_series should have 2 series for this upload (localizer + T1W)
     #        - localizer is skipped from conversion because of config settings `excluded_series_description`

--- a/python/tests/integration/scripts/test_run_nifti_insertion.py
+++ b/python/tests/integration/scripts/test_run_nifti_insertion.py
@@ -1,6 +1,7 @@
 import os.path
 import shutil
 from os.path import basename
+from pathlib import Path
 
 from lib.db.queries.file import try_get_file_with_unique_combination
 from lib.db.queries.file_parameter import try_get_parameter_value_with_file_id_parameter_name
@@ -320,12 +321,12 @@ def test_nifti_mri_protocol_violated_scans_features():
     violated_scan_entry = violated_scans[0]
 
     # Check that the NIfTI file can be found on the disk
-    assert violated_scan_entry.file_rel_path is not None
-    assert os.path.exists(os.path.join('/data/loris/', violated_scan_entry.file_rel_path))
+    assert violated_scan_entry.file_path is not None
+    assert os.path.exists(os.path.join('/data/loris/', violated_scan_entry.file_path))
 
     # Rerun the script to test that it did not duplicate the entry in MRI protocol violated scans
     # Note: need to copy the violated file into incoming to rerun the script
-    new_nifti_path = os.path.join('/data/loris/', violated_scan_entry.file_rel_path)
+    new_nifti_path = os.path.join('/data/loris/', violated_scan_entry.file_path)
     new_json_path = new_nifti_path.replace('.nii.gz', '.json')
     shutil.copyfile(new_nifti_path, nifti_path)
     shutil.copyfile(new_json_path, json_path)
@@ -382,7 +383,7 @@ def test_nifti_mri_protocol_violated_scans_features():
 
     # Check that all files related to that image have been properly linked in the database
     file_base_rel_path = 'assembly_bids/sub-400184/ses-V3/anat/sub-400184_ses-V3_run-1_T1w'
-    assert file.rel_path == f'{file_base_rel_path}.nii.gz'
+    assert file.path == Path(f'{file_base_rel_path}.nii.gz')
     file_json_data = try_get_parameter_value_with_file_id_parameter_name(db, file.id, 'bids_json_file')
     file_pic_data = try_get_parameter_value_with_file_id_parameter_name(db, file.id, 'check_pic_filename')
     assert file_json_data is not None and file_json_data.value == f'{file_base_rel_path}.json'
@@ -393,7 +394,7 @@ def test_nifti_mri_protocol_violated_scans_features():
             'sub-400184': {
                 'ses-V3': {
                     'anat': {
-                        basename(file.rel_path): None,
+                        basename(file.path): None,
                         basename(str(file_json_data.value)): None,
                     }
                 }
@@ -463,13 +464,13 @@ def test_nifti_mri_violations_log_exclude_features():
     # can be found on the disk
     assert len(violations) == 1
     violation_entry = violations[0]
-    assert violation_entry.file_rel_path is not None
+    assert violation_entry.file_path is not None
     assert violation_entry.severity == 'exclude'
 
     # Check that the NIfTI file can be found in the filesystem
-    assert os.path.exists(os.path.join('/data/loris/', violation_entry.file_rel_path))
+    assert os.path.exists(os.path.join('/data/loris/', violation_entry.file_path))
     # Check that the rest of the expected files have been created
-    new_nifti_path = os.path.join('/data/loris/', violation_entry.file_rel_path)
+    new_nifti_path = os.path.join('/data/loris/', violation_entry.file_path)
     new_json_path = new_nifti_path.replace('.nii.gz', '.json')
     new_bval_path = new_nifti_path.replace('.nii.gz', '.bval')
     new_bvec_path = new_nifti_path.replace('.nii.gz', '.bvec')
@@ -539,7 +540,7 @@ def test_nifti_mri_violations_log_exclude_features():
 
     # Check that all files related to that image have been properly linked in the database
     file_base_rel_path = 'assembly_bids/sub-400184/ses-V3/dwi/sub-400184_ses-V3_acq-65dir_run-1_dwi'
-    assert file.rel_path == f'{file_base_rel_path}.nii.gz'
+    assert file.path == Path(f'{file_base_rel_path}.nii.gz')
     file_json_data = try_get_parameter_value_with_file_id_parameter_name(db, file.id, 'bids_json_file')
     file_bval_data = try_get_parameter_value_with_file_id_parameter_name(db, file.id, 'check_bval_filename')
     file_bvec_data = try_get_parameter_value_with_file_id_parameter_name(db, file.id, 'check_bvec_filename')
@@ -554,7 +555,7 @@ def test_nifti_mri_violations_log_exclude_features():
             'sub-400184': {
                 'ses-V3': {
                     'dwi': {
-                        basename(file.rel_path): None,
+                        basename(file.path): None,
                         basename(str(file_bval_data.value)): None,
                         basename(str(file_bvec_data.value)): None,
                         basename(str(file_json_data.value)): None,
@@ -617,14 +618,14 @@ def test_dwi_insertion_with_mri_violations_log_warning():
     assert file is not None
     assert len(violations) == 1
     violation_entry = violations[0]
-    assert violation_entry.file_rel_path is not None
+    assert violation_entry.file_path is not None
     assert violation_entry.severity == 'warning'
 
     # Check that all files related to that image have been properly linked in the database
     file_base_rel_path = 'assembly_bids/sub-400184/ses-V3/dwi/sub-400184_ses-V3_acq-25dir_run-1_dwi'
-    assert violation_entry.file_rel_path \
-           == file.rel_path \
-           == f'{file_base_rel_path}.nii.gz'
+    assert violation_entry.file_path \
+           == file.path \
+           == Path(f'{file_base_rel_path}.nii.gz')
     file_json_data = try_get_parameter_value_with_file_id_parameter_name(db, file.id, 'bids_json_file')
     file_bval_data = try_get_parameter_value_with_file_id_parameter_name(db, file.id, 'check_bval_filename')
     file_bvec_data = try_get_parameter_value_with_file_id_parameter_name(db, file.id, 'check_bvec_filename')
@@ -639,7 +640,7 @@ def test_dwi_insertion_with_mri_violations_log_warning():
             'sub-400184': {
                 'ses-V3': {
                     'dwi': {
-                        basename(file.rel_path): None,
+                        basename(file.path): None,
                         basename(str(file_bval_data.value)): None,
                         basename(str(file_bvec_data.value)): None,
                         basename(str(file_json_data.value)): None,

--- a/python/tests/unit/db/query/test_dicom_archive.py
+++ b/python/tests/unit/db/query/test_dicom_archive.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
 from sqlalchemy import select
@@ -33,7 +34,7 @@ def setup():
         creating_user             = 'admin',
         sum_type_version          = 2,
         tar_type_version          = 2,
-        source_location           = '/tests/DCC001_111111_V1',
+        source_path               = Path('/tests/DCC001_111111_V1'),
         scanner_manufacturer      = 'Test scanner manufacturer',
         scanner_model             = 'Test scanner model',
         scanner_serial_number     = 'Test scanner serial number',
@@ -54,7 +55,7 @@ def setup():
         creating_user             = 'admin',
         sum_type_version          = 2,
         tar_type_version          = 2,
-        source_location           = '/test/DCC002_222222_V2',
+        source_path               = Path('/test/DCC002_222222_V2'),
         scanner_manufacturer      = 'Test scanner manufacturer',
         scanner_model             = 'Test scanner model',
         scanner_serial_number     = 'Test scanner serial number',


### PR DESCRIPTION
Builds on #1349

# Description

Migrate the ORM models and queries from the `str` type for paths, to `pathlib.Path`, and consolidate the ORM around the `path` naming for paths (instead of `path`, `rel_path`, `location`...).

# Testing

- Ran the DICOM study importer manually and checked the result.
- PR code is strictly typed and change is rather straightforward.

# Detailed changes

Add a new `StringPath` decorator to translate back and forth between SQL strings and Python paths.

Renamings:
- `DbDicomArchive.source_location` -> `DbDicomArchive.source_path`
- `DbDicomArchive.archive_location` -> `DbDicomArchive.archive_path`
- `DbFile.rel_path` -> `DbFile.path`
- `DbMriProtocolViolatedScan.file_rel_path` -> `DbMriProtocolViolatedScan.file_path`
- `DbMriUpload.upload_location` -> `DbMriUpload.upload_path`
- `DbMriUpload.decompressed_location` -> `DbMriUpload.decompressed_path`
- `DbMriViolationLog.file_rel_path` -> `DbMriViolationLog.file_path`

Type changes (from `str` to `Path`):
- `DbDicomArchive.source_path`
- `DbDicomArchive.archive_path`
- `DbFile.path`
- `DbMriProtocolViolatedScan.file_path`
- `DbMriUpload.upload_path`
- `DbMriUpload.decompressed_path`
- `DbMriViolationLog.file_path`
- `DbPhysioChannel.file_path`
- `DbPhysioCoordSystem.file_path`
- `DbPhysioEventFile.file_path`
- `DbPhysioFile.path`
