### PR TITLE
Fix EEG chunks path bug with EEGChunksPath in EEG BIDS import (27 release)

### DIFF
--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -1224,11 +1224,13 @@ class Physiological:
 
             chunk_root_dir_config = self.config_db_obj.get_config("EEGChunksPath")
             chunk_root_dir = chunk_root_dir_config
-            if not chunk_root_dir:
-                # the bids_rel_dir is the first two directories in file_path (
-                # bids_imports/BIDS_dataset_name_BIDSVersion)
-                bids_rel_dir   = file_path.split('/')[0] + '/' + file_path.split('/')[1]
-                chunk_root_dir = data_dir + bids_rel_dir + '_chunks' + '/'
+            file_path_parts = file_path.split('/')
+            if chunk_root_dir_config:
+                chunk_root_dir = chunk_root_dir_config
+            else:
+                chunk_root_dir = data_dir + file_path_parts[0] + '/'
+
+            chunk_root_dir = chunk_root_dir + file_path_parts[1] + '_chunks' + '/'
 
             # determine which script to run based on the file type
             file_type = self.grep_file_type_from_file_id(physio_file_id)
@@ -1258,6 +1260,5 @@ class Physiological:
                 self.insert_physio_parameter_file(
                     physiological_file_id = physio_file_id,
                     parameter_name = 'electrophysiology_chunked_dataset_path',
-                    value = chunk_path.replace(chunk_root_dir_config, '') if chunk_root_dir_config
-                        else chunk_path.replace(data_dir, '')
+                    value = chunk_path.replace(data_dir, '')
                 )

--- a/python/react-series-data-viewer/edf_to_chunks.py
+++ b/python/react-series-data-viewer/edf_to_chunks.py
@@ -35,8 +35,8 @@ if __name__ == '__main__':
             eog=None,
             misc=None,
             exclude=(),
-            preload=False,
-            infer_types=False
+            infer_types=False,
+            file_type=mne_edf.FileType.EDF,
         )
         channel_names = edf_info['ch_names']
 


### PR DESCRIPTION
Port of #1345 and #1343 (only the bug fix part) for 27 release

The code of the first fix is slightly different because the newer version of the code uses `os.path`, whereas the 27 release version uses string operations.

Tested the PR manually with `EEGChunksPath` both set and not set.

The integration tests for this PR do not pass yet as we still did not fix the 27 release dependencies versions, but that is unrelated to this PR.