### PR TITLE
Run CI daily

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,8 @@ on:
     branches:
     - 'main'
     - '*-release'
+  schedule:
+    - cron: '30 0 * * *'
 
 env:
   DATABASE_NAME: TestDatabase

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -6,6 +6,8 @@ on:
     branches:
     - 'main'
     - '*-release'
+  schedule:
+    - cron: '30 0 * * *'
 
 jobs:
   ruff:


### PR DESCRIPTION
## Description

Run the static and integration tests daily on the main branch to detect breakages caused by external factors such as library or LORIS PHP updates.

## Details

I originally wanted CI to run daily on both the main (development) branch and supported release branches, but apparently GitHub only supports running scheduled actions on the default branch, so I settled for main only.