### PR TITLE
Fix Matplotlib warning

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -80,5 +80,7 @@ jobs:
         echo ${{ env.BUCKET_ACCESS_KEY }}:${{ env.BUCKET_SECRET_KEY }} > .passwd-s3fs
         sudo s3fs ${{ env.BUCKET_NAME }} /data-imaging -o url=${{ env.BUCKET_URL }} -o passwd_file=.passwd-s3fs -o use_path_request_style -o allow_other
 
+    # FIXME: The Python warning is a bug in nilearn 0.13.0, remove when the library is updated.
+    # https://github.com/nilearn/nilearn/issues/5927
     - name: Run integration tests
-      run: docker compose --file ./test/docker-compose.yml run mri pytest python/tests/integration
+      run: docker compose --file ./test/docker-compose.yml run -e PYTHONWARNINGS="ignore:You are using the 'agg' matplotlib backend that is non-interactive.:UserWarning" mri pytest python/tests/integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ requires-python = ">= 3.11"
 dependencies = [
     "boto3==1.35.99",
     "mat73",
-    "matplotlib",
     "mysqlclient",
     "nibabel",
     "nilearn",


### PR DESCRIPTION
Since yesterday, a warning has appeared in CI due to `matplotlib` warning us that we have no GUI backend. Alhough the recommended solution in the warning is to install the PyQT6 backend, I tried it and it did not remove the warning. However, it kind of makes sense as GitHub Actions Runner actually do not have any GUI.

After trying several solutions, I found that the origin of the problem is in a `nilearn` update, see the issue linked in the code for more details, I settled with just silencing the warning for now. I also removed the `matplotlib` dependency from our dependencies list since we do not use it directly (it is still present as a transitive dependency).
https://github.com/nilearn/nilearn/blob/70e1eb214f4aa58c5917d69a2f1f5a0e88849af1/nilearn/_utils/helpers.py#L74-L85
