### PR TITLE
Typed database configuration getters for EEG/physiology

### DIFF
--- a/python/lib/config.py
+++ b/python/lib/config.py
@@ -79,6 +79,84 @@ def get_dicom_archive_dir_path_config(env: Env) -> Path:
     return dicom_archive_dir_path
 
 
+def get_default_bids_visit_label_config(env: Env) -> str | None:
+    """
+    Get the default BIDS visit label from the in-database configuration.
+    """
+
+    return _try_get_config_value(env, 'default_bids_vl')
+
+
+def get_eeg_viz_enabled_config(env: Env) -> bool:
+    """
+    Get whether the EEG visualization is enabled from the in-database configuration.
+    """
+
+    eeg_viz_enabled = _try_get_config_value(env, 'useEEGBrowserVisualizationComponents')
+    return eeg_viz_enabled == 'true' or eeg_viz_enabled == '1'
+
+
+def get_eeg_chunks_dir_path_config(env: Env) -> Path | None:
+    """
+    Get the EEG chunks directory path configuration value from the in-database configuration.
+    """
+
+    eeg_chunks_path = _try_get_config_value(env, 'EEGChunksPath')
+    if eeg_chunks_path is None:
+        return None
+
+    eeg_chunks_path = Path(eeg_chunks_path)
+
+    if not eeg_chunks_path.is_dir():
+        log_error_exit(
+            env,
+            (
+                f"The configuration value for the LORIS EEG chunks directory path '{eeg_chunks_path}' does not refer to"
+                " an existing directory."
+            ),
+        )
+
+    if not os.access(eeg_chunks_path, os.R_OK) or not os.access(eeg_chunks_path, os.W_OK):
+        log_error_exit(
+            env,
+            f"Missing read or write permission on the LORIS EEG chunks directory '{eeg_chunks_path}'.",
+        )
+
+    return eeg_chunks_path
+
+
+def get_eeg_pre_package_download_dir_path_config(env: Env) -> Path | None:
+    """
+    Get the EEG pre-packaged download path configuration value from the in-database configuration.
+    """
+
+    eeg_pre_package_path = _try_get_config_value(env, 'prePackagedDownloadPath')
+    if eeg_pre_package_path is None:
+        return None
+
+    eeg_pre_package_path = Path(eeg_pre_package_path)
+
+    if not eeg_pre_package_path.is_dir():
+        log_error_exit(
+            env,
+            (
+                "The configuration value for the LORIS EEG pre-packaged download directory path"
+                f" '{eeg_pre_package_path}' does not refer to an existing directory."
+            ),
+        )
+
+    if not os.access(eeg_pre_package_path, os.R_OK) or not os.access(eeg_pre_package_path, os.W_OK):
+        log_error_exit(
+            env,
+            (
+                "Missing read or write permission on the LORIS EEG pre-packaged download directory"
+                f" '{eeg_pre_package_path}'."
+            ),
+        )
+
+    return eeg_pre_package_path
+
+
 def _get_config_value(env: Env, setting_name: str) -> str:
     """
     Get a configuration value from the database using a configuration setting name, or exit the
@@ -99,3 +177,13 @@ def _get_config_value(env: Env, setting_name: str) -> str:
         )
 
     return config.value
+
+
+def _try_get_config_value(env: Env, setting_name: str) -> str | None:
+    """
+    Get a configuration value from the database using a configuration setting name, or return
+    `None` if that configuration setting or value does not exist in the database.
+    """
+
+    config = try_get_config_with_setting_name(env.db, setting_name)
+    return config.value if config is not None else None

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -8,11 +8,12 @@ import sys
 import lib.exitcode
 import lib.utilities as utilities
 from lib.candidate import Candidate
-from lib.database_lib.config import Config
+from lib.config import get_eeg_pre_package_download_dir_path_config, get_eeg_viz_enabled_config
 from lib.database_lib.physiological_event_archive import PhysiologicalEventArchive
 from lib.database_lib.physiological_event_file import PhysiologicalEventFile
 from lib.database_lib.physiological_modality import PhysiologicalModality
 from lib.database_lib.physiological_output_type import PhysiologicalOutputType
+from lib.env import Env
 from lib.physiological import Physiological
 from lib.scanstsv import ScansTSV
 from lib.session import Session
@@ -75,7 +76,7 @@ class Eeg:
         db.disconnect()
     """
 
-    def __init__(self, bids_reader, bids_sub_id, bids_ses_id, bids_modality, db,
+    def __init__(self, env: Env, bids_reader, bids_sub_id, bids_ses_id, bids_modality, db,
                  verbose, data_dir, default_visit_label, loris_bids_eeg_rel_dir,
                  loris_bids_root_dir, dataset_tag_dict, dataset_type):
         """
@@ -108,8 +109,7 @@ class Eeg:
          :type dataset_type          : string
         """
 
-        # config
-        self.config_db_obj = Config(db, verbose)
+        self.env = env
 
         # load bids objects
         self.bids_reader   = bids_reader
@@ -281,7 +281,7 @@ class Eeg:
         if not inserted_eegs:
             return
 
-        physiological = Physiological(self.db, self.verbose)
+        physiological = Physiological(self.env, self.db, self.verbose)
 
         for inserted_eeg in inserted_eegs:
             eeg_file_id        = inserted_eeg['file_id']
@@ -340,8 +340,8 @@ class Eeg:
             )
 
             # create data chunks for React visualization
-            eeg_viz_enabled = self.config_db_obj.get_config("useEEGBrowserVisualizationComponents")
-            if eeg_viz_enabled == 'true' or eeg_viz_enabled == '1':
+            eeg_viz_enabled = get_eeg_viz_enabled_config(self.env)
+            if eeg_viz_enabled:
                 physiological.create_chunks_for_visualization(eeg_file_id, self.data_dir)
 
     def fetch_and_insert_eeg_files(self, derivatives=False, detect=True):
@@ -366,7 +366,7 @@ class Eeg:
         inserted_eegs = []
         # load the Physiological object that will be used to insert the
         # physiological data into the database
-        physiological = Physiological(self.db, self.verbose)
+        physiological = Physiological(self.env, self.db, self.verbose)
 
         if detect:
             # TODO if derivatives, grep the source file as well as the input file ID???
@@ -552,7 +552,7 @@ class Eeg:
 
         # load the Physiological object that will be used to insert the
         # physiological data into the database
-        physiological = Physiological(self.db, self.verbose)
+        physiological = Physiological(self.env, self.db, self.verbose)
 
         electrode_files = self.bids_layout.get_nearest(
             original_physiological_file_path,
@@ -662,7 +662,7 @@ class Eeg:
 
         # load the Physiological object that will be used to insert the
         # physiological data into the database
-        physiological = Physiological(self.db, self.verbose)
+        physiological = Physiological(self.env, self.db, self.verbose)
 
         channel_file = self.bids_layout.get_nearest(
             original_physiological_file_path,
@@ -726,7 +726,7 @@ class Eeg:
 
         # load the Physiological object that will be used to insert the
         # physiological data into the database
-        physiological = Physiological(self.db, self.verbose)
+        physiological = Physiological(self.env, self.db, self.verbose)
 
         event_data_file = self.bids_layout.get_nearest(
             original_physiological_file_path,
@@ -886,7 +886,7 @@ class Eeg:
 
         # load the Physiological object that will be used to insert the
         # physiological archive into the database
-        physiological = Physiological(self.db, self.verbose)
+        physiological = Physiological(self.env, self.db, self.verbose)
 
         # check if archive is on the filesystem
         (archive_rel_name, archive_full_path) = self.get_archive_paths(archive_rel_name)
@@ -985,7 +985,7 @@ class Eeg:
         physiological_event_archive_obj.insert(eeg_file_id, blake2, archive_rel_name)
 
     def get_archive_paths(self, archive_rel_name):
-        package_path = self.config_db_obj.get_config("prePackagedDownloadPath")
+        package_path = get_eeg_pre_package_download_dir_path_config(self.env)
         if package_path:
             raw_package_dir = os.path.join(package_path, 'raw')
             os.makedirs(raw_package_dir, exist_ok=True)

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -9,8 +9,8 @@ from functools import reduce
 from pathlib import Path
 
 import lib.exitcode
+from lib.config import get_eeg_chunks_dir_path_config
 from lib.database_lib.bids_event_mapping import BidsEventMapping
-from lib.database_lib.config import Config
 from lib.database_lib.parameter_type import ParameterType
 from lib.database_lib.physiological_coord_system import PhysiologicalCoordSystem
 from lib.database_lib.physiological_event_file import PhysiologicalEventFile
@@ -20,6 +20,7 @@ from lib.database_lib.physiological_task_event import PhysiologicalTaskEvent
 from lib.database_lib.physiological_task_event_hed_rel import PhysiologicalTaskEventHEDRel
 from lib.database_lib.physiological_task_event_opt import PhysiologicalTaskEventOpt
 from lib.database_lib.point_3d import Point3DDB
+from lib.env import Env
 from lib.point_3d import Point3D
 
 
@@ -37,7 +38,7 @@ class Physiological:
         db = Database(config.mysql, verbose)
         db.connect()
 
-        physiological = Physiological(db, verbose)
+        physiological = Physiological(env, db, verbose)
 
         # Get file type for the physiological file
         file_type = physiological.get_file_type(eeg_file)
@@ -53,7 +54,7 @@ class Physiological:
         ...
     """
 
-    def __init__(self, db, verbose):
+    def __init__(self, env: Env, db, verbose):
         """
         Constructor method for the Physiological class.
 
@@ -63,9 +64,9 @@ class Physiological:
          :type verbose: bool
         """
 
+        self.env     = env
         self.db      = db
         self.verbose = verbose
-        self.config_db_obj = Config(self.db, self.verbose)
 
         self.physiological_event_file_obj                   = PhysiologicalEventFile(self.db, self.verbose)
         self.physiological_task_event                       = PhysiologicalTaskEvent(self.db, self.verbose)
@@ -1221,7 +1222,7 @@ class Physiological:
             script    = None
             file_path = self.grep_file_path_from_file_id(physio_file_id)
 
-            chunk_root_dir_config = self.config_db_obj.get_config("EEGChunksPath")
+            chunk_root_dir_config = get_eeg_chunks_dir_path_config(self.env)
             chunk_root_dir = chunk_root_dir_config
             file_path_parts = Path(file_path).parts
             if chunk_root_dir_config:


### PR DESCRIPTION
## Description

Extract the EEG/phyisology-related typed database configuration getters from #1335 and adopt them in the current EEG/phyisology pipelines.

## Details

- Add an `env` parameter to the `Eeg` and `Physiological` constructors to access the typed database abstraction.
- Add EEG/physiology-related getters to `lib.config`.
- Use `lib.config.get_*` instead of the old `Config` objects to get the related configuration values.

## Future works

The next PR (which builds upon this one and #1359) will be to factorize the chunking subscript calling.