### PR TITLE
BIDS channels.tsv reader (LORIS BIDS reader PR 5)

### DIFF
--- a/python/loris_bids_reader/src/loris_bids_reader/eeg/channels.py
+++ b/python/loris_bids_reader/src/loris_bids_reader/eeg/channels.py
@@ -1,0 +1,58 @@
+import re
+from pathlib import Path
+from typing import Any
+
+from loris_bids_reader.tsv import BidsTsvFile, BidsTsvRow
+
+
+class BidsEegChannelTsvRow(BidsTsvRow):
+    """
+    Class representing a BIDS EEG or iEEG channels.tsv row.
+
+    Documentation:
+    - https://bids-specification.readthedocs.io/en/stable/modality-specific-files/electroencephalography.html#channels-description-_channelstsv
+    - https://bids-specification.readthedocs.io/en/stable/modality-specific-files/intracranial-electroencephalography.html#channels-description-_channelstsv
+    """
+
+    def __init__(self, data: dict[str, Any]):
+        super().__init__(data)
+
+        # nullify not present optional cols
+        for field in OPTIONAL_CHANNEL_FIELDS:
+            if field not in data.keys():
+                data[field] = None
+
+        if data['manual'] == 'TRUE':
+            data['manual'] = 1
+        elif data['manual'] == 'FALSE':
+            data['manual'] = 0
+
+        if data['high_cutoff'] == 'Inf':
+            # replace 'Inf' by the maximum float value to be stored in the
+            # physiological_channel table (a.k.a. 99999.999)
+            data['high_cutoff'] = 99999.999
+
+        if re.match(r"n.?a", str(data['notch']), re.IGNORECASE):
+            # replace n/a, N/A, na, NA by None which will translate to NULL
+            # in the physiological_channel table
+            data['notch'] = None
+
+
+class BidsEegChannelsTsvFile(BidsTsvFile[BidsEegChannelTsvRow]):
+    """
+    Class representing a BIDS EEG or iEEG channels.tsv file.
+
+    Documentation:
+    - https://bids-specification.readthedocs.io/en/stable/modality-specific-files/electroencephalography.html#channels-description-_channelstsv
+    - https://bids-specification.readthedocs.io/en/stable/modality-specific-files/intracranial-electroencephalography.html#channels-description-_channelstsv
+    """
+
+    def __init__(self, path: Path):
+        super().__init__(BidsEegChannelTsvRow, path)
+
+
+OPTIONAL_CHANNEL_FIELDS = [
+    'description',        'sampling_frequency', 'low_cutoff',
+    'high_cutoff',        'manual',             'notch',
+    'status_description', 'units',              'reference',
+]


### PR DESCRIPTION
Builds on #1366 ([diff](https://github.com/MaximeBICMTL/LORIS-MRI/compare/loris_bids_reader_4_events_reader...MaximeBICMTL:LORIS-MRI:loris_bids_reader_5_channels_reader))

# Description

This PR adds two new `BidsEegChannelsTsvFile` and `BidsEegChannelTsvRow` classes, moves the BIDS validation logic outside of `Physiological` into these classes, and adopts these classes in the BIDS EEG importer pipeline.