### PR TITLE
Add typing for the EEG chunker  (EEG chunker PR 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ select = ["E", "EXE", "F", "I", "N", "RUF", "UP", "W"]
 # `test` directory.
 [tool.pyright]
 include = [
+    "python/loris_eeg_chunker",
     "python/tests",
     "python/lib/db",
     "python/lib/imaging_lib",
@@ -84,6 +85,9 @@ include = [
     "python/scripts/summarize_dicom_study.py",
     "python/loris_bids_reader",
     "python/loris_utils",
+]
+exclude = [
+    "python/loris_eeg_chunker/src/loris_eeg_chunker/protocol_buffers",
 ]
 typeCheckingMode = "strict"
 reportMissingTypeStubs = "none"

--- a/python/loris_eeg_chunker/src/loris_eeg_chunker/chunking.py
+++ b/python/loris_eeg_chunker/src/loris_eeg_chunker/chunking.py
@@ -4,14 +4,20 @@ import math
 import os
 import sys
 from collections import OrderedDict
+from collections.abc import Callable
+from typing import Any, cast
 
 import numpy as np
+import numpy.typing as npt
+from mne.io import BaseRaw
 from scipy import signal
 
 from loris_eeg_chunker.protocol_buffers import chunk_pb2 as chunk_pb
 
+ChannelArray = npt.NDArray[np.float64]
 
-def pad_values(values, chunk_size):
+
+def pad_values(values: ChannelArray, chunk_size: int) -> ChannelArray:
     num_chunks = math.ceil(values.shape[-1] / chunk_size)
     total_chunked_points = num_chunks * chunk_size
     padding = total_chunked_points - values.shape[-1]
@@ -21,7 +27,7 @@ def pad_values(values, chunk_size):
     return padded_values
 
 
-def values_to_chunks(values, chunk_size):
+def values_to_chunks(values: ChannelArray, chunk_size: int) -> ChannelArray:
     padded_values = pad_values(values, chunk_size)
     padded_values = np.expand_dims(padded_values, axis=-2)
     shape = list(padded_values.shape)
@@ -32,7 +38,7 @@ def values_to_chunks(values, chunk_size):
     return padded_values
 
 
-def create_chunks_from_values_lists(values_lists, chunk_size):
+def create_chunks_from_values_lists(values_lists: list[ChannelArray], chunk_size: int) -> list[ChannelArray]:
     chunks_lists = [
         values_to_chunks(values, chunk_size)
         for values in values_lists
@@ -40,25 +46,25 @@ def create_chunks_from_values_lists(values_lists, chunk_size):
     return chunks_lists
 
 
-def downsample_channel(channel, chunk_size, downsampling):
+def downsample_channel(channel: ChannelArray, chunk_size: int, downsampling: int) -> ChannelArray:
     if downsampling == 0:
         return channel
     down = chunk_size**downsampling
     downsampled_size = channel.shape[-1] / down
     if downsampled_size <= chunk_size * 2:
         downsampled_size = chunk_size * 2
-    return signal.resample(channel, downsampled_size, axis=-1)
+    return signal.resample(channel, downsampled_size, axis=-1)  # type: ignore
 
 
-def create_downsampled_values_lists(channel, chunk_size):
+def create_downsampled_values_lists(channel: ChannelArray, chunk_size: int) -> list[ChannelArray]:
     downsamplings = math.ceil(math.log(channel.shape[-1]) / math.log(chunk_size))
     downsamplings = range(downsamplings - 1, -1, -1)
     downsampled_channels = [
         downsample_channel(channel, chunk_size, downsampling)
         for downsampling in downsamplings
     ]
-    sizes = set()
-    unique_sized = []
+    sizes: set[int] = set()
+    unique_sized: list[ChannelArray] = []
     for channel in downsampled_channels:
         if channel.shape[-1] in sizes:
             continue
@@ -67,7 +73,7 @@ def create_downsampled_values_lists(channel, chunk_size):
     return unique_sized
 
 
-def chunk_dir_path(input_path, prefix=None, destination=None):
+def chunk_dir_path(input_path: str, prefix: str | None = None, destination: str | None = None) -> str:
     base_path, _ = os.path.splitext(input_path)
     root, chunk_dir_name = os.path.split(base_path)
     root = root if destination is None else destination
@@ -76,7 +82,7 @@ def chunk_dir_path(input_path, prefix=None, destination=None):
     return chunk_dir + '.chunks'
 
 
-def create_path_dirs(path):
+def create_path_dirs(path: str):
     try:
         os.makedirs(path)
     except OSError as e:
@@ -85,16 +91,43 @@ def create_path_dirs(path):
 
 
 def write_index_json(
-    chunk_dir,
-    time_interval,
-    series_range,
-    channel_metadata,
-    chunk_size,
-    downsamplings,
-    valid_samples_in_last_chunk,
-    shapes,
-    trace_types={}
+    chunk_dir: str,
+    time_interval: tuple[np.float64, np.float64],
+    series_range: tuple[float, float],
+    channel_metadata: list[dict[str, Any]],
+    chunk_size: int,
+    downsamplings: list[int],
+    valid_samples_in_last_chunk: list[int],
+    shapes: list[list[int]],
+    trace_types: dict[Any, Any] = {},
 ):
+    create_path_dirs(chunk_dir)
+
+    data = None
+    try:
+        with open(os.path.join(chunk_dir, 'index.json'), 'r+') as index_json:
+            data = json.load(index_json)
+            if chunk_size != data['chunkSize']:
+                sys.exit("Chunk size does not match the one found in index.json.")
+
+            if downsamplings != data['downsamplings']:
+                sys.exit("Downsamplings does not match the one found in index.json.")
+
+            indices = [channelMetadata['index'] for channelMetadata in channel_metadata]
+            channel_metadata.extend(
+                channelMetadata for channelMetadata in data['channelMetadata']
+                if channelMetadata['index'] not in indices
+            )
+            channel_metadata = sorted(channel_metadata, key=lambda k: k['index'])
+            if data['seriesRange'][0] < series_range[0]:
+                series_range = (data['seriesRange'][0], series_range[1])
+
+            if data['seriesRange'][1] > series_range[1]:
+                series_range = (series_range[0], data['seriesRange'][1])
+    except Exception as e:
+        print(e)
+        print('Unable to read an existing index.json file. A new one will be created.')
+
     json_dict = OrderedDict([
         ('timeInterval', list(time_interval)),
         ('seriesRange', series_range),
@@ -105,45 +138,19 @@ def write_index_json(
         ('traceTypes', trace_types),
         ('channelMetadata', channel_metadata)
     ])
-    create_path_dirs(chunk_dir)
-
-    data = None
-    try:
-        with open(os.path.join(chunk_dir, 'index.json'), 'r+') as index_json:
-            data = json.load(index_json)
-            if json_dict['chunkSize'] != data['chunkSize']:
-                sys.exit("Chunk size does not match the one found in index.json.")
-
-            if json_dict['downsamplings'] != data['downsamplings']:
-                sys.exit("Downsamplings does not match the one found in index.json.")
-
-            indices = [channelMetadata['index'] for channelMetadata in json_dict['channelMetadata']]
-            json_dict['channelMetadata'].extend(
-                channelMetadata for channelMetadata in data['channelMetadata']
-                if channelMetadata['index'] not in indices
-            )
-            json_dict['channelMetadata'] = sorted(json_dict['channelMetadata'], key=lambda k: k['index'])
-            if data['seriesRange'][0] < json_dict['seriesRange'][0]:
-                json_dict['seriesRange'][0] = data['seriesRange'][0]
-
-            if data['seriesRange'][1] > json_dict['seriesRange'][1]:
-                json_dict['seriesRange'][1] = data['seriesRange'][1]
-    except Exception as e:
-        print(e)
-        print('Unable to read an existing index.json file. A new one will be created.')
 
     with open(os.path.join(chunk_dir, 'index.json'), 'w+') as index_json:
         json.dump(json_dict, index_json, indent=2, separators=(',', ': '))
 
 
-def encode_chunk(chunk, index, downsampling):
-    encoded = chunk_pb.FloatChunk(
+def encode_chunk(chunk: ChannelArray, index: int, downsampling: int) -> bytes:
+    encoded = chunk_pb.FloatChunk(  # type: ignore
         index=index, downsampling=downsampling, cutoff=len(chunk), samples=chunk
     )
-    return encoded.SerializeToString()
+    return encoded.SerializeToString()  # type: ignore
 
 
-def write_chunks(chunk_dir, channel_chunks_list, channel_index):
+def write_chunks(chunk_dir: str, channel_chunks_list: list[ChannelArray], channel_index: int):
     for downsampling, channels in enumerate(channel_chunks_list):
         for channel_offset, channel in enumerate(channels):
             for trace_index, trace in enumerate(channel):
@@ -164,12 +171,25 @@ def write_chunks(chunk_dir, channel_chunks_list, channel_index):
                         chunk_file.write(encoded_chunk)
 
 
-def mne_file_to_chunks(path, chunk_size, loader, from_channel_name, channel_count):
+def mne_file_to_chunks(
+    path: str,
+    chunk_size: int,
+    loader: Callable[[str], BaseRaw],
+    from_channel_name: str | None,
+    channel_count: int | None,
+) -> tuple[
+    list[ChannelArray],
+    tuple[np.float64, np.float64],
+    tuple[float, float],
+    list[str],
+    list[tuple[float, float]],
+    list[int],
+]:
     parsed = loader(path)
-    time_interval = (parsed.times[0], parsed.times[-1])
-    channel_names = parsed.info["ch_names"]
-    channel_ranges = []
-    signal_range = [np.inf, -np.inf]
+    time_interval: tuple[np.float64, np.float64] = (parsed.times[0], parsed.times[-1])
+    channel_names = cast(list[str], parsed.info["ch_names"])
+    channel_ranges: list[tuple[float, float]] = []
+    signal_range = (np.inf, -np.inf)
     channel_chunks_list = []
     selected_channels = []
     valid_samples_in_last_chunk = []
@@ -181,13 +201,13 @@ def mne_file_to_chunks(path, chunk_size, loader, from_channel_name, channel_coun
         else:
             selected_channels = channel_names[from_channel_index:]
 
-    for i, channel_name in enumerate(selected_channels):
+    for _, channel_name in enumerate(selected_channels):
         print("Processing channel " + channel_name)
-        channel = parsed.get_data(channel_name)
+        channel = cast(ChannelArray, parsed.get_data(channel_name))  # type: ignore
         channel_min = np.amin(channel)
         channel_max = np.amax(channel)
         channel_ranges.append((channel_min, channel_max))
-        signal_range = [min(channel_min, signal_range[0]), max(channel_max, signal_range[1])]
+        signal_range = (min(channel_min, signal_range[0]), max(channel_max, signal_range[1]))
 
         channel = np.expand_dims(channel, axis=-2)
         downsampled_values_lists = create_downsampled_values_lists(channel, chunk_size)
@@ -207,9 +227,17 @@ def mne_file_to_chunks(path, chunk_size, loader, from_channel_name, channel_coun
     return channel_chunks_list, time_interval, signal_range, channel_names, channel_ranges, valid_samples_in_last_chunk
 
 
-def write_chunk_directory(path, chunk_size, loader, from_channel_index=0, from_channel_name=None,
-                          channel_count=None, downsamplings=None, prefix=None, destination=None):
-
+def write_chunk_directory(
+    path: str,
+    chunk_size: int,
+    loader: Callable[[str], BaseRaw],
+    from_channel_index: int = 0,
+    from_channel_name: str | None = None,
+    channel_count: int | None = None,
+    downsamplings: int | None = None,
+    prefix: str | None = None,
+    destination: str | None = None,
+):
     chunk_dir = chunk_dir_path(path, prefix=prefix, destination=destination)
     channel_chunks_list, time_interval, signal_range, \
         channel_names, channel_ranges, valid_samples_in_last_chunk = \

--- a/python/loris_eeg_chunker/src/loris_eeg_chunker/scripts/eeglab_to_chunks.py
+++ b/python/loris_eeg_chunker/src/loris_eeg_chunker/scripts/eeglab_to_chunks.py
@@ -2,15 +2,17 @@
 
 import argparse
 import sys
+from typing import cast
 
 import mne.io
 import mne.io.eeglab.eeglab as mne_eeglab
+from mne.io.eeglab.eeglab import RawEEGLAB
 
 from loris_eeg_chunker.chunking import write_chunk_directory
 
 
-def load_channels(path):
-    return mne.io.read_raw_eeglab(path, preload=False)
+def load_channels(path: str) -> RawEEGLAB:
+    return mne.io.read_raw_eeglab(path, preload=False)  # type: ignore
 
 
 def main():
@@ -33,9 +35,9 @@ def main():
 
     args = parser.parse_args()
     for path in args.files:
-        eeg = mne_eeglab._check_load_mat(path, None)
-        eeglab_info = mne_eeglab._get_info(eeg, eog=(), montage_units="auto")
-        channel_names = eeglab_info[0]['ch_names']
+        eeg = mne_eeglab._check_load_mat(path, None)  # type: ignore
+        eeglab_info = mne_eeglab._get_info(eeg, eog=(), montage_units="auto")  # type: ignore
+        channel_names = cast(list[str], eeglab_info[0]['ch_names'])
 
         if args.channel_index < 0:
             sys.exit("Channel index must be a positive integer")
@@ -50,7 +52,7 @@ def main():
         write_chunk_directory(
             path=path,
             from_channel_index=args.channel_index,
-            from_channel_name=channel_names[args.channel_index],
+            from_channel_name=channel_names[args.channel_index],  # type: ignore
             channel_count=args.channel_count,
             loader=load_channels,
             chunk_size=args.chunk_size,


### PR DESCRIPTION
## Description

I have to do some debugging for MEG on the EEG chunker, which is kinda hard since this package does not contain any type hints or documentation :slightly_frowning_face:. This PR adds full type hints to the package, as well as adds the package to our strict type checking configuration.

# Details

- Add complete type hints to the EEG chunker.
- Add the EEG chunker to the strict type checking configuration, which is checked by CI.
- This PR does not change any of the code logic, the only non-type hints changes are:
  -  `# type: ignore` whenever an external library uses unknown types
  -  `cast(type, expr)` to cast unknown types to known types
  - Use the function parameters directly instead of through a dictionary in `chunking.write_index_json` to type check the code using these parameters types.
  - Use a tuple instead of a list for the signal range for more precise typing.