### PR TITLE
Extract physiological chunking into its own module (PR 4)

### DIFF
--- a/python/lib/db/queries/physio_parameter.py
+++ b/python/lib/db/queries/physio_parameter.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session as Database
 
 from lib.db.models.parameter_type import DbParameterType
 from lib.db.models.physio_file_parameter import DbPhysioFileParameter
+from lib.db.queries.parameter_type import try_get_parameter_type_with_name_source
 
 
 def get_physio_file_parameters(
@@ -19,3 +20,50 @@ def get_physio_file_parameters(
         .join(DbPhysioFileParameter.type)
         .where(DbPhysioFileParameter.file_id == physio_file_id)
     ).tuples().all()
+
+
+def try_get_physio_parameter_type_with_name(
+    db: Database,
+    name: str
+) -> DbParameterType | None:
+    """
+    Try to get a physiological parameter type using its name, or return `None` if no physiological
+    parameter is found.
+    """
+
+    return try_get_parameter_type_with_name_source(db, name, 'physiological_file')
+
+
+def try_get_physio_file_parameter_with_file_id_type_id(
+    db: Database,
+    file_id: int,
+    type_id: int,
+) -> DbPhysioFileParameter | None:
+    """
+    Get a physiological file parameter from the database using its file ID and type ID, or return
+    `None` if no physiological file parameter is found.
+    """
+
+    return db.execute(select(DbPhysioFileParameter)
+        .where(
+            DbPhysioFileParameter.type_id == type_id,
+            DbPhysioFileParameter.file_id == file_id,
+        )
+    ).scalar_one_or_none()
+
+
+def try_get_physio_file_parameter_with_file_id_name(
+    db: Database,
+    file_id: int,
+    name: str,
+) -> DbPhysioFileParameter | None:
+    """
+    Try to get a physiological file parameter using its file ID and parameter type name, or return
+    `None` if no parameter is found.
+    """
+
+    parameter_type = try_get_physio_parameter_type_with_name(db, name)
+    if parameter_type is None:
+        return None
+
+    return try_get_physio_file_parameter_with_file_id_type_id(db, file_id, parameter_type.id)

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -29,6 +29,7 @@ from lib.import_bids_dataset.physio import (
     get_check_bids_physio_output_type,
 )
 from lib.logging import log
+from lib.physio.chunking import create_physio_channels_chunks
 from lib.physio.file import insert_physio_file
 from lib.physio.parameters import insert_physio_file_parameters
 from lib.physiological import Physiological
@@ -297,8 +298,6 @@ class Eeg:
         if not inserted_eegs:
             return
 
-        physiological = Physiological(self.env, self.db, self.verbose)
-
         for inserted_eeg in inserted_eegs:
             eeg_file           = inserted_eeg['file']
             eeg_file_path      = inserted_eeg['file_path']
@@ -358,7 +357,7 @@ class Eeg:
             # create data chunks for React visualization
             eeg_viz_enabled = get_eeg_viz_enabled_config(self.env)
             if eeg_viz_enabled:
-                physiological.create_chunks_for_visualization(eeg_file, self.data_dir)
+                create_physio_channels_chunks(self.env, eeg_file, Path(original_file_data.path))
 
     def fetch_and_insert_eeg_files(self, derivatives=False, detect=True):
         """

--- a/python/lib/physio/chunking.py
+++ b/python/lib/physio/chunking.py
@@ -1,0 +1,97 @@
+import subprocess
+from pathlib import Path
+
+from loris_utils.path import get_path_stem
+
+import lib.exitcode
+from lib.config import get_data_dir_path_config, get_eeg_chunks_dir_path_config
+from lib.db.models.physio_file import DbPhysioFile
+from lib.db.queries.physio_parameter import try_get_physio_file_parameter_with_file_id_name
+from lib.env import Env
+from lib.logging import log, log_error_exit
+from lib.physio.parameters import insert_physio_file_parameter
+
+
+def create_physio_channels_chunks(env: Env, physio_file: DbPhysioFile, file_path: Path):
+    """
+    Create the channels chunks for a physiological file based on its source MEG CTF directory.
+    """
+
+    data_dir = get_data_dir_path_config(env)
+
+    chunk_path = try_get_physio_file_parameter_with_file_id_name(
+        env.db,
+        physio_file.id,
+        'electrophysiology_chunked_dataset_path',
+    )
+
+    if chunk_path is not None:
+        log(env, "Chunk path already exists for this file.")
+        return
+
+    match physio_file.type:
+        case 'ctf':
+            script = 'ctf-to-chunks'
+        case 'edf':
+            script = 'edf-to-chunks'
+        case 'set':
+            script = 'eeglab-to-chunks'
+        case _:
+            log_error_exit(
+                env,
+                f"Chunking not supported for physiological file type '{physio_file.type}'.",
+                lib.exitcode.CHUNK_CREATION_FAILURE,
+            )
+
+    chunk_root_dir = get_dataset_chunks_dir_path(env, physio_file)
+
+    command_parts = [script, str(file_path), '--destination', str(chunk_root_dir)]
+
+    try:
+        log(env, f"Running chunking script with command: {' '.join(command_parts)}")
+        subprocess.call(command_parts, stdout=subprocess.DEVNULL if not env.verbose else None)
+    except OSError:
+        log_error_exit(
+            env,
+            "Chunking script not found.",
+            lib.exitcode.CHUNK_CREATION_FAILURE,
+        )
+    except subprocess.CalledProcessError as error:
+        log_error_exit(
+            env,
+            f"Chunking script execution failure. Error was:\n{error}",
+            lib.exitcode.CHUNK_CREATION_FAILURE,
+        )
+
+    chunk_path = chunk_root_dir / f'{get_path_stem(physio_file.path)}.chunks'
+    if not chunk_path.is_dir():
+        log_error_exit(
+            env,
+            f"Chunk creation failed, directory '{chunk_path}' does not exist.",
+            lib.exitcode.CHUNK_CREATION_FAILURE,
+        )
+
+    insert_physio_file_parameter(
+        env,
+        physio_file,
+        'electrophysiology_chunked_dataset_path',
+        chunk_path.relative_to(data_dir),
+    )
+
+
+def get_dataset_chunks_dir_path(env: Env, physio_file: DbPhysioFile):
+    """
+    Get the chunks directory path of the dataset of a physiological file, creating that directory
+    if it does not exist.
+    """
+
+    # The first part of the physiological file path is assumed to be the BIDS imports directory name.
+    # The second part of the physiological file path is assumed to be the dataset name.
+    eeg_chunks_dir_path = get_eeg_chunks_dir_path_config(env)
+    if eeg_chunks_dir_path is None:
+        data_dir = get_data_dir_path_config(env)
+        eeg_chunks_dir_path = data_dir / physio_file.path.parts[0]
+
+    eeg_chunks_path = eeg_chunks_dir_path / f'{physio_file.path.parts[1]}_chunks'
+    eeg_chunks_path.mkdir(exist_ok=True)
+    return eeg_chunks_path


### PR DESCRIPTION
Extracted from #1335
Builds on #1376 ([diff](https://github.com/MaximeBICMTL/LORIS-MRI/compare/migrate_physio_file_orm...MaximeBICMTL:LORIS-MRI:isolate_physio_chunking))

## Description

- Extract the EEG/MEG "run channel chunking script" our of `Physiological` into its own module `lib.physio.chunking`.
- Notice that the script is run on the original file path instead of the LORIS file path. This is not relevant for EEG, but it is for MEG as CTF are directories, which are tarred when going into the LORIS BIDS.