### PR TITLE
Factorize BIDS information and simplify `Eeg` paramaters (PR 6)

### DIFF
--- a/python/loris_bids_reader/src/loris_bids_reader/info.py
+++ b/python/loris_bids_reader/src/loris_bids_reader/info.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class BidsSubjectInfo:
+    """
+    Information about a BIDS subject directory.
+    """
+
+    subject: str
+    """
+    The BIDS subject label.
+    """
+
+
+@dataclass
+class BidsSessionInfo(BidsSubjectInfo):
+    """
+    Information about a BIDS session directory.
+    """
+
+    session: str | None
+    """
+    The BIDS session label.
+    """
+
+
+@dataclass
+class BidsDataTypeInfo(BidsSessionInfo):
+    """
+    Information about a BIDS data type directory.
+    """
+
+    data_type: str
+    """
+    The BIDS data type name.
+    """

--- a/python/scripts/bids_import.py
+++ b/python/scripts/bids_import.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 
+from loris_bids_reader.info import BidsDataTypeInfo
 from loris_utils.crypto import compute_file_blake2b_hash
 
 import lib.exitcode
@@ -324,11 +325,8 @@ def read_and_insert_bids(
                 Eeg(
                     env,
                     bids_reader   = bids_reader,
-                    bids_sub_id   = row['bids_sub_id'],
-                    bids_ses_id   = row['bids_ses_id'],
-                    bids_modality = modality,
+                    bids_info     = BidsDataTypeInfo(row['bids_sub_id'], row['bids_ses_id'], modality),
                     db            = db,
-                    verbose       = verbose,
                     data_dir      = data_dir,
                     default_visit_label    = default_bids_vl,
                     loris_bids_eeg_rel_dir = loris_bids_modality_rel_dir,


### PR DESCRIPTION
Builds on #1378 ([diff](https://github.com/MaximeBICMTL/LORIS-MRI/compare/harness_physio_orm_power...MaximeBICMTL:LORIS-MRI:bids_info))

## Description

- Add a new `lorids_bids_reader.info` module to store typed information about a BIDS subject/session/data type directory.
- Use a new `BidsDataTypeInfo` object instead of separate untyped parameters in the `Eeg` class.
- Use `env.verbose` instead of a separate `verbose` parameter in the `Eeg` class.