### PR TITLE
Update ORM event types

### DIFF
--- a/python/lib/db/models/physio_task_event.py
+++ b/python/lib/db/models/physio_task_event.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time
+from datetime import datetime
 from decimal import Decimal
 
 from sqlalchemy import ForeignKey
@@ -21,10 +21,10 @@ class DbPhysioTaskEvent(Base):
     channel        : Mapped[str | None]     = mapped_column('Channel')
     event_code     : Mapped[int | None]     = mapped_column('EventCode')
     event_value    : Mapped[str | None]     = mapped_column('EventValue')
-    event_sample   : Mapped[Decimal | None] = mapped_column('EventSample')
+    event_sample   : Mapped[int | None]     = mapped_column('EventSample')
     event_type     : Mapped[str | None]     = mapped_column('EventType')
     trial_type     : Mapped[str | None]     = mapped_column('TrialType')
-    response_time  : Mapped[time | None]    = mapped_column('ResponseTime')
+    response_time  : Mapped[Decimal | None] = mapped_column('ResponseTime')
 
     physio_file : Mapped['db_physio_file.DbPhysioFile']            = relationship('PhysiologicalFile')
     event_file  : Mapped['db_physio_event_file.DbPhysioEventFile'] = relationship('PhysiologicalEventFile', back_populates='task_events')


### PR DESCRIPTION
## Description

Update the ORM event types to match LORIS schema changes in https://github.com/aces/Loris/pull/10358 and  https://github.com/aces/Loris/pull/10358. These fields are not yet used in LORIS so just updating the ORM models is sufficient.

## Testing

CI passes