### PR TITLE
Physiological file download path

### DIFF
--- a/python/lib/db/models/physio_file.py
+++ b/python/lib/db/models/physio_file.py
@@ -28,9 +28,20 @@ class DbPhysioFile(Base):
     type             : Mapped[str | None]      = mapped_column('FileType')
     acquisition_time : Mapped[datetime | None] = mapped_column('AcquisitionTime')
     inserted_by_user : Mapped[str]             = mapped_column('InsertedByUser')
-    path             : Mapped[Path]            = mapped_column('FilePath', StringPath)
     index            : Mapped[int | None]      = mapped_column('Index')
     parent_id        : Mapped[int | None]      = mapped_column('ParentID')
+
+    path: Mapped[Path] = mapped_column('FilePath', StringPath)
+    """
+    The path of this physiological file, which may be a directory (notably for MEG CTF data). The
+    path is relative to the LORIS data directory.
+    """
+
+    download_path: Mapped[Path] = mapped_column('DownloadPath', StringPath)
+    """
+    The path from which to download this physiological file, which is guaranteed to be a normal
+    file or an archive. The path is relative to the LORIS data directory.
+    """
 
     head_shape_file_id: Mapped[int | None] = mapped_column('HeadShapeFileID', ForeignKey('meg_ctf_head_shape_file.ID'))
     """

--- a/python/lib/physio/file.py
+++ b/python/lib/physio/file.py
@@ -18,13 +18,19 @@ def insert_physio_file(
     modality: DbPhysioModality,
     output_type: DbPhysioOutputType,
     acquisition_time: datetime | None,
+    download_path: Path | None = None,
 ) -> DbPhysioFile:
     """
     Insert a physiological file into the database.
     """
 
+    # If the download path is not provided, use the normal file path.
+    if download_path is None:
+        download_path = file_path
+
     file = DbPhysioFile(
         path             = file_path,
+        download_path    = download_path,
         type             = file_type.name,
         session_id       = session.id,
         modality_id      = modality.id,


### PR DESCRIPTION
Sister PR to https://github.com/aces/Loris/pull/10411, add the `DbPhysioFile.download_path` field and adapt the insertion code to use it.

Also, document the difference between `DbPhysioFile.path` and `DbPhysioFile.download_path` in the ORM (I believe we should do that a lot more).