### PR TITLE
Simplify EEG/MEG signal chunking signature

### DIFF
--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -222,9 +222,8 @@ class Eeg:
             )
 
             # create data chunks for React visualization
-            eeg_viz_enabled = get_eeg_viz_enabled_config(self.env)
-            if eeg_viz_enabled:
-                create_physio_channels_chunks(self.env, eeg_file, Path(original_file_data.path))
+            if get_eeg_viz_enabled_config(self.env):
+                create_physio_channels_chunks(self.env, eeg_file)
 
     def fetch_and_insert_eeg_files(self, derivatives=False, detect=True):
         """

--- a/python/lib/physio/chunking.py
+++ b/python/lib/physio/chunking.py
@@ -1,5 +1,4 @@
 import subprocess
-from pathlib import Path
 
 from loris_utils.path import get_path_stem
 
@@ -12,7 +11,7 @@ from lib.logging import log, log_error_exit
 from lib.physio.parameters import insert_physio_file_parameter
 
 
-def create_physio_channels_chunks(env: Env, physio_file: DbPhysioFile, file_path: Path):
+def create_physio_channels_chunks(env: Env, physio_file: DbPhysioFile):
     """
     Create the channels chunks for a physiological file based on its source MEG CTF directory.
     """
@@ -43,9 +42,12 @@ def create_physio_channels_chunks(env: Env, physio_file: DbPhysioFile, file_path
                 lib.exitcode.CHUNK_CREATION_FAILURE,
             )
 
-    chunk_root_dir = get_dataset_chunks_dir_path(env, physio_file)
+    data_dir_path = get_data_dir_path_config(env)
+    file_path = data_dir_path / physio_file.path
 
-    command_parts = [script, str(file_path), '--destination', str(chunk_root_dir)]
+    chunk_root_dir_path = get_dataset_chunks_dir_path(env, physio_file)
+
+    command_parts = [script, str(file_path), '--destination', str(chunk_root_dir_path)]
 
     try:
         log(env, f"Running chunking script with command: {' '.join(command_parts)}")
@@ -63,7 +65,7 @@ def create_physio_channels_chunks(env: Env, physio_file: DbPhysioFile, file_path
             lib.exitcode.CHUNK_CREATION_FAILURE,
         )
 
-    chunk_path = chunk_root_dir / f'{get_path_stem(physio_file.path)}.chunks'
+    chunk_path = chunk_root_dir_path / f'{get_path_stem(physio_file.path)}.chunks'
     if not chunk_path.is_dir():
         log_error_exit(
             env,
@@ -89,8 +91,8 @@ def get_dataset_chunks_dir_path(env: Env, physio_file: DbPhysioFile):
     # name. The second part of the physiological file path is assumed to be the dataset name.
     eeg_chunks_dir_path = get_eeg_chunks_dir_path_config(env)
     if eeg_chunks_dir_path is None:
-        data_dir = get_data_dir_path_config(env)
-        eeg_chunks_dir_path = data_dir / physio_file.path.parts[0]
+        data_dir_path = get_data_dir_path_config(env)
+        eeg_chunks_dir_path = data_dir_path / physio_file.path.parts[0]
 
     eeg_chunks_path = eeg_chunks_dir_path / f'{physio_file.path.parts[1]}_chunks'
     eeg_chunks_path.mkdir(exist_ok=True)

--- a/python/scripts/mass_electrophysiology_chunking.py
+++ b/python/scripts/mass_electrophysiology_chunking.py
@@ -7,7 +7,6 @@ import sys
 
 import lib.exitcode
 import lib.utilities
-from lib.config import get_data_dir_path_config
 from lib.config_file import load_config
 from lib.db.queries.physio_file import try_get_physio_file_with_id
 from lib.env import Env
@@ -110,14 +109,11 @@ def make_chunks(env: Env, physio_file_id: int):
     Call the channel signal chunking script on the provided physiological file.
     """
 
-    # grep config settings from the Config module
-    data_dir = get_data_dir_path_config(env)
-
     # create the chunked dataset
     physio_file = try_get_physio_file_with_id(env.db, physio_file_id)
     if physio_file is not None:
         print(f"Chunking physiological file ID {physio_file.id}")
-        create_physio_channels_chunks(env, physio_file, data_dir / physio_file.path)
+        create_physio_channels_chunks(env, physio_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, the `lib.physio.chunking.create_physio_channels_chunks` took a separate parameter for the path of the file to chunk, this was done for the work-in-progress MEG implementation where in a previous design, the path of the "real" file may not have been the path of the physiological file. That work-in-progress MEG design is obsolete thanks to https://github.com/aces/Loris/pull/10411, so this additional parameter is no longer needed. 

This PR also fixes a bug where the created chunk directories had an incorrect name.