### PR TITLE
Fix physiological file hash parameter name

### DIFF
--- a/python/lib/db/queries/physio_file.py
+++ b/python/lib/db/queries/physio_file.py
@@ -39,7 +39,7 @@ def try_get_physio_file_with_hash(db: Database, file_hash: str) -> DbPhysioFile 
         .join(DbPhysioFile.parameters)
         .join(DbPhysioFileParameter.type)
         .where(
-            DbParameterType.name == 'physiological_json_file_blake2b_hash',
+            DbParameterType.name == 'physiological_file_blake2b_hash',
             DbPhysioFileParameter.value == file_hash,
         )
     ).scalar_one_or_none()


### PR DESCRIPTION
## Description

The query to get the in-database hash of a physiological was getting that of the JSON file instead of the acquisition file. This PR fixes that.
