### PR TITLE
Factorize check LORIS directory (PR 2)

### DIFF
--- a/python/lib/config.py
+++ b/python/lib/config.py
@@ -34,22 +34,7 @@ def get_data_dir_path_config(env: Env) -> Path:
     """
 
     data_dir_path = Path(_get_config_value(env, 'dataDirBasepath'))
-
-    if not data_dir_path.is_dir():
-        log_error_exit(
-            env,
-            (
-                f"The LORIS base data directory path configuration value '{data_dir_path}' does not refer to an"
-                " existing directory."
-            )
-        )
-
-    if not os.access(data_dir_path, os.R_OK) or not os.access(data_dir_path, os.W_OK):
-        log_error_exit(
-            env,
-            f"Missing read or write permission on the LORIS base data directory '{data_dir_path}'.",
-        )
-
+    check_loris_directory(env, data_dir_path, "data")
     return data_dir_path
 
 
@@ -60,22 +45,7 @@ def get_dicom_archive_dir_path_config(env: Env) -> Path:
     """
 
     dicom_archive_dir_path = Path(_get_config_value(env, 'tarchiveLibraryDir'))
-
-    if not dicom_archive_dir_path.is_dir():
-        log_error_exit(
-            env,
-            (
-                f"The LORIS DICOM archive directory path configuration value '{dicom_archive_dir_path}' does not refer"
-                " to an existing directory."
-            ),
-        )
-
-    if not os.access(dicom_archive_dir_path, os.R_OK) or not os.access(dicom_archive_dir_path, os.W_OK):
-        log_error_exit(
-            env,
-            f"Missing read or write permission on the LORIS DICOM archive directory '{dicom_archive_dir_path}'.",
-        )
-
+    check_loris_directory(env, dicom_archive_dir_path, "DICOM archive")
     return dicom_archive_dir_path
 
 
@@ -87,74 +57,65 @@ def get_default_bids_visit_label_config(env: Env) -> str | None:
     return _try_get_config_value(env, 'default_bids_vl')
 
 
-def get_eeg_viz_enabled_config(env: Env) -> bool:
+def get_ephys_visualization_enabled_config(env: Env) -> bool:
     """
-    Get whether the EEG visualization is enabled from the in-database configuration.
-    """
-
-    eeg_viz_enabled = _try_get_config_value(env, 'useEEGBrowserVisualizationComponents')
-    return eeg_viz_enabled == 'true' or eeg_viz_enabled == '1'
-
-
-def get_eeg_chunks_dir_path_config(env: Env) -> Path | None:
-    """
-    Get the EEG chunks directory path configuration value from the in-database configuration.
+    Get whether the electrophysiology visualization is enabled from the in-database configuration.
     """
 
-    eeg_chunks_path = _try_get_config_value(env, 'EEGChunksPath')
-    if eeg_chunks_path is None:
+    visualization_enabled = _try_get_config_value(env, 'useEEGBrowserVisualizationComponents')
+    return visualization_enabled == 'true' or visualization_enabled == '1'
+
+
+def get_ephys_chunks_dir_path_config(env: Env) -> Path | None:
+    """
+    Get the electrophysiology chunks directory path configuration value from the in-database
+    configuration.
+    """
+
+    ephys_chunks_path = _try_get_config_value(env, 'EEGChunksPath')
+    if ephys_chunks_path is None:
         return None
 
-    eeg_chunks_path = Path(eeg_chunks_path)
-
-    if not eeg_chunks_path.is_dir():
-        log_error_exit(
-            env,
-            (
-                f"The configuration value for the LORIS EEG chunks directory path '{eeg_chunks_path}' does not refer to"
-                " an existing directory."
-            ),
-        )
-
-    if not os.access(eeg_chunks_path, os.R_OK) or not os.access(eeg_chunks_path, os.W_OK):
-        log_error_exit(
-            env,
-            f"Missing read or write permission on the LORIS EEG chunks directory '{eeg_chunks_path}'.",
-        )
-
-    return eeg_chunks_path
+    ephys_chunks_path = Path(ephys_chunks_path)
+    check_loris_directory(env, ephys_chunks_path, "electrophysiology chunks")
+    return ephys_chunks_path
 
 
-def get_eeg_pre_package_download_dir_path_config(env: Env) -> Path | None:
+def get_ephys_archive_dir_path_config(env: Env) -> Path | None:
     """
-    Get the EEG pre-packaged download path configuration value from the in-database configuration.
+    Get the electrophysiology archive directory path configuration value from the in-database
+    configuration.
     """
 
-    eeg_pre_package_path = _try_get_config_value(env, 'prePackagedDownloadPath')
-    if eeg_pre_package_path is None:
+    ephys_archive_dir_path = _try_get_config_value(env, 'prePackagedDownloadPath')
+    if ephys_archive_dir_path is None:
         return None
 
-    eeg_pre_package_path = Path(eeg_pre_package_path)
+    ephys_archive_dir_path = Path(ephys_archive_dir_path)
+    check_loris_directory(env, ephys_archive_dir_path, "electrophysiology archive")
+    return ephys_archive_dir_path
 
-    if not eeg_pre_package_path.is_dir():
+
+def check_loris_directory(env: Env, dir_path: Path, display_name: str):
+    """
+    Check that a LORIS directory exists and is readable and writable, or exit the program with an
+    error otherwise.
+    """
+
+    if not dir_path.is_dir():
         log_error_exit(
             env,
             (
-                "The configuration value for the LORIS EEG pre-packaged download directory path"
-                f" '{eeg_pre_package_path}' does not refer to an existing directory."
+                f"The LORIS {display_name} directory path configuration value '{dir_path}' does not refer to an"
+                " existing directory."
             ),
         )
 
-    if not os.access(eeg_pre_package_path, os.R_OK) or not os.access(eeg_pre_package_path, os.W_OK):
+    if not os.access(dir_path, os.R_OK) or not os.access(dir_path, os.W_OK):
         log_error_exit(
             env,
-            (
-                "Missing read or write permission on the LORIS EEG pre-packaged download directory"
-                f" '{eeg_pre_package_path}'."
-            ),
+            f"Missing read or write permission on the {display_name} directory '{dir_path}'.",
         )
-
-    return eeg_pre_package_path
 
 
 def _get_config_value(env: Env, setting_name: str) -> str:

--- a/python/lib/database_lib/physiological_event_archive.py
+++ b/python/lib/database_lib/physiological_event_archive.py
@@ -1,6 +1,9 @@
 """This class performs database queries for the physiological_event_archive table"""
 
+from typing_extensions import deprecated
 
+
+@deprecated('Use `lib.db.physio_event_archive.DbPhysioEventArchive` instead')
 class PhysiologicalEventArchive:
 
     def __init__(self, db, verbose):
@@ -17,6 +20,7 @@ class PhysiologicalEventArchive:
         self.table = 'physiological_event_archive'
         self.verbose = verbose
 
+    @deprecated('Use `lib.db.physio_event_archive.DbPhysioEventArchive.physio_file_id` instead')
     def grep_from_physiological_file_id(self, physiological_file_id):
         """
         Gets rows given a physiological_file_id
@@ -33,6 +37,7 @@ class PhysiologicalEventArchive:
             args=(physiological_file_id,)
         )
 
+    @deprecated('Use `lib.db.physio_event_archive.DbPhysioEventArchive` instead')
     def insert(self, physiological_file_id, blake2, archive_path):
         """
         Inserts a new entry in the physiological_event_archive table.

--- a/python/lib/db/models/physio_event_archive.py
+++ b/python/lib/db/models/physio_event_archive.py
@@ -14,6 +14,6 @@ class DbPhysioEventArchive(Base):
     id             : Mapped[int]  = mapped_column('EventArchiveID', primary_key=True)
     physio_file_id : Mapped[int]  = mapped_column('PhysiologicalFileID', ForeignKey('physiological_file.PhysiologicalFileID'))
     blake2b_hash   : Mapped[str]  = mapped_column('Blake2bHash')
-    file_path      : Mapped[Path] = mapped_column('FilePath', StringPath)
+    path           : Mapped[Path] = mapped_column('FilePath', StringPath)
 
     physio_file: Mapped['db_physio_file.DbPhysioFile'] = relationship('DbPhysioFile')

--- a/python/lib/db/models/physio_file_archive.py
+++ b/python/lib/db/models/physio_file_archive.py
@@ -16,6 +16,6 @@ class DbPhysioFileArchive(Base):
     physio_file_id : Mapped[int]      = mapped_column('PhysiologicalFileID', ForeignKey('physiological_file.PhysiologicalFileID'))
     insert_time    : Mapped[datetime] = mapped_column('InsertTime', default=datetime.now)
     blake2b_hash   : Mapped[str]      = mapped_column('Blake2bHash')
-    file_path      : Mapped[Path]     = mapped_column('FilePath', StringPath)
+    path           : Mapped[Path]     = mapped_column('FilePath', StringPath)
 
     physio_file: Mapped['db_physio_file.DbPhysioFile'] = relationship('DbPhysioFile')

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -14,12 +14,12 @@ from loris_utils.crypto import compute_file_blake2b_hash
 
 import lib.exitcode
 import lib.utilities as utilities
-from lib.config import get_eeg_pre_package_download_dir_path_config, get_eeg_viz_enabled_config
-from lib.database_lib.physiological_event_archive import PhysiologicalEventArchive
+from lib.config import get_eeg_viz_enabled_config
 from lib.db.models.physio_file import DbPhysioFile
 from lib.db.models.session import DbSession
 from lib.db.queries.physio_file import try_get_physio_file_with_path
 from lib.env import Env
+from lib.import_bids_dataset.archive import import_physio_event_archive, import_physio_file_archive
 from lib.import_bids_dataset.copy_files import (
     copy_loris_bids_file,
     copy_scans_tsv_file_to_loris_bids_dir,
@@ -190,34 +190,27 @@ class Eeg:
             )
 
             # archive all files in a tar ball for downloading all files at once
-            files_to_archive: list[str] = [os.path.join(self.data_dir, eeg_file.path)]
+            files_to_archive: list[Path] = [self.data_dir / eeg_file.path]
 
             if eegjson_file_path:
-                files_to_archive.append(os.path.join(self.data_dir, eegjson_file_path))
+                files_to_archive.append(self.data_dir / eegjson_file_path)
+            if channel_file_path:
+                files_to_archive.append(self.data_dir / channel_file_path)
             if fdt_file_path:
-                files_to_archive.append(os.path.join(self.data_dir, fdt_file_path))
+                files_to_archive.append(self.data_dir / fdt_file_path)
             if electrode_file_path:
-                files_to_archive.append(os.path.join(self.data_dir, electrode_file_path))
+                files_to_archive.append(self.data_dir / electrode_file_path)
             if event_file_paths:
                 # archive all event files in a tar ball for event download
-                event_files_to_archive: list[str] = []
+                event_files_to_archive: list[Path] = []
 
                 for event_file_path in event_file_paths:
-                    files_to_archive.append(os.path.join(self.data_dir, event_file_path))
-                    event_files_to_archive.append(os.path.join(self.data_dir, event_file_path))
+                    files_to_archive.append(self.data_dir / event_file_path)
+                    event_files_to_archive.append(self.data_dir / event_file_path)
 
-                event_archive_rel_name = os.path.splitext(event_file_paths[0])[0] + ".tgz"
-                self.create_and_insert_event_archive(
-                    event_files_to_archive, event_archive_rel_name, eeg_file
-                )
+                import_physio_event_archive(self.env, eeg_file, event_files_to_archive)
 
-            if channel_file_path:
-                files_to_archive.append(os.path.join(self.data_dir, channel_file_path))
-
-            archive_rel_name = os.path.splitext(eeg_file.path)[0] + ".tgz"
-            self.create_and_insert_archive(
-                files_to_archive, archive_rel_name, eeg_file
-            )
+            import_physio_file_archive(self.env, eeg_file, files_to_archive)
 
             # create data chunks for React visualization
             if get_eeg_viz_enabled_config(self.env):
@@ -694,126 +687,3 @@ class Eeg:
 
         copy_loris_bids_file(self.info, Path(file), loris_file_path)
         return loris_file_path
-
-    def create_and_insert_archive(self, files_to_archive: list[str], archive_rel_name: str, eeg_file: DbPhysioFile):
-        """
-        Create an archive with all electrophysiology files associated to a
-        specific recording (including electrodes.tsv, channels.tsv etc...)
-        :param files_to_archive: list of files to include in the archive
-        :param archive_rel_name: path to the archive relative to data_dir
-        :param eeg_file_id     : PhysiologicalFileID
-        """
-
-        # load the Physiological object that will be used to insert the
-        # physiological archive into the database
-        physiological = Physiological(self.env, self.db, self.env.verbose)
-
-        # check if archive is on the filesystem
-        (archive_rel_name, archive_full_path) = self.get_archive_paths(archive_rel_name)
-        if os.path.isfile(archive_full_path):
-            blake2 = compute_file_blake2b_hash(archive_full_path)
-        else:
-            blake2 = None
-
-        # check if archive already inserted in database and matches the one
-        # on the filesystem using blake2b hash
-        if eeg_file.archive is not None:
-            if not blake2:
-                message = 'ERROR: no archive was found on the filesystem ' + \
-                          'while an entry was found in the database for '   + \
-                          f'PhysiologicalFileID = {eeg_file.id}'
-                print(message)
-                exit(lib.exitcode.MISSING_FILES)
-            elif eeg_file.archive.blake2b_hash != blake2:
-                message = '\nERROR: blake2b hash of ' + archive_full_path     +\
-                          ' does not match the one stored in the database.'   +\
-                          '\nblake2b of ' + archive_full_path + ': ' + blake2 +\
-                          '\nblake2b in the database: ' + eeg_file.archive.blake2b_hash
-                print(message)
-                exit(lib.exitcode.CORRUPTED_FILE)
-            else:
-                return
-
-        # create the archive directory if it does not exist
-        lib.utilities.create_dir(
-            os.path.dirname(archive_full_path),
-            self.env.verbose
-        )
-
-        # create the archive file
-        utilities.create_archive(files_to_archive, archive_full_path)
-
-        # insert the archive file in physiological_archive
-        blake2 = compute_file_blake2b_hash(archive_full_path)
-        archive_info = {
-            'PhysiologicalFileID': eeg_file.id,
-            'Blake2bHash'        : blake2,
-            'FilePath'           : archive_rel_name
-        }
-        physiological.insert_archive_file(archive_info)
-
-    def create_and_insert_event_archive(
-        self,
-        files_to_archive: list[str],
-        archive_rel_name: str,
-        eeg_file: DbPhysioFile,
-    ):
-        """
-        Create an archive with all event files associated to a specific recording
-        :param files_to_archive: list of files to include in the archive
-        :param archive_rel_name: path to the archive relative to data_dir
-        :param eeg_file     : Physiological file object
-        """
-
-        # check if archive is on the filesystem
-        (archive_rel_name, archive_full_path) = self.get_archive_paths(archive_rel_name)
-        if os.path.isfile(archive_full_path):
-            blake2 = compute_file_blake2b_hash(archive_full_path)
-        else:
-            blake2 = None
-
-        # check if archive already inserted in database and matches the one
-        # on the filesystem using blake2b hash
-        physiological_event_archive_obj = PhysiologicalEventArchive(self.db, self.env.verbose)
-
-        if eeg_file.event_archive is not None:
-            if not blake2:
-                message = '\nERROR: no archive was found on the filesystem ' + \
-                          'while an entry was found in the database for '   + \
-                          'PhysiologicalFileID = ' + str(eeg_file.id)
-                print(message)
-                exit(lib.exitcode.MISSING_FILES)
-            elif eeg_file.event_archive.blake2b_hash != blake2:
-                message = '\nERROR: blake2b hash of ' + archive_full_path     +\
-                          ' does not match the one stored in the database.'   +\
-                          '\nblake2b of ' + archive_full_path + ': ' + blake2 +\
-                          '\nblake2b in the database: ' + eeg_file.event_archive.blake2b_hash
-                print(message)
-                exit(lib.exitcode.CORRUPTED_FILE)
-            else:
-                return
-
-        # create the archive directory if it does not exist
-        lib.utilities.create_dir(
-            os.path.dirname(archive_full_path),
-            self.env.verbose
-        )
-
-        # create the archive file
-        utilities.create_archive(files_to_archive, archive_full_path)
-
-        # insert the archive into the physiological_annotation_archive table
-        blake2 = compute_file_blake2b_hash(archive_full_path)
-        physiological_event_archive_obj.insert(eeg_file.id, blake2, archive_rel_name)
-
-    def get_archive_paths(self, archive_rel_name):
-        package_path = get_eeg_pre_package_download_dir_path_config(self.env)
-        if package_path:
-            raw_package_dir = os.path.join(package_path, 'raw')
-            os.makedirs(raw_package_dir, exist_ok=True)
-            archive_rel_name = os.path.basename(archive_rel_name)
-            archive_full_path = os.path.join(raw_package_dir, archive_rel_name)
-        else:
-            archive_full_path = os.path.join(self.data_dir, archive_rel_name)
-
-        return (archive_rel_name, archive_full_path)

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -14,7 +14,7 @@ from loris_utils.crypto import compute_file_blake2b_hash
 
 import lib.exitcode
 import lib.utilities as utilities
-from lib.config import get_eeg_viz_enabled_config
+from lib.config import get_ephys_visualization_enabled_config
 from lib.db.models.physio_file import DbPhysioFile
 from lib.db.models.session import DbSession
 from lib.db.queries.physio_file import try_get_physio_file_with_path
@@ -213,7 +213,7 @@ class Eeg:
             import_physio_file_archive(self.env, eeg_file, files_to_archive)
 
             # create data chunks for React visualization
-            if get_eeg_viz_enabled_config(self.env):
+            if get_ephys_visualization_enabled_config(self.env):
                 create_physio_channels_chunks(self.env, eeg_file)
 
     def fetch_and_insert_eeg_files(self, derivatives=False, detect=True):

--- a/python/lib/import_bids_dataset/archive.py
+++ b/python/lib/import_bids_dataset/archive.py
@@ -4,7 +4,7 @@ from loris_utils.archive import create_archive_with_files
 from loris_utils.crypto import compute_file_blake2b_hash
 from loris_utils.path import remove_path_extension
 
-from lib.config import get_data_dir_path_config, get_eeg_pre_package_download_dir_path_config
+from lib.config import get_data_dir_path_config, get_ephys_archive_dir_path_config
 from lib.db.models.physio_event_archive import DbPhysioEventArchive
 from lib.db.models.physio_file import DbPhysioFile
 from lib.db.models.physio_file_archive import DbPhysioFileArchive
@@ -70,7 +70,7 @@ def get_archive_path(env: Env, file_path: Path) -> Path:
     """
 
     archive_rel_path = remove_path_extension(file_path).with_suffix('.tgz')
-    archive_dir_path = get_eeg_pre_package_download_dir_path_config(env)
+    archive_dir_path = get_ephys_archive_dir_path_config(env)
     if archive_dir_path is not None:
         data_dir_path = get_data_dir_path_config(env)
         return (archive_dir_path / 'raw' / archive_rel_path.name).relative_to(data_dir_path)

--- a/python/lib/import_bids_dataset/archive.py
+++ b/python/lib/import_bids_dataset/archive.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+from loris_utils.archive import create_archive_with_files
+from loris_utils.crypto import compute_file_blake2b_hash
+from loris_utils.path import remove_path_extension
+
+from lib.config import get_data_dir_path_config, get_eeg_pre_package_download_dir_path_config
+from lib.db.models.physio_event_archive import DbPhysioEventArchive
+from lib.db.models.physio_file import DbPhysioFile
+from lib.db.models.physio_file_archive import DbPhysioFileArchive
+from lib.env import Env
+
+
+def import_physio_file_archive(env: Env, physio_file: DbPhysioFile, file_paths: list[Path]):
+    """
+    Create and import a physiological file archive into LORIS.
+    """
+
+    archive_rel_path = get_archive_path(env, physio_file.path)
+
+    data_dir_path = get_data_dir_path_config(env)
+    archive_path = data_dir_path / archive_rel_path
+    if archive_path.exists():
+        raise Exception(f"Archive '{archive_rel_path}' already exists on the file system.")
+
+    archive_path.parent.mkdir(exist_ok=True)
+
+    create_archive_with_files(archive_path, file_paths)
+
+    blake2b_hash = compute_file_blake2b_hash(archive_path)
+
+    env.db.add(DbPhysioFileArchive(
+        physio_file_id = physio_file.id,
+        path           = archive_rel_path,
+        blake2b_hash   = blake2b_hash,
+    ))
+
+    env.db.flush()
+
+
+def import_physio_event_archive(env: Env, physio_file: DbPhysioFile, file_paths: list[Path]):
+    """
+    Create and import a physiological event archive into LORIS. The name of the archive is based on
+    the first file path provided.
+    """
+
+    data_dir_path = get_data_dir_path_config(env)
+    archive_rel_path = remove_path_extension(file_paths[0].relative_to(data_dir_path)).with_suffix('.tgz')
+
+    archive_path = data_dir_path / archive_rel_path
+    if archive_path.exists():
+        raise Exception(f"Event archive '{archive_rel_path}' already exists on the file system.")
+
+    create_archive_with_files(archive_path, file_paths)
+
+    blake2b_hash = compute_file_blake2b_hash(archive_path)
+
+    env.db.add(DbPhysioEventArchive(
+        physio_file_id = physio_file.id,
+        path           = archive_rel_path,
+        blake2b_hash   = blake2b_hash,
+    ))
+
+    env.db.flush()
+
+
+def get_archive_path(env: Env, file_path: Path) -> Path:
+    """
+    Get the path of a physiological file archive relative to the LORIS data directory.
+    """
+
+    archive_rel_path = remove_path_extension(file_path).with_suffix('.tgz')
+    archive_dir_path = get_eeg_pre_package_download_dir_path_config(env)
+    if archive_dir_path is not None:
+        data_dir_path = get_data_dir_path_config(env)
+        return (archive_dir_path / 'raw' / archive_rel_path.name).relative_to(data_dir_path)
+    else:
+        return archive_rel_path

--- a/python/lib/physio/chunking.py
+++ b/python/lib/physio/chunking.py
@@ -3,7 +3,7 @@ import subprocess
 from loris_utils.path import get_path_stem
 
 import lib.exitcode
-from lib.config import get_data_dir_path_config, get_eeg_chunks_dir_path_config
+from lib.config import get_data_dir_path_config, get_ephys_chunks_dir_path_config
 from lib.db.models.physio_file import DbPhysioFile
 from lib.db.queries.physio_parameter import try_get_physio_file_parameter_with_file_id_name
 from lib.env import Env
@@ -94,11 +94,11 @@ def get_dataset_chunks_dir_path(env: Env, physio_file: DbPhysioFile):
 
     # The first part of the physiological file path is assumed to be the BIDS imports directory
     # name. The second part of the physiological file path is assumed to be the dataset name.
-    eeg_chunks_dir_path = get_eeg_chunks_dir_path_config(env)
-    if eeg_chunks_dir_path is None:
+    ephys_chunks_dir_path = get_ephys_chunks_dir_path_config(env)
+    if ephys_chunks_dir_path is None:
         data_dir_path = get_data_dir_path_config(env)
-        eeg_chunks_dir_path = data_dir_path / physio_file.path.parts[0]
+        ephys_chunks_dir_path = data_dir_path / physio_file.path.parts[0]
 
-    eeg_chunks_path = eeg_chunks_dir_path / f'{physio_file.path.parts[1]}_chunks'
+    eeg_chunks_path = ephys_chunks_dir_path / f'{physio_file.path.parts[1]}_chunks'
     eeg_chunks_path.mkdir(exist_ok=True)
     return eeg_chunks_path

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -774,25 +774,3 @@ class Physiological:
                     )
         # insert blake2b hash of task event file into physiological_parameter_file
         insert_physio_file_parameter(self.env, physiological_file, 'event_file_blake2b_hash', blake2)
-
-    def insert_archive_file(self, archive_info):
-        """
-        Inserts the archive file of all physiological files (including
-        electrodes.tsv, channels.tsv and events.tsv) in the
-        physiological_archive table of the database.
-
-        :param archive_info: dictionary with key/value pairs to insert
-         :type archive_info: dict
-        """
-
-        # insert the archive into the physiological_archive table
-        archive_fields = ()
-        archive_values = ()
-        for key, value in archive_info.items():
-            archive_fields = (*archive_fields, key)
-            archive_values = (*archive_values, value)
-        self.db.insert(
-            table_name   = 'physiological_archive',
-            column_names = archive_fields,
-            values       = archive_values
-        )

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -137,6 +137,7 @@ def create_dir(dir_name, verbose):
     return dir_name
 
 
+@deprecated('Use `loris_utils.archive.create_archive_with_files` instead')
 def create_archive(files_to_archive, archive_path):
     """
     Creates an archive with the files listed in the files_to_archive tuple.

--- a/python/loris_utils/src/loris_utils/archive.py
+++ b/python/loris_utils/src/loris_utils/archive.py
@@ -1,0 +1,13 @@
+import tarfile
+from pathlib import Path
+
+
+def create_archive_with_files(archive_path: Path, file_paths: list[Path]):
+    """
+    Create a tar archive with the provided files. Files are added to the archive using their base
+    name, so the name of the provided files should all be distinct.
+    """
+
+    with tarfile.open(archive_path, 'w:gz') as tar:
+        for file_path in file_paths:
+            tar.add(file_path, arcname=file_path.name)

--- a/python/tests/integration/scripts/test_import_bids_dataset.py
+++ b/python/tests/integration/scripts/test_import_bids_dataset.py
@@ -37,7 +37,15 @@ def test_import_eeg_bids_dataset():
         db,
         Path('bids_imports/Face13_BIDSVersion_1.1.0/sub-OTT166/ses-V1/eeg/sub-OTT166_ses-V1_task-faceO_eeg.edf'),
     )
+
     assert file is not None
+    assert file.archive is not None
+    assert file.event_archive is not None
+
+    assert file.archive.path == \
+        Path('bids_imports/Face13_BIDSVersion_1.1.0/sub-OTT166/ses-V1/eeg/sub-OTT166_ses-V1_task-faceO_eeg.tgz')
+    assert file.event_archive.path == \
+        Path('bids_imports/Face13_BIDSVersion_1.1.0/sub-OTT166/ses-V1/eeg/sub-OTT166_ses-V1_task-faceO_events.tgz')
 
     # Check that the physiological file parameters has been inserted in the database.
     file_parameters = get_physio_file_parameters_dict(db, file.id)


### PR DESCRIPTION
Builds on top of #1393 ([diff](https://github.com/MaximeBICMTL/LORIS-MRI/compare/typed-physio-archives...MaximeBICMTL:LORIS-MRI:factorize-check-dir-config))

## Description

In the `lib.config` module, many functions get LORIS-specific directories and check their existence/permissions. There is a lot of repeated code here, that this PR factorizes. This PR also renames some electrophysiology-related configuration directory functions for better clarity (notably `eeg` -> `ephys` since those are also used by MEG).