### PR TITLE
Add optional uv configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,14 @@ packages = [
     "python/tests",
 ]
 
+[tool.uv.workspace]
+members = ["python/loris_*"]
+
+[tool.uv.sources]
+loris_bids_reader = { workspace = true }
+loris_eeg_chunker = { workspace = true }
+loris_utils       = { workspace = true }
+
 [tool.ruff]
 src = ["python"]
 include = ["python/**/*.py"]
@@ -71,7 +79,6 @@ max-doc-length = 100
 # `test` directory.
 [tool.pyright]
 include = [
-    "python/loris_eeg_chunker",
     "python/tests",
     "python/lib/db",
     "python/lib/imaging_lib",
@@ -87,6 +94,7 @@ include = [
     "python/scripts/import_dicom_study.py",
     "python/scripts/summarize_dicom_study.py",
     "python/loris_bids_reader",
+    "python/loris_eeg_chunker",
     "python/loris_utils",
 ]
 exclude = [


### PR DESCRIPTION
Part of #1339

## Description

This PR adds an optional uv configuration to LORIS Python. [uv](https://docs.astral.sh/uv/) is a third-party Python package manager by Astral-sh that has been gaining a lot of popularity in recent years due to its speed and convenience for working in multi-package projects (most notably, the ability to install all project packages in editable mode).

Adding an uv configuration to LORIS Python is just a convenience for uv users. It does **not** replace the usual pip-based workflow, which is still used in CI and must continue to be the preferred installation method.

## Testing

To do a full test of package installation with uv, do the following:
1. Install uv (refer to the official documentation)
2. Run the following commands in the LORIS Python root directory.

```sh
deactivate # Deactivate the LORIS Python virtual environment
rm -r .venv  # Delete the LORIS Python virtual environment
python3.11 -m venv .venv --prompt loris  # Recreate the LORIS Python virtual environment
source .venv/bin/activate  # Activate the new LORIS Python virtual environment
uv pip install -e .  # Re-install LORIS Python, including dependencies and all LORIS Python packages in editable mode
```

## Next step

Document all the packaging process and possibilities!