### PR TITLE
Miscellaneous DICOM to BIDS code improvements

### DIFF
--- a/python/lib/database_lib/files.py
+++ b/python/lib/database_lib/files.py
@@ -76,6 +76,7 @@ class Files:
 
         return results[0] if results else None
 
+    @deprecated('Use `lib.db.queries.try_get_file_with_hash` instead.')
     def find_file_with_hash(self, file_hash):
         """
         Select files stored in the `files` table with a given hash stored in `parameter_file`.
@@ -183,6 +184,7 @@ class Files:
 
         return self.db.pselect(query=query, args=(tarchive_id, scan_type_id, "series_number"))
 
+    @deprecated('Use `lib.db.models.dicom_archive.DbDicomArchive.mri_files` instead.')
     def get_files_inserted_for_tarchive_id(self, tarchive_id):
         """
         Get the list of files that were inserted into the `files` table for a given `TarchiveID`.
@@ -199,6 +201,7 @@ class Files:
 
         return self.db.pselect(query=query, args=(tarchive_id,))
 
+    @deprecated('Use `lib.db.models.session.DbSession.files` instead.')
     def get_files_inserted_for_session_id(self, session_id):
         """
         Get the list of files that were inserted into the `files` table for a given `SessionID`.

--- a/python/lib/database_lib/mri_scan_type.py
+++ b/python/lib/database_lib/mri_scan_type.py
@@ -1,6 +1,9 @@
 """This class performs database queries for the site mri_scan_type table"""
 
+from typing_extensions import deprecated
 
+
+@deprecated('Use `lib.db.models.mri_scan_type.DbMriScanType` instead.')
 class MriScanType:
     """
     This class performs database queries for imaging dataset stored in the mri_scan_type table.
@@ -32,6 +35,7 @@ class MriScanType:
         self.db = db
         self.verbose = verbose
 
+    @deprecated('Use `lib.db.queries.mri_scan_type.try_get_mri_scan_type_with_id` instead.')
     def get_scan_type_name_from_id(self, scan_type_id):
         """
         Get a scan type name based on a scan type ID.
@@ -50,6 +54,7 @@ class MriScanType:
 
         return results[0]['MriScanTypeName'] if results else None
 
+    @deprecated('Use `lib.db.queries.mri_scan_type.try_get_mri_scan_type_with_name` instead.')
     def get_scan_type_id_from_name(self, scan_type_name):
         """
         Get a scan type ID based on a scan type name.

--- a/python/lib/db/models/dicom_archive.py
+++ b/python/lib/db/models/dicom_archive.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 import lib.db.models.dicom_archive_file as db_dicom_archive_file
 import lib.db.models.dicom_archive_series as db_dicom_archive_series
+import lib.db.models.file as db_file
 import lib.db.models.mri_protocol_violated_scan as db_mri_protocol_violated_scan
 import lib.db.models.mri_upload as db_mri_upload
 import lib.db.models.mri_violation_log as db_mri_violation_log
@@ -39,8 +40,6 @@ class DbDicomArchive(Base):
     creating_user            : Mapped[str]             = mapped_column('CreatingUser')
     sum_type_version         : Mapped[int]             = mapped_column('sumTypeVersion')
     tar_type_version         : Mapped[int | None]      = mapped_column('tarTypeVersion')
-    source_path              : Mapped[Path]            = mapped_column('SourceLocation', StringPath)
-    archive_path             : Mapped[Path | None]     = mapped_column('ArchiveLocation', StringPath)
     scanner_manufacturer     : Mapped[str]             = mapped_column('ScannerManufacturer')
     scanner_model            : Mapped[str]             = mapped_column('ScannerModel')
     scanner_serial_number    : Mapped[str]             = mapped_column('ScannerSerialNumber')
@@ -51,6 +50,16 @@ class DbDicomArchive(Base):
     acquisition_metadata     : Mapped[str]             = mapped_column('AcquisitionMetadata')
     date_sent                : Mapped[datetime | None] = mapped_column('DateSent')
     pending_transfer         : Mapped[bool]            = mapped_column('PendingTransfer', IntBool)
+
+    source_path: Mapped[Path] = mapped_column('SourceLocation', StringPath)
+    """
+    The path of the source DICOM study directory from which this DICOM archive was imported.
+    """
+
+    path: Mapped[Path | None] = mapped_column('ArchiveLocation', StringPath)
+    """
+    The path of this DICOM archive relative to the LORIS DICOM archive directory.
+    """
 
     series      : Mapped[list['db_dicom_archive_series.DbDicomArchiveSeries']] \
         = relationship('DbDicomArchiveSeries', back_populates='archive')
@@ -64,3 +73,8 @@ class DbDicomArchive(Base):
         = relationship('DbMriProtocolViolatedScan', back_populates='archive')
     violations_log       : Mapped[list['db_mri_violation_log.DbMriViolationLog']] \
         = relationship('DbMriViolationLog', back_populates='archive')
+
+    mri_files: Mapped[list['db_file.DbFile']] = relationship('DbFile', back_populates='dicom_archive')
+    """
+    The volumetric MRI files (NIfTI or MINC) generated from this DICOM archive.
+    """

--- a/python/lib/db/models/file.py
+++ b/python/lib/db/models/file.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+import lib.db.models.dicom_archive as db_dicom_archive
 import lib.db.models.file_parameter as db_file_parameter
 import lib.db.models.session as db_session
 from lib.db.base import Base
@@ -33,13 +34,23 @@ class DbFile(Base):
     source_file_id                 : Mapped[int | None]   = mapped_column('SourceFileID')
     process_protocol_id            : Mapped[int | None]   = mapped_column('ProcessProtocolID')
     caveat                         : Mapped[bool | None]  = mapped_column('Caveat', IntBool)
-    dicom_archive_id               : Mapped[int | None]   = mapped_column('TarchiveSource')
+    dicom_archive_id               : Mapped[int | None]   = mapped_column('TarchiveSource', ForeignKey('tarchive.TarchiveID'))
     hrrt_archive_id                : Mapped[int | None]   = mapped_column('HrrtArchiveID')
     scanner_id                     : Mapped[int | None]   = mapped_column('ScannerID')
     acquisition_order_per_modality : Mapped[int | None]   = mapped_column('AcqOrderPerModality')
     acquisition_date               : Mapped[date | None]  = mapped_column('AcquisitionDate')
 
-    session    : Mapped['db_session.DbSession'] \
-        = relationship('DbSession', back_populates='files')
-    parameters : Mapped[list['db_file_parameter.DbFileParameter']] \
-        = relationship('DbFileParameter', back_populates='file')
+    session: Mapped['db_session.DbSession'] = relationship('DbSession', back_populates='files')
+    """
+    The session to which this file belongs.
+    """
+
+    parameters: Mapped[list['db_file_parameter.DbFileParameter']] = relationship('DbFileParameter', back_populates='file')
+    """
+    The parameters attached to this file.
+    """
+
+    dicom_archive: Mapped['db_dicom_archive.DbDicomArchive | None'] = relationship('DbDicomArchive', back_populates='mri_files')
+    """
+    The source DICOM archive from which this file was generated.
+    """

--- a/python/lib/db/models/meg_ctf_head_shape_file.py
+++ b/python/lib/db/models/meg_ctf_head_shape_file.py
@@ -15,7 +15,7 @@ class DbMegCtfHeadShapeFile(Base):
 
     __tablename__ = 'meg_ctf_head_shape_file'
 
-    id: Mapped[int]  = mapped_column('ID', primary_key=True)
+    id: Mapped[int] = mapped_column('ID', primary_key=True)
     """
     ID of the head shape file.
     """

--- a/python/lib/db/queries/dicom_archive.py
+++ b/python/lib/db/queries/dicom_archive.py
@@ -38,7 +38,7 @@ def try_get_dicom_archive_with_archive_path(db: Database, archive_path: Path) ->
     """
 
     return db.execute(select(DbDicomArchive)
-        .where(DbDicomArchive.archive_path.like(f'%{archive_path}%'))
+        .where(DbDicomArchive.path.like(f'%{archive_path}%'))
     ).scalar_one_or_none()
 
 

--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -150,7 +150,7 @@ class BasePipeline:
                 )
 
             self.dicom_archive = self.mri_upload.dicom_archive
-            if os.path.join(self.data_dir, 'tarchive', self.dicom_archive.archive_path) != tarchive_path:
+            if os.path.join(self.data_dir, 'tarchive', self.dicom_archive.path) != tarchive_path:
                 log_error_exit(
                     self.env,
                     f"UploadID {upload_id} and ArchiveLocation {tarchive_path} do not refer to the same upload",

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -36,9 +36,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         super().__init__(loris_getopt_obj, script_name)
         self.init_session_info()
         self.series_uid = self.options_dict["series_uid"]["value"]
-        self.tarchive_path = os.path.join(
-            self.data_dir, "tarchive", self.dicom_archive.archive_path
-        )
+        self.tarchive_path = os.path.join(self.data_dir, "tarchive", self.dicom_archive.path)
 
         # ------------------------------------------------------------------------------------------
         # Run the DICOM archive validation script to check if the DICOM archive is valid
@@ -49,7 +47,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         # Extract DICOM files from the tarchive
         # ------------------------------------------------------------------------------------------
         self.extracted_dicom_dir = self.imaging_obj.extract_files_from_dicom_archive(
-            os.path.join(self.data_dir, 'tarchive', self.dicom_archive.archive_path),
+            os.path.join(self.data_dir, 'tarchive', self.dicom_archive.path),
             self.tmp_dir
         )
 
@@ -342,7 +340,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         """
 
         acq_date = self.dicom_archive.date_acquired
-        archive_location = str(self.dicom_archive.archive_path)
+        archive_location = str(self.dicom_archive.path)
 
         pattern = re.compile(r"^[0-9]{4}/")
         if acq_date and not pattern.match(archive_location):
@@ -357,7 +355,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
             os.replace(self.tarchive_path, new_tarchive_path)
             self.tarchive_path = new_tarchive_path
             # add the new archive location to the list of fields to update in the tarchive table
-            self.dicom_archive.archive_path = Path(new_archive_location)
+            self.dicom_archive.path = Path(new_archive_location)
 
         self.dicom_archive.session = self.session
 
@@ -420,12 +418,10 @@ class DicomArchiveLoaderPipeline(BasePipeline):
             - `SessionID`              => `SessionID` associated to the upload
         """
 
-        files_inserted_list = self.imaging_obj.files_db_obj.get_files_inserted_for_tarchive_id(self.dicom_archive.id)
-
         # Update the MRI upload.
         self.mri_upload.inserting = False
         self.mri_upload.insertion_complete = True
-        self.mri_upload.number_of_minc_inserted = len(files_inserted_list)
+        self.mri_upload.number_of_minc_inserted = len(self.dicom_archive.mri_files)
         self.mri_upload.number_of_minc_created = len(self.nifti_files_to_insert)
         self.mri_upload.session = self.session
         self.env.db.commit()
@@ -441,8 +437,6 @@ class DicomArchiveLoaderPipeline(BasePipeline):
             - path to the log file
         """
 
-        files_results = self.imaging_obj.files_db_obj.get_files_inserted_for_tarchive_id(self.dicom_archive.id)
-        files_inserted_list = [v["File"] for v in files_results] if files_results else None
         prot_viol_results = self.imaging_obj.mri_prot_viol_scan_db_obj.get_protocol_violations_for_tarchive_id(
             self.dicom_archive.id
         )
@@ -452,17 +446,21 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         )
         excluded_violations_list = [v["MincFile"] for v in excl_viol_results] if excl_viol_results else None
 
-        nb_files_inserted = len(files_inserted_list) if files_inserted_list else 0
+        nb_files_inserted = len(self.dicom_archive.mri_files)
         nb_prot_violation = len(protocol_violations_list) if protocol_violations_list else 0
         nb_excluded_viol = len(excluded_violations_list) if excluded_violations_list else 0
 
-        files_list = ', '.join(files_inserted_list) if files_inserted_list else 0
+        if self.dicom_archive.mri_files != []:
+            files_list = ', '.join([str(file.path) for file in self.dicom_archive.mri_files])
+        else:
+            files_list = '0'
+
         prot_viol_list = ', '.join(protocol_violations_list) if protocol_violations_list else 0
         excl_viol_list = ', '.join(excluded_violations_list) if excluded_violations_list else 0
 
         summary = f"""
         Finished processing UploadID {self.mri_upload.id}!
-        - DICOM archive info: {self.dicom_archive.id} => {self.tarchive_path}
+        - DICOM archive info: {self.dicom_archive.id} => {self.dicom_archive.path}
         - {nb_files_inserted} files were inserted into the files table: {files_list}
         - {nb_prot_violation} files did not match any protocol: {prot_viol_list}
         - {nb_excluded_viol} files were exclusionary violations: {excl_viol_list}

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_validation_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_validation_pipeline.py
@@ -54,7 +54,7 @@ class DicomValidationPipeline(BasePipeline):
 
         log_verbose(self.env, "Verifying DICOM archive md5sum (checksum)")
 
-        dicom_archive_path = os.path.join(self.dicom_lib_dir, self.dicom_archive.archive_path)
+        dicom_archive_path = os.path.join(self.dicom_lib_dir, self.dicom_archive.path)
         result = _validate_dicom_archive_md5sum(self.env, self.dicom_archive, dicom_archive_path)
         if not result:
             # Update the MRI upload.

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -11,6 +11,7 @@ from loris_utils.crypto import compute_file_blake2b_hash, compute_file_md5_hash
 
 import lib.exitcode
 from lib.db.queries.dicom_archive import try_get_dicom_archive_series_with_series_uid_echo_time
+from lib.db.queries.file import try_get_file_with_hash
 from lib.db.queries.mri_scan_type import try_get_mri_scan_type_with_id, try_get_mri_scan_type_with_name
 from lib.dcm2bids_imaging_pipeline_lib.base_pipeline import BasePipeline
 from lib.get_session_info import SessionConfigError, get_dicom_archive_session_info
@@ -340,18 +341,18 @@ class NiftiInsertionPipeline(BasePipeline):
                     error_msg = f"Found a DICOM archive containing DICOM files with the same SeriesUID ({series_uid})" \
                                 f" and EchoTime ({tar_echo_time}) as the one present in the JSON side car file. " \
                                 f" The DICOM archive location containing those DICOM files is " \
-                                f" {self.dicom_archive.archive_path}. Please, rerun " \
+                                f" {self.dicom_archive.path}. Please, rerun " \
                                 f" <run_nifti_insertion.py> with either --upload_id or --tarchive_path option."
 
         # verify that a file with the same MD5 or blake2b hash has not already been inserted
-        md5_match = self.imaging_obj.grep_file_info_from_hash(self.nifti_md5)
-        blake2b_match = self.imaging_obj.grep_file_info_from_hash(self.nifti_blake2)
-        if md5_match:
+        md5_match = try_get_file_with_hash(self.env.db, self.nifti_md5)
+        blake2b_match = try_get_file_with_hash(self.env.db, self.nifti_blake2)
+        if md5_match is not None:
             error_msg = f"There is already a file registered in the files table with MD5 hash {self.nifti_md5}." \
-                        f" The already registered file is {md5_match['File']}"
-        elif blake2b_match:
+                        f" The already registered file is {md5_match.path}"
+        elif blake2b_match is not None:
             error_msg = f"There is already a file registered in the files table with Blake2b hash {self.nifti_blake2}."\
-                        f" The already registered file is {blake2b_match['File']}"
+                        f" The already registered file is {blake2b_match.path}"
 
         if error_msg:
             log_error_exit(self.env, error_msg, lib.exitcode.FILE_NOT_UNIQUE)
@@ -452,10 +453,8 @@ class NiftiInsertionPipeline(BasePipeline):
         bids_subfolder = self.bids_categories_dict['BIDSCategoryName']
 
         # determine NIfTI file name
+        already_inserted_filenames = [file.path.name for file in self.session.files]
         new_nifti_name = self._construct_nifti_filename(file_bids_entities_dict)
-        already_inserted_filenames = self.imaging_obj.get_list_of_files_already_inserted_for_session_id(
-            self.session.id,
-        )
         while new_nifti_name in already_inserted_filenames:
             file_bids_entities_dict['run'] += 1
             new_nifti_name = self._construct_nifti_filename(file_bids_entities_dict)

--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -3,6 +3,7 @@ import re
 import sys
 
 from loris_utils.fs import remove_empty_directories
+from sqlalchemy import inspect
 
 import lib.exitcode
 from lib.dcm2bids_imaging_pipeline_lib.base_pipeline import BasePipeline
@@ -95,17 +96,18 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         Get the list of files associated to the TarchiveID present in the files table.
         """
 
-        file_entries = self.imaging_obj.files_db_obj.get_files_inserted_for_tarchive_id(self.dicom_archive.id)
-        for file in file_entries:
-            if file['File'].startswith('s3://'):
+        for file in self.dicom_archive.mri_files:
+            # Get the raw path of that file, without converting it to a Python path object.
+            raw_path: str = inspect(file).attrs.path.loaded_value
+            if raw_path.startswith('s3://'):
                 # skip since file already pushed to S3
                 continue
             self.files_to_push_list.append({
                 "table_name": "files",
                 "id_field_name": "FileID",
-                "id_field_value": file["FileID"],
+                "id_field_value": file.id,
                 "file_path_field_name": "File",
-                "original_file_path_field_value": file["File"]
+                "original_file_path_field_value": raw_path
             })
 
     def _get_list_of_files_from_parameter_file(self):
@@ -269,7 +271,6 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
 
         # remove empty folders from file system
         print("Cleaning up empty folders")
-        bids_cand_id = f"sub-{self.session.candidate.cand_id}"
-        remove_empty_directories(os.path.join(self.data_dir, "assembly_bids", bids_cand_id))
-        remove_empty_directories(os.path.join(self.data_dir, "pic", str(self.session.candidate.cand_id)))
-        remove_empty_directories(os.path.join(self.data_dir, "trashbin"))
+        remove_empty_directories(self.data_dir / 'assembly_bids' / f'sub-{self.session.candidate.cand_id}')
+        remove_empty_directories(self.data_dir / 'pic' / str(self.session.candidate.cand_id))
+        remove_empty_directories(self.data_dir / 'trashbin')

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -101,6 +101,7 @@ class Imaging:
 
         return file_type
 
+    @deprecated('Use `lib.db.queries.try_get_file_with_hash` instead.')
     def grep_file_info_from_hash(self, hash_string):
         """
         Greps the file ID from the files table. If it cannot be found, the method will return None.
@@ -466,6 +467,7 @@ class Imaging:
         if param_type_id:
             return self.param_file_db_obj.get_parameter_file_for_file_id_param_type_id(file_id, param_type_id)
 
+    @deprecated('Use `lib.db.models.file.DbFile.file_type` instead.')
     def grep_file_type_from_file_id(self, file_id):
         """
         Greps the file type stored in the files table using its FileID.
@@ -484,6 +486,7 @@ class Imaging:
         # return the result
         return results[0]['FileType'] if results else None
 
+    @deprecated('Use `lib.db.models.file.DbFile.path` instead.')
     def grep_file_path_from_file_id(self, file_id):
         """
         Greps the file path stored in the files table using its FileID.
@@ -502,6 +505,7 @@ class Imaging:
         # return the result
         return results[0]['File'] if results else None
 
+    @deprecated('Use `lib.db.models.file.DbFile.candidate.cand_id` instead.')
     def grep_cand_id_from_file_id(self, file_id):
         """
         Greps the CandID using the file's FileID.
@@ -887,6 +891,7 @@ class Imaging:
 
         return sorted_fmap_files_dict
 
+    @deprecated('Use `lib.db.models.dicom_archive.DbDicomArchive.mri_files` instead.')
     def get_list_of_files_already_inserted_for_tarchive_id(self, tarchive_id):
         """
         Get the list of filenames already inserted for a given TarchiveID.
@@ -907,6 +912,7 @@ class Imaging:
 
         return files_list
 
+    @deprecated('Use `lib.db.models.session.DbSession.files` instead.')
     def get_list_of_files_already_inserted_for_session_id(self, session_id):
         """
         Get the list of filenames already inserted for a given SessionID.

--- a/python/lib/import_dicom_study/dicom_database.py
+++ b/python/lib/import_dicom_study/dicom_database.py
@@ -85,7 +85,7 @@ def populate_dicom_archive(
     dicom_archive.sum_type_version         = dicom_import_log.summary_version
     dicom_archive.tar_type_version         = dicom_import_log.archive_version
     dicom_archive.source_path              = dicom_import_log.source_path
-    dicom_archive.archive_path             = archive_path
+    dicom_archive.path                     = archive_path
     dicom_archive.scanner_manufacturer     = dicom_summary.info.scanner.manufacturer or ''
     dicom_archive.scanner_model            = dicom_summary.info.scanner.model or ''
     dicom_archive.scanner_serial_number    = dicom_summary.info.scanner.serial_number or ''

--- a/python/loris_utils/src/loris_utils/fs.py
+++ b/python/loris_utils/src/loris_utils/fs.py
@@ -1,4 +1,3 @@
-import os
 import re
 import tarfile
 import tempfile
@@ -35,23 +34,27 @@ def iter_all_dir_files(dir_path: Path) -> Iterator[Path]:
             yield item_path.relative_to(dir_path)
 
 
-def is_directory_empty(dir_path: str) -> bool:
+def is_directory_empty(dir_path: Path) -> bool:
     """
     Check whether a directory is empty or not.
     """
 
-    with os.scandir(dir_path) as dir_iterator:
-        return next(dir_iterator, None) is None
+    return next(dir_path.iterdir(), None) is None
 
 
-def remove_empty_directories(dir_path: str):
+def remove_empty_directories(dir_path: Path):
     """
     Recursively remove all the empty directories in a directory, including itself if needed.
     """
 
-    for subdir_path, _, _ in os.walk(dir_path, topdown=False):
-        if is_directory_empty(subdir_path):
-            os.rmdir(subdir_path)
+    for sub_path in dir_path.iterdir():
+        if not sub_path.is_dir():
+            continue
+
+        remove_empty_directories(sub_path)
+
+    if is_directory_empty(dir_path):
+        dir_path.rmdir()
 
 
 def search_dir_file_with_regex(dir_path: Path, regex: str) -> Path | None:

--- a/python/tests/integration/scripts/test_run_dicom_archive_loader.py
+++ b/python/tests/integration/scripts/test_run_dicom_archive_loader.py
@@ -99,7 +99,7 @@ def test_successful_run_on_valid_tarchive_path():
     assert mri_upload.dicom_archive is not None
     assert mri_upload.dicom_archive.session is not None
     # check that archive location has been updated
-    assert mri_upload.dicom_archive.archive_path == archive_new_path
+    assert mri_upload.dicom_archive.path == archive_new_path
     # check series/files counts
     # notes: - tarchive_series should have 2 series for this upload (localizer + T1W)
     #        - localizer is skipped from conversion because of config settings


### PR DESCRIPTION
## Description

Various minor code improvements, notably in the DICOM to BIDS pipeline.

## List of changes

- Use ORM relations instead of small queries.
- Add some comments in the ORM.
- Rename `dicom_archive.archive_path` to `dicom_archive.path` (note that this attribute was named `dicom_archive.archive_location` in LORIS Python 27).
- Deprecate a bunch of stuff in the old database abstraction and the `Imaging` class (some were unused but not deprecated yet).
- Convert the `loris_utils.fs.is_directory_empty` and `loris_utils.fs.remove_empty_directories` functions  to `pathlib.Path`.