### PR TITLE
Clean up Python and static tests CI

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -11,9 +11,13 @@ runs:
   - name: Set up the Python environment
     uses: actions/setup-python@v5
     with:
-      python-version: ${{ matrix.python-version }}
+      python-version: '3.11'
       cache: 'pip'
 
-  - name: Install Python dependencies
-    run: pip install .[dev]
+  - name: Install Python project
     shell: bash
+    run: |
+      pip install --no-cache-dir --editable .[dev] && \
+      for pkg in python/loris_*; do \
+          pip install --no-cache-dir --no-deps --editable "$pkg"; \
+      done

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,4 +1,4 @@
-name: Python checks
+name: Static tests
 
 on:
   pull_request:
@@ -11,12 +11,8 @@ on:
 
 jobs:
   ruff:
-    name: Lints
+    name: Ruff
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
 
     steps:
     - name: Check out LORIS-MRI
@@ -24,19 +20,12 @@ jobs:
 
     - name: Set up Python
       uses: ./.github/actions/setup-python
-      with:
-        python-version: ${{ matrix.python-version }}
-
     - name: Run Ruff
       run: ruff check --output-format=github
 
   pyright-strict:
-    name: Strict type checks
+    name: Pyright strict
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
 
     steps:
     - name: Check out LORIS-MRI
@@ -44,20 +33,15 @@ jobs:
 
     - name: Set up Python
       uses: ./.github/actions/setup-python
-      with:
-        python-version: ${{ matrix.python-version }}
 
     - name: Run Pyright
       run: |
+        set -o pipefail
         pyright --outputjson | test/pyright_to_github.sh
 
   pyrigh-global:
-    name: Global type checks
+    name: Pyright global
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
 
     steps:
     - name: Check out LORIS-MRI
@@ -65,28 +49,22 @@ jobs:
 
     - name: Set up Python
       uses: ./.github/actions/setup-python
-      with:
-        python-version: ${{ matrix.python-version }}
 
     - name: Run Pyright
-      run: pyright --project test --outputjson | test/pyright_to_github.sh
+      run: |
+        set -o pipefail
+        pyright --project test --outputjson | test/pyright_to_github.sh
 
   pytest:
     name: Unit tests
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
-
     steps:
     - name: Check out LORIS-MRI
       uses: actions/checkout@v4
 
     - name: Set up Python
       uses: ./.github/actions/setup-python
-      with:
-        python-version: ${{ matrix.python-version }}
 
     - name: Run Pytest
       run: pytest python/tests/unit

--- a/python/loris_utils/src/loris_utils/error.py
+++ b/python/loris_utils/src/loris_utils/error.py
@@ -24,8 +24,6 @@ def group_errors(message: str, functions: Iterable[Callable[[], T]]) -> list[T]:
     return results
 
 
-i: str = 100
-
 T1 = TypeVar('T1')
 T2 = TypeVar('T2')
 T3 = TypeVar('T3')

--- a/python/loris_utils/src/loris_utils/error.py
+++ b/python/loris_utils/src/loris_utils/error.py
@@ -24,6 +24,8 @@ def group_errors(message: str, functions: Iterable[Callable[[], T]]) -> list[T]:
     return results
 
 
+i: str = 100
+
 T1 = TypeVar('T1')
 T2 = TypeVar('T2')
 T3 = TypeVar('T3')

--- a/test/mri.Dockerfile
+++ b/test/mri.Dockerfile
@@ -78,7 +78,13 @@ ARG DATABASE_PASS
 # Install LORIS-MRI Python
 WORKDIR /opt/loris/bin/mri
 COPY . .
-RUN pip install --no-cache-dir --editable .[dev]
+
+# First, install the main LORIS package and all its dependencies.
+# Then, iterate and re-install each LORIS subpackage in editable mode.
+RUN pip install --no-cache-dir --editable .[dev] && \
+    for pkg in python/loris_*; do \
+        pip install --no-cache-dir --no-deps --editable "$pkg"; \
+    done
 
 # Run the test LORIS-MRI installer
 RUN bash ./test/imaging_install_test.sh $DATABASE_NAME $DATABASE_USER $DATABASE_PASS

--- a/test/pyright_to_github.sh
+++ b/test/pyright_to_github.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Script to convert Pyright JSON output to GitHub annotation format.
-# Usage: pyright --outputjson | .pyright_to_github.sh
+# Usage: pyright --outputjson | ./pyright_to_github.sh
 
 set -euo pipefail
 
@@ -14,7 +14,4 @@ echo "$pyright_json" | jq -r '
 "::\(.severity |
     if . == "error" then "error"
     elif . == "warning" then "warning"
-    else "notice" end) file=\(.file),line=\(.range.start.line + 1),col=\(.range.start.character + 1),title=Pyright \(.rule // "diagnostic")::\(.message)"'
-
-# Exit with Pyright's return code.
-exit ${PIPESTATUS[0]}
+    else "notice" end) file=\(.file),line=\(.range.start.line),col=\(.range.start.character),title=Pyright \(.rule // "diagnostic")::\(.message)"'


### PR DESCRIPTION
## Description

This PR does the following:
- Fix the Python project installation in the Docker image and GitHub actions so that both static and integration tests run with editable packages. This notably fixes some type errors that were appearing in CI but not locally.
- Remove the Python version matrix in the static tests. We've had this dual Python version setup running for years and it never caught any version-specific issue, making it mostly just report errors twice for no gain. Python versions are forward-compatible so just running static checks with our minimally supported Python version (currently Python 3.11, which is notably specified in our `pyproject.toml` file) is sufficient to catch all errors without getting an overly verbose output.
- Fix a bug in the Pyright to GitHub script were the errors were reported below the relevant line instead of above.
- Fix a bug in the GitHub action were Pyright would always succeed even if it exited with an error.

See the first commit where there is an intentional mistake to see the output in case of error.