### PR TITLE
Refactor BIDS root events import (PR 3)

### DIFF
--- a/python/lib/config.py
+++ b/python/lib/config.py
@@ -34,22 +34,7 @@ def get_data_dir_path_config(env: Env) -> Path:
     """
 
     data_dir_path = Path(_get_config_value(env, 'dataDirBasepath'))
-
-    if not data_dir_path.is_dir():
-        log_error_exit(
-            env,
-            (
-                f"The LORIS base data directory path configuration value '{data_dir_path}' does not refer to an"
-                " existing directory."
-            )
-        )
-
-    if not os.access(data_dir_path, os.R_OK) or not os.access(data_dir_path, os.W_OK):
-        log_error_exit(
-            env,
-            f"Missing read or write permission on the LORIS base data directory '{data_dir_path}'.",
-        )
-
+    check_loris_directory(env, data_dir_path, "data")
     return data_dir_path
 
 
@@ -60,22 +45,7 @@ def get_dicom_archive_dir_path_config(env: Env) -> Path:
     """
 
     dicom_archive_dir_path = Path(_get_config_value(env, 'tarchiveLibraryDir'))
-
-    if not dicom_archive_dir_path.is_dir():
-        log_error_exit(
-            env,
-            (
-                f"The LORIS DICOM archive directory path configuration value '{dicom_archive_dir_path}' does not refer"
-                " to an existing directory."
-            ),
-        )
-
-    if not os.access(dicom_archive_dir_path, os.R_OK) or not os.access(dicom_archive_dir_path, os.W_OK):
-        log_error_exit(
-            env,
-            f"Missing read or write permission on the LORIS DICOM archive directory '{dicom_archive_dir_path}'.",
-        )
-
+    check_loris_directory(env, dicom_archive_dir_path, "DICOM archive")
     return dicom_archive_dir_path
 
 
@@ -87,74 +57,65 @@ def get_default_bids_visit_label_config(env: Env) -> str | None:
     return _try_get_config_value(env, 'default_bids_vl')
 
 
-def get_eeg_viz_enabled_config(env: Env) -> bool:
+def get_ephys_visualization_enabled_config(env: Env) -> bool:
     """
-    Get whether the EEG visualization is enabled from the in-database configuration.
-    """
-
-    eeg_viz_enabled = _try_get_config_value(env, 'useEEGBrowserVisualizationComponents')
-    return eeg_viz_enabled == 'true' or eeg_viz_enabled == '1'
-
-
-def get_eeg_chunks_dir_path_config(env: Env) -> Path | None:
-    """
-    Get the EEG chunks directory path configuration value from the in-database configuration.
+    Get whether the electrophysiology visualization is enabled from the in-database configuration.
     """
 
-    eeg_chunks_path = _try_get_config_value(env, 'EEGChunksPath')
-    if eeg_chunks_path is None:
+    visualization_enabled = _try_get_config_value(env, 'useEEGBrowserVisualizationComponents')
+    return visualization_enabled == 'true' or visualization_enabled == '1'
+
+
+def get_ephys_chunks_dir_path_config(env: Env) -> Path | None:
+    """
+    Get the electrophysiology chunks directory path configuration value from the in-database
+    configuration.
+    """
+
+    ephys_chunks_path = _try_get_config_value(env, 'EEGChunksPath')
+    if ephys_chunks_path is None:
         return None
 
-    eeg_chunks_path = Path(eeg_chunks_path)
-
-    if not eeg_chunks_path.is_dir():
-        log_error_exit(
-            env,
-            (
-                f"The configuration value for the LORIS EEG chunks directory path '{eeg_chunks_path}' does not refer to"
-                " an existing directory."
-            ),
-        )
-
-    if not os.access(eeg_chunks_path, os.R_OK) or not os.access(eeg_chunks_path, os.W_OK):
-        log_error_exit(
-            env,
-            f"Missing read or write permission on the LORIS EEG chunks directory '{eeg_chunks_path}'.",
-        )
-
-    return eeg_chunks_path
+    ephys_chunks_path = Path(ephys_chunks_path)
+    check_loris_directory(env, ephys_chunks_path, "electrophysiology chunks")
+    return ephys_chunks_path
 
 
-def get_eeg_pre_package_download_dir_path_config(env: Env) -> Path | None:
+def get_ephys_archive_dir_path_config(env: Env) -> Path | None:
     """
-    Get the EEG pre-packaged download path configuration value from the in-database configuration.
+    Get the electrophysiology archive directory path configuration value from the in-database
+    configuration.
     """
 
-    eeg_pre_package_path = _try_get_config_value(env, 'prePackagedDownloadPath')
-    if eeg_pre_package_path is None:
+    ephys_archive_dir_path = _try_get_config_value(env, 'prePackagedDownloadPath')
+    if ephys_archive_dir_path is None:
         return None
 
-    eeg_pre_package_path = Path(eeg_pre_package_path)
+    ephys_archive_dir_path = Path(ephys_archive_dir_path)
+    check_loris_directory(env, ephys_archive_dir_path, "electrophysiology archive")
+    return ephys_archive_dir_path
 
-    if not eeg_pre_package_path.is_dir():
+
+def check_loris_directory(env: Env, dir_path: Path, display_name: str):
+    """
+    Check that a LORIS directory exists and is readable and writable, or exit the program with an
+    error otherwise.
+    """
+
+    if not dir_path.is_dir():
         log_error_exit(
             env,
             (
-                "The configuration value for the LORIS EEG pre-packaged download directory path"
-                f" '{eeg_pre_package_path}' does not refer to an existing directory."
+                f"The LORIS {display_name} directory path configuration value '{dir_path}' does not refer to an"
+                " existing directory."
             ),
         )
 
-    if not os.access(eeg_pre_package_path, os.R_OK) or not os.access(eeg_pre_package_path, os.W_OK):
+    if not os.access(dir_path, os.R_OK) or not os.access(dir_path, os.W_OK):
         log_error_exit(
             env,
-            (
-                "Missing read or write permission on the LORIS EEG pre-packaged download directory"
-                f" '{eeg_pre_package_path}'."
-            ),
+            f"Missing read or write permission on the {display_name} directory '{dir_path}'.",
         )
-
-    return eeg_pre_package_path
 
 
 def _get_config_value(env: Env, setting_name: str) -> str:

--- a/python/lib/database_lib/physiological_event_archive.py
+++ b/python/lib/database_lib/physiological_event_archive.py
@@ -1,6 +1,9 @@
 """This class performs database queries for the physiological_event_archive table"""
 
+from typing_extensions import deprecated
 
+
+@deprecated('Use `lib.db.physio_event_archive.DbPhysioEventArchive` instead')
 class PhysiologicalEventArchive:
 
     def __init__(self, db, verbose):
@@ -17,6 +20,7 @@ class PhysiologicalEventArchive:
         self.table = 'physiological_event_archive'
         self.verbose = verbose
 
+    @deprecated('Use `lib.db.physio_event_archive.DbPhysioEventArchive.physio_file_id` instead')
     def grep_from_physiological_file_id(self, physiological_file_id):
         """
         Gets rows given a physiological_file_id
@@ -33,6 +37,7 @@ class PhysiologicalEventArchive:
             args=(physiological_file_id,)
         )
 
+    @deprecated('Use `lib.db.physio_event_archive.DbPhysioEventArchive` instead')
     def insert(self, physiological_file_id, blake2, archive_path):
         """
         Inserts a new entry in the physiological_event_archive table.

--- a/python/lib/db/models/bids_event_dataset_mapping.py
+++ b/python/lib/db/models/bids_event_dataset_mapping.py
@@ -1,6 +1,8 @@
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+import lib.db.models.project as db_project
+import lib.db.models.user as db_user
 from lib.db.base import Base
 from lib.db.decorators.int_bool import IntBool
 
@@ -18,4 +20,7 @@ class DbBidsEventDatasetMapping(Base):
     has_pairing        : Mapped[bool | None] = mapped_column('HasPairing', IntBool)
     pair_rel_id        : Mapped[int | None]  = mapped_column('PairRelID')
     additional_members : Mapped[int | None]  = mapped_column('AdditionalMembers')
-    tagged_by          : Mapped[int | None]  = mapped_column('TaggedBy', ForeignKey('users.ID'))
+    tagger_id          : Mapped[int | None]  = mapped_column('TaggedBy', ForeignKey('users.ID'))
+
+    project : Mapped['db_project.DbProject'] = relationship('DbProject')
+    tagger  : Mapped['db_user.DbUser | None'] = relationship('DbUser')

--- a/python/lib/db/models/bids_event_file_mapping.py
+++ b/python/lib/db/models/bids_event_file_mapping.py
@@ -1,6 +1,7 @@
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+import lib.db.models.user as db_user
 from lib.db.base import Base
 from lib.db.decorators.int_bool import IntBool
 
@@ -18,4 +19,6 @@ class DbBidsEventFileMapping(Base):
     has_pairing        : Mapped[bool | None] = mapped_column('HasPairing', IntBool)
     pair_rel_id        : Mapped[int | None]  = mapped_column('PairRelID')
     additional_members : Mapped[int | None]  = mapped_column('AdditionalMembers')
-    tagged_by          : Mapped[int | None]  = mapped_column('TaggedBy', ForeignKey('users.ID'))
+    tagger_id          : Mapped[int | None]  = mapped_column('TaggedBy', ForeignKey('users.ID'))
+
+    tagger: Mapped['db_user.DbUser | None'] = relationship('DbUser')

--- a/python/lib/db/models/physio_event_archive.py
+++ b/python/lib/db/models/physio_event_archive.py
@@ -14,6 +14,6 @@ class DbPhysioEventArchive(Base):
     id             : Mapped[int]  = mapped_column('EventArchiveID', primary_key=True)
     physio_file_id : Mapped[int]  = mapped_column('PhysiologicalFileID', ForeignKey('physiological_file.PhysiologicalFileID'))
     blake2b_hash   : Mapped[str]  = mapped_column('Blake2bHash')
-    file_path      : Mapped[Path] = mapped_column('FilePath', StringPath)
+    path           : Mapped[Path] = mapped_column('FilePath', StringPath)
 
     physio_file: Mapped['db_physio_file.DbPhysioFile'] = relationship('DbPhysioFile')

--- a/python/lib/db/models/physio_event_file.py
+++ b/python/lib/db/models/physio_event_file.py
@@ -21,8 +21,8 @@ class DbPhysioEventFile(Base):
     project_id     : Mapped[int | None]  = mapped_column('ProjectID', ForeignKey('Project.ProjectID'))
     file_type      : Mapped[str]         = mapped_column('FileType', ForeignKey('ImagingFileTypes.type'))
     file_path      : Mapped[Path | None] = mapped_column('FilePath', StringPath)
-    last_update    : Mapped[datetime]    = mapped_column('LastUpdate')
-    last_written   : Mapped[datetime]    = mapped_column('LastWritten')
+    last_update    : Mapped[datetime]    = mapped_column('LastUpdate', default=datetime.now)
+    last_written   : Mapped[datetime]    = mapped_column('LastWritten', default=datetime.now)
 
     physio_file       : Mapped['db_physio_file.DbPhysioFile | None']                     = relationship('DbPhysioFile')
     project           : Mapped['db_project.DbProject | None']                            = relationship('DbProject')

--- a/python/lib/db/models/physio_file_archive.py
+++ b/python/lib/db/models/physio_file_archive.py
@@ -16,6 +16,6 @@ class DbPhysioFileArchive(Base):
     physio_file_id : Mapped[int]      = mapped_column('PhysiologicalFileID', ForeignKey('physiological_file.PhysiologicalFileID'))
     insert_time    : Mapped[datetime] = mapped_column('InsertTime', default=datetime.now)
     blake2b_hash   : Mapped[str]      = mapped_column('Blake2bHash')
-    file_path      : Mapped[Path]     = mapped_column('FilePath', StringPath)
+    path           : Mapped[Path]     = mapped_column('FilePath', StringPath)
 
     physio_file: Mapped['db_physio_file.DbPhysioFile'] = relationship('DbPhysioFile')

--- a/python/lib/db/queries/bids_event_dataset_mapping.py
+++ b/python/lib/db/queries/bids_event_dataset_mapping.py
@@ -1,0 +1,19 @@
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session as Database
+
+from lib.db.models.bids_event_dataset_mapping import DbBidsEventDatasetMapping
+
+
+def get_bids_event_dataset_mappings_with_project_id(
+    db: Database,
+    project_id: int,
+) -> Sequence[DbBidsEventDatasetMapping]:
+    """
+    Get the BIDS event dataset mappings of project using its ID.
+    """
+
+    return db.execute(select(DbBidsEventDatasetMapping)
+        .where(DbBidsEventDatasetMapping.project_id == project_id)
+    ).scalars().all()

--- a/python/lib/db/queries/hed_schema_node.py
+++ b/python/lib/db/queries/hed_schema_node.py
@@ -1,0 +1,14 @@
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session as Database
+
+from lib.db.models.hed_schema_node import DbHedSchemaNode
+
+
+def get_all_hed_schema_nodes(db: Database) -> Sequence[DbHedSchemaNode]:
+    """
+    Get all the HED schema nodes from the database.
+    """
+
+    return db.execute(select(DbHedSchemaNode)).scalars().all()

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -14,12 +14,12 @@ from loris_utils.crypto import compute_file_blake2b_hash
 
 import lib.exitcode
 import lib.utilities as utilities
-from lib.config import get_eeg_pre_package_download_dir_path_config, get_eeg_viz_enabled_config
-from lib.database_lib.physiological_event_archive import PhysiologicalEventArchive
+from lib.config import get_eeg_viz_enabled_config
 from lib.db.models.physio_file import DbPhysioFile
 from lib.db.models.session import DbSession
 from lib.db.queries.physio_file import try_get_physio_file_with_path
 from lib.env import Env
+from lib.import_bids_dataset.archive import import_physio_event_archive, import_physio_file_archive
 from lib.import_bids_dataset.copy_files import (
     copy_loris_bids_file,
     copy_scans_tsv_file_to_loris_bids_dir,
@@ -190,34 +190,27 @@ class Eeg:
             )
 
             # archive all files in a tar ball for downloading all files at once
-            files_to_archive: list[str] = [os.path.join(self.data_dir, eeg_file.path)]
+            files_to_archive: list[Path] = [self.data_dir / eeg_file.path]
 
             if eegjson_file_path:
-                files_to_archive.append(os.path.join(self.data_dir, eegjson_file_path))
+                files_to_archive.append(self.data_dir / eegjson_file_path)
+            if channel_file_path:
+                files_to_archive.append(self.data_dir / channel_file_path)
             if fdt_file_path:
-                files_to_archive.append(os.path.join(self.data_dir, fdt_file_path))
+                files_to_archive.append(self.data_dir / fdt_file_path)
             if electrode_file_path:
-                files_to_archive.append(os.path.join(self.data_dir, electrode_file_path))
+                files_to_archive.append(self.data_dir / electrode_file_path)
             if event_file_paths:
                 # archive all event files in a tar ball for event download
-                event_files_to_archive: list[str] = []
+                event_files_to_archive: list[Path] = []
 
                 for event_file_path in event_file_paths:
-                    files_to_archive.append(os.path.join(self.data_dir, event_file_path))
-                    event_files_to_archive.append(os.path.join(self.data_dir, event_file_path))
+                    files_to_archive.append(self.data_dir / event_file_path)
+                    event_files_to_archive.append(self.data_dir / event_file_path)
 
-                event_archive_rel_name = os.path.splitext(event_file_paths[0])[0] + ".tgz"
-                self.create_and_insert_event_archive(
-                    event_files_to_archive, event_archive_rel_name, eeg_file
-                )
+                import_physio_event_archive(self.env, eeg_file, event_files_to_archive)
 
-            if channel_file_path:
-                files_to_archive.append(os.path.join(self.data_dir, channel_file_path))
-
-            archive_rel_name = os.path.splitext(eeg_file.path)[0] + ".tgz"
-            self.create_and_insert_archive(
-                files_to_archive, archive_rel_name, eeg_file
-            )
+            import_physio_file_archive(self.env, eeg_file, files_to_archive)
 
             # create data chunks for React visualization
             if get_eeg_viz_enabled_config(self.env):
@@ -694,126 +687,3 @@ class Eeg:
 
         copy_loris_bids_file(self.info, Path(file), loris_file_path)
         return loris_file_path
-
-    def create_and_insert_archive(self, files_to_archive: list[str], archive_rel_name: str, eeg_file: DbPhysioFile):
-        """
-        Create an archive with all electrophysiology files associated to a
-        specific recording (including electrodes.tsv, channels.tsv etc...)
-        :param files_to_archive: list of files to include in the archive
-        :param archive_rel_name: path to the archive relative to data_dir
-        :param eeg_file_id     : PhysiologicalFileID
-        """
-
-        # load the Physiological object that will be used to insert the
-        # physiological archive into the database
-        physiological = Physiological(self.env, self.db, self.env.verbose)
-
-        # check if archive is on the filesystem
-        (archive_rel_name, archive_full_path) = self.get_archive_paths(archive_rel_name)
-        if os.path.isfile(archive_full_path):
-            blake2 = compute_file_blake2b_hash(archive_full_path)
-        else:
-            blake2 = None
-
-        # check if archive already inserted in database and matches the one
-        # on the filesystem using blake2b hash
-        if eeg_file.archive is not None:
-            if not blake2:
-                message = 'ERROR: no archive was found on the filesystem ' + \
-                          'while an entry was found in the database for '   + \
-                          f'PhysiologicalFileID = {eeg_file.id}'
-                print(message)
-                exit(lib.exitcode.MISSING_FILES)
-            elif eeg_file.archive.blake2b_hash != blake2:
-                message = '\nERROR: blake2b hash of ' + archive_full_path     +\
-                          ' does not match the one stored in the database.'   +\
-                          '\nblake2b of ' + archive_full_path + ': ' + blake2 +\
-                          '\nblake2b in the database: ' + eeg_file.archive.blake2b_hash
-                print(message)
-                exit(lib.exitcode.CORRUPTED_FILE)
-            else:
-                return
-
-        # create the archive directory if it does not exist
-        lib.utilities.create_dir(
-            os.path.dirname(archive_full_path),
-            self.env.verbose
-        )
-
-        # create the archive file
-        utilities.create_archive(files_to_archive, archive_full_path)
-
-        # insert the archive file in physiological_archive
-        blake2 = compute_file_blake2b_hash(archive_full_path)
-        archive_info = {
-            'PhysiologicalFileID': eeg_file.id,
-            'Blake2bHash'        : blake2,
-            'FilePath'           : archive_rel_name
-        }
-        physiological.insert_archive_file(archive_info)
-
-    def create_and_insert_event_archive(
-        self,
-        files_to_archive: list[str],
-        archive_rel_name: str,
-        eeg_file: DbPhysioFile,
-    ):
-        """
-        Create an archive with all event files associated to a specific recording
-        :param files_to_archive: list of files to include in the archive
-        :param archive_rel_name: path to the archive relative to data_dir
-        :param eeg_file     : Physiological file object
-        """
-
-        # check if archive is on the filesystem
-        (archive_rel_name, archive_full_path) = self.get_archive_paths(archive_rel_name)
-        if os.path.isfile(archive_full_path):
-            blake2 = compute_file_blake2b_hash(archive_full_path)
-        else:
-            blake2 = None
-
-        # check if archive already inserted in database and matches the one
-        # on the filesystem using blake2b hash
-        physiological_event_archive_obj = PhysiologicalEventArchive(self.db, self.env.verbose)
-
-        if eeg_file.event_archive is not None:
-            if not blake2:
-                message = '\nERROR: no archive was found on the filesystem ' + \
-                          'while an entry was found in the database for '   + \
-                          'PhysiologicalFileID = ' + str(eeg_file.id)
-                print(message)
-                exit(lib.exitcode.MISSING_FILES)
-            elif eeg_file.event_archive.blake2b_hash != blake2:
-                message = '\nERROR: blake2b hash of ' + archive_full_path     +\
-                          ' does not match the one stored in the database.'   +\
-                          '\nblake2b of ' + archive_full_path + ': ' + blake2 +\
-                          '\nblake2b in the database: ' + eeg_file.event_archive.blake2b_hash
-                print(message)
-                exit(lib.exitcode.CORRUPTED_FILE)
-            else:
-                return
-
-        # create the archive directory if it does not exist
-        lib.utilities.create_dir(
-            os.path.dirname(archive_full_path),
-            self.env.verbose
-        )
-
-        # create the archive file
-        utilities.create_archive(files_to_archive, archive_full_path)
-
-        # insert the archive into the physiological_annotation_archive table
-        blake2 = compute_file_blake2b_hash(archive_full_path)
-        physiological_event_archive_obj.insert(eeg_file.id, blake2, archive_rel_name)
-
-    def get_archive_paths(self, archive_rel_name):
-        package_path = get_eeg_pre_package_download_dir_path_config(self.env)
-        if package_path:
-            raw_package_dir = os.path.join(package_path, 'raw')
-            os.makedirs(raw_package_dir, exist_ok=True)
-            archive_rel_name = os.path.basename(archive_rel_name)
-            archive_full_path = os.path.join(raw_package_dir, archive_rel_name)
-        else:
-            archive_full_path = os.path.join(self.data_dir, archive_rel_name)
-
-        return (archive_rel_name, archive_full_path)

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -14,7 +14,7 @@ from loris_utils.crypto import compute_file_blake2b_hash
 
 import lib.exitcode
 import lib.utilities as utilities
-from lib.config import get_eeg_viz_enabled_config
+from lib.config import get_ephys_visualization_enabled_config
 from lib.db.models.physio_file import DbPhysioFile
 from lib.db.models.session import DbSession
 from lib.db.queries.physio_file import try_get_physio_file_with_path
@@ -213,7 +213,7 @@ class Eeg:
             import_physio_file_archive(self.env, eeg_file, files_to_archive)
 
             # create data chunks for React visualization
-            if get_eeg_viz_enabled_config(self.env):
+            if get_ephys_visualization_enabled_config(self.env):
                 create_physio_channels_chunks(self.env, eeg_file)
 
     def fetch_and_insert_eeg_files(self, derivatives=False, detect=True):

--- a/python/lib/import_bids_dataset/archive.py
+++ b/python/lib/import_bids_dataset/archive.py
@@ -4,7 +4,7 @@ from loris_utils.archive import create_archive_with_files
 from loris_utils.crypto import compute_file_blake2b_hash
 from loris_utils.path import remove_path_extension
 
-from lib.config import get_data_dir_path_config, get_eeg_pre_package_download_dir_path_config
+from lib.config import get_data_dir_path_config, get_ephys_archive_dir_path_config
 from lib.db.models.physio_event_archive import DbPhysioEventArchive
 from lib.db.models.physio_file import DbPhysioFile
 from lib.db.models.physio_file_archive import DbPhysioFileArchive
@@ -70,7 +70,7 @@ def get_archive_path(env: Env, file_path: Path) -> Path:
     """
 
     archive_rel_path = remove_path_extension(file_path).with_suffix('.tgz')
-    archive_dir_path = get_eeg_pre_package_download_dir_path_config(env)
+    archive_dir_path = get_ephys_archive_dir_path_config(env)
     if archive_dir_path is not None:
         data_dir_path = get_data_dir_path_config(env)
         return (archive_dir_path / 'raw' / archive_rel_path.name).relative_to(data_dir_path)

--- a/python/lib/import_bids_dataset/archive.py
+++ b/python/lib/import_bids_dataset/archive.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+from loris_utils.archive import create_archive_with_files
+from loris_utils.crypto import compute_file_blake2b_hash
+from loris_utils.path import remove_path_extension
+
+from lib.config import get_data_dir_path_config, get_eeg_pre_package_download_dir_path_config
+from lib.db.models.physio_event_archive import DbPhysioEventArchive
+from lib.db.models.physio_file import DbPhysioFile
+from lib.db.models.physio_file_archive import DbPhysioFileArchive
+from lib.env import Env
+
+
+def import_physio_file_archive(env: Env, physio_file: DbPhysioFile, file_paths: list[Path]):
+    """
+    Create and import a physiological file archive into LORIS.
+    """
+
+    archive_rel_path = get_archive_path(env, physio_file.path)
+
+    data_dir_path = get_data_dir_path_config(env)
+    archive_path = data_dir_path / archive_rel_path
+    if archive_path.exists():
+        raise Exception(f"Archive '{archive_rel_path}' already exists on the file system.")
+
+    archive_path.parent.mkdir(exist_ok=True)
+
+    create_archive_with_files(archive_path, file_paths)
+
+    blake2b_hash = compute_file_blake2b_hash(archive_path)
+
+    env.db.add(DbPhysioFileArchive(
+        physio_file_id = physio_file.id,
+        path           = archive_rel_path,
+        blake2b_hash   = blake2b_hash,
+    ))
+
+    env.db.flush()
+
+
+def import_physio_event_archive(env: Env, physio_file: DbPhysioFile, file_paths: list[Path]):
+    """
+    Create and import a physiological event archive into LORIS. The name of the archive is based on
+    the first file path provided.
+    """
+
+    data_dir_path = get_data_dir_path_config(env)
+    archive_rel_path = remove_path_extension(file_paths[0].relative_to(data_dir_path)).with_suffix('.tgz')
+
+    archive_path = data_dir_path / archive_rel_path
+    if archive_path.exists():
+        raise Exception(f"Event archive '{archive_rel_path}' already exists on the file system.")
+
+    create_archive_with_files(archive_path, file_paths)
+
+    blake2b_hash = compute_file_blake2b_hash(archive_path)
+
+    env.db.add(DbPhysioEventArchive(
+        physio_file_id = physio_file.id,
+        path           = archive_rel_path,
+        blake2b_hash   = blake2b_hash,
+    ))
+
+    env.db.flush()
+
+
+def get_archive_path(env: Env, file_path: Path) -> Path:
+    """
+    Get the path of a physiological file archive relative to the LORIS data directory.
+    """
+
+    archive_rel_path = remove_path_extension(file_path).with_suffix('.tgz')
+    archive_dir_path = get_eeg_pre_package_download_dir_path_config(env)
+    if archive_dir_path is not None:
+        data_dir_path = get_data_dir_path_config(env)
+        return (archive_dir_path / 'raw' / archive_rel_path.name).relative_to(data_dir_path)
+    else:
+        return archive_rel_path

--- a/python/lib/import_bids_dataset/copy_files.py
+++ b/python/lib/import_bids_dataset/copy_files.py
@@ -3,11 +3,46 @@ import re
 import shutil
 from pathlib import Path
 
+from loris_bids_reader.files.dataset_description import BidsDatasetDescriptionJsonFile
 from loris_bids_reader.files.scans import BidsScansTsvFile
 
 import lib.utilities
+from lib.config import get_data_dir_path_config
 from lib.db.models.session import DbSession
+from lib.env import Env
 from lib.import_bids_dataset.env import BidsImportEnv
+
+
+def get_loris_bids_dataset_path(env: Env, dataset_description: BidsDatasetDescriptionJsonFile) -> Path:
+    """
+    Get the LORIS BIDS directory path for the BIDS dataset to import, and create that directory if
+    it does not exist yet.
+    """
+
+    # Sanitize the dataset metadata to have a usable name for the directory.
+    dataset_name    = re.sub(r'[^0-9a-zA-Z]+',   '_', dataset_description.data['Name'])
+    dataset_version = re.sub(r'[^0-9a-zA-Z\.]+', '_', dataset_description.data['BIDSVersion'])
+
+    data_dir_path = get_data_dir_path_config(env)
+    loris_bids_path = data_dir_path / 'bids_imports' / f'{dataset_name}_BIDSVersion_{dataset_version}'
+
+    if not loris_bids_path.exists():
+        loris_bids_path.mkdir()
+
+    return loris_bids_path
+
+
+def get_loris_bids_root_file_path(import_env: BidsImportEnv, file_path: Path) -> Path:
+    """
+    Get the path of a BIDS file relative to the LORIS data directory, maintaining the same relative
+    path in the LORIS BIDS dataset as within the source BIDS dataset.
+    """
+
+    # In the import is run in no-copy mode, simply return the original file path.
+    if import_env.loris_bids_path is None:
+        return file_path.relative_to(import_env.data_dir_path)
+
+    return import_env.loris_bids_path / file_path.relative_to(import_env.source_bids_path)
 
 
 def get_loris_bids_file_path(
@@ -76,6 +111,29 @@ def copy_loris_bids_file(import_env: BidsImportEnv, file_path: Path, loris_file_
         shutil.copyfile(file_path, full_loris_file_path)
     elif file_path.is_dir():
         shutil.copytree(file_path, full_loris_file_path)
+
+
+def copy_bids_static_files(import_env: BidsImportEnv):
+    """
+    Copy the static files of the source BIDS dataset to the LORIS BIDS dataset.
+    """
+
+    # Do not copy files in no-copy mode.
+    if import_env.loris_bids_path is None:
+        return
+
+    for file_name in ['README', 'dataset_description.json']:
+        source_file_path = import_env.source_bids_path / file_name
+        if not source_file_path.is_file():
+            continue
+
+        loris_file_path = import_env.loris_bids_path / file_name
+
+        # Do not copy the file if it is already present during an incremental import.
+        if (import_env.data_dir_path / loris_file_path).is_file():
+            continue
+
+        copy_loris_bids_file(import_env, source_file_path, loris_file_path)
 
 
 # TODO: This function is ugly and should be replaced.

--- a/python/lib/import_bids_dataset/events.py
+++ b/python/lib/import_bids_dataset/events.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+from loris_bids_reader.json import BidsJsonFile
+from loris_utils.crypto import compute_file_blake2b_hash
+
+from lib.db.models.physio_event_file import DbPhysioEventFile
+from lib.db.models.project import DbProject
+from lib.env import Env
+from lib.import_bids_dataset.copy_files import copy_loris_bids_file, get_loris_bids_root_file_path
+from lib.import_bids_dataset.env import BidsImportEnv
+from lib.physio.events import EventDictFileSource, insert_event_dict_file, parse_and_insert_event_dict
+from lib.physio.parameters import insert_physio_file_parameter, insert_physio_project_parameter
+from lib.physiological import Physiological
+
+
+def import_bids_root_event_dict_file(
+    env: Env,
+    import_env: BidsImportEnv,
+    project: DbProject,
+    bids_event_dict_file: BidsJsonFile,
+) -> tuple[DbPhysioEventFile, dict[str, dict[str, list[list[Physiological.TagGroupMember]]]]]:
+    """
+    Import a root-level BIDS event dictionary file and its associated HED tags into LORIS.
+    """
+
+    loris_event_dict_file_path = get_loris_bids_root_file_path(import_env, bids_event_dict_file.path)
+
+    copy_loris_bids_file(import_env, bids_event_dict_file.path, loris_event_dict_file_path)
+
+    event_dict_file, hed_tags_dict = insert_bids_event_dict_file(
+        env,
+        EventDictFileSource.from_dataset(project),
+        bids_event_dict_file,
+        loris_event_dict_file_path,
+    )
+
+    env.db.commit()
+
+    return event_dict_file, hed_tags_dict
+
+
+def insert_bids_event_dict_file(
+    env: Env,
+    source: EventDictFileSource,
+    bids_event_dict_file: BidsJsonFile,
+    loris_event_dict_file_path: Path,
+) -> tuple[DbPhysioEventFile, dict[str, dict[str, list[list[Physiological.TagGroupMember]]]]]:
+    """
+    Insert a BIDS event dictionary file and its associated HED tags into the LORIS database.
+    """
+
+    event_dict_file = insert_event_dict_file(env, source, loris_event_dict_file_path)
+
+    blake2b_hash = compute_file_blake2b_hash(bids_event_dict_file.path)
+
+    hed_tags_dict = parse_and_insert_event_dict(env, bids_event_dict_file.data, source)
+
+    if source.physio_file is not None:
+        insert_physio_file_parameter(env, source.physio_file, 'event_file_json_blake2b_hash', blake2b_hash)
+    else:
+        insert_physio_project_parameter(env, source.project.id, 'event_file_json_blake2b_hash', blake2b_hash)
+
+    return event_dict_file, hed_tags_dict

--- a/python/lib/physio/chunking.py
+++ b/python/lib/physio/chunking.py
@@ -3,7 +3,7 @@ import subprocess
 from loris_utils.path import get_path_stem
 
 import lib.exitcode
-from lib.config import get_data_dir_path_config, get_eeg_chunks_dir_path_config
+from lib.config import get_data_dir_path_config, get_ephys_chunks_dir_path_config
 from lib.db.models.physio_file import DbPhysioFile
 from lib.db.queries.physio_parameter import try_get_physio_file_parameter_with_file_id_name
 from lib.env import Env
@@ -94,11 +94,11 @@ def get_dataset_chunks_dir_path(env: Env, physio_file: DbPhysioFile):
 
     # The first part of the physiological file path is assumed to be the BIDS imports directory
     # name. The second part of the physiological file path is assumed to be the dataset name.
-    eeg_chunks_dir_path = get_eeg_chunks_dir_path_config(env)
-    if eeg_chunks_dir_path is None:
+    ephys_chunks_dir_path = get_ephys_chunks_dir_path_config(env)
+    if ephys_chunks_dir_path is None:
         data_dir_path = get_data_dir_path_config(env)
-        eeg_chunks_dir_path = data_dir_path / physio_file.path.parts[0]
+        ephys_chunks_dir_path = data_dir_path / physio_file.path.parts[0]
 
-    eeg_chunks_path = eeg_chunks_dir_path / f'{physio_file.path.parts[1]}_chunks'
+    eeg_chunks_path = ephys_chunks_dir_path / f'{physio_file.path.parts[1]}_chunks'
     eeg_chunks_path.mkdir(exist_ok=True)
     return eeg_chunks_path

--- a/python/lib/physio/events.py
+++ b/python/lib/physio/events.py
@@ -1,0 +1,205 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lib.db.queries.hed_schema_node import get_all_hed_schema_nodes
+
+from lib.db.models.bids_event_dataset_mapping import DbBidsEventDatasetMapping
+from lib.db.models.bids_event_file_mapping import DbBidsEventFileMapping
+from lib.db.models.physio_event_file import DbPhysioEventFile
+from lib.db.models.physio_file import DbPhysioFile
+from lib.db.models.project import DbProject
+from lib.env import Env
+from lib.physiological import Physiological
+
+
+@dataclass
+class EventDictFileSource:
+    """
+    Class representing whether an event dictionary file is dataset-wide or comes from a specific acquisition.
+    """
+
+    project: DbProject
+    physio_file: DbPhysioFile | None
+
+    @staticmethod
+    def from_dataset(project: DbProject) -> 'EventDictFileSource':
+        """
+        Create an event dictionary file source from dataset-wide information.
+        """
+
+        return EventDictFileSource(
+            project = project,
+            physio_file = None,
+        )
+
+    @staticmethod
+    def from_file(physio_file: DbPhysioFile) -> 'EventDictFileSource':
+        """
+        Create an event dictionary file source from a specific acquisition file.
+        """
+
+        return EventDictFileSource(
+            project = physio_file.session.project,
+            physio_file = physio_file,
+        )
+
+
+def insert_event_dict_file(env: Env, source: EventDictFileSource, event_file_path: Path) -> DbPhysioEventFile:
+    """
+    Insert an event dictionary file into the LORIS database.
+    """
+
+    event_dict_file = DbPhysioEventFile(
+        physio_file_id = source.physio_file.id if source.physio_file else None,
+        project_id     = source.project.id,
+        file_type      = 'json',
+        file_path      = event_file_path,
+    )
+
+    env.db.add(event_dict_file)
+    env.db.flush()
+    return event_dict_file
+
+
+def insert_bids_event_mapping(
+    env: Env,
+    source: EventDictFileSource,
+    property_name: str,
+    property_value: str,
+    level_description: str,
+    hed_tag_group: list[Physiological.TagGroupMember],
+) -> None:
+    """
+    Insert BIDS event mappings into the LORIS database.
+    """
+
+    for hed_tag_member in hed_tag_group:
+        if source.physio_file is None:
+            insert_bids_dataset_event_mapping(
+                env,
+                source.project,
+                property_name,
+                property_value,
+                level_description,
+                hed_tag_member,
+            )
+        else:
+            insert_bids_file_event_mapping(
+                env,
+                source.physio_file,
+                property_name,
+                property_value,
+                level_description,
+                hed_tag_member,
+            )
+
+
+def insert_bids_dataset_event_mapping(
+    env: Env,
+    project: DbProject,
+    property_name: str,
+    property_value: str,
+    level_description: str,
+    hed_tag_member: Physiological.TagGroupMember,
+) -> DbBidsEventDatasetMapping:
+    """
+    Insert a dataset-wide BIDS event mapping into the LORIS database.
+    """
+
+    mapping = DbBidsEventDatasetMapping(
+        project_id         = project.id,
+        property_name      = property_name,
+        property_value     = property_value,
+        description        = level_description,
+        hed_tag_id         = hed_tag_member.hed_tag_id,
+        tag_value          = hed_tag_member.tag_value,
+        has_pairing        = hed_tag_member.has_pairing,
+        additional_members = hed_tag_member.additional_members
+    )
+
+    env.db.add(mapping)
+    env.db.flush()
+    return mapping
+
+
+def insert_bids_file_event_mapping(
+    env: Env,
+    physio_file: DbPhysioFile,
+    property_name: str,
+    property_value: str,
+    level_description: str,
+    hed_tag_member: Physiological.TagGroupMember,
+) -> DbBidsEventFileMapping:
+    """
+    Insert a acquisition-specific BIDS event mapping into the LORIS database.
+    """
+
+    mapping = DbBidsEventFileMapping(
+        event_file_id      = physio_file.id,
+        property_name      = property_name,
+        property_value     = property_value,
+        description        = level_description,
+        hed_tag_id         = hed_tag_member.hed_tag_id,
+        tag_value          = hed_tag_member.tag_value,
+        has_pairing        = hed_tag_member.has_pairing,
+        additional_members = hed_tag_member.additional_members
+    )
+
+    env.db.add(mapping)
+    env.db.flush()
+    return mapping
+
+
+def parse_and_insert_event_dict(
+    env: Env,
+    event_dict: dict[str, Any],
+    source: EventDictFileSource,
+) -> dict[str, dict[str, list[list[Physiological.TagGroupMember]]]]:
+    """
+    Parse a BIDS event dictionary and insert its mappings into the LORIS database.
+    """
+
+    # This function uses a lot of legacy code and is copied from the `Physiological` class.
+
+    hed_schema_nodes = get_all_hed_schema_nodes(env.db)
+
+    # Format the HED nodes to be compatible with the legacy HED reader.
+    hed_union: list[dict[str, Any]] = list(map(lambda node: {
+        'ID': node.id,
+        'Name': node.name,
+    }, hed_schema_nodes))
+
+    tag_dict: dict[str, dict[str, list[list[Physiological.TagGroupMember]]]] = {}
+
+    for event_name, event in event_dict.items():
+        tag_dict[event_name] = {}
+        # TODO: Commented fields below currently not supported # ruff: noqa
+        # description = event_metadata[parameter]['Description'] \
+        #     if 'Description' in event_metadata[parameter] \
+        #     else None
+        # long_name = event_metadata[parameter]['LongName'] if 'LongName' in event_metadata[parameter] else None
+        # units = event_metadata[parameter]['Units'] if 'Units' in event_metadata[parameter] else None
+        if 'Levels' in event:
+            is_categorical = 'Y'
+            # value_hed = None
+        else:
+            is_categorical = 'N'
+            # value_hed = event_metadata[parameter]['HED'] if 'HED' in event_metadata[parameter] else None
+
+        if is_categorical == 'Y':
+            for level in event['Levels']:
+                level_name = level
+                tag_dict[event_name][level_name] = []
+                level_description = event['Levels'][level]
+                level_hed = event['HED'][level] \
+                    if 'HED' in event and level in event['HED'] \
+                    else None
+
+                if level_hed:
+                    tag_groups: list[list[Physiological.TagGroupMember]] = Physiological.build_hed_tag_groups(hed_union, level_hed)  # type: ignore
+                    for tag_group in tag_groups:
+                        insert_bids_event_mapping(env, source, event_name, level_name, level_description, tag_group)
+                    tag_dict[event_name][level_name] = tag_groups
+
+    return tag_dict

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -774,25 +774,3 @@ class Physiological:
                     )
         # insert blake2b hash of task event file into physiological_parameter_file
         insert_physio_file_parameter(self.env, physiological_file, 'event_file_blake2b_hash', blake2)
-
-    def insert_archive_file(self, archive_info):
-        """
-        Inserts the archive file of all physiological files (including
-        electrodes.tsv, channels.tsv and events.tsv) in the
-        physiological_archive table of the database.
-
-        :param archive_info: dictionary with key/value pairs to insert
-         :type archive_info: dict
-        """
-
-        # insert the archive into the physiological_archive table
-        archive_fields = ()
-        archive_values = ()
-        for key, value in archive_info.items():
-            archive_fields = (*archive_fields, key)
-            archive_values = (*archive_values, value)
-        self.db.insert(
-            table_name   = 'physiological_archive',
-            column_names = archive_fields,
-            values       = archive_values
-        )

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -137,6 +137,7 @@ def create_dir(dir_name, verbose):
     return dir_name
 
 
+@deprecated('Use `loris_utils.archive.create_archive_with_files` instead')
 def create_archive(files_to_archive, archive_path):
     """
     Creates an archive with the files listed in the files_to_archive tuple.

--- a/python/loris_bids_reader/src/loris_bids_reader/reader.py
+++ b/python/loris_bids_reader/src/loris_bids_reader/reader.py
@@ -11,6 +11,8 @@ from loris_bids_reader.files.dataset_description import BidsDatasetDescriptionJs
 from loris_bids_reader.files.participants import BidsParticipantsTsvFile, BidsParticipantTsvRow
 from loris_bids_reader.files.scans import BidsScansTsvFile
 from loris_bids_reader.info import BidsDataTypeInfo, BidsSessionInfo, BidsSubjectInfo
+from loris_bids_reader.json import BidsJsonFile
+from loris_bids_reader.utils import get_pybids_file_path
 
 # Circular imports
 if TYPE_CHECKING:
@@ -37,12 +39,12 @@ class BidsDatasetReader:
     The path of this BIDS dataset.
     """
 
-    def __init__(self, path: Path, validate: bool = True):
+    def __init__(self, path: Path, derivatives: bool = True, validate: bool = True):
         self.path = path
         self.layout = BIDSLayout(
             path,
             validate=validate,
-            derivatives=True,
+            derivatives=derivatives,
             indexer=BIDSLayoutIndexer(
                 ignore=PYBIDS_IGNORE,
                 force_index=PYBIDS_FORCE_INDEX,
@@ -72,6 +74,29 @@ class BidsDatasetReader:
             return None
 
         return BidsParticipantsTsvFile(participants_path)
+
+    @cached_property
+    def event_dict_file(self) -> BidsJsonFile | None:
+        """
+        The root event dictionary file of this BIDS dataset, if it exists.
+        """
+
+        pybids_event_dict_file = self.layout.get_nearest(  # type: ignore
+            self.path,
+            return_type='tuple',
+            strict=False,
+            extension='json',
+            suffix='events',
+            all_=False,
+            subject=None,
+            session=None
+        )
+
+        if pybids_event_dict_file is None:
+            return None
+
+        event_dict_file_path = get_pybids_file_path(pybids_event_dict_file)  # type: ignore
+        return BidsJsonFile(event_dict_file_path)
 
     @cached_property
     def subject_labels(self) -> list[str]:

--- a/python/loris_utils/src/loris_utils/archive.py
+++ b/python/loris_utils/src/loris_utils/archive.py
@@ -1,0 +1,13 @@
+import tarfile
+from pathlib import Path
+
+
+def create_archive_with_files(archive_path: Path, file_paths: list[Path]):
+    """
+    Create a tar archive with the provided files. Files are added to the archive using their base
+    name, so the name of the provided files should all be distinct.
+    """
+
+    with tarfile.open(archive_path, 'w:gz') as tar:
+        for file_path in file_paths:
+            tar.add(file_path, arcname=file_path.name)

--- a/python/scripts/bids_import.py
+++ b/python/scripts/bids_import.py
@@ -3,19 +3,15 @@
 """Script to import BIDS structure into LORIS."""
 
 import getopt
-import json
 import os
-import re
 import sys
 from pathlib import Path
 
 from loris_bids_reader.files.participants import BidsParticipantsTsvFile
 from loris_bids_reader.mri.reader import BidsMriDataTypeReader
 from loris_bids_reader.reader import BidsDatasetReader
-from loris_utils.crypto import compute_file_blake2b_hash
 
 import lib.exitcode
-import lib.physiological
 import lib.utilities
 from lib.candidate import Candidate
 from lib.config import get_default_bids_visit_label_config
@@ -28,8 +24,11 @@ from lib.eeg import Eeg
 from lib.env import Env
 from lib.import_bids_dataset.check_sessions import check_or_create_bids_sessions
 from lib.import_bids_dataset.check_subjects import check_or_create_bids_subjects
+from lib.import_bids_dataset.copy_files import copy_bids_static_files, get_loris_bids_dataset_path
 from lib.import_bids_dataset.env import BidsImportEnv
+from lib.import_bids_dataset.events import import_bids_root_event_dict_file
 from lib.import_bids_dataset.mri import import_bids_mri_data_type
+from lib.logging import log_error_exit
 from lib.make_env import make_env
 
 
@@ -201,7 +200,7 @@ def read_and_insert_bids(
         validateids(bids_dir, db, verbose)
 
     # load the BIDS directory
-    bids_reader = BidsDatasetReader(Path(bids_dir), not nobidsvalidation)
+    bids_reader = BidsDatasetReader(Path(bids_dir), type == 'derivative', not nobidsvalidation)
 
     if bids_reader.data_types == []:
         print(f"Could not read the BIDS directory '{bids_dir}'.")
@@ -222,7 +221,7 @@ def read_and_insert_bids(
     if not nocopy:
         # create the LORIS_BIDS directory in data_dir based on Name and BIDS version
         loris_bids_root_dir = create_loris_bids_directory(
-            bids_reader, data_dir, verbose
+            env, bids_reader, verbose
         )
 
     check_or_create_bids_subjects(
@@ -240,63 +239,30 @@ def read_and_insert_bids(
     env.db.commit()
 
     # Assumption all same project (for project-wide tags)
-    single_project_id = sessions[0].project.id
-
-    # Import root-level (dataset-wide) events.json
-    # Assumption: Single project for project-wide tags
-    bids_layout = bids_reader.layout
-    root_event_metadata_file = bids_layout.get_nearest(
-        bids_dir,
-        return_type='tuple',
-        strict=False,
-        extension='json',
-        suffix='events',
-        all_=False,
-        subject=None,
-        session=None
-    )
-
-    dataset_tag_dict = {}
-    if not root_event_metadata_file:
-        message = '\nWARNING: no events metadata files (events.json) in ' \
-                  'root directory'
-        print(message)
-    else:
-        # copy the event file to the LORIS BIDS import directory
-        copy_file = str.replace(
-            root_event_metadata_file.path,
-            bids_layout.root,
-            ""
-        ).lstrip('/')
-
-        if not nocopy:
-            event_metadata_path = loris_bids_root_dir + copy_file
-            lib.utilities.copy_file(root_event_metadata_file.path, event_metadata_path, verbose)
-
-        # TODO: Move
-        hed_query = 'SELECT * FROM hed_schema_nodes WHERE 1'
-        hed_union = db.pselect(query=hed_query, args=())
-
-        # load json data
-        with open(root_event_metadata_file.path) as metadata_file:
-            event_metadata = json.load(metadata_file)
-        blake2 = compute_file_blake2b_hash(root_event_metadata_file.path)
-        physio = lib.physiological.Physiological(env, db, verbose)
-        _, dataset_tag_dict = physio.insert_event_metadata(
-            event_metadata=event_metadata,
-            event_metadata_file=event_metadata_path,
-            physiological_file=None,
-            project_id=single_project_id,
-            blake2=blake2,
-            project_wide=True,
-            hed_union=hed_union
-        )
+    single_project = sessions[0].project
 
     import_env = BidsImportEnv(
         data_dir_path    = Path(data_dir),
         source_bids_path = Path(bids_dir),
         loris_bids_path  = Path(loris_bids_root_dir).relative_to(data_dir) if loris_bids_root_dir is not None else None,
     )
+
+    copy_bids_static_files(import_env)
+
+    # Import root-level (dataset-wide) events.json
+    # Assumption: Single project for project-wide tags
+    dataset_tag_dict = {}
+    if bids_reader.event_dict_file is None:
+        message = '\nWARNING: no events metadata files (events.json) in ' \
+                  'root directory'
+        print(message)
+    else:
+        _, dataset_tag_dict = import_bids_root_event_dict_file(
+            env,
+            import_env,
+            single_project,
+            bids_reader.event_dict_file,
+        )
 
     # read list of modalities per session / candidate and register data
     for data_type_reader in bids_reader.data_types:
@@ -366,7 +332,7 @@ def validateids(bids_dir, db, verbose):
         sys.exit(lib.exitcode.CANDIDATE_MISMATCH)
 
 
-def create_loris_bids_directory(bids_reader: BidsDatasetReader, data_dir, verbose):
+def create_loris_bids_directory(env: Env, bids_reader: BidsDatasetReader, verbose):
     """
     Creates the LORIS BIDS import root directory (with name and BIDS version)
     and copy over the dataset_description.json, README and participants.tsv
@@ -383,52 +349,35 @@ def create_loris_bids_directory(bids_reader: BidsDatasetReader, data_dir, verbos
      :rtype: str
     """
 
-    if bids_reader.dataset_description_file is None:
-        print("ERROR: Could not read BIDS dataset description.")
-        sys.exit(lib.exitcode.UNREADABLE_FILE)
+    try:
+        dataset_description = bids_reader.dataset_description_file
+    except Exception as error:
+        log_error_exit(env, str(error))
 
-    # determine the root directory of the LORIS BIDS and create it if does not exist
-    name = re.sub(r"[^0-9a-zA-Z]+", "_", bids_reader.dataset_description_file.data['Name'])
-    version = re.sub(r"[^0-9a-zA-Z\.]+", "_", bids_reader.dataset_description_file.data['BIDSVersion'])
-
-    # the LORIS BIDS directory will be in data_dir/BIDS/ and named with the
-    # concatenation of the dataset name and the BIDS version
-    loris_bids_dirname = lib.utilities.create_dir(
-        os.path.join(data_dir, 'bids_imports', f'{name}_BIDSVersion_{version}'),
-        verbose
-    )
-
-    # copy the dataset JSON file to the new directory
-    lib.utilities.copy_file(
-        bids_reader.path / "dataset_description.json",
-        os.path.join(loris_bids_dirname, "dataset_description.json"),
-        verbose
-    )
-
-    # copy the README file to the new directory
-    if os.path.isfile(bids_reader.path / "README"):
-        lib.utilities.copy_file(
-            bids_reader.path / "README",
-            os.path.join(loris_bids_dirname, "README"),
-            verbose
+    if dataset_description is None:
+        log_error_exit(
+            env,
+            "No file 'dataset_description.json' found in the input BIDS dataset.",
         )
 
+    loris_bids_path = get_loris_bids_dataset_path(env, dataset_description)
+
     # copy the participant.tsv file to the new directory
-    if os.path.exists(os.path.join(loris_bids_dirname, "participants.tsv")):
+    if os.path.exists(os.path.join(loris_bids_path, "participants.tsv")):
         lib.utilities.append_to_tsv_file(
             bids_reader.path / "participants.tsv",
-            os.path.join(loris_bids_dirname, "participants.tsv"),
+            os.path.join(loris_bids_path, "participants.tsv"),
             "participant_id",
             verbose
         )
     else:
         lib.utilities.copy_file(
             bids_reader.path / "participants.tsv",
-            os.path.join(loris_bids_dirname, "participants.tsv"),
+            os.path.join(loris_bids_path, "participants.tsv"),
             verbose
         )
 
-    return loris_bids_dirname
+    return loris_bids_path
 
 
 def validate_participants(bids_reader: BidsDatasetReader, participants_file: BidsParticipantsTsvFile):

--- a/python/tests/integration/scripts/test_import_bids_dataset.py
+++ b/python/tests/integration/scripts/test_import_bids_dataset.py
@@ -37,7 +37,15 @@ def test_import_eeg_bids_dataset():
         db,
         Path('bids_imports/Face13_BIDSVersion_1.1.0/sub-OTT166/ses-V1/eeg/sub-OTT166_ses-V1_task-faceO_eeg.edf'),
     )
+
     assert file is not None
+    assert file.archive is not None
+    assert file.event_archive is not None
+
+    assert file.archive.path == \
+        Path('bids_imports/Face13_BIDSVersion_1.1.0/sub-OTT166/ses-V1/eeg/sub-OTT166_ses-V1_task-faceO_eeg.tgz')
+    assert file.event_archive.path == \
+        Path('bids_imports/Face13_BIDSVersion_1.1.0/sub-OTT166/ses-V1/eeg/sub-OTT166_ses-V1_task-faceO_events.tgz')
 
     # Check that the physiological file parameters has been inserted in the database.
     file_parameters = get_physio_file_parameters_dict(db, file.id)

--- a/python/tests/integration/scripts/test_import_bids_dataset.py
+++ b/python/tests/integration/scripts/test_import_bids_dataset.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from lib.db.queries.bids_event_dataset_mapping import get_bids_event_dataset_mappings_with_project_id
 from lib.db.queries.candidate import try_get_candidate_with_psc_id
 from lib.db.queries.config import set_config_with_setting_name
 from lib.db.queries.physio_file import try_get_physio_file_with_path
@@ -20,11 +21,13 @@ def test_import_eeg_bids_dataset():
     process = run_integration_script([
         'bids_import.py',
         '--createcandidate', '--createsession',
+        '--type', 'raw',
         '--directory', '/data/loris/incoming/Face13',
     ])
 
     # Check the return code.
     assert process.returncode == 0
+    assert process.stderr == ''
 
     # Check that the candidate and sessions are present in the database.
     candidate = try_get_candidate_with_psc_id(db, 'OTT166')
@@ -79,10 +82,16 @@ def test_import_eeg_bids_dataset():
         'electrophysiology_chunked_dataset_path': 'chunks/Face13_BIDSVersion_1.1.0_chunks/sub-OTT166_ses-V1_task-faceO_eeg.chunks',  # noqa: E501
     }
 
+    # Check that the event files has been inserted in the database.
+    bids_event_dataset_mappings = get_bids_event_dataset_mappings_with_project_id(db, session.project.id)
+    assert len(file.event_files) == 1
+    assert len(bids_event_dataset_mappings) == 12
+
     # Check that the BIDS files have been copied.
     assert_files_exist('/data/loris/bids_imports', {
         'Face13_BIDSVersion_1.1.0': {
             'dataset_description.json': None,
+            'events.json': None,
             'participants.tsv': None,
             'README': None,
             'sub-OTT166': {
@@ -137,6 +146,7 @@ def test_import_mri_bids_dataset():
 
     # Check the return code.
     assert process.returncode == 0
+    assert process.stderr == ''
 
     # Check that the candidate and sessions are present in the database.
     candidate = try_get_candidate_with_psc_id(db, 'DCC090')


### PR DESCRIPTION
Builds on #1401 ([diff](https://github.com/MaximeBICMTL/LORIS-MRI/compare/factorize-check-dir-config...MaximeBICMTL:LORIS-MRI:refactor-bids-import-script))

## Description

This PR refactors the "import root event dictionary (`events.json`)" logic using the typed database abstraction, in preparation to finally type the whole `bids_import.py` file. For now the new typed import events infrasctructure is only used for the root event dictionary file, but it shall eventually be used for all event files.

## Details

- This PR also fixes a bug on main where the root event file path was not correctly concatenated, which prevented it from being imported.
- I still use the old code for HED tag parsing, would prefer to not touch it NGL.

## Testing

This PR improves the BIDS EEG importer integration test by ensuring the root-level `events.json` file is copied and the events are inserted in the database. In order for the tests to pass, the following file needs to be added to the imaging testing bucket as `incoming/Face13/events.json`.

```json
{
  "trial_type": {
    "Description": "Category of the stimulus presented",
    "Levels": {
      "happy": "Happy facial expression",
      "fearful": "Fearful facial expression",
      "neutral": "Neutral facial expression",
      "scrambled": "Phase-scrambled face image"
    },
    "HED": {
      "happy": "(Sensory-event, Face, Happy, Experimental-stimulus)",
      "fearful": "(Sensory-event, Face, Fearful, Experimental-stimulus)",
      "neutral": "(Sensory-event, Face, Experimental-stimulus)",
      "scrambled": "(Experimental-stimulus)"
    }
  },
  "response_time": {
    "Description": "Reaction time in seconds from stimulus onset to button press",
    "Units": "s"
  },
  "stimulus_file": {
    "Description": "Filename of the stimulus image",
    "Format": "string"
  },
  "face_gender": {
    "Description": "Perceived gender of the face stimulus",
    "Levels": {
      "M": "Male",
      "F": "Female",
      "n/a": "Not applicable"
    }
  },
  "accuracy": {
    "Description": "Correct response (1) or incorrect (0)",
    "Units": "binary"
  }
}
```