### PR TITLE
Fix regex that excludes scans to be excluded based on their series descriptions in the Perl pipeline

### DIFF
--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -1531,7 +1531,7 @@ sub dicom_to_minc {
     #-----------------------------------------------------------------------------------#
     my $cmd = "find $study_dir -type f "
          . "| $get_dicom_info -studyuid -attvalue 0020 000e -echo -series_descr -stdin";
-    $cmd .= ' | grep -iv -P "\t(' . $excluded_regex . ')\s*$"' if ($excluded_regex);
+    $cmd .= ' | grep -iv -P "\t\s*(' . $excluded_regex . ')\s*\t[^\t]+\t$"' if ($excluded_regex);
     $cmd .= " | sort | uniq";
 
     my @cmdOutputLines = `$cmd`;


### PR DESCRIPTION
Some scans are processed by the Perl pipeline even though it should have ignored them based on the value of the config setting `excluded_series_description`. This PR fixes the command that select the scans to process according to that setting.


Fixes #1415 
