### PR TITLE
Improve electrophysiology chunker error checking

### DIFF
--- a/python/lib/physio/chunking.py
+++ b/python/lib/physio/chunking.py
@@ -51,17 +51,22 @@ def create_physio_channels_chunks(env: Env, physio_file: DbPhysioFile):
 
     try:
         log(env, f"Running chunking script with command: {' '.join(command_parts)}")
-        subprocess.call(command_parts, stdout=subprocess.DEVNULL if not env.verbose else None)
+        subprocess.run(
+            command_parts,
+            stdout=subprocess.DEVNULL if not env.verbose else None,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
     except OSError:
         log_error_exit(
             env,
-            "Chunking script not found.",
+            "Electrophysiology chunker script not found.",
             lib.exitcode.CHUNK_CREATION_FAILURE,
         )
     except subprocess.CalledProcessError as error:
         log_error_exit(
             env,
-            f"Chunking script execution failure. Error was:\n{error}",
+            f"Electrophysiology chunker execution failure. Error was:\n{error}",
             lib.exitcode.CHUNK_CREATION_FAILURE,
         )
 


### PR DESCRIPTION
## Description

While testing my PRs, Jefferson encountered a bug likely due to an incorrectly set-up environment. However, the error reported was misleading as it indicated that the expected directory name was not found rather than the electrophysiology chunker failed to run in the first place, which made it sound like the electrophysiology chunker did run but used the wrong directory name.

This PR improves electrophysiology chunker subscript execution error reporting by checking the process exit code. The previous code used `subprocess.call`, but this is a deprecated API (see [official documentation](https://docs.python.org/3/library/subprocess.html#older-high-level-api)) that does not raise an exception if the subprocess returns an error. This PR changes that call to `subprocess.run(..., check=True)` to ensure an exception is raised (and caught) if an error happens in the subscript.
