### PR TITLE
Simply `Env` creation

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/base_pipeline.py
@@ -11,7 +11,7 @@ from lib.db.queries.mri_upload import try_get_mri_upload_with_id
 from lib.get_session_info import SessionConfigError, get_dicom_archive_session_info
 from lib.imaging import Imaging
 from lib.logging import log_error_exit, log_verbose, log_warning
-from lib.make_env import make_env_from_opts
+from lib.lorisgetopt import LorisGetOpt
 
 
 class BasePipeline:
@@ -19,7 +19,7 @@ class BasePipeline:
     Series of checks done by most scripts of the dcm2bids imaging pipeline.
     """
 
-    def __init__(self, loris_getopt_obj, script_name):
+    def __init__(self, loris_getopt_obj: LorisGetOpt, script_name):
         """
         This initialize runs all the base functions that are always run by the following scripts:
         - nifti_insertion.py
@@ -64,7 +64,7 @@ class BasePipeline:
         # Create tmp dir and log file (their basename being the name of the script run)
         # ------------------------------------------------------------------------------------------
         self.tmp_dir = self.loris_getopt_obj.tmp_dir
-        self.env = make_env_from_opts(self.loris_getopt_obj)
+        self.env = self.loris_getopt_obj.env
         self.env.add_cleanup(self.remove_tmp_dir)
 
         # ------------------------------------------------------------------------------------------

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_archive_loader_pipeline.py
@@ -464,7 +464,7 @@ class DicomArchiveLoaderPipeline(BasePipeline):
         - {nb_files_inserted} files were inserted into the files table: {files_list}
         - {nb_prot_violation} files did not match any protocol: {prot_viol_list}
         - {nb_excluded_viol} files were exclusionary violations: {excl_viol_list}
-        - Log of process in {self.env.log_file}
+        - Log of process in {self.env.log_file_path}
         """
 
         log_verbose(self.env, summary)

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -519,7 +519,7 @@ class NiftiInsertionPipeline(BasePipeline):
         """
         self.trashbin_nifti_rel_path = os.path.join(
             'trashbin',
-            re.sub(r'\.log', '', os.path.basename(self.env.log_file)),
+            re.sub(r'\.log', '', self.env.log_file_path.name),
             os.path.basename(self.nifti_path)
         )
         self._create_destination_dir_and_move_image_files('trashbin')

--- a/python/lib/env.py
+++ b/python/lib/env.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from sqlalchemy import Engine
@@ -37,7 +38,8 @@ class Env:
     db: Session
     script_name: str
     config_info: Any
-    log_file: str
+    tmp_dir_path: Path
+    log_file_path: Path
     verbose: bool
     cleanups: list[Callable[[], None]]
     notifier: Notifier | None = None

--- a/python/lib/logging.py
+++ b/python/lib/logging.py
@@ -65,7 +65,7 @@ def write_to_log_file(env: Env, message: str):
     Write a message to the log file of the environment.
     """
 
-    with open(env.log_file, 'a') as file:
+    with open(env.log_file_path, 'a') as file:
         file.write(f"{message}\n")
 
 

--- a/python/lib/lorisgetopt.py
+++ b/python/lib/lorisgetopt.py
@@ -4,11 +4,11 @@ import os
 import sys
 
 import lib.exitcode
-import lib.utilities
 from lib.aws_s3 import AwsS3
 from lib.config_file import load_config
 from lib.database import Database
 from lib.database_lib.config import Config
+from lib.make_env import make_env
 
 
 class LorisGetOpt:
@@ -82,7 +82,16 @@ class LorisGetOpt:
         self.populate_options_dict_values(opts)
         self.check_required_options_are_set()
         self.load_config_file()
-        self.tmp_dir = lib.utilities.create_processing_tmp_dir(script_name)
+
+        # Create the environment object using the provided arguments.
+        self.env = make_env(
+            self.script_name,
+            self.options_dict,
+            self.config_info,
+            self.options_dict['verbose']['value'],
+        )
+
+        self.tmp_dir = self.env.tmp_dir_path
 
         # ------------------------------------------------------------------------------------------
         # Establish database connection

--- a/python/lib/make_env.py
+++ b/python/lib/make_env.py
@@ -1,5 +1,7 @@
-import os
 import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
 from typing import Any, cast
 
 from sqlalchemy.orm import Session
@@ -10,27 +12,12 @@ from lib.db.connect import get_database_engine
 from lib.db.queries.config import try_get_config_with_setting_name
 from lib.env import Env
 from lib.logging import log_verbose, write_to_log_file
-from lib.lorisgetopt import LorisGetOpt
-
-
-def make_env_from_opts(loris_get_opt: LorisGetOpt) -> Env:
-    """
-    Create a new script environment using the provided LORIS options object.
-    """
-
-    script_name = loris_get_opt.script_name
-    script_options = loris_get_opt.options_dict
-    config_info = loris_get_opt.config_info
-    tmp_dir = loris_get_opt.tmp_dir
-    verbose = loris_get_opt.options_dict['verbose']['value']   # type: ignore
-    return make_env(script_name, script_options, config_info, tmp_dir, verbose)  # type: ignore
 
 
 def make_env(
     script_name: str,
     script_options: dict[str, Any],
     config_info: Any,
-    tmp_dir_path: str,
     verbose: bool,
 ) -> Env:
     """
@@ -60,19 +47,22 @@ def make_env(
         print("Missing 'dataDirBasepath' configuration in the database.", file=sys.stderr)
         sys.exit(lib.exitcode.BAD_CONFIG_SETTING)
 
-    data_dir = data_dir_config.value
-    log_dir = os.path.join(data_dir, 'logs', script_name)
-    if not os.path.isdir(log_dir):
-        os.makedirs(log_dir)
+    data_dir = Path(data_dir_config.value)
 
-    log_file = os.path.join(log_dir, f'{os.path.basename(tmp_dir_path)}.log')
+    tmp_dir_path = create_script_tmp_dir(script_name)
+
+    log_dir_path = data_dir / 'logs' / script_name
+    log_dir_path.mkdir(exist_ok=True)
+
+    log_file_path = log_dir_path / f'{tmp_dir_path.name}.log'
 
     env = Env(
         engine,
         db,
         script_name,
         config_info,
-        log_file,
+        tmp_dir_path,
+        log_file_path,
         verbose,
         [],
     )
@@ -86,7 +76,7 @@ def make_env(
 
 
 def get_log_file_header(env: Env, script_options: dict[str, Any]):
-    run_info = os.path.basename(env.log_file[:-13])
+    run_info = env.log_file_path.name[:-13]
     title = run_info.replace('_', ' ').upper()
     message = (
         "\n"
@@ -103,3 +93,19 @@ def get_log_file_header(env: Env, script_options: dict[str, Any]):
 
     message += "\n"
     return message
+
+
+def create_script_tmp_dir(script_name: str) -> Path:
+    """
+    Create a recognizable temporary directory for the current pipeline.
+    """
+
+    # Get the temporary directory from the OS, notably from the `TMPDIR` environment variable.
+    env_tmp_dir = tempfile.gettempdir()
+
+    # Create a recognizable temporary directory name for this pipeline.
+    date_string = datetime.now().strftime('%Y-%m-%d_%Hh%Mm%Ss_')
+    tmp_dir_prefix = f'{script_name}_{date_string}'
+
+    # Create and return the pipeline temporary directory.
+    return Path(tempfile.mkdtemp(prefix=tmp_dir_prefix, dir=env_tmp_dir))

--- a/python/lib/utilities.py
+++ b/python/lib/utilities.py
@@ -234,6 +234,7 @@ def compute_md5_hash(file_path):
         return loris_utils.crypto.compute_file_md5_hash(file_path)
 
 
+@deprecated('Use `lib.make_env.create_script_tmp_dir` instead.')
 def create_processing_tmp_dir(template_prefix):
     """
     Creates a temporary directory with a name based on the concatenation of the

--- a/python/loris_dicom_importer/src/loris_dicom_importer/scripts/import_dicom_study.py
+++ b/python/loris_dicom_importer/src/loris_dicom_importer/scripts/import_dicom_study.py
@@ -15,7 +15,6 @@ from lib.db.queries.dicom_archive import try_get_dicom_archive_with_study_uid
 from lib.get_session_info import SessionConfigError
 from lib.logging import log, log_error_exit, log_warning
 from lib.lorisgetopt import LorisGetOpt
-from lib.make_env import make_env_from_opts
 from loris_utils.fs import iter_all_dir_files
 
 import loris_dicom_importer.text
@@ -111,7 +110,7 @@ def main() -> None:
     # Get the CLI arguments and connect to the database.
 
     loris_getopt_obj = LorisGetOpt(usage, options_dict, 'import_dicom_study')
-    env = make_env_from_opts(loris_getopt_obj)
+    env = loris_getopt_obj.env
     args = Args(loris_getopt_obj.options_dict)
 
     # Check arguments.

--- a/python/scripts/bids_import.py
+++ b/python/scripts/bids_import.py
@@ -100,8 +100,7 @@ def main():
     # input error checking and load config_file file
     config_file = load_config(profile)
     input_error_checking(bids_dir, usage)
-    tmp_dir_path = lib.utilities.create_processing_tmp_dir('mass_nifti_pic')
-    env = make_env('bids_import', {}, config_file, tmp_dir_path, verbose)
+    env = make_env('bids_import', {}, config_file, verbose)
 
     dataset_json = bids_dir + "/dataset_description.json"
     if not os.path.isfile(dataset_json) and not type:

--- a/python/scripts/extract_eeg_bids_archive.py
+++ b/python/scripts/extract_eeg_bids_archive.py
@@ -17,7 +17,6 @@ from lib.env import Env
 from lib.exitcode import BAD_CONFIG_SETTING, SUCCESS
 from lib.logging import log, log_error, log_error_exit, log_verbose, log_warning
 from lib.lorisgetopt import LorisGetOpt
-from lib.make_env import make_env_from_opts
 
 
 def main():
@@ -78,7 +77,7 @@ def main():
     # and create the log object (their basename being the name of the script run)
     # ---------------------------------------------------------------------------------------------
     tmp_dir = loris_getopt_obj.tmp_dir
-    env = make_env_from_opts(loris_getopt_obj)
+    env = loris_getopt_obj.env
 
     # ---------------------------------------------------------------------------------------------
     # Grep config settings from the Config module

--- a/python/scripts/mass_electrophysiology_chunking.py
+++ b/python/scripts/mass_electrophysiology_chunking.py
@@ -6,7 +6,6 @@ import getopt
 import sys
 
 import lib.exitcode
-import lib.utilities
 from lib.config_file import load_config
 from lib.db.queries.physio_file import try_get_physio_file_with_id
 from lib.env import Env
@@ -58,8 +57,7 @@ def main():
     # input error checking and load config_file file
     config_file = load_config(profile)
     input_error_checking(smallest_id, largest_id, usage)
-    tmp_dir_path = lib.utilities.create_processing_tmp_dir('mass_nifti_pic')
-    env = make_env('mass_nifti_pic', {}, config_file, tmp_dir_path, verbose)
+    env = make_env('mass_electrophysiology_chunking', {}, config_file, verbose)
 
     # run chunking script on electrophysiology datasets with a PhysiologicalFileID
     # between smallest_id and largest_id

--- a/python/scripts/mass_nifti_pic.py
+++ b/python/scripts/mass_nifti_pic.py
@@ -7,7 +7,6 @@ import re
 import sys
 
 import lib.exitcode
-import lib.utilities
 from lib.config import get_data_dir_path_config
 from lib.config_file import load_config
 from lib.database import Database
@@ -66,8 +65,7 @@ def main():
     # input error checking and load config_file file
     config_info = load_config(profile)
     input_error_checking(smallest_id, largest_id, usage)
-    tmp_dir_path = lib.utilities.create_processing_tmp_dir('mass_nifti_pic')
-    env = make_env('mass_nifti_pic', {}, config_info, tmp_dir_path, verbose)
+    env = make_env('mass_nifti_pic', {}, config_info, verbose)
 
     # create pic for NIfTI files with a FileID between smallest_id and largest_id
     if (smallest_id == largest_id):


### PR DESCRIPTION
## Description

Simplify the `Env` object creation by moving temporary directory creation (either provided manually or through `LorisGetOpt`) inside the `make_env` function.

## Changelog

- Remove the `tmp_dir_path` argument from the `make_env` function.
- Replace `make_env_from_opts(LorisGetOpt)` by `LorisGetOpt.env` (dependency inversion).
- Replace `lib.utilities.create_processing_tmp_dir` by `lib.make_env.create_script_tmp_dir`.
- Use `Path` instead of `str` for paths inside the `Env` object.
- Renamed `env.log_file` to `env.log_file_path` to better follow our naming conventions.

## Migration guide

### Manual `Env` creation

Before (main, not present in LORIS 27):

```py
import lib.utilities
from lib.config_file import load_config
from lib.make_env import make_env

config_info = load_config(profile)
tmp_dir_path = lib.utilities.create_processing_tmp_dir(options)
env = make_env(script_name, options, config_info, tmp_dir_path, verbose)
```

After:

```py
from lib.config_file import load_config
from lib.make_env import make_env

config_info = load_config(profile)
env = make_env(script_name, options, config_info, verbose)
```

### `LorisGetOpt`-based `Env` creation

Before (main):


```py
from lib.make_env import make_env_get_opts

env = make_env_from_opts(loris_get_opt)
```

Before (LORIS Python 27):

```py
from lib.make_env import make_env

env = make_env(loris_get_opt)
```

After:

```py
env = loris_get_opt.env
```
