### PR TITLE
Fix LORIS Python electrophysiology chunks directory installation process

### DIFF
--- a/install/imaging_install.sh
+++ b/install/imaging_install.sh
@@ -113,6 +113,7 @@ echo "Creating the data directories"
   sudo -S su $USER -c "mkdir -m 2770 -p /data/$PROJ/data/"
   sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/trashbin"         #holds mincs that didn't match protocol
   sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/tarchive"         #holds tared dicom-folder
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/chunks"           #holds electrophysiology chunks folder
   sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/hrrtarchive"      #holds tared hrrt-folder
   sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/pic"              #holds jpegs generated for the MRI-browser
   sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/data/logs"             #holds logs from pipeline script

--- a/install/install_database.sql
+++ b/install/install_database.sql
@@ -19,6 +19,8 @@ UPDATE Config SET Value = CONCAT('/data/', @project, '/')
   WHERE ConfigID = (SELECT ID FROM ConfigSettings WHERE Name = 'imagePath');
 UPDATE Config SET Value = CONCAT('/data/', @project, '/tarchive/')
   WHERE ConfigID = (SELECT ID FROM ConfigSettings WHERE Name = 'tarchiveLibraryDir');
+UPDATE Config SET Value = CONCAT('/data/', @project, '/chunks/')
+  WHERE ConfigID = (SELECT ID FROM ConfigSettings WHERE Name = 'EEGChunksPath');
 UPDATE Config SET Value = CONCAT('/opt/', @project, '/bin/mri/dicom-archive/get_dicom_info.pl')
   WHERE ConfigID = (SELECT ID FROM ConfigSettings WHERE Name = 'get_dicom_info');
 UPDATE Config SET Value = CONCAT('/opt/', @project, '/bin/mri/')

--- a/python/tests/integration/scripts/test_import_bids_dataset.py
+++ b/python/tests/integration/scripts/test_import_bids_dataset.py
@@ -68,7 +68,7 @@ def test_import_eeg_bids_dataset():
         'electrode_file_blake2b_hash': '0206db2650ae5a07e4225ff87b6fb2a6bfcf6ea088dd8cdfd77d04e9e25a171ffe68878aa156478babb32dcaf9b46459f87fe0516b728278cc0d9372a0d49299',  # noqa: E501
         'channel_file_blake2b_hash': '7b91e3650086ef50ecc00f1c50e17e7ad8dc39c484536bbc2423af4be7d2b50a3a0010f840d457fec68fbfb3e136edf4d616a31bab0ca09ed686f555727341dd',  # noqa: E501
         'event_file_blake2b_hash': '532aa0b52749eb9ee52c2bbb65fa7b1d00d7126cb9a4e10bd4b9dbb4c5527b06e30acdaf17d5806e81d3ce8ad224a9f456e27aba1bf8b92fd43522837c7ffec7',  # noqa: E501
-        'electrophysiology_chunked_dataset_path': 'bids_imports/Face13_BIDSVersion_1.1.0_chunks/sub-OTT166_ses-V1_task-faceO_eeg.chunks',  # noqa: E501
+        'electrophysiology_chunked_dataset_path': 'chunks/Face13_BIDSVersion_1.1.0_chunks/sub-OTT166_ses-V1_task-faceO_eeg.chunks',  # noqa: E501
     }
 
     # Check that the BIDS files have been copied.
@@ -92,7 +92,7 @@ def test_import_eeg_bids_dataset():
     })
 
     # Check that the chunk files have been created.
-    assert_files_exist('/data/loris/bids_imports', {
+    assert_files_exist('/data/loris/chunks', {
         'Face13_BIDSVersion_1.1.0_chunks': {
             'sub-OTT166_ses-V1_task-faceO_eeg.chunks': {
                 'index.json': None,

--- a/test/imaging_install_test.sh
+++ b/test/imaging_install_test.sh
@@ -17,6 +17,7 @@ echo "Creating the data directories"
   sudo -S su $USER -c "mkdir -m 2770 -p /data/$PROJ/"
   sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/trashbin"         #holds mincs that didn't match protocol
   sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/tarchive"         #holds tared dicom-folder
+  sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/chunks"           #holds electrophysiology chunks folder
   sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/hrrtarchive"      #holds tared hrrt-folder
   sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/pic"              #holds jpegs generated for the MRI-browser
   sudo -S su $USER -c "mkdir -m 770 -p /data/$PROJ/logs"             #holds logs from pipeline script


### PR DESCRIPTION
## Problem

CI has been failing for a few days due to the LORIS Python installation process being broken since https://github.com/aces/Loris/pull/10455.

## Solution

Properly create the electrophysiology directories and set the database configuration during the installation process.

## Follow-up

We have a mismatch right now where the default install creates the `/data/$project/data/thingies` directories but sets up the `/data/$project/thingies` database configuration. If you often reset raisinbread you know what this is. We should fix that one day to make the installation process smoother, but this is obviously out-of-scope for that PR.

