### PR TITLE
Typed NIfTI preview picture script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ include = [
     "python/lib/logging.py",
     "python/lib/make_env.py",
     "python/scripts/mass_electrophysiology_chunking.py",
+    "python/scripts/mass_nifti_pic.py",
     "python/loris_bids_importer",
     "python/loris_bids_reader",
     "python/loris_dicom_importer",

--- a/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/nifti_insertion_pipeline.py
@@ -18,7 +18,7 @@ from lib.db.queries.mri_scan_type import try_get_mri_scan_type_with_id, try_get_
 from lib.dcm2bids_imaging_pipeline_lib.base_pipeline import BasePipeline
 from lib.get_session_info import SessionConfigError, get_dicom_archive_session_info
 from lib.imaging_lib.file import register_mri_file
-from lib.imaging_lib.file_parameter import register_mri_file_parameter, register_mri_file_parameters
+from lib.imaging_lib.file_parameter import register_mri_file_parameters
 from lib.imaging_lib.nifti import add_nifti_spatial_file_parameters
 from lib.imaging_lib.nifti_pic import create_nifti_preview_picture
 from lib.logging import log_error_exit, log_verbose
@@ -190,7 +190,7 @@ class NiftiInsertionPipeline(BasePipeline):
         # Create the pic images
         # ------------------------------------------------------------------------------------------
         if self.create_pic_bool:
-            self._create_pic_image()
+            create_nifti_preview_picture(self.env, self.file)
 
         # ------------------------------------------------------------------------------------------
         # Remove the tmp directory from the file system
@@ -692,15 +692,6 @@ class NiftiInsertionPipeline(BasePipeline):
         self.env.db.commit()
 
         return file
-
-    def _create_pic_image(self):
-        """
-        Creates the pic image of the NIfTI file.
-        """
-
-        pic_rel_path = create_nifti_preview_picture(self.env, self.file)
-        register_mri_file_parameter(self.env, self.file, 'check_pic_filename', str(pic_rel_path))
-        self.env.db.commit()
 
     def _run_push_to_s3_pipeline(self):
         """

--- a/python/lib/imaging_lib/nifti_pic.py
+++ b/python/lib/imaging_lib/nifti_pic.py
@@ -9,6 +9,7 @@ from nilearn import plotting
 from lib.config import get_data_dir_path_config
 from lib.db.models.file import DbFile
 from lib.env import Env
+from lib.imaging_lib.file_parameter import register_mri_file_parameter
 
 
 def create_nifti_preview_picture(env: Env, nifti_file: DbFile) -> Path:
@@ -52,4 +53,10 @@ def create_nifti_preview_picture(env: Env, nifti_file: DbFile) -> Path:
         annotate=False,
     )
 
-    return pic_path.relative_to(data_dir_path / 'pic')
+    pic_rel_path = pic_path.relative_to(data_dir_path / 'pic')
+
+    # Register the preview picture path as a file parameter.
+    register_mri_file_parameter(env, nifti_file, 'check_pic_filename', str(pic_rel_path))
+    env.db.commit()
+
+    return pic_rel_path

--- a/python/loris_bids_importer/src/loris_bids_importer/mri/main.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/mri/main.py
@@ -7,7 +7,7 @@ from lib.db.queries.file import try_get_file_with_hash, try_get_file_with_path
 from lib.db.queries.mri_scan_type import try_get_mri_scan_type_with_name
 from lib.env import Env
 from lib.imaging_lib.file import register_mri_file
-from lib.imaging_lib.file_parameter import register_mri_file_parameter, register_mri_file_parameters
+from lib.imaging_lib.file_parameter import register_mri_file_parameters
 from lib.imaging_lib.nifti import add_nifti_spatial_file_parameters
 from lib.imaging_lib.nifti_pic import create_nifti_preview_picture
 from lib.imaging_lib.scan_type import create_mri_scan_type
@@ -176,11 +176,7 @@ def import_bids_mri_acquisition(
 
     # Create and register the file picture.
 
-    pic_rel_path = create_nifti_preview_picture(env, file)
-
-    register_mri_file_parameter(env, file, 'check_pic_filename', str(pic_rel_path))
-
-    env.db.commit()
+    create_nifti_preview_picture(env, file)
 
 
 def get_check_bids_nifti_file_hash(env: Env, acquisition: MriAcquisition) -> str:

--- a/python/scripts/mass_nifti_pic.py
+++ b/python/scripts/mass_nifti_pic.py
@@ -2,171 +2,116 @@
 
 """Script to mass create the pic images of inserted NIfTI files."""
 
-import getopt
-import re
-import sys
+import argparse
+from pathlib import Path
+
+from loris_utils.path import get_path_extension
 
 import lib.exitcode
 from lib.config import get_data_dir_path_config
 from lib.config_file import load_config
-from lib.database import Database
 from lib.db.queries.file import try_get_file_with_id
+from lib.db.queries.file_parameter import try_get_parameter_value_with_file_id_parameter_name
 from lib.env import Env
-from lib.imaging import Imaging
-from lib.imaging_lib.file_parameter import register_mri_file_parameter
 from lib.imaging_lib.nifti_pic import create_nifti_preview_picture
+from lib.logging import log, log_error, log_error_exit, log_warning
 from lib.make_env import make_env
 
 
 def main():
-    profile     = None
-    verbose     = False
-    force       = False
-    smallest_id = None
-    largest_id  = None
-
-    long_options = [
-        "help", "profile=", "smallest_id=", "largest_id=", "force", "verbose"
-    ]
-
-    usage = (
-        '\n'
-        'usage  : mass_nifti_pic.py -p <profile> -s <smallest_id> -l <largest_id>\n\n'
-        'options: \n'
-        '\t-p, --profile    : name of the python database config file in the config'
-                              ' directory\n'
-        '\t-s, --smallest_id: smallest FileID for which the pic will be created\n'
-        '\t-l, --largest_id : largest FileID for which the pic will be created\n'
-        '\t-f, --force      : overwrite the pic already present in the filesystem with new pic\n'
-        '\t-v, --verbose    : be verbose\n'
+    parser = argparse.ArgumentParser(
+        description="Mass create pic images for inserted NIfTI files.",
     )
 
-    try:
-        opts, _ = getopt.getopt(sys.argv[1:], 'hp:s:l:fv', long_options)
-    except getopt.GetoptError:
-        print(usage)
-        sys.exit(lib.exitcode.GETOPT_FAILURE)
+    parser.add_argument(
+        '-p', '--profile',
+        help="Name of the python database config file in the config directory."
+    )
 
-    for opt, arg in opts:
-        if opt in ('-h', '--help'):
-            print(usage)
-            sys.exit()
-        elif opt in ('-p', '--profile'):
-            profile = arg
-        elif opt in ('-s', '--smallest_id'):
-            smallest_id = int(arg)
-        elif opt in ('-l', '--largest_id'):
-            largest_id = int(arg)
-        elif opt in ('-f', '--force'):
-            force = True
-        elif opt in ('-v', '--verbose'):
-            verbose = True
+    parser.add_argument(
+        '-s', '--smallest-id',
+        type=int,
+        required=True,
+        help="Smallest file ID for which the pic will be created."
+    )
 
-    # input error checking and load config_file file
-    config_info = load_config(profile)
-    input_error_checking(smallest_id, largest_id, usage)
-    env = make_env('mass_nifti_pic', {}, config_info, verbose)
+    parser.add_argument(
+        '-l', '--largest-id',
+        type=int,
+        required=True,
+        help="Largest file ID for which the pic will be created."
+    )
 
-    # create pic for NIfTI files with a FileID between smallest_id and largest_id
-    if (smallest_id == largest_id):
-        make_pic(env, smallest_id, config_info, force, verbose)
-    else:
-        for file_id in range(smallest_id, largest_id + 1):
-            make_pic(env, file_id, config_info, force, verbose)
+    parser.add_argument(
+        '-f', '--force',
+        action='store_true',
+        help="Overwrite the pic already present in the filesystem with new pic."
+    )
 
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        help="If set, be verbose."
+    )
 
-def input_error_checking(smallest_id, largest_id, usage):
-    """
-    Checks whether the required inputs are correctly set.
+    args = parser.parse_args()
 
-    :param smallest_id: smallest FileID for which to create the pic
-     :type smallest_id: int
-    :param largest_id : largest FileID for which to create the pic
-     :type largest_id : int
-    :param usage      : script usage to be displayed when encountering an error
-     :type usage      : str
-    """
+    config_file = load_config(args.profile)
+    env = make_env('mass_nifti_pic', {}, config_file, args.verbose)
 
-    if not smallest_id:
-        message = '\n\tERROR: you must specify a smallest FileID on which to run the' \
-                  ' mass_nifti_pic.py script using -s or --smallest_id option'
-        print(message)
-        print(usage)
-        sys.exit(lib.exitcode.MISSING_ARG)
-
-    if not largest_id:
-        message = '\n\tERROR: you must specify a largest FileID on which to run the ' \
-                  'mass_nifti_pic.py script using -l or --largest_id option'
-        print(message)
-        print(usage)
-        sys.exit(lib.exitcode.MISSING_ARG)
-
-    if not smallest_id <= largest_id:
-        message = '\n\tERROR: the value for --smallest_id option is bigger than ' \
-                  'value for --largest_id option'
-        print(message)
-        print(usage)
-        sys.exit(lib.exitcode.INVALID_ARG)
-
-
-def make_pic(env: Env, file_id, config_file, force, verbose):
-    """
-    Call the function create_imaging_pic of the Imaging class on
-    the FileID provided as argument to this function.
-
-    :param file_id    : FileID of the file for which to create the pic
-     :type file_id    : int
-    :param config_file: path to the config file with database connection information
-     :type config_file: str
-    :param force      : if a pic is already present for the FileID, overwrite the pic in the
-                        filesystem with newly generated pic
-     :type force      : bool
-    :param verbose    : flag for more printing if set
-     :type verbose    : bool
-    """
-
-    # database connection
-    db = Database(config_file.mysql, verbose)
-    db.connect()
+    if not (args.smallest_id <= args.largest_id):
+        log_error_exit(
+            env,
+            "The --smallest-id value should be smaller than the --largest-id value",
+            lib.exitcode.INVALID_ARG,
+        )
 
     data_dir_path = get_data_dir_path_config(env)
 
-    # load the Imaging object
-    imaging = Imaging(db, verbose)
+    # Create pic for NIfTI files with a file ID between the smallest and largest IDs.
+    for file_id in range(args.smallest_id, args.largest_id + 1):
+        make_pic(env, data_dir_path, file_id, args.force)
 
-    # grep the NIfTI file path
+
+def make_pic(env: Env, data_dir_path: Path, file_id: int, force: bool):
+    """
+    Call the NIfTI preview picture creation function on the provided file ID.
+    """
+
     nifti_file = try_get_file_with_id(env.db, file_id)
     if nifti_file is None:
-        print(f'WARNING: no file in the database with FileID = {file_id}')
+        log_warning(env, f"No file with ID {file_id} in the database, skipping.")
         return
-    if not re.search(r'.nii.gz$', str(nifti_file.path)):
-        print(f'WARNING: wrong file type. File {nifti_file.path} is not a .nii.gz file')
+
+    if get_path_extension(nifti_file.path) != 'nii.gz':
+        log_warning(env, f"Wrong file type. File '{nifti_file.path}' is not a .nii.gz file, skipping.")
         return
+
     if not (data_dir_path / nifti_file.path).exists():
-        print(f'WARNING: file {nifti_file.path} not found on the filesystem')
+        log_warning(env, f"File '{nifti_file.path}' not found on the filesystem, skipping.")
         return
 
-    # checks if there is already a pic for the NIfTI file
-    existing_pic_file_in_db = imaging.grep_parameter_value_from_file_id_and_parameter_name(
-        file_id, 'check_pic_filename'
+    # Check if there is already a preview picture for the NIfTI file.
+    current_pic = try_get_parameter_value_with_file_id_parameter_name(
+        env.db, file_id, 'check_pic_filename'
     )
-    if existing_pic_file_in_db and not force:
-        print(f'WARNING: there is already a pic for FileID {nifti_file.id}. Use -f or --force to overwrite it')
+
+    if current_pic is not None and not force:
+        log_warning(
+            env,
+            f"There is already a pic for file ID {nifti_file.id}. Use -f or --force to overwrite it, skipping."
+        )
         return
 
-    # create the pic
+    log(env, f"Creating preview picture for NIfTI file ID {nifti_file.id}")
+
     pic_rel_path = create_nifti_preview_picture(env, nifti_file)
 
     pic_path = data_dir_path / 'pic' / pic_rel_path
     if not pic_path.exists():
-        print(f'WARNING: the pic {pic_path} was not created')
+        log_error(env, f"The pic {pic_path} was not created")
         return
 
-    # insert the relative path to the pic in the parameter_file table
-    if not existing_pic_file_in_db:
-        register_mri_file_parameter(env, nifti_file, 'check_pic_filename', pic_rel_path)
-        env.db.commit()
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/python/tests/integration/scripts/test_mass_nifti_pic.py
+++ b/python/tests/integration/scripts/test_mass_nifti_pic.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from lib.db.models.file import DbFile
 from lib.db.queries.file import delete_file
 from lib.db.queries.file_parameter import delete_file_parameter, try_get_parameter_value_with_file_id_parameter_name
-from lib.exitcode import INVALID_ARG, INVALID_PATH, MISSING_ARG, SUCCESS
+from lib.exitcode import INVALID_ARG, INVALID_PATH, SUCCESS
 from tests.util.database import get_integration_database_session
 from tests.util.run_integration_script import run_integration_script
 
@@ -17,67 +17,32 @@ def test_invalid_profile_arg():
 
     process = run_integration_script([
         'mass_nifti_pic.py',
-        '--profile', 'invalid_profile.py'
+        '--profile', 'invalid_profile.py',
+        '--smallest-id', '1',
+        '--largest-id', '1',
     ])
 
     # Check return code, STDOUT and STDERR
-    message = "ERROR: No configuration file 'invalid_profile.py' found in the '/opt/loris/bin/mri/config' directory.\n"
     assert process.returncode == INVALID_PATH
     assert process.stdout == ""
-    assert process.stderr == message
-
-
-def test_missing_smallest_id_arg():
-    """
-    Test running the script without the --smallest_id argument.
-    """
-
-    process = run_integration_script([
-        'mass_nifti_pic.py',
-    ])
-
-    # Check return code, STDOUT and STDERR
-    message = 'ERROR: you must specify a smallest FileID on which to run' \
-              ' the mass_nifti_pic.py script using -s or --smallest_id option'
-    assert process.returncode == MISSING_ARG
-    assert message in process.stdout
-    assert process.stderr == ""
-
-
-def test_missing_largest_id_arg():
-    """
-    Test running the script without the --largest_id argument.
-    """
-
-    process = run_integration_script([
-        'mass_nifti_pic.py',
-        '--smallest_id', '2',
-    ])
-
-    # Check return code, STDOUT and STDERR
-    message = 'ERROR: you must specify a largest FileID on which to run the' \
-              ' mass_nifti_pic.py script using -l or --largest_id option'
-    assert process.returncode == MISSING_ARG
-    assert message in process.stdout
-    assert process.stderr == ""
+    assert process.stderr == "ERROR: No configuration file 'invalid_profile.py' found in the '/opt/loris/bin/mri/config' directory.\n"  # noqa: E501
 
 
 def test_smallest_id_bigger_than_largest_id():
     """
-    Test running the script with a --smallest_id higher than the --largest_id.
+    Test running the script with a --smallest-id higher than the --largest-id.
     """
 
     process = run_integration_script([
         'mass_nifti_pic.py',
-        '--smallest_id', '6',
-        '--largest_id', '2'
+        '--smallest-id', '6',
+        '--largest-id', '2'
     ])
 
     # Check return code, STDOUT and STDERR
-    message = 'ERROR: the value for --smallest_id option is bigger than value for --largest_id option'
     assert process.returncode == INVALID_ARG
-    assert message in process.stdout
-    assert process.stderr == ""
+    assert process.stdout == ""
+    assert process.stderr == "ERROR: The --smallest-id value should be smaller than the --largest-id value\n"
 
 
 def test_on_invalid_file_id():
@@ -87,15 +52,14 @@ def test_on_invalid_file_id():
 
     process = run_integration_script([
         'mass_nifti_pic.py',
-        '--smallest_id', '999',
-        '--largest_id', '999'
+        '--smallest-id', '999',
+        '--largest-id', '999'
     ])
 
     # Check return code, STDOUT and STDERR
-    message = 'WARNING: no file in the database with FileID = 999'
     assert process.returncode == SUCCESS
-    assert message in process.stdout
-    assert process.stderr == ""
+    assert process.stdout == ""
+    assert process.stderr == "WARNING: No file with ID 999 in the database, skipping.\n"
 
 
 def test_on_file_id_that_already_has_a_pic():
@@ -105,15 +69,14 @@ def test_on_file_id_that_already_has_a_pic():
 
     process = run_integration_script([
         'mass_nifti_pic.py',
-        '--smallest_id', '2',
-        '--largest_id', '2'
+        '--smallest-id', '2',
+        '--largest-id', '2'
     ])
 
     # Check return code, STDOUT and STDERR
-    message = 'WARNING: there is already a pic for FileID 2. Use -f or --force to overwrite it'
     assert process.returncode == SUCCESS
-    assert message in process.stdout
-    assert process.stderr == ""
+    assert process.stdout == ""
+    assert process.stderr == "WARNING: There is already a pic for file ID 2. Use -f or --force to overwrite it, skipping.\n"  # noqa: E501
 
 
 def test_force_option():
@@ -134,14 +97,14 @@ def test_force_option():
 
     process = run_integration_script([
         'mass_nifti_pic.py',
-        '--smallest_id', '2',
-        '--largest_id', '2',
+        '--smallest-id', '2',
+        '--largest-id', '2',
         '--force'
     ])
 
     # Check return code, STDOUT and STDERR
     assert process.returncode == SUCCESS
-    assert process.stdout == ""
+    assert process.stdout == "Creating preview picture for NIfTI file ID 2\n"
     assert process.stderr == ""
 
     file_pic_data = try_get_parameter_value_with_file_id_parameter_name(db, 2, 'check_pic_filename')
@@ -174,15 +137,14 @@ def test_running_on_a_text_file():
     # run NIfTI pic script on the inserted file
     process = run_integration_script([
         'mass_nifti_pic.py',
-        '--smallest_id', str(file.id),
-        '--largest_id', str(file.id)
+        '--smallest-id', str(file.id),
+        '--largest-id', str(file.id)
     ])
 
     # Check return code, STDOUT and STDERR
-    message = 'WARNING: wrong file type. File test.txt is not a .nii.gz file'
     assert process.returncode == SUCCESS
-    assert message in process.stdout
-    assert process.stderr == ""
+    assert process.stdout == ""
+    assert process.stderr == "WARNING: Wrong file type. File 'test.txt' is not a .nii.gz file, skipping.\n"
 
     # Clean up the file that was inserted before this test
     delete_file(db, file.id)
@@ -217,13 +179,13 @@ def test_successful_run():
 
     process = run_integration_script([
         'mass_nifti_pic.py',
-        '--smallest_id', '2',
-        '--largest_id', '2'
+        '--smallest-id', '2',
+        '--largest-id', '2'
     ])
 
     # Check return code, STDOUT and STDERR
     assert process.returncode == SUCCESS
-    assert process.stdout == ""
+    assert process.stdout == "Creating preview picture for NIfTI file ID 2\n"
     assert process.stderr == ""
 
     # check pic in database and file system


### PR DESCRIPTION
PR largely generated by AI based on https://github.com/aces/Loris-MRI/pull/1427 (with manual directions, verifications, and additions)

## Description

Make the `mass_nifti_pic.py` script typed. Also move the "add physiological file parameter" from the three call sites to the common `create_nifti_preview_picture` function (it would not really make sense to create the preview picture without updating the parameters anyway, it is the same pattern as with the `create_physio_file_chunks` function).

## Breaking changes

- Rename the options `--smallest_id` and `--largest_id` to `--smallest-id` and `--largest-id` to be more consistent with newer scripts.

## Testing

Manually tested:

591 has no file attached to it and 592 already has a pic:
```sh
(loris) lorisadmin@loris:/opt/loris/bin/mri$ mass_nifti_pic.py --smallest-id 591 --largest-id 592
WARNING: No file with ID 591 in the database, skipping.
WARNING: There is already a pic for file ID 592. Use -f or --force to overwrite it, skipping.
```
After deleting 592 pic:
```sh
(loris) lorisadmin@loris:/opt/loris/bin/mri$ mass_nifti_pic.py --smallest-id 591 --largest-id 592
WARNING: No file with ID 591 in the database, skipping.
Creating preview picture for NIfTI file ID 592
```
The pic can be seen in the electrophysiology browser :ok_hand:
After using `-f`:
```sh
(loris) lorisadmin@loris:/opt/loris/bin/mri$ mass_nifti_pic.py --smallest-id 592 --largest-id 592 -f
Creating preview picture for NIfTI file ID 592
```
There is no output telling that the image is being overriden but that is also the case of the current script, IMO out of scope for this PR.