### PR TITLE
Add Typos to CI

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -10,6 +10,21 @@ on:
     - cron: '30 0 * * *'
 
 jobs:
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out LORIS-MRI
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: ./.github/actions/setup-python
+    - name: Run Typos
+      run:  |
+        set -o pipefail
+        typos --format=json | test/typos_to_github.sh
+
   ruff:
     name: Ruff
     runs-on: ubuntu-latest

--- a/docs/02-Install.md
+++ b/docs/02-Install.md
@@ -59,7 +59,7 @@ identified with the `mri_protocol` table to be a `t1`. Additional headers could
 be checked in order to flag with a caveat or exclude the scan based on the value
 of that header.
 
-**Behaviour of the `*Min` and `*Max` columns of the `mri_protocol` and
+**Behavior of the `*Min` and `*Max` columns of the `mri_protocol` and
 `mri_protocol_checks` tables:**
 
 > - if for a given parameter (*e.g.* TR) a `*Min` **AND** a `*Max` value have
@@ -84,7 +84,7 @@ there will be no constraint on that header.
 The following tables are used by pipelines generating BIDS files either directly from DICOM files
 (using dcm2niix as a converter) or from the MINC files already inserted into the database.
 
-> - `bids_mri_scan_type_rel`: this table maps a given scan type with BIDS labelling convention
+> - `bids_mri_scan_type_rel`: this table maps a given scan type with BIDS labeling convention
 that should be used to determine the name of the NIfTI and JSON files. This table also links
 to the `mri_scan_type`, `bids_category`, `bids_phase_encoding_direction`, `bids_scan_type`
 and `bids_scan_type_subcategory` tables.
@@ -308,7 +308,7 @@ scripts (in the `python` directory). It accesses data stored in the
     * By default, any scan will be inserted if it matches an `mri_protocol`
     table entry.
     * To **whitelist/blacklist** specific scan types -- *e.g.* in the case of
-    protocol exclusion, case sensitivity or labelling variance -- modify the
+    protocol exclusion, case sensitivity or labeling variance -- modify the
     subroutine, *e.g.*:
 
 ```perl

--- a/docs/04-Scripts.md
+++ b/docs/04-Scripts.md
@@ -168,7 +168,7 @@ In general, to re-load an imaging dataset through the pipeline from the start
 - `files` (best to delete from this table last)
 - `mri_upload`
 - `session` - not recommended - only if necessary, and only if no other data is
-    associated to this session (*e.g.* on the Behavioural side of LORIS).
+    associated to this session (*e.g.* on the Behavioral side of LORIS).
 - `tarchive`
 
 It is also recommended to remove from the `tarchive` directory the last generated
@@ -181,7 +181,7 @@ If any Quality Control flags or comments exist for these scans, you may also
 **A script has been created in order to perform a safe deletion of an upload. Please,
 see section 4.4 for instructions on how to use the script.**
 
-For backing up, re-labelling and re-loading MRI datasets with QC information,
+For backing up, re-labeling and re-loading MRI datasets with QC information,
   see [Beta Tutorial](https://github.com/aces/Loris/wiki/Reloading-MRI-data-for-mislabelled-session)
 
 ### 4.3.3 Multiple scanner datasets per session
@@ -203,5 +203,5 @@ from the MRI upload. Note that by default, all removed data will be backed up.
 Detailed information about the script can be found in:
 https://github.com/aces/Loris-MRI/blob/21.0-dev/docs/scripts_md/delete_imaging_upload.md
 
-> Accordng to chosen options, deleting values can generate backup files with `mysqldump`.
+> According to chosen options, deleting values can generate backup files with `mysqldump`.
 > To allow `mysqldump` to work properly, be sure the user accessing the database has the `RELOAD` privilege.

--- a/docs/python/Database_abstraction.md
+++ b/docs/python/Database_abstraction.md
@@ -4,7 +4,7 @@ LORIS-MRI Python interacts extensively with the LORIS database. As such, several
 
 ## SQLAlchemy database abstraction
 
-The SQLAlchemy database abstraction is the latest and preferred method to interract with the database in LORIS-MRI Python. As its name implies, it uses the SQLAlchemy 2 Python library, which is an ORM library that allows to map SQL tables with Python classes. Compared to the older database abstractions, it is notably statically typed and has a flexible module structure that separates models and queries.
+The SQLAlchemy database abstraction is the latest and preferred method to interact with the database in LORIS-MRI Python. As its name implies, it uses the SQLAlchemy 2 Python library, which is an ORM library that allows to map SQL tables with Python classes. Compared to the older database abstractions, it is notably statically typed and has a flexible module structure that separates models and queries.
 
 ### Module organization
 
@@ -50,7 +50,7 @@ def foo(db: Database):
 
 The changes made in a database session are not sent to the database until `db.flush()` or `db.commit()` is called. Be mindful of this behavior when reading database-populated fields such as auto-incremented numbers or before exiting a script.
 
-Finally, a database session is **transactional**, that is, the changes made in a session are not visible by other sessions and do not persist in the database unless they are commited. Use `db.commit()` to commit the current changes or `db.rollback()` to discard them and go back to the latest database commit. There may be several database sessions living simultaneously to handle independent transactions.
+Finally, a database session is **transactional**, that is, the changes made in a session are not visible by other sessions and do not persist in the database unless they are committed. Use `db.commit()` to commit the current changes or `db.rollback()` to discard them and go back to the latest database commit. There may be several database sessions living simultaneously to handle independent transactions.
 
 [^2]: Code that interacts with advanced SQLAlchemy APIs should not use these renamings but instead stick to the SQLAlchemy naming convention.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "pyright",
     "pytest",
     "ruff",
+    "typos",
 ]
 
 [project.urls]
@@ -108,6 +109,24 @@ exclude = [
 ]
 typeCheckingMode = "strict"
 reportMissingTypeStubs = "none"
+
+[tool.typos.files]
+# Ignore Perl files for now.
+extend-exclude = [
+    "*.al", "*.pl", "*.pm",
+    "/docs/scripts_md",
+]
+
+[tool.typos.default]
+locale = "en-us"
+
+[tool.typos.default.extend-words]
+Centre = "Centre"  # McGill Centre for Integrative Neuroscience
+HED = "HED"  # Hierarchical Event Descriptors
+ND = "ND"  # Image Type DICOM attribute
+
+[tool.typos.default.extend-identifiers]
+ba = "ba"  # A CLI option of dcm2niix
 
 [tool.pytest.ini_options]
 # Integration tests are located in `python/tests/integration`, but they should be ran from the

--- a/python/lib/aws_s3.py
+++ b/python/lib/aws_s3.py
@@ -124,7 +124,7 @@ class AwsS3:
         :param s3_object_name: S3 object name. It should be identical to the LORIS relative path to
                                data_dir
          :type s3_object_name: str
-        :param force: Whether to force upload if the file aready exists on the bucket.
+        :param force: Whether to force upload if the file already exists on the bucket.
          :type force: bool
         """
 

--- a/python/lib/database_lib/mri_upload_db.py
+++ b/python/lib/database_lib/mri_upload_db.py
@@ -24,7 +24,7 @@ class MriUploadDB:
 
     def __init__(self, db, verbose):
         """
-        Constructor method for the MriUplaodDB class.
+        Constructor method for the MriUploadDB class.
 
         :param db                 : Database class object
          :type db                 : object

--- a/python/lib/database_lib/parameter_type.py
+++ b/python/lib/database_lib/parameter_type.py
@@ -59,7 +59,7 @@ class ParameterType:
     @deprecated('Use `lib.imaging_lib.file_parameter.get_bids_to_loris_parameter_types_dict` instead')
     def get_bids_to_minc_mapping_dict(self):
         """
-        Queries the BIDS to MINC mapping dictionary stored in the paramater_type table and returns a
+        Queries the BIDS to MINC mapping dictionary stored in the parameter_type table and returns a
         dictionary with the BIDS term as keys and the MINC terms as values.
 
         :return: BIDS to MINC mapping dictionary

--- a/python/lib/db/connect.py
+++ b/python/lib/db/connect.py
@@ -18,6 +18,6 @@ def get_database_engine(config: DatabaseConfig):
         database   = config.database,
     )
 
-    # 'READ COMMITED' means that the records read in a session can be modified by other sessions
+    # 'READ COMMITTED' means that the records read in a session can be modified by other sessions
     # (such as subscripts or other scripts) during this session's lifetime.
     return create_engine(url, isolation_level='READ COMMITTED')

--- a/python/lib/dcm2bids_imaging_pipeline_lib/dicom_validation_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/dicom_validation_pipeline.py
@@ -74,7 +74,7 @@ def _validate_dicom_archive_md5sum(env: Env, dicom_archive: DbDicomArchive, dico
     This function validates that the md5sum of the DICOM archive on the filesystem is the same
     as the md5sum of the registered entry in the tarchive table.
 
-    Retrun `true` if the MD5 sums match, or `false` if they don't.
+    Return `true` if the MD5 sums match, or `false` if they don't.
     """
 
     # compute the md5sum of the tarchive file

--- a/python/lib/imaging_lib/file_parameter.py
+++ b/python/lib/imaging_lib/file_parameter.py
@@ -11,7 +11,7 @@ from lib.imaging_lib.parameter import get_or_create_parameter_type
 
 def register_mri_file_parameters(env: Env, file: DbFile, file_parameters: dict[str, Any]):
     """
-    Insert or upate some MRI file parameters with the provided parameter names and values.
+    Insert or update some MRI file parameters with the provided parameter names and values.
     """
 
     for parameter_name, parameter_value in file_parameters.items():
@@ -20,7 +20,7 @@ def register_mri_file_parameters(env: Env, file: DbFile, file_parameters: dict[s
 
 def register_mri_file_parameter(env: Env, file: DbFile, parameter_name: str, parameter_value: Any):
     """
-    Insert or upate an MRI file parameter with the provided parameter name and value.
+    Insert or update an MRI file parameter with the provided parameter name and value.
     """
 
     if isinstance(parameter_value, list):

--- a/python/lib/imaging_lib/nifti_pic.py
+++ b/python/lib/imaging_lib/nifti_pic.py
@@ -38,7 +38,7 @@ def create_nifti_preview_picture(env: Env, nifti_file: DbFile) -> Path:
         # Load the full data for a 3D image.
         data = img.dataobj[...]  # type: ignore
 
-    # Explicitely load the volume as float32 for plotting.
+    # Explicitly load the volume as float32 for plotting.
     volume = Nifti1Image(
         data.astype(np.float32, copy=False),  # type: ignore
         img.affine,  # type: ignore

--- a/python/loris_bids_importer/src/loris_bids_importer/copy_files.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/copy_files.py
@@ -64,7 +64,7 @@ def get_loris_bids_file_path(
     if derivative:
         return import_env.loris_bids_path / file_path.relative_to(import_env.source_bids_path)
 
-    # Otherwise, normalize the subject and session directrory names using the LORIS session
+    # Otherwise, normalize the subject and session directory names using the LORIS session
     # information.
     loris_file_name = get_loris_bids_file_name(file_path.name, session)
 

--- a/python/loris_bids_importer/src/loris_bids_importer/env.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/env.py
@@ -25,7 +25,7 @@ class BidsImportEnv:
 
     imported_acquisitions_count: int = 0
     """
-    The number of succesfully imported BIDS acquisitions.
+    The number of successfully imported BIDS acquisitions.
     """
 
     ignored_acquisitions_count: int = 0

--- a/python/loris_bids_importer/src/loris_bids_importer/mri/sidecar.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/mri/sidecar.py
@@ -14,7 +14,7 @@ def get_bids_mri_sidecar_scanner_info(sidecar: BidsMriSidecarJsonFile) -> MriSca
     """
 
     return MriScannerInfo(
-        manufacturer     = sidecar.data.get('Manufaturer'),
+        manufacturer     = sidecar.data.get('Manufacturer'),
         model            = sidecar.data.get('ManufacturersModelName'),
         serial_number    = sidecar.data.get('DeviceSerialNumber'),
         software_version = sidecar.data.get('SoftwareVersions'),

--- a/python/loris_dicom_importer/src/loris_dicom_importer/summary_write.py
+++ b/python/loris_dicom_importer/src/loris_dicom_importer/summary_write.py
@@ -174,7 +174,7 @@ def write_dicom_study_ending(dicom_summary: DicomStudySummary) -> str:
 
 def compare_dicom_files(a: DicomStudyDicomFile, b: DicomStudyDicomFile):
     """
-    Compare two DICOM file informations in accordance with `functools.cmp_to_key`.
+    Compare two DICOM file information in accordance with `functools.cmp_to_key`.
     """
 
     return \
@@ -185,7 +185,7 @@ def compare_dicom_files(a: DicomStudyDicomFile, b: DicomStudyDicomFile):
 
 def compare_dicom_series(a: DicomStudyDicomSeries, b: DicomStudyDicomSeries):
     """
-    Compare two acquisition informations in accordance with `functools.cmp_to_key`.
+    Compare two acquisition information in accordance with `functools.cmp_to_key`.
     """
 
     return \

--- a/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/ctf_to_chunks.py
+++ b/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/ctf_to_chunks.py
@@ -24,7 +24,7 @@ def load_channels(path: Path) -> RawCTF:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Convert CTF MEG files (.ds directories) to chunks for browser based visualisation.")
+        description="Convert CTF MEG files (.ds directories) to chunks for browser based visualization.")
     parser.add_argument('files', metavar='FILE', type=Path, nargs='+',
                         help="one or more CTF .ds directories to convert to a directory of chunks")
     parser.add_argument('--channel-index', '-i', type=int, default=0,

--- a/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/edf_to_chunks.py
+++ b/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/edf_to_chunks.py
@@ -19,7 +19,7 @@ def load_channels(exclude: list[str]) -> Callable[[Path], RawEDF]:
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Convert .edf files to chunks for browser based visualisation.')
+        description='Convert .edf files to chunks for browser based visualization.')
     parser.add_argument('files', metavar='FILE', type=Path, nargs='+',
                         help='one or more .edf files to convert to a directory of chunks next to the input file')
     parser.add_argument('--channel_index', '-i', dest='channel_index', type=int, default=0,

--- a/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/eeglab_to_chunks.py
+++ b/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/eeglab_to_chunks.py
@@ -18,7 +18,7 @@ def load_channels(path: Path) -> RawEEGLAB:
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Convert .set files to chunks for browser based visualisation.')
+        description='Convert .set files to chunks for browser based visualization.')
     parser.add_argument('files', metavar='FILE', type=Path, nargs='+',
                         help='one or more .set files to convert to a directory of chunks next to the input file')
     parser.add_argument('--channel_index', '-i', dest='channel_index', type=int, default=0,

--- a/test/typos_to_github.sh
+++ b/test/typos_to_github.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Script to convert Typos JSON output to GitHub annotation format.
+# Usage: typos --format=json | ./typos_to_github.sh
+
+set -euo pipefail
+
+# Read JSON input from standard input.
+typos_json=$(cat)
+
+# Convert Typos JSON to GitHub annotations.
+echo "$typos_json" | jq -s -r --arg root $(pwd) '
+.[] |
+    select(.type == "typo") |
+    ($root + "/" + (.path | sub("^\\./"; ""))) as $fullpath |
+    "::error file=\($fullpath),line=\(.line_num),col=\(.byte_offset),title=Typos::Found typo \(.typo) - suggestions: \(.corrections | join(", "))"'

--- a/tools/petupload_cron_prod
+++ b/tools/petupload_cron_prod
@@ -33,7 +33,7 @@ then
   exit 125
 fi
 
-# Start finding and transfering data
+# Start finding and transferring data
 echo "#### FIND NEW IMAGING FILES ON BIC (newer than ${daysSince} days ago) ####" >&2 &&
 echo "#### OUTPUT RESULTS TO ${uploadList} ####" >&2 &&
 # Connect to BIC and run find_hrrt


### PR DESCRIPTION
## Description

This PR adds [Typos](https://github.com/crate-ci/typos) as a development tool for LORIS Python.

Typos is a language-agnostic tool to find typos in a codebase, including code files, documentation... It can be installed using pip (among others), and run locally, as an IDE extension, and/or in CI. It is really fast (built in Rust) and usually has a small number of false positives (it uses a dictionary of known typos, 3 false positives found in this PR).

## Details

- This first commit does the following:
  - Add Typos as a Python development dependency (`pip install .[dev]`)
  - Configure Typos in `pyproject.toml`
  - Add a dedicated Typos step in our GitHub Actions
  - Add a new `typos_to_github.sh` test file to display the typos found directly in the GitHub interface.
- The second commit fixes non-bug typos.
- The third commit fixes a bug typo ( :scream_cat: ).

The configuration uses the US English locale since it is the most international English variant and is arguably simpler.