### PR TITLE
Small BIDS importer improvements

### DIFF
--- a/python/loris_bids_importer/src/loris_bids_importer/main.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/main.py
@@ -6,7 +6,7 @@ from lib.db.models.session import DbSession
 from lib.db.queries.candidate import try_get_candidate_with_psc_id
 from lib.db.queries.session import try_get_session_with_cand_id_visit_label
 from lib.env import Env
-from lib.logging import log, log_error_exit, log_warning
+from lib.logging import log, log_error, log_error_exit, log_warning
 from loris_bids_reader.mri.reader import BidsMriDataTypeReader
 from loris_bids_reader.reader import BidsDatasetReader, BidsDataTypeReader, BidsSessionReader
 
@@ -207,13 +207,24 @@ def import_bids_eeg_data_type_files(
     Read the provided BIDS EEG data type directory and import it into LORIS.
     """
 
-    Eeg(
-        env                    = env,
-        import_env             = import_env,
-        bids_layout            = data_type.session.subject.dataset.layout,
-        bids_info              = data_type.info,
-        db                     = legacy_db,
-        session                = session,
-        dataset_tag_dict       = dataset_tag_dict,
-        dataset_type           = args.type,
-    )
+    try:
+        Eeg(
+            env              = env,
+            import_env       = import_env,
+            bids_layout      = data_type.session.subject.dataset.layout,
+            bids_info        = data_type.info,
+            db               = legacy_db,
+            session          = session,
+            dataset_tag_dict = dataset_tag_dict,
+            dataset_type     = args.type,
+        )
+    except Exception as exception:
+        log_error(
+            env,
+            (
+                f"Error while importing EEG session. Error message:\n"
+                f"{exception}\n"
+                "Skipping."
+            )
+        )
+        import_env.failed_acquisitions_count += 1

--- a/python/loris_bids_importer/src/loris_bids_importer/print.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/print.py
@@ -10,10 +10,6 @@ def print_bids_info(env: Env, bids: BidsDatasetReader):
     Print information about the BIDS dataset to import.
     """
 
-    log(env, f"Found {len(bids.data_types)} data types:")
-    for data_type in bids.data_types:
-        log(env, f"- {data_type.name}")
-
     log(env, f"Found {len(bids.subject_labels)} subjects:")
     for subject_label in bids.subject_labels:
         log(env, f"- {subject_label}")
@@ -21,6 +17,10 @@ def print_bids_info(env: Env, bids: BidsDatasetReader):
     log(env, f"Found {len(bids.session_labels)} sessions:")
     for session_label in bids.session_labels:
         log(env, f"- {session_label}")
+
+    log(env, f"Found {len(bids.data_type_names)} data types:")
+    for data_type_name in bids.data_type_names:
+        log(env, f"- {data_type_name}")
 
 
 def print_bids_import_summary(env: Env, import_env: BidsImportEnv):

--- a/python/loris_bids_reader/src/loris_bids_reader/reader.py
+++ b/python/loris_bids_reader/src/loris_bids_reader/reader.py
@@ -115,6 +115,14 @@ class BidsDatasetReader:
         return self.layout.get_sessions()  # type: ignore
 
     @cached_property
+    def data_type_names(self) -> list[str]:
+        """
+        The names of the data types present in this BIDS dataset.
+        """
+
+        return self.layout.get_datatypes()  # type: ignore
+
+    @cached_property
     def subjects(self) -> list['BidsSubjectReader']:
         """
         Get the subject directory readers of this BIDS dataset.


### PR DESCRIPTION
Small BIDS improrter improvements based on the Q1K tests for C-BIG (https://github.com/ridz1208/Loris-MRI/pull/14):
1. Catch EEG import exceptions so the script can be somewhat incremental for EEG.
2. Display the _unique_ data types found in the BIDS dataset rather than duplicates.