### PR TITLE
Remove `Scan_done` field from the Python ORM

### DIFF
--- a/python/lib/db/models/session.py
+++ b/python/lib/db/models/session.py
@@ -43,7 +43,6 @@ class DbSession(Base):
     bvl_qc_type              : Mapped[str | None]      = mapped_column('BVLQCType')
     bvl_qc_exclusion         : Mapped[str | None]      = mapped_column('BVLQCExclusion')
     qcd                      : Mapped[str | None]      = mapped_column('QCd')
-    scan_done                : Mapped[bool | None]     = mapped_column('Scan_done', YNBool)
     mri_qc_status            : Mapped[str]             = mapped_column('MRIQCStatus')
     mri_qc_pending           : Mapped[bool]            = mapped_column('MRIQCPending', YNBool)
     mri_qc_first_change_time : Mapped[datetime | None] = mapped_column('MRIQCFirstChangeTime')

--- a/python/lib/get_session_info.py
+++ b/python/lib/get_session_info.py
@@ -250,7 +250,6 @@ def create_session(
         visit_number     = visit_number,
         site_id          = create_session_info.site.id,
         current_stage    = 'Not Started',
-        scan_done        = True,
         submitted        = False,
         project_id       = create_session_info.project.id,
         cohort_id        = create_session_info.cohort.id if create_session_info.cohort is not None else None,

--- a/python/loris_bids_importer/src/loris_bids_importer/validation/sessions.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/validation/sessions.py
@@ -100,7 +100,6 @@ def create_bids_session(
         site_id          = candidate.registration_site_id,
         project_id       = candidate.registration_project_id,
         cohort_id        = cohort.id,
-        scan_done        = True,
         submitted        = False,
         active           = True,
         user_id          = '',

--- a/test/db.Dockerfile
+++ b/test/db.Dockerfile
@@ -23,6 +23,7 @@ RUN ( \
         0000-00-03-ConfigTables.sql \
         0000-00-04-Help.sql \
         0000-00-05-ElectrophysiologyTables.sql \
+        0000-00-06-BiobankTables.sql \
         raisinbread/instruments/*.sql \
         raisinbread/*.sql \
     ) > source.sql


### PR DESCRIPTION
Accomodate of https://github.com/aces/Loris/pull/10236 to the Python side. The `Scan_done` field does not seem to be used outside of the ORM, which this PR updates accordingly. It does seem to be used in Perl, but that is a subject for another PR.

Also accomodate for https://github.com/aces/Loris/pull/10512 by adding the biobank tables to the test database (required to load Raisinbread).
