### PR TITLE
Use ORM for MRI files associated files

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -6,7 +6,9 @@ from loris_utils.fs import remove_empty_directories
 from sqlalchemy import inspect
 
 import lib.exitcode
+from lib.db.queries.file import try_get_file_with_id
 from lib.dcm2bids_imaging_pipeline_lib.base_pipeline import BasePipeline
+from lib.imaging_lib.file import get_mri_file_associated_files
 from lib.logging import log_error_exit
 
 
@@ -117,29 +119,19 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
 
         file_ids = [v["id_field_value"] for v in self.files_to_push_list] if self.files_to_push_list else []
 
-        files_info = []
         for file_id in file_ids:
-            files_info.extend(self.imaging_obj.get_bids_files_info_from_parameter_file_for_file_id(file_id))
-            pic_entry_dict = self.imaging_obj.grep_parameter_value_from_file_id_and_parameter_name(
-                file_id, "check_pic_filename"
-            )
-            if pic_entry_dict:
-                # for the pic, we need to add the pic/ subdir to the Value
-                # otherwise, it will not be found on the filesystem
-                pic_entry_dict["Value"] = "pic/" + pic_entry_dict["Value"]
-
-            files_info.extend([pic_entry_dict])
-
-        for file_entry in files_info:
-            if not file_entry:
+            file = try_get_file_with_id(self.env.db, file_id)
+            if file is None:
                 continue
-            self.files_to_push_list.append({
-                "table_name": "parameter_file",
-                "id_field_name": "ParameterFileID",
-                "id_field_value": file_entry["ParameterFileID"],
-                "file_path_field_name": "Value",
-                "original_file_path_field_value": file_entry["Value"]
-            })
+
+            for file_path in get_mri_file_associated_files(self.env, file):
+                self.files_to_push_list.append({
+                    "table_name": "parameter_file",
+                    "id_field_name": "ParameterFileID",
+                    "id_field_value": file.id,
+                    "file_path_field_name": "Value",
+                    "original_file_path_field_value": str(file_path)
+                })
 
     def _get_list_of_files_from_mri_protocol_violated_scans(self):
         """

--- a/python/lib/imaging.py
+++ b/python/lib/imaging.py
@@ -436,6 +436,7 @@ class Imaging:
             project_id, cohort_id, center_id, visit_label, scanner_id
         )
 
+    @deprecated('Use `lib.imaging_lib.file.get_mri_file_associated_files` instead.')
     def get_bids_files_info_from_parameter_file_for_file_id(self, file_id):
         """
         Fetch other BIDS files associated to the NIfTI file present in the files table.
@@ -450,6 +451,7 @@ class Imaging:
             self.grep_parameter_value_from_file_id_and_parameter_name(file_id, "check_bvec_filename")
         ]
 
+    @deprecated('Use `lib.imaging_lib.file_parameter.get_mri_file_parameter` instead.')
     def grep_parameter_value_from_file_id_and_parameter_name(self, file_id, param_type_name):
         """
         Grep a Value in parameter_file based on a FileID and parameter type Name.

--- a/python/lib/imaging_lib/file.py
+++ b/python/lib/imaging_lib/file.py
@@ -9,6 +9,7 @@ from lib.db.models.mri_scan_type import DbMriScanType
 from lib.db.models.mri_scanner import DbMriScanner
 from lib.db.models.session import DbSession
 from lib.env import Env
+from lib.imaging_lib.file_parameter import try_get_mri_file_parameter
 
 
 def register_mri_file(
@@ -57,3 +58,35 @@ def register_mri_file(
     env.db.flush()
 
     return file
+
+
+def get_mri_file_associated_files(env: Env, file: DbFile) -> list[Path]:
+    """
+    Get the paths of the associated files of an MRI file from the file parameters table.
+
+    Paths are relative to the LORIS data directory and include:
+    - BIDS sidecar JSON file
+    - BVAL and BVEC files
+    - Preview picture file
+    """
+
+    # Get the associated file paths from the file parameters table.
+    file_parameters = [
+        try_get_mri_file_parameter(env, file, 'bids_json_file'),
+        try_get_mri_file_parameter(env, file, 'check_bval_filename'),
+        try_get_mri_file_parameter(env, file, 'check_bvec_filename'),
+    ]
+
+    # Filter the files that are actually registered.
+    file_paths = [
+        Path(parameter_file)
+        for parameter_file in file_parameters
+        if parameter_file is not None
+    ]
+
+    # The preview picture file parameter is relative to the 'pic' directory, treat it separately.
+    preview_picture_parameter = try_get_mri_file_parameter(env, file, 'check_pic_filename')
+    if preview_picture_parameter is not None:
+        file_paths.append(Path('pic') / preview_picture_parameter)
+
+    return file_paths

--- a/python/lib/imaging_lib/file_parameter.py
+++ b/python/lib/imaging_lib/file_parameter.py
@@ -4,7 +4,7 @@ from typing import Any
 from lib.db.models.file import DbFile
 from lib.db.models.file_parameter import DbFileParameter
 from lib.db.queries.file_parameter import try_get_file_parameter_with_file_id_type_id
-from lib.db.queries.parameter_type import get_all_parameter_types
+from lib.db.queries.parameter_type import get_all_parameter_types, try_get_parameter_type_with_name_source
 from lib.env import Env
 from lib.imaging_lib.parameter import get_or_create_parameter_type
 
@@ -77,3 +77,20 @@ def map_bids_to_loris_file_parameters(env: Env, file_parameters: dict[str, Any])
         file_parameter_type = parameter_types_dict.get(file_parameter)
         if file_parameter_type is not None:
             file_parameters[file_parameter_type] = file_parameters[file_parameter]
+
+
+def try_get_mri_file_parameter(env: Env, file: DbFile, parameter_name: str) -> str | None:
+    """
+    Get a file parameter of an MRI file, or return `None` if that parameter does not exist or has
+    no value.
+    """
+
+    parameter_type = try_get_parameter_type_with_name_source(env.db, parameter_name, 'MRI Variables')
+    if parameter_type is None:
+        return None
+
+    parameter = try_get_file_parameter_with_file_id_type_id(env.db, file.id, parameter_type.id)
+    if parameter is None:
+        return None
+
+    return parameter.value

--- a/python/scripts/mass_nifti_pic.py
+++ b/python/scripts/mass_nifti_pic.py
@@ -11,8 +11,8 @@ import lib.exitcode
 from lib.config import get_data_dir_path_config
 from lib.config_file import load_config
 from lib.db.queries.file import try_get_file_with_id
-from lib.db.queries.file_parameter import try_get_parameter_value_with_file_id_parameter_name
 from lib.env import Env
+from lib.imaging_lib.file_parameter import try_get_mri_file_parameter
 from lib.imaging_lib.nifti_pic import create_nifti_preview_picture
 from lib.logging import log, log_error, log_error_exit, log_warning
 from lib.make_env import make_env
@@ -92,10 +92,7 @@ def make_pic(env: Env, data_dir_path: Path, file_id: int, force: bool):
         return
 
     # Check if there is already a preview picture for the NIfTI file.
-    current_pic = try_get_parameter_value_with_file_id_parameter_name(
-        env.db, file_id, 'check_pic_filename'
-    )
-
+    current_pic = try_get_mri_file_parameter(env, nifti_file, 'check_pic_filename')
     if current_pic is not None and not force:
         log_warning(
             env,


### PR DESCRIPTION
A local branch I had on my laptop.

List of changes:
- Use the ORM to get the associated files of an MRI files in the S3 upload pipelime.
- Also use the new `try_get_mri_file_parameter` function in the NIfTI pic script, which is safer than the previous function as it is restricted to MRI parameters instead of all parameters.
- Deprecate the old untyped functions.