### PR TITLE
[MRI] Check if CenterID is defined before going further

### DIFF
--- a/docs/scripts_md/MRI.md
+++ b/docs/scripts_md/MRI.md
@@ -231,19 +231,17 @@ RETURNS: `CandID` (int)
 
 ### getPSC($patientName, $dbhr, $db)
 
-Looks for the site alias using the `session` table `CenterID` as
-a first resource, for the cases where it is created using the front-end,
-otherwise, find the site alias in whatever field (usually `patient_name`
-or `patient_id`) is provided, and return the `MRI_alias` and `CenterID`.
+Looks for the `CenterID` of a scan. If the configuration already provides a
+`CenterID`, it is validated against the `psc` table. Otherwise, the `CenterID`
+is looked up using the `session` table, and as a last resort by matching the site alias against whatever field
+(usually `patient_name` or `patient_id`) is provided.
 
 INPUTS:
   - $patientName: patient name
   - $dbhr       : database handle reference
   - $db         : database object
 
-RETURNS: a two element array:
-  - first is the MRI alias of the PSC or "UNKN"
-  - second is the `CenterID` or 0
+RETURNS: the `CenterID` or 0 if no center could be found
 
 ### getProject($subjectIDsref, $dbhr, $db)
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1086,8 +1086,7 @@ sub createNewCandID {
 
 Looks for the C<CenterID> of a scan. If the configuration already provides a
 C<CenterID>, it is validated against the C<psc> table. Otherwise, the C<CenterID>
-is looked up using the C<session> table (for cases where it is created using the
-front-end), and as a last resort by matching the site alias against whatever field
+is looked up using the C<session> table, and as a last resort by matching the site alias against whatever field
 (usually C<patient_name> or C<patient_id>) is provided.
 
 INPUTS:

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1084,19 +1084,18 @@ sub createNewCandID {
 
 =head3 getPSC($patientName, $dbhr, $db)
 
-Looks for the site alias using the C<session> table C<CenterID> as
-a first resource, for the cases where it is created using the front-end,
-otherwise, find the site alias in whatever field (usually C<patient_name>
-or C<patient_id>) is provided, and return the C<MRI_alias> and C<CenterID>.
+Looks for the C<CenterID> of a scan. If the configuration already provides a
+C<CenterID>, it is validated against the C<psc> table. Otherwise, the C<CenterID>
+is looked up using the C<session> table (for cases where it is created using the
+front-end), and as a last resort by matching the site alias against whatever field
+(usually C<patient_name> or C<patient_id>) is provided.
 
 INPUTS:
   - $patientName: patient name
   - $dbhr       : database handle reference
   - $db         : database object
 
-RETURNS: a two element array:
-  - first is the MRI alias of the PSC or "UNKN"
-  - second is the C<CenterID> or 0
+RETURNS: the C<CenterID> or 0 if no center could be found
 
 =cut
 
@@ -1110,6 +1109,20 @@ sub getPSC {
                             $dbhr,
                             $db
                         );
+    ## If the configuration (e.g. the prod file) already provides a CenterID,
+    ## validate it against the psc table rather than trusting it blindly or
+    ## falling through to the error-prone patient-name matching below.
+    if ($subjectIDsref->{'CenterID'}) {
+        my $centerID = $subjectIDsref->{'CenterID'};
+        my $sth = $${dbhr}->prepare("SELECT CenterID FROM psc WHERE CenterID = ?");
+        $sth->execute($centerID);
+        if ($sth->rows > 0) {
+            return $centerID;
+        }
+        die "ERROR: CenterID $centerID provided by the configuration "
+          . "does not exist in the psc table.\n";
+    }
+
     my $PSCID = $subjectIDsref->{'PSCID'};
     my $visitLabel = $subjectIDsref->{'visitLabel'};
 

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1119,8 +1119,7 @@ sub getPSC {
         if ($sth->rows > 0) {
             return $centerID;
         }
-        die "ERROR: CenterID $centerID provided by the configuration "
-          . "does not exist in the psc table.\n";
+        return 0;
     }
 
     my $PSCID = $subjectIDsref->{'PSCID'};
@@ -1129,8 +1128,7 @@ sub getPSC {
     ## Get the CenterID from the session table, if the PSCID and visit labels exist
     ## and could be extracted
     if ($PSCID && $visitLabel) {
-        my $query = "SELECT s.CenterID, p.MRI_alias FROM session s
-                    JOIN psc p on p.CenterID=s.CenterID
+        my $query = "SELECT s.CenterID FROM session s
                     JOIN candidate c on c.ID=s.CandidateID
                     WHERE c.PSCID = ? AND s.Visit_label = ?";
 
@@ -1138,21 +1136,21 @@ sub getPSC {
         $sth->execute($PSCID, $visitLabel);
         if ($sth->rows > 0) {
             my $row = $sth->fetchrow_hashref();
-            return ($row->{'MRI_alias'},$row->{'CenterID'});
+            return $row->{'CenterID'};
         }
     }
 
-    ## Otherwise, use the patient name to match it to the site alias or MRI alias
+    ## Otherwise, use the patient name to match it to the site alias
     my $pscOB   = NeuroDB::objectBroker::PSCOB->new( db => $db );
-    my $pscsRef = $pscOB->get({ MRI_alias => { NOT => '' } });
+    my $pscsRef = $pscOB->get({ Alias => { NOT => '' } });
 
     foreach my $psc (@$pscsRef) {
-        if ($patientName =~ /$psc->{'Alias'}/i || $patientName =~ /$psc->{'MRI_alias'}/i) {
-            return ($psc->{'MRI_alias'}, $psc->{'CenterID'});
+        if ($patientName =~ /$psc->{'Alias'}/i) {
+            return $psc->{'CenterID'};
         }
     }
 
-    return ("UNKN", 0);
+    return 0;
 }
 
 =pod

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -1113,9 +1113,9 @@ sub getPSC {
     ## falling through to the error-prone patient-name matching below.
     if ($subjectIDsref->{'CenterID'}) {
         my $centerID = $subjectIDsref->{'CenterID'};
-        my $sth = $${dbhr}->prepare("SELECT CenterID FROM psc WHERE CenterID = ?");
-        $sth->execute($centerID);
-        if ($sth->rows > 0) {
+        my $pscOB = NeuroDB::objectBroker::PSCOB->new( db => $db );
+        my $pscsRef = $pscOB->get({ CenterID => $centerID });
+        if (@$pscsRef) {
             return $centerID;
         }
         return 0;

--- a/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
+++ b/uploadNeuroDB/NeuroDB/MRIProcessingUtility.pm
@@ -2311,11 +2311,12 @@ sub getUploadIDUsingTarchiveSrcLoc {
 
 =head3 getCenterNameFromCenterID($centerID)
 
-Gets the MRI ALIAS form the C<psc> table using the center ID.
+Gets the human-readable center C<Name> from the C<psc> table using the center ID.
+Used to display a readable center name (rather than a numeric ID) in the logs.
 
 INPUT: Center ID
 
-RETURNS: MRI ALIAS
+RETURNS: center Name
 
 =cut
 
@@ -2325,17 +2326,17 @@ sub getCenterNameFromCenterID {
 
     my $centerID = shift;
     my $query = '';
-    my $alias = undef;
+    my $name = undef;
 
     if ($centerID) {
-        $query = "SELECT MRI_alias FROM psc WHERE CenterID =?";
+        $query = "SELECT Name FROM psc WHERE CenterID =?";
         my $sth = $dbh->prepare($query);
         $sth->execute($centerID);
         if ( $sth->rows > 0 ) {
-           $alias = $sth->fetchrow_array;
+           $name = $sth->fetchrow_array;
         }
     }
-    return $alias[0];
+    return $name;
 }
 
 

--- a/uploadNeuroDB/NeuroDB/objectBroker/PSCOB.pm
+++ b/uploadNeuroDB/NeuroDB/objectBroker/PSCOB.pm
@@ -43,7 +43,7 @@ NeuroDB::objectBroker::PSCOB -- An object broker for records stored in table C<p
   my $pscRef;
   try {
       $pscRef = $pscOB->get(
-          { MRI_alias => 'my_alias' }
+          { Alias => 'my_alias' }
       );
       foreach (@$pscRef) {
           printf "ID for PSC named $_->{'Name'} is $_->{'ID'}\n";
@@ -86,7 +86,7 @@ use TryCatch;
 
 my $TABLE_NAME = "psc";
 
-my @COLUMN_NAMES = qw(CenterID Name Alias MRI_alias);
+my @COLUMN_NAMES = qw(CenterID Name Alias);
 
 =pod
 

--- a/uploadNeuroDB/tarchiveLoader.pl
+++ b/uploadNeuroDB/tarchiveLoader.pl
@@ -377,7 +377,7 @@ if (($output != 0)  && ($force==0)) {
 ################################################################
 my $centerID =
      $utility->determinePSC(\%tarchiveInfo, 0, $upload_id);
-my $mri_alias = $utility->getCenterNameFromCenterID($centerID);
+my $center_name = $utility->getCenterNameFromCenterID($centerID);
 
 ################################################################
 ######### Determine the ScannerID ##############################
@@ -606,7 +606,7 @@ if ($valid_study) {
 ################################################################
 # make final logfile name without overwriting phantom logs #####
 ################################################################
-my $final_logfile = $mri_alias;
+my $final_logfile = $center_name;
 unless ($tarchiveInfo{'DateAcquired'} && $subjectIDsref->{'CandID'}) {
     ### if something went wrong and there is no acq date or CandID
     $final_logfile .= '_'.$temp[$#temp];

--- a/uploadNeuroDB/tarchiveLoader.pl
+++ b/uploadNeuroDB/tarchiveLoader.pl
@@ -377,7 +377,6 @@ if (($output != 0)  && ($force==0)) {
 ################################################################
 my $centerID =
      $utility->determinePSC(\%tarchiveInfo, 0, $upload_id);
-my $center_name = $utility->getCenterNameFromCenterID($centerID);
 
 ################################################################
 ######### Determine the ScannerID ##############################
@@ -602,6 +601,11 @@ if ($valid_study) {
 		    'tarchiveLoader.pl', $upload_id, 'Y',
 		    $notify_notsummary);
 }
+
+################################################################
+#################### Get the center name #######################
+################################################################
+my $center_name = $utility->getCenterNameFromCenterID($centerID);
 
 ################################################################
 # make final logfile name without overwriting phantom logs #####


### PR DESCRIPTION
Supercedes: #1228

Validate config-provided CenterID against the database in getPSC

When the config (e.g. the prod file) already provides a CenterID,
check it exists in the psc table and return it, instead of trusting it
blindly or falling through to the error-prone patient-name matching.

Raises an error if the CenterID is invalid. (Or maybe simply return 0 instead?)
Update the getPSC POD to reflect that it now returns the CenterID.
