### PR TITLE
Fix BIDS `scans.tsv` row matching

### DIFF
--- a/python/loris_bids_importer/src/loris_bids_importer/eeg/main.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/eeg/main.py
@@ -2,10 +2,8 @@
 
 import json
 import os
-import sys
 from pathlib import Path
 
-import lib.exitcode
 import lib.utilities as utilities
 from lib.config import get_ephys_visualization_enabled_config
 from lib.db.models.physio_file import DbPhysioFile
@@ -28,7 +26,7 @@ from loris_utils.crypto import compute_file_blake2b_hash
 
 from loris_bids_importer.archive import import_physio_event_archive, import_physio_file_archive
 from loris_bids_importer.channels import insert_bids_channels_file
-from loris_bids_importer.copy_files import copy_loris_bids_file, get_loris_bids_file_path, get_loris_scans_path
+from loris_bids_importer.copy_files import copy_loris_bids_file, get_loris_bids_file_path
 from loris_bids_importer.eeg.physiological import Physiological
 from loris_bids_importer.env import BidsImportEnv
 from loris_bids_importer.events import insert_bids_event_dict_file, insert_bids_events_file
@@ -38,6 +36,7 @@ from loris_bids_importer.physio import (
     get_check_bids_physio_modality,
     get_check_bids_physio_output_type,
 )
+from loris_bids_importer.scans import add_bids_scans_file_parameters
 
 
 class Eeg:
@@ -306,17 +305,8 @@ class Eeg:
             if self.scans_file is not None:
                 scan_info = self.scans_file.get_row(eeg_file_path)
                 if scan_info is not None:
-                    try:
-                        eeg_acq_time = scan_info.get_acquisition_time()
-                        eeg_file_data['age_at_scan'] = scan_info.get_age_at_scan()
-                    except Exception as error:
-                        print(f"ERROR: {error}")
-                        sys.exit(lib.exitcode.PROGRAM_EXECUTION_FAILURE)
-
-                    loris_scans_path = get_loris_scans_path(self.info, self.scans_file, self.session)
-                    eeg_file_data['scans_tsv_file'] = loris_scans_path
-                    scans_blake2 = compute_file_blake2b_hash(self.scans_file.path)
-                    eeg_file_data['physiological_scans_tsv_file_bake2hash'] = scans_blake2
+                    eeg_acq_time = scan_info.get_acquisition_time()
+                    add_bids_scans_file_parameters(self.info, self.session, self.scans_file, scan_info, eeg_file_data)
 
             # if file type is set and fdt file exists, append fdt path to the
             # eeg_file_data dictionary

--- a/python/loris_bids_importer/src/loris_bids_importer/mri/main.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/mri/main.py
@@ -139,7 +139,7 @@ def import_bids_mri_acquisition(
     file_parameters['file_blake2b_hash'] = file_hash
 
     if bids_info.scans_file is not None and bids_info.scan_row is not None:
-        add_bids_scans_file_parameters(bids_info.scans_file, bids_info.scan_row, file_parameters)
+        add_bids_scans_file_parameters(import_env, session, bids_info.scans_file, bids_info.scan_row, file_parameters)
 
     for aux_file_type, aux_file_path in aux_file_paths:
         aux_file_hash = compute_file_blake2b_hash(aux_file_path)

--- a/python/loris_bids_importer/src/loris_bids_importer/scans.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/scans.py
@@ -1,10 +1,16 @@
 from typing import Any
 
+from lib.db.models.session import DbSession
 from loris_bids_utils.files.scans import BidsScansTsvFile, BidsScanTsvRow
 from loris_utils.crypto import compute_file_blake2b_hash
 
+from loris_bids_importer.copy_files import get_loris_scans_path
+from loris_bids_importer.env import BidsImportEnv
+
 
 def add_bids_scans_file_parameters(
+    import_env: BidsImportEnv,
+    session: DbSession,
     scans_file: BidsScansTsvFile,
     scan_row: BidsScanTsvRow,
     file_parameters: dict[str, Any],
@@ -14,7 +20,7 @@ def add_bids_scans_file_parameters(
     dictionary.
     """
 
-    file_parameters['scan_acquisition_time']    = scan_row.get_acquisition_time()
-    file_parameters['age_at_scan']              = scan_row.get_age_at_scan()
-    file_parameters['scans_tsv_file']           = scans_file.path
-    file_parameters['scans_tsv_file_bake2hash'] = compute_file_blake2b_hash(scans_file.path)
+    file_parameters['scan_acquisition_time']     = scan_row.get_acquisition_time()
+    file_parameters['age_at_scan']               = scan_row.get_age_at_scan()
+    file_parameters['scans_tsv_file']            = get_loris_scans_path(import_env, scans_file, session)
+    file_parameters['scans_tsv_file_blake2hash'] = compute_file_blake2b_hash(scans_file.path)

--- a/python/loris_bids_utils/src/loris_bids_utils/files/scans.py
+++ b/python/loris_bids_utils/src/loris_bids_utils/files/scans.py
@@ -63,7 +63,10 @@ class BidsScansTsvFile(BidsTsvFile[BidsScanTsvRow]):
         Get the row corresponding to the given file path.
         """
 
-        return find(self.rows, lambda row: file_path.name == row.data['filename'])
+        # According to the specification, the 'filename' column is the path of the acquisition file
+        # relative to the directory in which the scans.tsv file is located.
+        relative_path = file_path.relative_to(self.path.parent)
+        return find(self.rows, lambda row: str(relative_path) == row.data['filename'])
 
     def set_row(self, scan: BidsScanTsvRow):
         """

--- a/python/tests/integration/scripts/test_import_bids_dataset.py
+++ b/python/tests/integration/scripts/test_import_bids_dataset.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 
 from lib.db.queries.bids_event_dataset_mapping import get_bids_event_dataset_mappings_with_project_id
@@ -27,9 +28,7 @@ def test_import_eeg_bids_dataset():
 
     # Check the return code.
     assert process.returncode == 0
-    assert process.stderr == (
-        "WARNING: No 'scans.tsv' file found, 'scans.tsv' data will be ignored.\n"
-    )
+    assert process.stderr == ""
 
     # Check that the candidate and sessions are present in the database.
     candidate = try_get_candidate_with_psc_id(db, 'OTT166')
@@ -47,6 +46,7 @@ def test_import_eeg_bids_dataset():
     assert len(file.channels) == 128
     assert len(file.event_files) == 1
     assert len(file.task_events) == 3185
+    assert file.acquisition_time == datetime(2025, 10, 10, 15, 1, 10)
     assert file.archive is not None
     assert file.archive.path == Path('bids_imports/Face13_BIDSVersion_1.1.0/sub-OTT166/ses-V1/eeg/sub-OTT166_ses-V1_task-faceO_eeg.tgz')  # noqa: E501
     assert file.event_archive is not None
@@ -82,6 +82,10 @@ def test_import_eeg_bids_dataset():
         'channel_file_blake2b_hash': '7b91e3650086ef50ecc00f1c50e17e7ad8dc39c484536bbc2423af4be7d2b50a3a0010f840d457fec68fbfb3e136edf4d616a31bab0ca09ed686f555727341dd',  # noqa: E501
         'event_file_blake2b_hash': '532aa0b52749eb9ee52c2bbb65fa7b1d00d7126cb9a4e10bd4b9dbb4c5527b06e30acdaf17d5806e81d3ce8ad224a9f456e27aba1bf8b92fd43522837c7ffec7',  # noqa: E501
         'electrophysiology_chunked_dataset_path': 'chunks/Face13_BIDSVersion_1.1.0_chunks/sub-OTT166_ses-V1_task-faceO_eeg.chunks',  # noqa: E501
+        'scan_acquisition_time': '2025-10-10 15:01:10.720100+00:00',
+        'age_at_scan': 'None',
+        'scans_tsv_file': 'bids_imports/Face13_BIDSVersion_1.1.0/sub-OTT166/ses-V1/sub-OTT166_ses-V1_scans.tsv',
+        'scans_tsv_file_blake2hash': '4d9b695ba6b35257531b96375ca15c36179b08360f373c46425d958e406132b84ad029113ed4be5e458e762a8af0792ddde5127b5044778c8c8705d8df8f8621',  # noqa: E501
     }
 
     # Check that the event files has been inserted in the database.

--- a/python/tests/integration/scripts/test_import_bids_dataset.py
+++ b/python/tests/integration/scripts/test_import_bids_dataset.py
@@ -101,6 +101,7 @@ def test_import_eeg_bids_dataset():
             'README': None,
             'sub-OTT166': {
                 'ses-V1': {
+                    'sub-OTT166_ses-V1_scans.tsv': None,
                     'eeg': {
                         'sub-OTT166_ses-V1_task-faceO_channels.tsv': None,
                         'sub-OTT166_ses-V1_task-faceO_eeg.edf': None,


### PR DESCRIPTION
## Description

This PR solves two `scans.tsv`-related BIDS importer bugs:
1. The importer did not correctly match an acquisition file to its BIDS row using the `filename` column.
2. The (MRI) BIDS importer used the original BIDS path instead of the new BIDS path in the file parameters.

To solve these bugs, this PR notably unifies the MRI and EEG `scans.tsv` import using the same function (I thought that was already done actually). This is technically a breaking change since the two previously used different parameter names. No reason to do that IMO, especially since there was a typo in the parameter names.

Also this PR adds a `scans.tsv` file to the Face13 EEG BIDS import integration tests, the contents of the file is this:
```tsv
filename	acq_time
eeg/sub-OTT166_ses-V1_task-faceO_eeg.edf	2025-10-10T15:01:10.720100Z

```

There should be a trailing newline at the end of the file, this file needs to be copied as `/data-imaging/incoming/Face13/sub-OTT166/ses-V1/sub-OTT166_ses-V1_scans.tsv`.