### PR TITLE
Re-add `InsertTime` default

### DIFF
--- a/python/lib/imaging_lib/file.py
+++ b/python/lib/imaging_lib/file.py
@@ -1,5 +1,5 @@
 import getpass
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 
 from lib.db.models.dicom_archive import DbDicomArchive
@@ -35,6 +35,7 @@ def register_mri_file(
         file_type                = file_type.name,
         session_id               = session.id,
         inserted_by_user_id      = getpass.getuser(),
+        insert_time              = datetime.now(),
         coordinate_space         = 'native',
         output_type              = 'native',
         series_uid               = series_instance_uid,

--- a/python/lib/imaging_lib/file_parameter.py
+++ b/python/lib/imaging_lib/file_parameter.py
@@ -31,13 +31,11 @@ def register_mri_file_parameter(env: Env, file: DbFile, parameter_name: str, par
 
     parameter = try_get_file_parameter_with_file_id_type_id(env.db, file.id, parameter_type.id)
     if parameter is None:
-        time = datetime.now()
-
         parameter = DbFileParameter(
             type_id     = parameter_type.id,
             file_id     = file.id,
             value       = parameter_value,
-            insert_time = time,
+            insert_time = datetime.now(),
         )
 
         env.db.add(parameter)


### PR DESCRIPTION
In #1429, I removed the explicit `InsertTime` values for some records because they were explicitly defined in the schema. However, I forgot that our schema defaults are incorrect, as those are the 0 timestamps rather than the current time.

Short-term fix (this PR): re-add explicit `InsertTime` where incorrect defaults are used.

Long-term fix: fix the LORIS schema.