### PR TITLE
Use corresponding LORIS branch for integation tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,7 +31,11 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Clone the LORIS core repository
-      run: git clone https://github.com/aces/Loris.git ./test/Loris
+      # Use the corresponding LORIS branch for integration tests.
+      # The branch name is either the target branch for PRs, or the current branch otherwise.
+      run: |
+        BRANCH_NAME="${{ github.base_ref || github.ref_name }}"
+        git clone --branch "$BRANCH_NAME" --single-branch https://github.com/aces/Loris.git ./test/Loris
 
     - name: Overwrite Raisinbread SQL files
       run: cp -f ./test/RB_SQL/*.sql ./test/Loris/raisinbread/RB_files/


### PR DESCRIPTION
CI currently always uses the main LORIS branch for integration tests.

This PR updates CI to use the corresponding LORIS branch independently of the version, based on the fact that LORIS-MRI and LORIS branches are named similarly.