### PR TITLE
Fix environment file to source python environment first

### DIFF
--- a/install/templates/environment_template
+++ b/install/templates/environment_template
@@ -1,7 +1,7 @@
 PROJECT=%PROJECT%
 MINC_TOOLKIT_DIR=%MINC_TOOLKIT_DIR%
 
-# for the Python scripts
+# source the Python environment first so that other environment variables are added to this environment
 export LORIS_MRI=/opt/${PROJECT}/bin/mri
 source /opt/${PROJECT}/bin/mri/.venv/bin/activate
 

--- a/install/templates/environment_template
+++ b/install/templates/environment_template
@@ -1,6 +1,10 @@
 PROJECT=%PROJECT%
 MINC_TOOLKIT_DIR=%MINC_TOOLKIT_DIR%
 
+# for the Python scripts
+export LORIS_MRI=/opt/${PROJECT}/bin/mri
+source /opt/${PROJECT}/bin/mri/.venv/bin/activate
+
 # to source the MINC toolkit
 source ${MINC_TOOLKIT_DIR}/minc-toolkit-config.sh
 umask 0002
@@ -10,10 +14,6 @@ export PATH=/opt/${PROJECT}/bin/mri/uploadNeuroDB:/opt/${PROJECT}/bin/mri/upload
 export PERL5LIB=/opt/${PROJECT}/bin/mri/uploadNeuroDB:/opt/${PROJECT}/bin/mri/dicom-archive:$PERL5LIB
 export TMPDIR=/tmp
 export LORIS_CONFIG=/opt/${PROJECT}/bin/mri/config
-
-# for the Python scripts
-export LORIS_MRI=/opt/${PROJECT}/bin/mri
-source /opt/${PROJECT}/bin/mri/.venv/bin/activate
 
 # for the defacing scripts
 export BEASTLIB=${MINC_TOOLKIT_DIR}/../share/beast-library-1.1


### PR DESCRIPTION
# Description

When sourcing the python environment, the `PATH` variable gets reset which causes the MINC tools and the perl script to fail. Moved the Python virtual environment sourcing at the top of the template_environment file to fix this issue.