### PR TITLE
Use shallow clone of the LORIS repository in CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,9 +33,10 @@ jobs:
     - name: Clone the LORIS core repository
       # Use the corresponding LORIS branch for integration tests.
       # The branch name is either the target branch for PRs, or the current branch otherwise.
+      # Only copy the current state of the repository, the history is not needed for CI.
       run: |
         BRANCH_NAME="${{ github.base_ref || github.ref_name }}"
-        git clone --branch "$BRANCH_NAME" --single-branch https://github.com/aces/Loris.git ./test/Loris
+        git clone --depth 1 --single-branch --branch "$BRANCH_NAME" https://github.com/aces/Loris.git ./test/Loris
 
     - name: Overwrite Raisinbread SQL files
       run: cp -f ./test/RB_SQL/*.sql ./test/Loris/raisinbread/RB_files/


### PR DESCRIPTION
Use `--depth 1` to clone the LORIS repository in CI, which gets only the current state of the repo rather than all its history. Based on my local experiments, shallow-copying the main branch of the LORIS repository drops its size from 235MB to 135MB, which saves 100MB of download/storage, on a 10GB Github runner this is 1% of the total storage, or 10% of the last optimization I did (#1333), which is pretty nice!