### PR TITLE
Fix BIDS scans.tsv row rename

### DIFF
--- a/python/loris_bids_importer/src/loris_bids_importer/acquisitions.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/acquisitions.py
@@ -1,11 +1,50 @@
 from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
 from typing import TypeVar
 
+from lib.db.models.session import DbSession
 from lib.env import Env
 from lib.logging import log, log_error
 from loris_bids_utils.info import BidsAcquisitionInfo
 
+from loris_bids_importer.copy_files import add_bids_scan_row, get_loris_scans_path
 from loris_bids_importer.env import BidsImportEnv
+
+
+class BidsImportFileStatus(Enum):
+    """
+    The status of a BIDS file import.
+    """
+
+    SUCCESS = 1
+    """
+    The file was successfully imported.
+    """
+
+    IGNORE = 2
+    """
+    The file was ignored, usually because it is already in LORIS.
+    """
+
+
+@dataclass
+class BidsImportFileResult:
+    """
+    The result of a BIDS acquisition import.
+    """
+
+    status: BidsImportFileStatus
+    """
+    The status of the BIDS file import.
+    """
+
+    path: Path
+    """
+    The path of the imported file relative to the LORIS data directory.
+    """
+
 
 T = TypeVar('T')
 
@@ -13,8 +52,9 @@ T = TypeVar('T')
 def import_bids_acquisitions(
     env: Env,
     import_env: BidsImportEnv,
+    session: DbSession,
     acquisitions: list[tuple[T, BidsAcquisitionInfo]],
-    importer: Callable[[T, BidsAcquisitionInfo], None]
+    importer: Callable[[T, BidsAcquisitionInfo], BidsImportFileResult]
 ):
     """
     Run an import function on a list of BIDS acquisitions, logging the overall import progress,
@@ -28,10 +68,22 @@ def import_bids_acquisitions(
         )
 
         try:
-            importer(acquisition, bids_info)
-            log(env, f"Successfully imported acquisition '{bids_info.name}'.")
-            import_env.imported_acquisitions_count += 1
+            result = importer(acquisition, bids_info)
+            match result.status:
+                case BidsImportFileStatus.SUCCESS:
+                    # Update the LORIS scans.tsv file.
+                    if bids_info.scans_file is not None and bids_info.scan_row is not None:
+                        loris_scans_path = get_loris_scans_path(import_env, bids_info.scans_file, session)
+                        bids_info.scan_row.set_file_name(result.path.name)
+                        add_bids_scan_row(import_env, bids_info.scan_row, loris_scans_path)
+
+                    import_env.imported_acquisitions_count += 1
+                    log(env, f"Successfully imported acquisition '{bids_info.name}'.")
+                case BidsImportFileStatus.IGNORE:
+                    import_env.ignored_acquisitions_count += 1
+                    log(env, f"File '{result.path}' is already registered in LORIS. Skipping.")
         except Exception as exception:
+            import_env.failed_acquisitions_count += 1
             log_error(
                 env,
                 (
@@ -40,4 +92,3 @@ def import_bids_acquisitions(
                     "Skipping."
                 )
             )
-            import_env.failed_acquisitions_count += 1

--- a/python/loris_bids_importer/src/loris_bids_importer/copy_files.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/copy_files.py
@@ -7,7 +7,7 @@ from lib.db.models.session import DbSession
 from lib.env import Env
 from loris_bids_utils.files.dataset_description import BidsDatasetDescriptionJsonFile
 from loris_bids_utils.files.participants import BidsParticipantsTsvFile
-from loris_bids_utils.files.scans import BidsScansTsvFile
+from loris_bids_utils.files.scans import BidsScansTsvFile, BidsScanTsvRow
 
 from loris_bids_importer.env import BidsImportEnv
 
@@ -175,18 +175,20 @@ def copy_bids_participants_file(
     participants_file.write(participants_path)
 
 
-def copy_bids_scans_file(import_env: BidsImportEnv, scans_file: BidsScansTsvFile, loris_scans_path: Path):
+def add_bids_scan_row(import_env: BidsImportEnv, scan_row: BidsScanTsvRow, loris_scans_path: Path):
     """
-    Copy some `scans.tsv` rows into a LORIS `scans.tsv` file, creating it if necessary.
+    Add a BIDS `scans.tsv` row into a LORIS `scans.tsv` file, creating it if necessary.
     """
 
-    # Do not copy the file in no-copy mode.
+    # Do not copy the row in no-copy mode.
     if import_env.loris_bids_path is None:
         return
 
     scans_path = import_env.data_dir_path / loris_scans_path
-    if scans_path.exists():
-        scans_file.merge(BidsScansTsvFile(scans_path))
 
-    scans_path.parent.mkdir(parents=True, exist_ok=True)
-    scans_file.write(scans_path)
+    # Create the LORIS scans.tsv file if it does not exist yet.
+    scans_path.touch(exist_ok=True)
+
+    scans_file = BidsScansTsvFile(scans_path)
+    scans_file.set_row(scan_row)
+    scans_file.write()

--- a/python/loris_bids_importer/src/loris_bids_importer/eeg/main.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/eeg/main.py
@@ -26,7 +26,12 @@ from loris_utils.crypto import compute_file_blake2b_hash
 
 from loris_bids_importer.archive import import_physio_event_archive, import_physio_file_archive
 from loris_bids_importer.channels import insert_bids_channels_file
-from loris_bids_importer.copy_files import copy_loris_bids_file, get_loris_bids_file_path
+from loris_bids_importer.copy_files import (
+    add_bids_scan_row,
+    copy_loris_bids_file,
+    get_loris_bids_file_path,
+    get_loris_scans_path,
+)
 from loris_bids_importer.eeg.physiological import Physiological
 from loris_bids_importer.env import BidsImportEnv
 from loris_bids_importer.events import insert_bids_event_dict_file, insert_bids_events_file
@@ -303,10 +308,10 @@ class Eeg:
             # get the acquisition date of the EEG file or the age at the time of the EEG recording
             eeg_acq_time = None
             if self.scans_file is not None:
-                scan_info = self.scans_file.get_row(eeg_file_path)
-                if scan_info is not None:
-                    eeg_acq_time = scan_info.get_acquisition_time()
-                    add_bids_scans_file_parameters(self.info, self.session, self.scans_file, scan_info, eeg_file_data)
+                scan_row = self.scans_file.get_row(eeg_file_path)
+                if scan_row is not None:
+                    eeg_acq_time = scan_row.get_acquisition_time()
+                    add_bids_scans_file_parameters(self.info, self.session, self.scans_file, scan_row, eeg_file_data)
 
             # if file type is set and fdt file exists, append fdt path to the
             # eeg_file_data dictionary
@@ -350,6 +355,15 @@ class Eeg:
 
             insert_physio_file_parameters(self.env, physio_file, eeg_file_data)
             self.env.db.commit()
+
+            # Update the LORIS scans.tsv file.
+
+            if self.scans_file is not None:
+                scan_row = self.scans_file.get_row(eeg_file_path)
+                if scan_row is not None:
+                    loris_scans_path = get_loris_scans_path(self.info, self.scans_file, self.session)
+                    scan_row.set_file_name(eeg_path.name)
+                    add_bids_scan_row(self.info, scan_row, loris_scans_path)
 
             if self.info.loris_bids_path:
                 # If we copy the file in assembly_bids and

--- a/python/loris_bids_importer/src/loris_bids_importer/main.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/main.py
@@ -13,11 +13,9 @@ from loris_bids_utils.reader import BidsDatasetReader, BidsDataTypeReader, BidsS
 from loris_bids_importer.args import Args
 from loris_bids_importer.copy_files import (
     copy_bids_participants_file,
-    copy_bids_scans_file,
     copy_bids_static_files,
     get_loris_bids_dataset_path,
     get_loris_bids_root_file_path,
-    get_loris_scans_path,
 )
 from loris_bids_importer.eeg.main import Eeg
 from loris_bids_importer.env import BidsImportEnv
@@ -151,17 +149,6 @@ def import_bids_session(
     if session is None:
         # This should not happen as BIDS session labels should have been checked previously.
         log_error_exit(env, f"Visit not found for visit label '{visit_label}'.")
-
-    try:
-        # Read the scans.tsv property to raise an exception if the file is incorrect.
-        if bids_session.scans_file is not None:
-            loris_scans_path = get_loris_scans_path(import_env, bids_session.scans_file, session)
-            copy_bids_scans_file(import_env, bids_session.scans_file, loris_scans_path)
-    except Exception as exception:
-        log_warning(
-            env,
-            f"Error while reading the session scans.tsv file, scans.tsv data will be ignored. Full error:\n{exception}"
-        )
 
     # Process each data type directory.
 

--- a/python/loris_bids_importer/src/loris_bids_importer/mri/main.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/mri/main.py
@@ -11,14 +11,13 @@ from lib.imaging_lib.file_parameter import register_mri_file_parameters
 from lib.imaging_lib.nifti import add_nifti_spatial_file_parameters
 from lib.imaging_lib.nifti_pic import create_nifti_preview_picture
 from lib.imaging_lib.scan_type import create_mri_scan_type
-from lib.logging import log
 from loris_bids_utils.info import BidsAcquisitionInfo
 from loris_bids_utils.mri.acquisition import MriAcquisition
 from loris_bids_utils.mri.reader import BidsMriDataTypeReader
 from loris_utils.crypto import compute_file_blake2b_hash
 from loris_utils.error import group_errors_tuple
 
-from loris_bids_importer.acquisitions import import_bids_acquisitions
+from loris_bids_importer.acquisitions import BidsImportFileResult, BidsImportFileStatus, import_bids_acquisitions
 from loris_bids_importer.copy_files import copy_loris_bids_file, get_loris_bids_file_path
 from loris_bids_importer.env import BidsImportEnv
 from loris_bids_importer.file_type import get_check_bids_imaging_file_type_from_extension
@@ -55,6 +54,7 @@ def import_bids_mri_data_type(
     import_bids_acquisitions(
         env,
         import_env,
+        session,
         data_type.acquisitions,
         lambda acquisition, bids_info: import_bids_mri_acquisition(
             env,
@@ -72,7 +72,7 @@ def import_bids_mri_acquisition(
     session: DbSession,
     acquisition: MriAcquisition,
     bids_info: BidsAcquisitionInfo,
-):
+) -> BidsImportFileResult:
     """
     Import a BIDS NIfTI file and its associated files in LORIS.
     """
@@ -87,9 +87,7 @@ def import_bids_mri_acquisition(
 
     loris_file = try_get_file_with_path(env.db, loris_file_path)
     if loris_file is not None:
-        import_env.ignored_acquisitions_count += 1
-        log(env, f"File '{loris_file_path}' is already registered in LORIS. Skipping.")
-        return
+        return BidsImportFileResult(BidsImportFileStatus.IGNORE, loris_file_path)
 
     # Get information about the file.
 
@@ -177,6 +175,8 @@ def import_bids_mri_acquisition(
     # Create and register the file picture.
 
     create_nifti_preview_picture(env, file)
+
+    return BidsImportFileResult(BidsImportFileStatus.SUCCESS, loris_file_path)
 
 
 def get_check_bids_nifti_file_hash(env: Env, acquisition: MriAcquisition) -> str:

--- a/python/loris_bids_utils/src/loris_bids_utils/files/scans.py
+++ b/python/loris_bids_utils/src/loris_bids_utils/files/scans.py
@@ -14,6 +14,27 @@ class BidsScanTsvRow(BidsTsvRow):
     Documentation: https://bids-specification.readthedocs.io/en/stable/modality-agnostic-files/data-summary-files.html#scans-file
     """
 
+    file_path: Path
+    """
+    The path of the scan file relative to the scans.tsv file.
+    """
+
+    def __init__(self, data: dict[str, str | None]):
+        super().__init__(data)
+        file_path = self.data.get('filename')
+        if file_path is None:
+            raise Exception("Missing filename field in `scans.tsv` file.")
+
+        self.file_path = Path(file_path)
+
+    def set_file_name(self, file_name: str):
+        """
+        Set the name of the scan file of this row.
+        """
+
+        self.file_path        = self.file_path.with_name(file_name)
+        self.data['filename'] = str(self.file_path)
+
     def get_acquisition_time(self) -> datetime | None:
         """
         Get the acquisition time of the acquisition file.
@@ -66,14 +87,14 @@ class BidsScansTsvFile(BidsTsvFile[BidsScanTsvRow]):
         # According to the specification, the 'filename' column is the path of the acquisition file
         # relative to the directory in which the scans.tsv file is located.
         relative_path = file_path.relative_to(self.path.parent)
-        return find(self.rows, lambda row: str(relative_path) == row.data['filename'])
+        return find(self.rows, lambda row: relative_path == row.file_path)
 
     def set_row(self, scan: BidsScanTsvRow):
         """
         Add a row in the `scans.tsv` file, replacing it if a row already exists for its file name.
         """
 
-        replace_or_append(self.rows, scan, lambda row: row.data['filename'] == scan.data['filename'])
+        replace_or_append(self.rows, scan, lambda row: row.file_path == scan.file_path)
 
     def merge(self, other: 'BidsScansTsvFile'):
         """

--- a/python/loris_bids_utils/src/loris_bids_utils/tsv.py
+++ b/python/loris_bids_utils/src/loris_bids_utils/tsv.py
@@ -58,10 +58,13 @@ class BidsTsvFile(Generic[T]):
 
         return fields
 
-    def write(self, path: Path):
+    def write(self, path: Path | None = None):
         """
-        Write the TSV file to a file at the given path, creating it if necessary.
+        Write the TSV file at the given path. If the path is not provided, the path of this file is
+        used, overwriting existing data.
         """
+
+        path = path if path is not None else self.path
 
         fields = self.get_field_names()
 


### PR DESCRIPTION
## Description

Fix a bug in the BIDS importer where if the BIDS file is renamed (which notably happens for no-session dataset), the BIDS row copied in the LORIS `scans.tsv` file contained the old name instead of the new one.

## Architecture

This PR moves the "update `scans.tsv` file operation" from the top-level to each acquisition import, and add a little factorization in related areas:
- Use a `Path` variable instead for the scan file path of a raw string in `BidsTsvRow`.
- Return an informative result from the `import_bids_acquisitions.importer` function (used by MRI and soon MEG), which is used by the `scans.tsv` code.
- There is some duplication with the `Eeg` code but that is expected given the current split between typed and untyped artchitecture.