### PR TITLE
Add a few test plans to the `docs/test_plans` directory

### DIFF
--- a/docs/test_plans/perl/mass_nii.md
+++ b/docs/test_plans/perl/mass_nii.md
@@ -1,0 +1,18 @@
+# Test plan for `mass_nii.pl`
+
+## Manual tests
+
+- If not already done, source the environment file: `source /opt/Loris-MRI/bin/mri/environment`
+
+- run `mass_nii.pl -help` and ensure the help for the script gets printed
+
+- remove NIfTI images for UploadID 106 (linked to TarchiveID 56)
+     - remove pics from the filesytem using `rm /data/Loris-MRI/data/assembly/400168/V2/mri/native/*nii  /data/Loris-MRI/data/assembly/400168/V2/mri/native/*bval  /data/Loris-MRI/data/assembly/400168/V2/mri/native/*bvec`
+     - in MySQL run the following query to delete path to pic images in `parameter_file`: `DELETE parameter_file FROM parameter_file JOIN files USING (FileID) WHERE TarchiveSource=56 AND Value like "%nii";` (should delete 5 rows)
+     - check that the following query returns no results: `SELECT FileID, Value FROM parameter_file JOIN files USING (FileID) WHERE TarchiveSource=56 AND Value like "%nii";`
+     - go to the imaging browser for CandID 400168 V2 and check that the buttons "download NIfTI" does not show up anymore under the image's screenshot"
+
+- run `mass_nii.pl` on `FileIDs` `335` to `339`: `mass_nii.pl -profile prod -minFileID 335 -maxFileID 339` 
+     - check that the "download NIfTI" button shows up again below the images' screenshots.
+     - check that the following query returns 5 rows: `SELECT FileID, Value FROM parameter_file JOIN files USING (FileID) WHERE TarchiveSource=56 AND Value like "%nii.gz";` 
+     - check that files with extension ".nii" or ".nii.gz" have been created under `/data/Loris-MRI/data/assembly/400168//V2/mri/native/`

--- a/docs/test_plans/perl/mass_nii.md
+++ b/docs/test_plans/perl/mass_nii.md
@@ -7,7 +7,7 @@
 - run `mass_nii.pl -help` and ensure the help for the script gets printed
 
 - remove NIfTI images for UploadID 106 (linked to TarchiveID 56)
-     - remove pics from the filesytem using `rm /data/Loris-MRI/data/assembly/400168/V2/mri/native/*nii  /data/Loris-MRI/data/assembly/400168/V2/mri/native/*bval  /data/Loris-MRI/data/assembly/400168/V2/mri/native/*bvec`
+     - remove pics from the filesystem using `rm /data/Loris-MRI/data/assembly/400168/V2/mri/native/*nii  /data/Loris-MRI/data/assembly/400168/V2/mri/native/*bval  /data/Loris-MRI/data/assembly/400168/V2/mri/native/*bvec`
      - in MySQL run the following query to delete path to pic images in `parameter_file`: `DELETE parameter_file FROM parameter_file JOIN files USING (FileID) WHERE TarchiveSource=56 AND Value like "%nii";` (should delete 5 rows)
      - check that the following query returns no results: `SELECT FileID, Value FROM parameter_file JOIN files USING (FileID) WHERE TarchiveSource=56 AND Value like "%nii";`
      - go to the imaging browser for CandID 400168 V2 and check that the buttons "download NIfTI" does not show up anymore under the image's screenshot"

--- a/docs/test_plans/python/mass_nifti_pic.md
+++ b/docs/test_plans/python/mass_nifti_pic.md
@@ -1,0 +1,18 @@
+# Test plan for `mass_nifti_pic.py`
+
+## Manual tests
+
+- If not already done, source the environment file: `source /opt/Loris-MRI/bin/mri/environment`
+- run `mass_nifti_pic.py -h`
+     => should print the help of the script. Make sure the help documentation is up-to-date.
+- Bonus points: verify that the automated tests are still implemented
+
+## Automated tests already implemented
+
+- test invalid profile
+- test smallest `FileID` bigger than largest `FileID`
+- test invalid FileID provided
+- test on a FileID that already has a pic
+- test force option
+- test running on a text file
+- test successful run

--- a/docs/test_plans/python/run_dicom_archive_loader.md
+++ b/docs/test_plans/python/run_dicom_archive_loader.md
@@ -1,0 +1,20 @@
+# Test plan for `run_dicom_archive_loader.py`
+
+## Manual tests
+
+- If not already done, source the environment file: `source /opt/Loris-MRI/bin/mri/environment`
+- run `run_dicom_archive_loader.py -h`
+     => should print the help of the script. Make sure the help documentation is up-to-date.
+- run `run_dicom_archive_loader.py -p config.py -u <UPLOAD ID>` on a valid upload ID with fieldmaps and BOLD images
+     => ensure that the `IntendedFor` field of the fieldmap has been updated to include the path to the BOLD images
+     => once the script is done running, ensure that the temporary directory that was used to run the script has been cleared out
+- run `run_dicom_archive_loader.py -p config.py -u <UPLOAD ID> -s <SERIES UID>`
+     => ensure only that the file(s) matching the `SeriesUID` have been ingested
+- Bonus points: verify that the automated tests are still implemented
+
+## Automated tests already implemented
+
+- test invalid argument
+- test invalid upload ID
+- test invalid tarchive path
+- test successful run on valid tarchive path

--- a/docs/test_plans/python/run_dicom_archive_validation.md
+++ b/docs/test_plans/python/run_dicom_archive_validation.md
@@ -1,0 +1,18 @@
+# Test plan for `run_dicom_archive_validation.py`
+
+## Manual tests
+
+- If not already done, source the environment file: `source /opt/Loris-MRI/bin/mri/environment`
+- run `run_dicom_archive_validation.py -h`
+     => should print the help of the script. Make sure the help documentation is up-to-date.
+- Bonus points: verify that the automated tests are still implemented
+
+## Automated tests already implemented
+
+- test missing upload ID argument
+- test missing tarchive path argument
+- test invalid argument
+- test invalid upload ID
+- test invalid tarchive path
+- test mixed up upload ID and tarchive path
+- test successful validation

--- a/docs/test_plans/python/run_nifti_insertion.md
+++ b/docs/test_plans/python/run_nifti_insertion.md
@@ -1,0 +1,25 @@
+# Test plan for `run_nifti_insertion.py`
+
+## Manual tests
+
+- If not already done, source the environment file: `source /opt/Loris-MRI/bin/mri/environment`
+- run `run_nifti_insertion.py -h`
+     => should print the help of the script. Make sure the help documentation is up-to-date.
+- Bonus points: verify that the automated tests are still implemented
+
+## Automated tests already implemented
+
+- test invalid argument
+- test missing NIfTI path argument
+- test invalid NIfTI path
+- test missing upload ID or tarchive path argument (one of them should be set)
+- test missing JSON path argument
+- test invalid JSON path
+- test invalid upload ID
+- test invalid tarchive path
+- test tarchive path and upload ID argument provided (only one should be set)
+- test NIfTI and tarchive `PatientName` differ
+- test NIfTI already inserted
+- test NIfTI MRI protocol violated scans features
+- test NIfTI MRI violations log exclude features
+- test DWI insertion with MRI violations warning

--- a/docs/test_plans/python/run_push_imaging_files_to_s3_pipeline.md
+++ b/docs/test_plans/python/run_push_imaging_files_to_s3_pipeline.md
@@ -1,0 +1,17 @@
+# Test plan for `run_dicom_archive_validation.py`
+
+## Manual tests
+
+- If not already done, source the environment file: `source /opt/Loris-MRI/bin/mri/environment`
+- run `run_push_imaging_files_to_s3_pipeline.py -h`
+     => should print the help of the script. Make sure the help documentation is up-to-date.
+- run `run_push_imaging_files_to_s3_pipeline.py -p config.py -u <UPLOAD ID>` on a valid Upload ID and 
+  ensure the files has been properly pushed to the S3 bucket
+- run `run_push_imaging_files_to_s3_pipeline.py -p config.py` without the `-u` 
+     => should print `[ERROR   ] argument --upload_id is required`
+- run `run_push_imaging_files_to_s3_pipeline.py -p config.py -u <UPLOAD ID>` on an invalid Upload ID 
+     => should print `[ERROR   ] Did not find an entry in mri_upload associated with 'UploadID' 1666`
+- run `run_push_imaging_files_to_s3_pipeline.py -p config.py -u <UPLOAD ID>` with the S3 config settings not set in `config.py`
+- run `run_push_imaging_files_to_s3_pipeline.py -p config.py -u <UPLOAD ID>` with incorrect S3 authentication settings  in `config.py`
+- run `run_push_imaging_files_to_s3_pipeline.py -p config.py -u <UPLOAD ID>` with the incorrect S3 bucket name in `config.py`
+


### PR DESCRIPTION
# Description

This adds a few example test plans to the repository for the following scripts (test plans extracted from https://github.com/orgs/aces/projects/70):
- perl script
    - mass_nii.pl
- python scripts
    - mass_nifti_pic.py
    - run_dicom_archive_loader.py
    - run_dicom_archive_validation.py
    - run_nifti_insertion.py
    - run_push_imaging_files_to_s3_pipeline.py