### PR TITLE
Test Plans: delete_imaging_upload, tarchiveLoader

### DIFF
--- a/docs/test_plans/perl/delete_imaging_upload.md
+++ b/docs/test_plans/perl/delete_imaging_upload.md
@@ -1,0 +1,11 @@
+# Test plan for `delete_imaging_upload.pl`
+
+## Manual tests
+
+- [ ] Test deletion of an entire MRI upload (UploadID) with SQL and file backup (ensure the SQL and file backup repopulate the database correctly after the deletion)
+- [ ] Test deletion of an UploadID that has the same TarchiveID as an other UploadID - this should fail with an error message explaining there are multiple UploadID for a given TarchiveID
+- [ ] Test deletion of an UploadID with QC information attached - this should fail with proper error message
+- [ ] Test deletion of an UploadID with a parameter_form filled and the option `-form` and ensure the entries in the parameter form have been deleted
+- [ ] On a defaced dataset, test running the delete script with the `-defaced` option - this should delete only non-defaced MINC files for that UploadID
+- [ ] Run the delete script with option `-basename <FileBaseName>` specifying a basename for the MINC files to be deleted - only images matching that basename should be deleted for the UploadID
+

--- a/docs/test_plans/perl/tarchiveLoader.md
+++ b/docs/test_plans/perl/tarchiveLoader.md
@@ -1,0 +1,12 @@
+# Test plan for `tarchiveLoader.md`
+
+## Manual tests
+
+- [ ] Check that -uploadID, -profile and an existing tarchive are mandatory script argument.
+- [ ] Ensure passing an invalid upload ID yields an error.
+- [ ] Ensure passing an invalid tarchive (e.g csv file) yields an error.
+- [ ] Check that if config setting get_dicom_info is not properly set, tarchiveLoader issues an error that the get_dicom_info command could not be run.
+- [ ]  Pick an archive that's already been successfully processed and find its associated upload ID. Run tarchiveLoader using this archive but use option -upload_id with an argument that is not its actual upload ID. Check that you get an error message that the archive and upload ID don't match.
+- [ ] Pick an archive that's already been successfully processed and find its associated upload ID. Run tarchiveLoader using this archive and option -upload_id with an argument that is its actual upload ID. Ensure that no minc files are inserted and you get an error message regarding duplicate md5sum for each scan that was originally inserted when the archive was processed.
+- [ ] Ensure that config setting default_project is not set and that your prod file does not define any PSCID, visitLabel and ProjectID in function getSubjectIDs. Run tarchiveLoader with a matching tarchive and upload ID and ensure that you get an error message saying that config setting default_project has to be set.
+


### PR DESCRIPTION
This PR adds the test plans for delete_imaging_upload.pl and tarchiveLoader.pl into the docs/test_plans/perl/ directory.