### PR TITLE
fix PosixPath error when running push to s3 script

### DIFF
--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -98,7 +98,7 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
 
         for file in self.dicom_archive.mri_files:
             # Get the raw path of that file, without converting it to a Python path object.
-            raw_path: str = inspect(file).attrs.path.loaded_value
+            raw_path: str = str(inspect(file).attrs.path.loaded_value)
             if raw_path.startswith('s3://'):
                 # skip since file already pushed to S3
                 continue

--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -271,6 +271,12 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
 
         # remove empty folders from file system
         print("Cleaning up empty folders")
-        remove_empty_directories(self.data_dir / 'assembly_bids' / f'sub-{self.session.candidate.cand_id}')
-        remove_empty_directories(self.data_dir / 'pic' / str(self.session.candidate.cand_id))
-        remove_empty_directories(self.data_dir / 'trashbin')
+        assembly_dir = self.data_dir / 'assembly_bids' / f'sub-{self.session.candidate.cand_id}'
+        pic_dir = self.data_dir / 'pic' / str(self.session.candidate.cand_id)
+        trashbin_dir = self.data_dir / 'trashbin'
+        if assembly_dir.exists():
+            remove_empty_directories(assembly_dir)
+        if pic_dir.exists():
+            remove_empty_directories(pic_dir)
+        if trashbin_dir.exists():
+            remove_empty_directories(trashbin_dir)

--- a/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
+++ b/python/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py
@@ -99,7 +99,7 @@ class PushImagingFilesToS3Pipeline(BasePipeline):
         for file in self.dicom_archive.mri_files:
             # Get the raw path of that file, without converting it to a Python path object.
             raw_path: str = str(inspect(file).attrs.path.loaded_value)
-            if raw_path.startswith('s3://'):
+            if raw_path.startswith('s3:/'):
                 # skip since file already pushed to S3
                 continue
             self.files_to_push_list.append({

--- a/python/loris_utils/src/loris_utils/fs.py
+++ b/python/loris_utils/src/loris_utils/fs.py
@@ -45,9 +45,6 @@ def remove_empty_directories(dir_path: Path):
     Recursively remove all the empty directories in a directory, including itself if needed.
     """
 
-    if not dir_path.exists():
-        return
-
     for sub_path in dir_path.iterdir():
         if not sub_path.is_dir():
             continue

--- a/python/loris_utils/src/loris_utils/fs.py
+++ b/python/loris_utils/src/loris_utils/fs.py
@@ -45,6 +45,9 @@ def remove_empty_directories(dir_path: Path):
     Recursively remove all the empty directories in a directory, including itself if needed.
     """
 
+    if not dir_path.exists():
+        return
+
     for sub_path in dir_path.iterdir():
         if not sub_path.is_dir():
             continue


### PR DESCRIPTION
# Description

This fixes the following error introduced after refactoring paths:

```
Traceback (most recent call last):
  File "/opt/Loris-MRI/bin/mri/python/scripts/run_push_imaging_files_to_s3_pipeline.py", line 54, in <module>
    main()
  File "/opt/Loris-MRI/bin/mri/python/scripts/run_push_imaging_files_to_s3_pipeline.py", line 50, in main
    PushImagingFilesToS3Pipeline(loris_getopt_obj, os.path.basename(__file__[:-3]))
  File "/opt/Loris-MRI/bin/mri/.venv/lib/python3.12/site-packages/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py", line 52, in __init__
    self._get_files_to_push_list()
  File "/opt/Loris-MRI/bin/mri/.venv/lib/python3.12/site-packages/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py", line 83, in _get_files_to_push_list
    self._get_list_of_files_from_files()
  File "/opt/Loris-MRI/bin/mri/.venv/lib/python3.12/site-packages/lib/dcm2bids_imaging_pipeline_lib/push_imaging_files_to_s3_pipeline.py", line 102, in _get_list_of_files_from_files
    if raw_path.startswith('s3://'):
       ^^^^^^^^^^^^^^^^^^^
AttributeError: 'PosixPath' object has no attribute 'startswith'
```