### PR TITLE
Remove scan done field from perl code

### DIFF
--- a/docs/scripts_md/MRIProcessingUtility.md
+++ b/docs/scripts_md/MRIProcessingUtility.md
@@ -14,7 +14,7 @@ utilities
 
     %tarchiveInfo     = $utility->createTarchiveArray($ArchiveLocation);
 
-    my $centerID      = $utility->determinePSC(\%tarchiveInfo,0);
+    my $centerID = $utility->determinePSC(\%tarchiveInfo,0);
 
     my $projectID     = $utility->determineProjectID(\%tarchiveInfo);
     my $scannerID     = $utility->determineScannerID(\%tarchiveInfo, 0, $centerID, $projectID);
@@ -472,6 +472,15 @@ Gets the upload ID form the `mri_upload` table using the DICOM archive
 INPUT: DICOM archive's source location
 
 RETURNS: the found upload ID
+
+### getCenterNameFromCenterID($centerID)
+
+Gets the human-readable center `Name` from the `psc` table using the center ID.
+Used to display a readable center name (rather than a numeric ID) in the logs.
+
+INPUT: Center ID
+
+RETURNS: center Name
 
 ### spool($message, $error, $upload\_id, $verb)
 

--- a/docs/scripts_md/PSCOB.md
+++ b/docs/scripts_md/PSCOB.md
@@ -39,7 +39,7 @@ NeuroDB::objectBroker::PSCOB -- An object broker for records stored in table `ps
     my $pscRef;
     try {
         $pscRef = $pscOB->get(
-            { MRI_alias => 'my_alias' }
+            { Alias => 'my_alias' }
         );
         foreach (@$pscRef) {
             printf "ID for PSC named $_->{'Name'} is $_->{'ID'}\n";

--- a/docs/scripts_md/batch_run_defacing_script.md
+++ b/docs/scripts_md/batch_run_defacing_script.md
@@ -8,7 +8,7 @@ perl batch\_run\_defacing\_script.pl \[-profile file\] < list\_of\_session\_IDs.
 
 Available options are:
 
-\-profile: name of config file in ../dicom-archive/.loris\_mri (typically called prod)
+\-profile: name of config file in ../config (typically called prod)
 
 # DESCRIPTION
 

--- a/docs/scripts_md/batch_run_pipeline_qc_face_script.md
+++ b/docs/scripts_md/batch_run_pipeline_qc_face_script.md
@@ -8,7 +8,7 @@ perl batch\_run\_pipeline\_qc\_face\_script.pl \[-profile file\] \[-out\_basedir
 
 Available options are:
 
-\-profile: name of config file in ../dicom-archive/.loris\_mri (typically called prod)
+\-profile: name of config file in ../config (typically called prod)
 
 \-out\_basedir: path to the output base directory where the jpg will be created
 

--- a/docs/scripts_md/delete_imaging_upload.md
+++ b/docs/scripts_md/delete_imaging_upload.md
@@ -97,8 +97,7 @@ All the deletions and modifications performed in the database are done as part o
 all succeed or a rollback is performed and the database is not modified in any way. The ID of the upload to delete
 is specified via option `-uploadID`. More than one upload can be deleted if they all have the same `TarchiveID`
 in table `mri_upload`: option `-uploadID` can take as argument a comma-separated list of upload IDs for this case.
-If an upload that is deleted is the only one that was associated to a given session, the script will set the `Scan_done`
-value for that session to 'N'. If option `-form` is used, the `mri_parameter_form` and its associated `flag` record
+If option `-form` is used, the `mri_parameter_form` and its associated `flag` record
 are also deleted, for each deleted upload. If option `-protocol` is used and if there is a record in table
 `mri_processing_protocol` that is tied only to the deleted upload(s), then that record is also deleted.
 
@@ -453,8 +452,7 @@ This method deletes all information in the database associated to the given uplo
 More specifically, it deletes records from tables `notification_spool`, `tarchive_files`, `tarchive_series`
 `files_intermediary`, `parameter_file`, `files`, `mri_protocol_violated_scans`, `mri_violations_log`
 `MRICandidateErrors`, `mri_upload`, `tarchive`, `mri_processing_protocol` and `mri_parameter_form`
-(the later is done only if requested). It will also set the `Scan_done` value of the scan's session to 'N' for
-each upload that is the last upload tied to that session. All the delete/update operations are done inside a single
+(the later is done only if requested). All the delete/update operations are done inside a single
 transaction so either they all succeed or they all fail (and a rollback is performed).
 
 INPUTS:

--- a/docs/scripts_md/remove_jiv_data_from_db_and_filesystem.md
+++ b/docs/scripts_md/remove_jiv_data_from_db_and_filesystem.md
@@ -9,7 +9,7 @@ perl remove\_jiv\_data\_from\_db\_and\_filesystem.pl `[options]`
 
 Available option is:
 
-\-profile: name of the config file in ../dicom-archive/.loris\_mri
+\-profile: name of the config file in ../config
 
 # DESCRIPTION
 

--- a/docs/scripts_md/updateMRI_Upload.md
+++ b/docs/scripts_md/updateMRI_Upload.md
@@ -7,10 +7,10 @@ updateMRI\_Upload.pl - updates database table `mri_upload` according to an entry
 
 updateMRI\_Upload.pl \[options\] -profile prod -tarchivePath tarchivePath -source\_location source\_location -timeZone tz
 
-- **-profile prod** : (mandatory) path (absolute or relative to the current directory) of the 
+- **-profile prod** : (mandatory) path (absolute or relative to the current directory) of the
     profile file
 - **-tarchivePath tarchivePath** : (mandatory) absolute path to the DICOM archive
-- **-source\_location source\_location** : (mandatory) value to set column 
+- **-source\_location source\_location** : (mandatory) value to set column
     `DecompressedLocation` for the newly created record in table `mri_upload` (see below)
 - **-verbose** : be verbose
 
@@ -18,11 +18,11 @@ updateMRI\_Upload.pl \[options\] -profile prod -tarchivePath tarchivePath -sourc
 
 This script first starts by reading the `prod` file (argument passed to the `-profile` switch)
 to fetch the `@db` variable, a Perl array containing four elements: the database
-name, the database user name used to connect to the database, the password and the 
-database hostname. It then checks for an entry in the `tarchive` table with the same 
-`ArchiveLocation` as the DICOM archive passed on the command line. Let `T` be the 
-DICOM archive record found in the `tarchive` table. The script will then proceed to scan table 
-`mri_upload` for a record with the same `tarchiveID` as `T`'s. If there is none (which is the 
+name, the database user name used to connect to the database, the password and the
+database hostname. It then checks for an entry in the `tarchive` table with the same
+`ArchiveLocation` as the DICOM archive passed on the command line. Let `T` be the
+DICOM archive record found in the `tarchive` table. The script will then proceed to scan table
+`mri_upload` for a record with the same `tarchiveID` as `T`'s. If there is none (which is the
 expected outcome), it will insert a record in `mri_upload` with the following properties/values:
 
 - `UploadedBy` : Unix username of the person currently running `updateMRI_upload.pl`

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -101,8 +101,7 @@ All the deletions and modifications performed in the database are done as part o
 all succeed or a rollback is performed and the database is not modified in any way. The ID of the upload to delete
 is specified via option C<-uploadID>. More than one upload can be deleted if they all have the same C<TarchiveID>
 in table C<mri_upload>: option C<-uploadID> can take as argument a comma-separated list of upload IDs for this case.
-If an upload that is deleted is the only one that was associated to a given session, the script will set the C<Scan_done>
-value for that session to 'N'. If option C<-form> is used, the C<mri_parameter_form> and its associated C<flag> record
+If option C<-form> is used, the C<mri_parameter_form> and its associated C<flag> record
 are also deleted, for each deleted upload. If option C<-protocol> is used and if there is a record in table
 C<mri_processing_protocol> that is tied only to the deleted upload(s), then that record is also deleted.
 
@@ -1710,8 +1709,7 @@ This method deletes all information in the database associated to the given uplo
 More specifically, it deletes records from tables C<notification_spool>, C<tarchive_files>, C<tarchive_series>
 C<files_intermediary>, C<parameter_file>, C<files>, C<mri_protocol_violated_scans>, C<mri_violations_log>
 C<MRICandidateErrors>, C<mri_upload>, C<tarchive>, C<mri_processing_protocol> and C<mri_parameter_form>
-(the later is done only if requested). It will also set the C<Scan_done> value of the scan's session to 'N' for
-each upload that is the last upload tied to that session. All the delete/update operations are done inside a single
+(the later is done only if requested). All the delete/update operations are done inside a single
 transaction so either they all succeed or they all fail (and a rollback is performed).
 
 INPUTS:

--- a/uploadNeuroDB/NeuroDB/MRI.pm
+++ b/uploadNeuroDB/NeuroDB/MRI.pm
@@ -257,7 +257,6 @@ sub getSessionInformation {
            . "    CenterID      = ?, "
            . "    VisitNo       = ?, "
            . "    Current_stage = 'Not Started', "
-           . "    Scan_done     = 'Y', "
            . "    Submitted     = 'N', "
            . "    CohortID  = ?, "
            . "    ProjectID     = ?";


### PR DESCRIPTION
# Description

This removes from the code and documentation the references to Scan_done field that was removed for release 29.0.

In addition, this generates all the perldoc MD files that have not yet been committed to the repo.