### PR TITLE
Fix test_name flag reference in delete_imaging_upload.pl

### DIFF
--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -1916,7 +1916,7 @@ sub deleteMriParameterForm {
     my $query = "SELECT f.CommentID FROM flag f "
               . "JOIN session s ON (s.ID=f.SessionID) "
               . "JOIN mri_upload mu ON (s.ID=mu.SessionID) "
-	      . "JOIN test_names tn ON tn.ID=f.TestID "
+              . "JOIN test_names tn ON tn.ID=f.TestID "
               . "WHERE tn.Test_name='mri_parameter_form' "
               . "AND mu.UploadID IN ( "
               . join(',', ('?') x @uploadIDs)

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -1916,7 +1916,8 @@ sub deleteMriParameterForm {
     my $query = "SELECT f.CommentID FROM flag f "
               . "JOIN session s ON (s.ID=f.SessionID) "
               . "JOIN mri_upload mu ON (s.ID=mu.SessionID) "
-              . "WHERE f.Test_name='mri_parameter_form' "
+	      . "JOIN test_names tn ON tn.ID=f.TestID "
+              . "WHERE tn.Test_name='mri_parameter_form' "
               . "AND mu.UploadID IN ( "
               . join(',', ('?') x @uploadIDs)
               . ") ";


### PR DESCRIPTION
Resolved issue #1466

In the delete_imaging_upload.pl script, there was an outdated reference to the `Test_name` column in flag. This column has been replaced with a `TestID` column in flag. We now have to join with the test_names table instead. 

I have double checked the rest of the repository for Test_name references, and this is the only one.

With this change, the script now runs successfully and deletes MRI uploads that have data in the MRI Parameter Form:
```
$ perl delete_imaging_upload.pl -profile prod -nosqlbk -nofilesbk -uploadID 62 -form
Successfully deleted data for upload 62.
```
To test: 
1. Find an MRI Upload that has data entered in the corresponding MRI Paramter Form
2. Make sure to delete any QC data from the database if it exists
3. Run the delete script with the `-form` argument
4. Make sure all is deleted successfully