### PR TITLE
Fix bug with deletion of defaced files in script delete_imaging_upload.pl

### DIFF
--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -1879,7 +1879,7 @@ sub updateFilesIntermediaryTable {
                   . ")";
         $dbh->do($query, undef, $tarchiveID, keys %defacedFiles);
 
-        if (defined $tmpSQLFile") {
+        if (defined $tmpSQLFile) {
             open(SQL, ">>$tmpSQLFile") or die "Cannot append text to file $tmpSQLFile: $!. Aborting.\n";
             print SQL "\n\n";
             while(my($fileID, $sourceFileID) = each %defacedFiles) {

--- a/tools/delete_imaging_upload.pl
+++ b/tools/delete_imaging_upload.pl
@@ -1879,12 +1879,14 @@ sub updateFilesIntermediaryTable {
                   . ")";
         $dbh->do($query, undef, $tarchiveID, keys %defacedFiles);
 
-        open(SQL, ">>$tmpSQLFile") or die "Cannot append text to file $tmpSQLFile: $!. Aborting.\n";
-        print SQL "\n\n";
-        while(my($fileID, $sourceFileID) = each %defacedFiles) {
-            print SQL "UPDATE files SET TarchiveSource = NULL, SourceFileID = $sourceFileID WHERE FileID = $fileID;\n";
+        if (defined $tmpSQLFile") {
+            open(SQL, ">>$tmpSQLFile") or die "Cannot append text to file $tmpSQLFile: $!. Aborting.\n";
+            print SQL "\n\n";
+            while(my($fileID, $sourceFileID) = each %defacedFiles) {
+                print SQL "UPDATE files SET TarchiveSource = NULL, SourceFileID = $sourceFileID WHERE FileID = $fileID;\n";
+            }
+            close(SQL);
         }
-        close(SQL);
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug that prevented script `delete_imaging_upload.pl` from being used with options `-defaced` together with option `-nosqlbk`.


Fixes #1468 
