### PR TITLE
Add 29.0 migration guide

### DIFF
--- a/docs/releases/29.md
+++ b/docs/releases/29.md
@@ -1,0 +1,282 @@
+# LORIS-MRI 29.0
+
+This document covers the LORIS-MRI changes from version 27.0.4 to 29.0.0.
+
+## Changes
+
+### Packaging enhancements
+
+PRs: [#1308](https://github.com/aces/loris-mri/pull/1308), [#1310](https://github.com/aces/loris-mri/pull/1310), [#1311](https://github.com/aces/loris-mri/pull/1311), [#1312](https://github.com/aces/loris-mri/pull/1312), [#1320](https://github.com/aces/loris-mri/pull/1320), [#1340](https://github.com/aces/loris-mri/pull/1340), [#1403](https://github.com/aces/loris-mri/pull/1403), [#1414](https://github.com/aces/loris-mri/pull/1414), and [#1417](https://github.com/aces/loris-mri/pull/1417).
+
+LORIS Python now uses modern Python packaging to install its Python code:
+- The main package is named `loris`, with its metadata and dependencies located in the root `pyproject.toml` file.
+- The previous `requirements.txt` file has been removed.
+- The default LORIS Python virtual environment created during installation has been renamed to `loris` instead of `loris-mri-python`.
+- Support has been added for the `uv` package manager, which allows for more seamless multi-package development.
+
+The LORIS Python environment and packages are all installed as part of the LORIS-MRI installation process as before, however, they can also be installed manually with `pip`, which installs all the LORIS Python packages:
+- `loris`: top-level package
+- `loris-bids-utils`
+- `loris-bids-importer`
+- `loris-dicom-importer`
+- `loris-ephys-chunker`
+- `loris-utils`
+
+More information about LORIS Python package management can be found in the [LORIS Python packaging documentation](https://github.com/aces/Loris-MRI/blob/29.0-release/docs/python/Packaging.md).
+
+### Configuration enhancements
+
+PRs: [#1313](https://github.com/aces/loris-mri/pull/1313), [#1317](https://github.com/aces/loris-mri/pull/1317), [#1318](https://github.com/aces/loris-mri/pull/1318), and [#1433](https://github.com/aces/loris-mri/pull/1433).
+
+The LORIS-MRI and LORIS Python configuration system has been improved:
+- The default LORIS-MRI configuration directory has been moved from `dicom-archive/.loris_mri/` to `config/`.
+- The default Python configuration file has been renamed to `config.py` instead of `database_config.py`.
+- LORIS Python CLI commands also now use the default Python configuration file as a default for the `--profile` argument, which is now optional.
+- The `--profile` argument can no longer traverse outside of the LORIS-MRI configuration directory.
+
+### BIDS importer
+
+PRs: [#1363](https://github.com/aces/loris-mri/pull/1363), [#1364](https://github.com/aces/loris-mri/pull/1364), [#1365](https://github.com/aces/loris-mri/pull/1365), [#1366](https://github.com/aces/loris-mri/pull/1366), [#1367](https://github.com/aces/loris-mri/pull/1367), [#1368](https://github.com/aces/loris-mri/pull/1368), [#1369](https://github.com/aces/loris-mri/pull/1369), [#1381](https://github.com/aces/loris-mri/pull/1381), [#1382](https://github.com/aces/loris-mri/pull/1382), [#1384](https://github.com/aces/loris-mri/pull/1384), [#1388](https://github.com/aces/loris-mri/pull/1388), [#1389](https://github.com/aces/loris-mri/pull/1389), [#1392](https://github.com/aces/loris-mri/pull/1392), [#1412](https://github.com/aces/loris-mri/pull/1412), [#1413](https://github.com/aces/loris-mri/pull/1413), [#1421](https://github.com/aces/loris-mri/pull/1421), [#1423](https://github.com/aces/loris-mri/pull/1423), [#1424](https://github.com/aces/loris-mri/pull/1424), [#1425](https://github.com/aces/loris-mri/pull/1425), [#1426](https://github.com/aces/loris-mri/pull/1426), [#1432](https://github.com/aces/loris-mri/pull/1432), [#1434](https://github.com/aces/loris-mri/pull/1434), [#1436](https://github.com/aces/loris-mri/pull/1436), [#1449](https://github.com/aces/loris-mri/pull/1449), [#1450](https://github.com/aces/loris-mri/pull/1450), [#1460](https://github.com/aces/loris-mri/pull/1460), and [#1464](https://github.com/aces/loris-mri/pull/1464).
+
+The BIDS importer was rewritten into typed, installable packages. The main CLI command is named `import-bids-dataset`. The BIDS importer is located in the `loris-bids-importer` package. An auxiliary `loris-bids-utils` package provides utility classes and functions to navigate BIDS datasets and files.
+
+The new LORIS BIDS importer can be called with the following command:
+
+```sh
+import-bids-dataset --create-candidate --create-session -d /path/to/bids/dataset
+```
+
+### Tooling enhancements
+
+PRs: [#1407](https://github.com/aces/loris-mri/pull/1407), [#1430](https://github.com/aces/loris-mri/pull/1430), [#1439](https://github.com/aces/loris-mri/pull/1439), [#1445](https://github.com/aces/loris-mri/pull/1445), and [#1472](https://github.com/aces/loris-mri/pull/1472).
+
+A new `check_orm_sql_sync.py` script has been added to check synchronization between the LORIS Python ORM and deployed SQL database. This tool is particularly useful to ensure compliance when using LORIS Python on a fork that uses a different database schema.
+
+The typing and linting configuration of LORIS Python have also been improved, in addition to the code itself that has gained better coverage.
+
+### New ORM models
+
+PRs: [#1303](https://github.com/aces/loris-mri/pull/1303), [#1344](https://github.com/aces/loris-mri/pull/1344), [#1378](https://github.com/aces/loris-mri/pull/1378), [#1399](https://github.com/aces/loris-mri/pull/1399), [#1423](https://github.com/aces/loris-mri/pull/1423), and [#1441](https://github.com/aces/loris-mri/pull/1441).
+
+The LORIS Python ORM has gained new models, notably for electrophysiology:
+- `DbBidsEventDatasetMapping`
+- `DbBidsEventFileMapping`
+- `DbHedSchema`
+- `DbHedSchemaNode`
+- `DbMegCtfHeadShapeFile`
+- `DbMegCtfHeadShapePoint`
+- `DbParameterTypeCategory`
+- `DbParameterTypeCategoryRel`
+- `DbPhysioChannel`
+- `DbPhysioChannelType`
+- `DbPhysioCoordSystem`
+- `DbPhysioCoordSystemElectrode`
+- `DbPhysioCoordSystemName`
+- `DbPhysioCoordSystemPoint3d`
+- `DbPhysioCoordSystemType`
+- `DbPhysioCoordSystemUnit`
+- `DbPhysioElectrode`
+- `DbPhysioElectrodeMaterial`
+- `DbPhysioElectrodeType`
+- `DbPhysioEventArchive`
+- `DbPhysioEventFile`
+- `DbPhysioEventParameter`
+- `DbPhysioEventParameterCategoryLevel`
+- `DbPhysioFile`
+- `DbPhysioFileArchive`
+- `DbPhysioFileParameter`
+- `DbPhysioModality`
+- `DbPhysioOutputType`
+- `DbPhysioStatusType`
+- `DbPhysioTaskEvent`
+- `DbPhysioTaskEventHed`
+- `DbPhysioTaskEventOpt`
+- `DbPoint3D`
+- `DbSex`
+- `DbUser`
+- `DbUserProject`
+- `DbUserSite`
+
+The LORIS Python code, in particular the BIDS importer, now uses these models and their associated queries.
+
+## Migration guide
+
+### Database changes
+
+The `psc.MRI_alias` field is no longer used for MRI session lookup. Sites are now solely identified using their name or normal alias. Update the LORIS Perl and Python configuration files accordingly.
+
+### Installation and package names
+
+PRs: [#1311](https://github.com/aces/loris-mri/pull/1311), [#1320](https://github.com/aces/loris-mri/pull/1320), [#1338](https://github.com/aces/loris-mri/pull/1338), [#1340](https://github.com/aces/loris-mri/pull/1340), [#1409](https://github.com/aces/loris-mri/pull/1409), [#1411](https://github.com/aces/loris-mri/pull/1411), [#1425](https://github.com/aces/loris-mri/pull/1425), and [#1436](https://github.com/aces/loris-mri/pull/1436).
+
+To update the LORIS Python packages, it is advised to install them in editable mode using one of the following commands:
+
+Using `pip`:
+```sh
+# Step 1: Go to the LORIS-MRI directory.
+cd /path/to/loris/mri
+# Step 2: Install the top-level LORIS Python package in editable mode.
+# This step will also install all LORIS subpackages and dependencies in non-editable mode.
+pip install -e .
+# Step 3: Re-install each LORIS subpackage in editable mode without re-installing its dependencies.
+for package in ./python/loris_*; do pip install --no-deps -e $package; done
+```
+
+Using `uv`:
+```sh
+uv pip install -e /path/to/loris/mri
+```
+
+More information can be found in the [LORIS Python packaging documentation](https://github.com/aces/Loris-MRI/blob/29.0-release/docs/python/Packaging.md).
+
+### Configuration
+
+PRs: [#1313](https://github.com/aces/loris-mri/pull/1313) and [#1317](https://github.com/aces/loris-mri/pull/1317).
+
+For the configuration directory migration:
+
+- To migrate, move the configuration from `<YOUR-OLD-CONFIG-DIR>/.loris_mri` (usually `<LORIS-MRI-DIR>/dicom-archive/.loris_mri`) to `<YOUR-NEW-CONFIG-DIR>` (usually `<LORIS-MRI-DIR>/config`), then change `LORIS_CONFIG` in the `environment` file from `<YOUR-OLD-CONFIG-DIR>` to `<YOUR-NEW-CONFIG-DIR>`.
+- To retain the existing configuration directory, change `LORIS_CONFIG` in the `environment` file from `<YOUR-CONFIG-DIR>` to `<YOUR-CONFIG-DIR>/.loris_mri`.
+
+For the Python configuration file name migration:
+
+- To rename it, update the LORIS-MRI Python configuration file in the LORIS database to `config.py`, and update external scripts and cron jobs to use `config.py` instead of `database_config.py`.
+- To retain `database_config.py`, no action is required.
+
+### CLI commands and options
+
+PRs: [#1338](https://github.com/aces/loris-mri/pull/1338), [#1411](https://github.com/aces/loris-mri/pull/1411), and [#1425](https://github.com/aces/loris-mri/pull/1425).
+
+Replace these direct-script invocations with installed console commands:
+
+| Previous command | LORIS-MRI 29 command |
+| --- | --- |
+| `bids_import.py` | `import-bids-dataset` |
+| `import_dicom_study.py` | `import-dicom-study` |
+| `summarize_dicom_study.py` | `summarize-dicom-study` |
+| `edf_to_chunks.py` | `edf-to-chunks` |
+| `eeglab_to_chunks.py` | `eeglab-to-chunks` |
+
+For the BIDS import script, the following options have been renamed:
+
+| Previous option | LORIS-MRI 29 option |
+| --- | --- |
+| `--createcandidate` | `--create-candidate` |
+| `--createsession` | `--create-session` |
+| `--nobidsvalidation` | `--no-bids-validation` |
+| `--nocopy` | `--no-copy` |
+
+### Code migration
+
+#### `Env` creation
+
+PRs: [#1420](https://github.com/aces/loris-mri/pull/1420).
+
+The dependency between the `LorisGetOpt` object and the `make_env` function has inverted:
+
+```py
+from lib.make_env import make_env
+
+# Before
+env = make_env(loris_get_opt)
+# After
+env = loris_get_opt.env
+```
+
+The `make_env(...)` function can also now be called manually with the appropriate arguments for non-`LorisGetOpt` pipelines.
+
+#### Module and package moves
+
+PRs: [#1304](https://github.com/aces/loris-mri/pull/1304), [#1350](https://github.com/aces/loris-mri/pull/1350), [#1374](https://github.com/aces/loris-mri/pull/1374), [#1411](https://github.com/aces/loris-mri/pull/1411), [#1425](https://github.com/aces/loris-mri/pull/1425), and [#1436](https://github.com/aces/loris-mri/pull/1436).
+
+| Previous import/package | Replacement |
+| --- | --- |
+| `lib.import_dicom_study` | `loris_dicom_importer` |
+| `lib.import_bids_dataset` | `loris_bids_importer` |
+| `loris_bids_reader` | `loris_bids_utils` |
+| `lib.util.crypto` | `loris_utils.crypto` |
+| `lib.util.fs` | `loris_utils.fs` |
+| `lib.util.iter` | `loris_utils.iter` |
+| `lib.scanner` | `lib.imaging_lib.mri_scanner` |
+
+#### ORM changes
+
+PRs: [#1350](https://github.com/aces/loris-mri/pull/1350), [#1429](https://github.com/aces/loris-mri/pull/1429), [#1435](https://github.com/aces/loris-mri/pull/1435), and [#1437](https://github.com/aces/loris-mri/pull/1437).
+
+The following ORM fields have been renamed:
+
+| Model | Previous attribute | LORIS-MRI 29 attribute |
+| --- | --- | --- |
+| `DbCandidate` | `dete_of_death` | `date_of_death` |
+| `DbDicomArchive` | `archive_location` | `path` |
+| `DbDicomArchive` | `source_location` | `source_path` |
+| `DbFile` | `rel_path` | `path` |
+| `DbImagingFileType` | `type` | `name` |
+| `DbMriProtocolViolatedScan` | `file_rel_path` | `file_path` |
+| `DbMriUpload` | `decompressed_location` | `decompressed_path` |
+| `DbMriUpload` | `upload_location` | `upload_path` |
+| `DbMriViolationLog` | `file_rel_path` | `file_path` |
+
+The following existing ORM fields changed from `str` to `pathlib.Path`, using a new `StringPath` ORM type decorator:
+- `DbDicomArchive.source_path`
+- `DbDicomArchive.path`
+- `DbFile.path`
+- `DbMriProtocolViolatedScan.file_path`
+- `DbMriUpload.upload_path`
+- `DbMriUpload.decompressed_path`
+- `DbMriViolationLog.file_path`
+
+The `DbSession.scan_done` field has been removed.
+
+The `DbSession.mri_caveat` field has been changed to a boolean instead of a string.
+
+#### Newly deprecated APIs
+
+PRs: [#1304](https://github.com/aces/loris-mri/pull/1304), [#1356](https://github.com/aces/loris-mri/pull/1356), [#1357](https://github.com/aces/loris-mri/pull/1357), [#1374](https://github.com/aces/loris-mri/pull/1374), [#1375](https://github.com/aces/loris-mri/pull/1375), [#1376](https://github.com/aces/loris-mri/pull/1376), [#1378](https://github.com/aces/loris-mri/pull/1378), [#1379](https://github.com/aces/loris-mri/pull/1379), and [#1402](https://github.com/aces/loris-mri/pull/1402).
+
+Several untyped classes and functions have been deprecated. They are all marked with a `@deprecated` decorator that produces a warning both during type checking and at runtime and points to the new typed APIs that replace them.
+
+| Deprecated API | Replacement named by the decorator |
+| --- | --- |
+| `lib.database_lib.bids_event_mapping.BidsEventMapping` | `lib.db.models.bids_event_dataset_mapping.BidsEventDatasetMapping` and `lib.db.models.bids_event_file_mapping.BidsEventFileMapping` |
+| `lib.database_lib.files.Files` | `lib.db.models.file.DbFile` |
+| `lib.database_lib.files.Files.find_file_with_hash` | `lib.db.queries.try_get_file_with_hash` |
+| `lib.database_lib.files.Files.insert_files` | `lib.db.models.file.DbFile` |
+| `lib.database_lib.files.Files.update_files` | `lib.db.models.file.DbFile` |
+| `lib.database_lib.files.Files.get_files_inserted_for_tarchive_id` | `lib.db.models.dicom_archive.DbDicomArchive.mri_files` |
+| `lib.database_lib.files.Files.get_files_inserted_for_session_id` | `lib.db.models.session.DbSession.files` |
+| `lib.database_lib.mri_scan_type.MriScanType` | `lib.db.models.mri_scan_type.DbMriScanType` |
+| `lib.database_lib.mri_scan_type.MriScanType.get_scan_type_name_from_id` | `lib.db.queries.mri_scan_type.try_get_mri_scan_type_with_id` |
+| `lib.database_lib.mri_scan_type.MriScanType.get_scan_type_id_from_name` | `lib.db.queries.mri_scan_type.try_get_mri_scan_type_with_name` |
+| `lib.database_lib.parameter_file.ParameterFile.insert_parameter_file` | `lib.imaging_lib.file_parameter.register_mri_file_parameter` |
+| `lib.database_lib.parameter_type.ParameterType.get_bids_to_minc_mapping_dict` | `lib.imaging_lib.file_parameter.get_bids_to_loris_parameter_types_dict` |
+| `lib.database_lib.physiological_event_archive.PhysiologicalEventArchive` | `lib.db.physio_event_archive.DbPhysioEventArchive` |
+| `lib.database_lib.physiological_event_archive.PhysiologicalEventArchive.grep_from_physiological_file_id` | `lib.db.physio_event_archive.DbPhysioEventArchive.physio_file_id` |
+| `lib.database_lib.physiological_event_archive.PhysiologicalEventArchive.insert` | `lib.db.physio_event_archive.DbPhysioEventArchive` |
+| `lib.database_lib.physiological_event_file.PhysiologicalEventFile` | `lib.db.models.physio_event_file.DbPhysioEventFile` |
+| `lib.database_lib.physiological_file.PhysiologicalFile` | `lib.db.physio_file.DbPhysioFile` |
+| `lib.database_lib.physiological_modality.PhysiologicalModality` | `lib.db.models.physio_modality.DbPhysioModality` |
+| `lib.database_lib.physiological_output_type.PhysiologicalOutputType` | `lib.db.models.physio_output_type.DbPhysioOutputType` |
+| `lib.database_lib.physiological_parameter_file.PhysiologicalParameterFile` | `lib.db.physio_file_parameter.DbPhysioFileParameter` |
+| `lib.database_lib.physiological_task_event.PhysiologicalTaskEvent` | `lib.db.models.physio_task_event.DbPhysioTaskEvent` |
+| `lib.database_lib.physiological_task_event_hed_rel.PhysiologicalTaskEventHEDRel` | `lib.db.models.physio_task_event_hed.DbPhysioTaskEventHed` |
+| `lib.database_lib.physiological_task_event_opt.PhysiologicalTaskEventOpt` | `lib.db.models.physio_task_event_opt.DbPhysioTaskEventOpt` |
+| `lib.imaging.determine_file_type` | `loris_bids_importer.file_type.get_check_bids_imaging_file_type_from_extension` |
+| `lib.imaging.grep_file_info_from_hash` | `lib.db.queries.try_get_file_with_hash` |
+| `lib.imaging.insert_imaging_file` | `lib.imaging_lib.file.register_mri_file` |
+| `lib.imaging.insert_parameter_file` | `lib.imaging_lib.file_parameter.register_mri_file_parameter` |
+| `lib.imaging.get_parameter_type_id` | `lib.imaging_lib.parameter.get_or_create_parameter_type` |
+| `lib.imaging.get_bids_to_minc_terms_mapping` | `lib.imaging_lib.file_parameter.get_bids_to_loris_parameter_types_dict` |
+| `lib.imaging.grep_file_type_from_file_id` | `lib.db.models.file.DbFile.file_type` |
+| `lib.imaging.grep_file_path_from_file_id` | `lib.db.models.file.DbFile.path` |
+| `lib.imaging.grep_cand_id_from_file_id` | `lib.db.models.file.DbFile.candidate.cand_id` |
+| `lib.imaging.get_list_of_files_already_inserted_for_tarchive_id` | `lib.db.models.dicom_archive.DbDicomArchive.mri_files` |
+| `lib.imaging.get_list_of_files_already_inserted_for_session_id` | `lib.db.models.session.DbSession.files` |
+| `lib.imaging.create_imaging_pic` | `lib.imaging_lib.nifti_pic.create_nifti_preview_picture` |
+| `lib.session.create_session` | `lib.db.models.session.DbSession` |
+| `lib.utilities.create_archive` | `loris_utils.archive.create_tar_gz_archive_with_files` |
+| `lib.utilities.create_processing_tmp_dir` | `lib.make_env.create_script_tmp_dir` |
+
+## List of PRs
+
+The full list of PRs for LORIS-MRI 29.0.0 can be found on GitHub in the [29.0.0 milestone](https://github.com/aces/Loris-MRI/pulls?q=is:pr+milestone:29.0.0).


### PR DESCRIPTION
The PR lists, code lists, and general formatting have been assisted by AI. The prose is hand-written. Everything has been proofread. [rendered](https://github.com/MaximeBICMTL/LORIS-MRI/blob/29-release-notes/docs/releases/29.md)