### PR TITLE
Fix ORM by adding back the DoD_precision field

### DIFF
--- a/python/lib/db/models/candidate.py
+++ b/python/lib/db/models/candidate.py
@@ -22,6 +22,7 @@ class DbCandidate(Base):
     external_id             : Mapped[str | None]  = mapped_column('ExternalID')
     date_of_birth           : Mapped[date | None] = mapped_column('DoB')
     date_of_death           : Mapped[date | None] = mapped_column('DoD')
+    date_of_death_precision : Mapped[str | None]  = mapped_column('DoD_precision')
     edc                     : Mapped[date | None] = mapped_column('EDC')
     sex                     : Mapped[str | None]  = mapped_column('Sex')
     registration_site_id    : Mapped[int]         = mapped_column('RegistrationCenterID', ForeignKey('psc.CenterID'))


### PR DESCRIPTION
A new field has been added to the candidate table on the main branch (see [change here](https://github.com/aces/Loris/commit/0374a164ce9faad786a8e322d14684109ee16525)). This updates the ORM to add the new field from the candidate table and fix the tests.