### PR TITLE
Fix electrophysiology chunking script on already chunked files

### DIFF
--- a/python/lib/db/queries/physio_parameter.py
+++ b/python/lib/db/queries/physio_parameter.py
@@ -31,7 +31,7 @@ def try_get_physio_parameter_type_with_name(
     parameter is found.
     """
 
-    return try_get_parameter_type_with_name_source(db, name, 'physiological_file')
+    return try_get_parameter_type_with_name_source(db, name, 'physiological_parameter_file')
 
 
 def try_get_physio_file_parameter_with_file_id_type_id(

--- a/python/lib/physio/chunking.py
+++ b/python/lib/physio/chunking.py
@@ -5,26 +5,15 @@ from loris_utils.path import get_path_stem
 import lib.exitcode
 from lib.config import get_data_dir_path_config, get_ephys_chunks_dir_path_config
 from lib.db.models.physio_file import DbPhysioFile
-from lib.db.queries.physio_parameter import try_get_physio_file_parameter_with_file_id_name
 from lib.env import Env
 from lib.logging import log, log_error_exit
-from lib.physio.parameters import insert_physio_file_parameter
+from lib.physio.parameters import register_physio_file_parameter
 
 
 def create_physio_channels_chunks(env: Env, physio_file: DbPhysioFile):
     """
     Create the channels chunks for a physiological file based on its source MEG CTF directory.
     """
-
-    chunk_path = try_get_physio_file_parameter_with_file_id_name(
-        env.db,
-        physio_file.id,
-        'electrophysiology_chunked_dataset_path',
-    )
-
-    if chunk_path is not None:
-        log(env, "Chunk path already exists for this file.")
-        return
 
     match physio_file.type:
         case 'ctf':
@@ -44,6 +33,7 @@ def create_physio_channels_chunks(env: Env, physio_file: DbPhysioFile):
     file_path = data_dir_path / physio_file.path
 
     chunk_root_dir_path = get_dataset_chunks_dir_path(env, physio_file)
+    chunk_path = chunk_root_dir_path / f'{get_path_stem(physio_file.path)}.chunks'
 
     command_parts = [script, str(file_path), '--destination', str(chunk_root_dir_path)]
 
@@ -68,7 +58,6 @@ def create_physio_channels_chunks(env: Env, physio_file: DbPhysioFile):
             lib.exitcode.CHUNK_CREATION_FAILURE,
         )
 
-    chunk_path = chunk_root_dir_path / f'{get_path_stem(physio_file.path)}.chunks'
     if not chunk_path.is_dir():
         log_error_exit(
             env,
@@ -76,7 +65,7 @@ def create_physio_channels_chunks(env: Env, physio_file: DbPhysioFile):
             lib.exitcode.CHUNK_CREATION_FAILURE,
         )
 
-    insert_physio_file_parameter(
+    register_physio_file_parameter(
         env,
         physio_file,
         'electrophysiology_chunked_dataset_path',

--- a/python/lib/physio/parameters.py
+++ b/python/lib/physio/parameters.py
@@ -5,7 +5,10 @@ from sqlalchemy.orm import Session as Database
 from lib.db.models.parameter_type import DbParameterType
 from lib.db.models.physio_file import DbPhysioFile
 from lib.db.models.physio_file_parameter import DbPhysioFileParameter
-from lib.db.queries.physio_parameter import get_physio_file_parameters
+from lib.db.queries.physio_parameter import (
+    get_physio_file_parameters,
+    try_get_physio_file_parameter_with_file_id_type_id,
+)
 from lib.env import Env
 from lib.imaging_lib.parameter import get_or_create_parameter_type
 
@@ -59,35 +62,45 @@ def insert_physio_project_parameter(
     return parameter
 
 
-def insert_physio_file_parameters(env: Env, file: DbPhysioFile, parameters: dict[str, Any]):
+def register_physio_file_parameters(env: Env, file: DbPhysioFile, parameters: dict[str, Any]):
     """
     Insert or update the parameters for a physiological file.
     """
 
     for name, value in parameters.items():
-        insert_physio_file_parameter(env, file, name, value)
+        register_physio_file_parameter(env, file, name, value)
 
 
-def insert_physio_file_parameter(
+def register_physio_file_parameter(
     env: Env,
     file: DbPhysioFile,
     parameter_name: str,
     parameter_value: Any,
 ) -> DbPhysioFileParameter:
     """
-    Insert a physiological file parameter with the provided parameter name and value.
+    Insert or update a physiological file parameter with the provided parameter name and value.
     """
 
     parameter_type = get_or_create_physio_parameter_type(env, parameter_name)
 
-    parameter = DbPhysioFileParameter(
-        file_id    = file.id,
-        project_id = file.session.project.id,
-        type_id    = parameter_type.id,
-        value      = str(parameter_value),
+    parameter = try_get_physio_file_parameter_with_file_id_type_id(
+        env.db,
+        file.id,
+        parameter_type.id,
     )
 
-    env.db.add(parameter)
+    if parameter is None:
+        parameter = DbPhysioFileParameter(
+            file_id    = file.id,
+            project_id = file.session.project.id,
+            type_id    = parameter_type.id,
+            value      = str(parameter_value),
+        )
+
+        env.db.add(parameter)
+    else:
+        parameter.value = str(parameter_value)
+
     env.db.flush()
 
     return parameter

--- a/python/loris_bids_importer/src/loris_bids_importer/channels.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/channels.py
@@ -7,7 +7,7 @@ from lib.db.models.session import DbSession
 from lib.db.queries.physio_channel import try_get_channel_type_with_name, try_get_status_type_with_name
 from lib.env import Env
 from lib.physio.channels import insert_physio_channel
-from lib.physio.parameters import insert_physio_file_parameter
+from lib.physio.parameters import register_physio_file_parameter
 from loris_bids_utils.eeg.channels import BidsEegChannelsTsvFile, BidsEegChannelTsvRow
 from loris_bids_utils.info import BidsAcquisitionInfo
 from loris_utils.crypto import compute_file_blake2b_hash
@@ -50,7 +50,7 @@ def insert_bids_channels_file(
     )
 
     get_or_create_loris_bids_file(env, importer, channels_file.path, loris_channels_file_path)
-    insert_physio_file_parameter(env, physio_file, 'channel_file_blake2b_hash', blake2_hash)
+    register_physio_file_parameter(env, physio_file, 'channel_file_blake2b_hash', blake2_hash)
 
     env.db.flush()
 

--- a/python/loris_bids_importer/src/loris_bids_importer/eeg/main.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/eeg/main.py
@@ -15,7 +15,7 @@ from lib.logging import log, log_warning
 from lib.physio.chunking import create_physio_channels_chunks
 from lib.physio.events import EventDictFileSource
 from lib.physio.file import insert_physio_file
-from lib.physio.parameters import insert_physio_file_parameters
+from lib.physio.parameters import register_physio_file_parameters
 from loris_bids_utils.eeg.channels import BidsEegChannelsTsvFile
 from loris_bids_utils.eeg.sidecar import BidsEegSidecarJsonFile
 from loris_bids_utils.files.events import BidsEventsTsvFile
@@ -368,7 +368,7 @@ class Eeg:
                 bids_info=bids_info,
             )
 
-            insert_physio_file_parameters(self.env, physio_file, eeg_file_data)
+            register_physio_file_parameters(self.env, physio_file, eeg_file_data)
             self.env.db.commit()
 
             # Update the LORIS scans.tsv file.

--- a/python/loris_bids_importer/src/loris_bids_importer/eeg/physiological.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/eeg/physiological.py
@@ -4,7 +4,7 @@ from lib.database_lib.physiological_coord_system import PhysiologicalCoordSystem
 from lib.database_lib.point_3d import Point3DDB
 from lib.db.models.physio_file import DbPhysioFile
 from lib.env import Env
-from lib.physio.parameters import insert_physio_file_parameter
+from lib.physio.parameters import register_physio_file_parameter
 from lib.point_3d import Point3D
 
 
@@ -159,7 +159,7 @@ class Physiological:
             electrode_ids.append(inserted_electrode_id)
 
         # insert blake2b hash of electrode file into physiological_parameter_file
-        insert_physio_file_parameter(self.env, physiological_file, 'electrode_file_blake2b_hash', blake2)
+        register_physio_file_parameter(self.env, physiological_file, 'electrode_file_blake2b_hash', blake2)
         return electrode_ids
 
     def insert_electrode_metadata(self, electrode_metadata, electrode_metadata_file,
@@ -273,4 +273,4 @@ class Physiological:
 
         if blake2:
             # insert blake2b hash of task event file into physiological_parameter_file
-            insert_physio_file_parameter(self.env, physiological_file, 'coordsystem_file_json_blake2b_hash', blake2)
+            register_physio_file_parameter(self.env, physiological_file, 'coordsystem_file_json_blake2b_hash', blake2)

--- a/python/loris_bids_importer/src/loris_bids_importer/events.py
+++ b/python/loris_bids_importer/src/loris_bids_importer/events.py
@@ -18,7 +18,7 @@ from lib.physio.events import (
     parse_and_insert_event_dict,
 )
 from lib.physio.hed import TagGroupMember, build_hed_tag_groups, filter_inherited_tags
-from lib.physio.parameters import insert_physio_file_parameter, insert_physio_project_parameter
+from lib.physio.parameters import insert_physio_project_parameter, register_physio_file_parameter
 from loris_bids_utils.files.events import OPTIONAL_EVENT_FIELDS, BidsEventsTsvFile
 from loris_bids_utils.json import BidsJsonFile
 from loris_utils.crypto import compute_file_blake2b_hash
@@ -74,7 +74,7 @@ def insert_bids_event_dict_file(
     hed_tags_dict = parse_and_insert_event_dict(env, bids_event_dict_file.data, source)
 
     if source.physio_file is not None:
-        insert_physio_file_parameter(env, source.physio_file, 'event_file_json_blake2b_hash', blake2b_hash)
+        register_physio_file_parameter(env, source.physio_file, 'event_file_json_blake2b_hash', blake2b_hash)
     else:
         insert_physio_project_parameter(env, source.project.id, 'event_file_json_blake2b_hash', blake2b_hash)
 
@@ -108,7 +108,7 @@ def insert_bids_events_file(
     event_file = insert_events_file(env, physio_file, bids_info, loris_events_file_path)
 
     # insert blake2b hash of task event file into physiological_parameter_file
-    insert_physio_file_parameter(env, physio_file, 'event_file_blake2b_hash', blake2_hash)
+    register_physio_file_parameter(env, physio_file, 'event_file_blake2b_hash', blake2_hash)
 
     event_fields = (
         'PhysiologicalFileID', 'Onset',     'Duration',   'TrialType',

--- a/python/scripts/mass_electrophysiology_chunking.py
+++ b/python/scripts/mass_electrophysiology_chunking.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python
 
 import argparse
+import shutil
+
+from loris_utils.path import get_path_stem
 
 import lib.exitcode
 from lib.config_file import load_config
 from lib.db.queries.physio_file import try_get_physio_file_with_id
+from lib.db.queries.physio_parameter import try_get_physio_file_parameter_with_file_id_name
 from lib.env import Env
 from lib.logging import log, log_error_exit, log_warning
 from lib.make_env import make_env
-from lib.physio.chunking import create_physio_channels_chunks
+from lib.physio.chunking import create_physio_channels_chunks, get_dataset_chunks_dir_path
 
 
 def main():
@@ -36,6 +40,12 @@ def main():
     )
 
     parser.add_argument(
+        '-f', '--force',
+        action='store_true',
+        help="Overwrite chunks already present for the physiological file."
+    )
+
+    parser.add_argument(
         '-v', '--verbose',
         action='store_true',
         help="If set, be verbose."
@@ -56,10 +66,10 @@ def main():
     # Run the chunking script on electrophysiology files with an ID between the smallest and largest
     # IDs.
     for file_id in range(args.smallest_id, args.largest_id + 1):
-        make_chunks(env, file_id)
+        make_chunks(env, file_id, args.force)
 
 
-def make_chunks(env: Env, physio_file_id: int):
+def make_chunks(env: Env, physio_file_id: int, force: bool):
     """
     Call the channel signal chunking script on the provided physiological file.
     """
@@ -68,6 +78,26 @@ def make_chunks(env: Env, physio_file_id: int):
     if physio_file is None:
         log_warning(env, f"No physiological file for ID {physio_file_id} in the database, skipping.")
         return
+
+    current_chunks = try_get_physio_file_parameter_with_file_id_name(
+        env.db,
+        physio_file.id,
+        'electrophysiology_chunked_dataset_path',
+    )
+
+    if current_chunks and not force:
+        log_warning(
+            env,
+            f"There are already chunks for physiological file ID {physio_file.id}. "
+            "Use -f or --force to overwrite them, skipping."
+        )
+        return
+
+    if force:
+        chunk_root_dir_path = get_dataset_chunks_dir_path(env, physio_file)
+        chunk_path = chunk_root_dir_path / f'{get_path_stem(physio_file.path)}.chunks'
+        if chunk_path.is_dir():
+            shutil.rmtree(chunk_path)
 
     log(env, f"Chunking physiological file ID {physio_file.id}")
     create_physio_channels_chunks(env, physio_file)


### PR DESCRIPTION
Two bug fixes in one.

## Bug 1

Currently, the way to insert physiological file parameters is to use the `insert_physio_file_parameter` function, which always adds a new parameter if a similar one already exists. When running the `mass_electrophysiology_chunking.py` script on an already-chunked script (which always works due to the second bug), this adds a new chunk path parameter to the file, which the electrophysiology browser reads as `path/to/file/1,path/to/file/2`, which is obviously an invalid path and therefore prevents the chunks from being loaded.

This PR refactors this function into `register_physio_parameter_file`, which has a similar structure as `register_mri_parameter_file`, and inserts a parameter if there is currently none, or updates the existing one otherwise, preventing the aforementioned situation from happening.

## Bug 2

The `try_get_physio_parameter_type_with_name` function currently uses `physiological_file` as the parameter type source, which is wrong! Because physiological file parameters are created using the `physiological_parameter_file` source. Thankfully this did not have too many consequences, as this query is only used by the electrophyisiology chunking script. 

This PR corrects the query.

## Improvement

This PR also further improves the `mass_electrophysiology_chunking.py` script by making it take a `--force` option just like the `mass_nifti_pic.py` script: without that option, a warning is emitted if the chunks already exist for a file, with it, the old chunks are deleted and new ones are generated.