### PR TITLE
Fix various electrophysiology chunker bugs

### DIFF
--- a/python/loris_ephys_chunker/src/loris_ephys_chunker/chunking.py
+++ b/python/loris_ephys_chunker/src/loris_ephys_chunker/chunking.py
@@ -167,7 +167,7 @@ def write_chunks(chunk_dir: Path, channel_chunks_list: list[ChannelArray], chann
                     / str(trace_index)
                 )
 
-                trace_path.mkdir(parents=True)
+                trace_path.mkdir(parents=True, exist_ok=True)
                 for chunk_index, chunk in enumerate(trace):
                     encoded_chunk = encode_chunk(chunk, chunk_index, downsampling)
                     with open(trace_path / f'{chunk_index}.buf', 'w+b') as chunk_file:

--- a/python/loris_ephys_chunker/src/loris_ephys_chunker/chunking.py
+++ b/python/loris_ephys_chunker/src/loris_ephys_chunker/chunking.py
@@ -194,12 +194,12 @@ def mne_file_to_chunks(
     channel_ranges: list[tuple[float, float]] = []
     signal_range = (np.inf, -np.inf)
     channel_chunks_list = []
-    selected_channels = []
+    selected_channels = channel_names
     valid_samples_in_last_chunk = []
 
-    if from_channel_name:
+    if from_channel_name is not None:
         from_channel_index = channel_names.index(from_channel_name)
-        if channel_count and from_channel_index + channel_count < len(channel_names):
+        if channel_count is not None:
             selected_channels = channel_names[from_channel_index:from_channel_index + channel_count]
         else:
             selected_channels = channel_names[from_channel_index:]
@@ -227,7 +227,14 @@ def mne_file_to_chunks(
             for j, chunk in enumerate(chunks):
                 channel_chunks_list[j] = np.append(channel_chunks_list[j], chunk, axis=0)
 
-    return channel_chunks_list, time_interval, signal_range, channel_names, channel_ranges, valid_samples_in_last_chunk
+    return (
+        channel_chunks_list,
+        time_interval,
+        signal_range,
+        selected_channels,
+        channel_ranges,
+        valid_samples_in_last_chunk,
+    )
 
 
 def write_chunk_directory(

--- a/python/loris_ephys_chunker/src/loris_ephys_chunker/chunking.py
+++ b/python/loris_ephys_chunker/src/loris_ephys_chunker/chunking.py
@@ -248,6 +248,7 @@ def write_chunk_directory(
 
     if downsamplings is not None:
         channel_chunks_list = channel_chunks_list[:downsamplings]
+        valid_samples_in_last_chunk = valid_samples_in_last_chunk[:downsamplings]
 
     channel_metadata = [
         {
@@ -259,13 +260,13 @@ def write_chunk_directory(
     ]
 
     write_index_json(
-        chunk_dir,
-        time_interval,
-        signal_range,
-        channel_metadata,
-        chunk_size,
-        valid_samples_in_last_chunk,
-        list(range(len(channel_chunks_list))),
-        [list(downsampled.shape) for downsampled in channel_chunks_list]
+        chunk_dir=chunk_dir,
+        time_interval=time_interval,
+        series_range=signal_range,
+        channel_metadata=channel_metadata,
+        chunk_size=chunk_size,
+        downsamplings=list(range(len(channel_chunks_list))),
+        valid_samples_in_last_chunk=valid_samples_in_last_chunk,
+        shapes=[list(downsampled.shape) for downsampled in channel_chunks_list],
     )
     write_chunks(chunk_dir, channel_chunks_list, from_channel_index)

--- a/python/loris_ephys_chunker/src/loris_ephys_chunker/chunking.py
+++ b/python/loris_ephys_chunker/src/loris_ephys_chunker/chunking.py
@@ -48,11 +48,28 @@ def create_chunks_from_values_lists(values_lists: list[ChannelArray], chunk_size
 def downsample_channel(channel: ChannelArray, chunk_size: int, downsampling: int) -> ChannelArray:
     if downsampling == 0:
         return channel
-    down = chunk_size**downsampling
-    downsampled_size = channel.shape[-1] / down
-    if downsampled_size <= chunk_size * 2:
-        downsampled_size = chunk_size * 2
-    return signal.resample(channel, downsampled_size, axis=-1)  # type: ignore
+
+    sample_count = channel.shape[-1]
+    requested_factor = chunk_size**downsampling
+    target_size = max(math.ceil(sample_count / requested_factor), chunk_size * 2)
+
+    # Keep the FIR filter reasonably sized even when the input and target lengths are relatively
+    # prime. Rounding down guarantees at least target_size output samples; chunk padding handles
+    # the small excess.
+    effective_factor = max(1, sample_count // target_size)
+    if effective_factor == 1:
+        return channel
+
+    # FFT resampling treats the recording as periodic and rings where the final and first samples
+    # are implicitly joined. Polyphase FIR resampling avoids that wraparound, while linear boundary
+    # extension prevents zero/constant padding from introducing a new endpoint discontinuity.
+    return signal.resample_poly(  # type: ignore
+        channel,
+        up=1,
+        down=effective_factor,
+        axis=-1,
+        padtype='line',
+    )
 
 
 def create_downsampled_values_lists(channel: ChannelArray, chunk_size: int) -> list[ChannelArray]:

--- a/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/ctf_to_chunks.py
+++ b/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/ctf_to_chunks.py
@@ -66,6 +66,7 @@ def main():
             channel_count=args.channel_count,
             loader=load_channels,
             chunk_size=args.chunk_size,
+            downsamplings=args.downsamplings,
             destination=args.destination,
             prefix=args.prefix
         )

--- a/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/edf_to_chunks.py
+++ b/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/edf_to_chunks.py
@@ -57,13 +57,12 @@ def main():
         if args.channel_count and args.channel_count < 0:
             sys.exit("Channel count must be a positive integer")
 
-        if args.channel_index in edf_info['stim_channel_idxs']:
-            continue
+        channel_count = args.channel_count
+        if channel_count is None:
+            channel_count = len(channel_names) - args.channel_index
+        channel_count = min(channel_count, len(channel_names) - args.channel_index)
 
-        if not args.channel_count:
-            args.channel_count = len(channel_names) - args.channel_index
-
-        for i in range(args.channel_count):
+        for i in range(channel_count):
             channel_index: int = args.channel_index + i
 
             # check if channel_index is a stim channel

--- a/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/edf_to_chunks.py
+++ b/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/edf_to_chunks.py
@@ -88,6 +88,7 @@ def main():
                 from_channel_name=channel_names[channel_index],
                 channel_count=1,
                 chunk_size=args.chunk_size,
+                downsamplings=args.downsamplings,
                 destination=args.destination,
                 prefix=args.prefix
             )

--- a/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/eeglab_to_chunks.py
+++ b/python/loris_ephys_chunker/src/loris_ephys_chunker/scripts/eeglab_to_chunks.py
@@ -57,6 +57,7 @@ def main():
             channel_count=args.channel_count,
             loader=load_channels,
             chunk_size=args.chunk_size,
+            downsamplings=args.downsamplings,
             destination=args.destination,
             prefix=args.prefix
         )


### PR DESCRIPTION
## Description

Fix various bugs in the electrophysiology chunking script. Each commit fixes one bug. It is therefore advised to review this PR commit-by-commit.

### Bug 1

The current code uses [`scipy.signal.resample`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.resample.html) to generate downsamplings. However, this function has the requirement that the signal must be periodic, which results in visible aberrant oscillations at the beginning of signals when that is not the case. The code has been changed to use the more general [`scipy.signal.resample_poly`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.resample_poly.html) that does not have this requirement and removed these aberrations.

### Bug 2

Chunk ranges and last valid samples parameters are currently inverted in the `write_index_json` function call.

### Bug 3

Signal extraction correctly began at `from_channel_name`, but channel metadata names were taken from
the beginning of the complete channel list. Selecting channel `B` from `[A, B]`, for example, could
write channel `B` samples and range under the name `A`.

### Bug 4

The `--downsamplings` CLI argument is currently not passed to the `write_chunk_directory` function.

### Bug 5

EDF code currently contains the following line:

```py
if args.channel_index in edf_info['stim_channel_idxs']:
    continue
```

but this is checked before the loop after it:

```py
for i in range(channel_count):
     channel_index: int = args.channel_index + i
```

So if the supplied CLI channel index was a stim channel ID, the full file was skipped, which looks incorrect since there is already a check inside the loop to skip stim channels.

```py
# check if channel_index is a stim channel
# to avoid a bug in mne.io.edf.edf
# (see issue https://github.com/mne-tools/mne-python/issues/9811)
stim_channel_idxs, _ = mne_edf._check_stim_channel(  # type: ignore
    'auto', [channel_names[channel_index]]
)
if len(stim_channel_idxs) == 1:
    continue
```

### Bug 6

Although there is a mechanism to merge `index.json` files, the code currently requires trace directories to not already exist, which makes incremental chunk generation fail.

## Results (Raisinbread Face13 OTT166)

### Before

<img width="2317" height="1438" alt="downsampling_original" src="https://github.com/user-attachments/assets/d9d4a5fc-f027-402e-9c9f-e7e83907690d" />

### After

<img width="2317" height="1438" alt="downsampling_corrected" src="https://github.com/user-attachments/assets/b3c9e9e8-ad6f-42ae-89b5-fbe4e055b8bc" />

This is the result fully zoomed out (and thus downsamples), which looks very different. The two main visible differences are:
- The oscillations at the beginning of some channels are gone, as a result of the fix of bug 1.
- There is much more data x-wise, with three notably abrupt energy level changes rather than one. Funnily enough, it seems this data was already similarly downsampled in the current code, but because of bug 2, it was not displayed properly, hence the difference with the fix.