### PR TITLE
Locally runnable integration tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.venv
+**/__pycache__
+**/*.pyc
+**/.pytest_cache
+**/.ruff_cache
+config
+dist
+environment

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,14 +13,6 @@ env:
   DATABASE_NAME: TestDatabase
   DATABASE_USERNAME: TestUsername
   DATABASE_PASSWORD: TestPassword
-  BUCKET_URL: https://ace-minio-1.loris.ca:9000
-  BUCKET_NAME: loris-rb-data
-  # NOTE: These are read-only keys on public data.
-  # Ideally, we would like to hide these keys. However, both GitHub variables and GitHub secrets
-  # are not accessible from pull requests from forks. Since we want to run integration tests on
-  # pull requests, we define these variables here.
-  BUCKET_ACCESS_KEY: lorisadmin-ro
-  BUCKET_SECRET_KEY: Tn=qP3LupmXnMuc
 
 jobs:
   docker:
@@ -30,60 +22,16 @@ jobs:
     - name: Check out LORIS-MRI
       uses: actions/checkout@v4
 
-    - name: Clone the LORIS core repository
-      # Use the corresponding LORIS branch for integration tests.
-      # The branch name is either the target branch for PRs, or the current branch otherwise.
-      # Only copy the current state of the repository, the history is not needed for CI.
-      run: |
-        BRANCH_NAME="${{ github.base_ref || github.ref_name }}"
-        git clone --depth 1 --single-branch --branch "$BRANCH_NAME" https://github.com/aces/Loris.git ./test/Loris
-
-    - name: Overwrite Raisinbread SQL files
-      run: cp -f ./test/RB_SQL/*.sql ./test/Loris/raisinbread/RB_files/
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Build Docker database image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: ./test/db.Dockerfile
-        build-args: |
-          DATABASE_NAME=${{ env.DATABASE_NAME }}
-          DATABASE_USER=${{ env.DATABASE_USERNAME }}
-          DATABASE_PASS=${{ env.DATABASE_PASSWORD }}
-        tags: loris-db
-        load: true
-        cache-from: type=gha,scope=loris-db
-        cache-to: type=gha,scope=loris-db
-
-    - name: Build Docker MRI image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: ./test/mri.Dockerfile
-        build-args: |
-          DATABASE_NAME=${{ env.DATABASE_NAME }}
-          DATABASE_USER=${{ env.DATABASE_USERNAME }}
-          DATABASE_PASS=${{ env.DATABASE_PASSWORD }}
-        tags: loris-mri
-        load: true
-        cache-from: type=gha,scope=loris-mri
-        cache-to: type=gha,mode=max,scope=loris-mri
-
-    # NOTE: Ideally, we would like to mount the S3 bucket in the Docker image, but since it
-    # interacts with the kernel to add a file system, it is hard to do so.
-    - name: Mount imaging files S3 bucket
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y s3fs fuse kmod
-        sudo modprobe fuse
-        sudo mkdir /data-imaging
-        touch .passwd-s3fs
-        chmod 600 .passwd-s3fs
-        echo ${{ env.BUCKET_ACCESS_KEY }}:${{ env.BUCKET_SECRET_KEY }} > .passwd-s3fs
-        sudo s3fs ${{ env.BUCKET_NAME }} /data-imaging -o url=${{ env.BUCKET_URL }} -o passwd_file=.passwd-s3fs -o use_path_request_style -o allow_other
+    # Expose the GitHub cache service variables to Docker Compose, using the action is recommended
+    # by the Docker documentation:
+    # https://docs.docker.com/build/cache/backends/gha#authentication
+    - name: Set up GitHub Actions cache access
+      uses: crazy-max/ghaction-github-runtime@v4
 
     - name: Run integration tests
-      run: docker compose --file ./test/docker-compose.yml run mri pytest python/tests/integration
+      env:
+        LORIS_TEST_COMPOSE_OVERRIDE: ./test/docker-compose.ci.yml
+      run: ./test/run_integration_tests.sh --loris-ref "${{ github.base_ref || github.ref_name }}"

--- a/docs/python/Tooling.md
+++ b/docs/python/Tooling.md
@@ -43,11 +43,11 @@ To run the LORIS-MRI Python unit tests, use the command `pytest` in the root LOR
 The LORIS-MRI integration tests are located in the `python/tests/integration` directory.
 
 The LORIS-MRI integration tests require a more complex testing environment with the following:
-- A copy of the main LORIS repository.
-- A file system mount of the S3 LORIS-MRI test dataset.
+- A (partial) copy of the main LORIS repository.
+- A copy of the S3 LORIS-MRI test dataset.
 - A LORIS database Docker image with the LORIS-MRI test dataset.
 - A LORIS-MRI code Docker image with all the required dependencies installed.
 
-To run the LORIS-MRI integration tests, use the command `pytest python/tests/integration` in the root LORIS-MRI directory **inside the LORIS-MRI code Docker image**.
+To run the LORIS-MRI integration tests, use the command `test/run_integration_tests.sh` in the root LORIS-MRI directory.
 
-As of December 2024, there is no easy way to set up and run this environment locally. You can however use the LORIS-MRI GitHub Actions workflow (that is, create a pull request) to set up this environment and run the integration tests in GitHub.
+Note that the first run of the LORIS-MRI integration test run might take some time, as the test data must be downloaded and the Docker images must be created. However, much of this setup should be cached in the Docker cache as well as the LORIS-MRI test cache directory (by default `~/.cache/loris/test`), so further test runs should be much faster. To avoid downloading data and building images locally, it is also possible to run the LORIS-MRI integration tests remotely by simply creating a pull request, which will trigger the LORIS-MRI CI workflow.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ reportMissingTypeStubs = "none"
 extend-exclude = [
     "*.al", "*.pl", "*.pm",
     "/docs/scripts_md",
+    "/test/loris-data.env",
 ]
 
 [tool.typos.default]

--- a/test/db.Dockerfile
+++ b/test/db.Dockerfile
@@ -1,9 +1,14 @@
 FROM mariadb:latest
 
-# Copy the SQL schema files and the Raisinbread data from the main LORIS repository.
-COPY test/Loris/SQL/*.sql .
-COPY test/Loris/raisinbread/instruments/instrument_sql/*.sql ./raisinbread/instruments/
-COPY test/Loris/raisinbread/RB_files/*.sql ./raisinbread/
+# Copy the SQL schema files and the Raisinbread data from the main LORIS repository. The
+# `loris_core` build context is supplied by Docker Compose, so it does not need to live inside this
+# repository.
+COPY --from=loris_core SQL/*.sql .
+COPY --from=loris_core raisinbread/instruments/instrument_sql/*.sql ./raisinbread/instruments/
+COPY --from=loris_core raisinbread/RB_files/*.sql ./raisinbread/
+
+# Override the LORIS core Raisinbread schema with the versions maintained by LORIS-MRI.
+COPY test/RB_SQL/*.sql ./raisinbread/
 
 # Usually, MariaDB creates the SQL user and database at runtime. Since we want to embed the
 # database in the image, we instead create them manually at build time.

--- a/test/docker-compose.ci.yml
+++ b/test/docker-compose.ci.yml
@@ -1,0 +1,17 @@
+# The GitHub Actions cache service is ephemeral-runner storage for BuildKit layers. These settings
+# live in an override so local Compose builds continue to use Docker's normal local cache and do not
+# require GitHub runtime credentials. Separate scopes prevent the two image caches overwriting one
+# another.
+services:
+  db:
+    build:
+      cache_from:
+        - type=gha,scope=loris-db
+      cache_to:
+        - type=gha,scope=loris-db,mode=max
+  mri:
+    build:
+      cache_from:
+        - type=gha,scope=loris-mri
+      cache_to:
+        - type=gha,scope=loris-mri,mode=max

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,8 +1,15 @@
 services:
   db:
     image: loris-db
-    volumes:
-      - ./test/mysql-config:/etc/mysql/conf.d
+    build:
+      context: ..
+      dockerfile: test/db.Dockerfile
+      additional_contexts:
+        loris_core: ${LORIS_CORE_DIR:?Set LORIS_CORE_DIR to a LORIS core checkout}
+      args:
+        DATABASE_NAME: ${DATABASE_NAME:-TestDatabase}
+        DATABASE_USER: ${DATABASE_USERNAME:-TestUsername}
+        DATABASE_PASS: ${DATABASE_PASSWORD:-TestPassword}
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       start_period: 10s
@@ -11,8 +18,15 @@ services:
       retries: 5
   mri:
     image: loris-mri
+    build:
+      context: ..
+      dockerfile: test/mri.Dockerfile
+      args:
+        DATABASE_NAME: ${DATABASE_NAME:-TestDatabase}
+        DATABASE_USER: ${DATABASE_USERNAME:-TestUsername}
+        DATABASE_PASS: ${DATABASE_PASSWORD:-TestPassword}
     volumes:
-      - /data-imaging:/data-imaging
+      - ${LORIS_TEST_DATA:?Set LORIS_TEST_DATA to the imaging test dataset}:/data-loris:ro
     depends_on:
       db:
         condition: service_healthy

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Create a writable directory with links to the imaging dataset files
-replicate_raisinbread_for_mcin_dev_vm.pl /data-imaging /data/loris
+replicate_raisinbread_for_mcin_dev_vm.pl /data-loris /data/loris
 
 # Run the provided command (usually the integration test command)
 exec "$@"

--- a/test/loris-data.env
+++ b/test/loris-data.env
@@ -1,0 +1,6 @@
+# These are read-only keys on public data.
+# Ideally, we would like to hide these keys. However, both GitHub variables and GitHub secrets
+# are not accessible from pull requests from forks. Since we want to run integration tests on
+# pull requests, we define these variables here.
+BUCKET_ACCESS_KEY=lorisadmin-ro
+BUCKET_SECRET_KEY=Tn=qP3LupmXnMuc

--- a/test/run_integration_tests.sh
+++ b/test/run_integration_tests.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly AWS_CLI_IMAGE="amazon/aws-cli:2.17.57"
+
+source "$SCRIPT_DIR/loris-data.env"
+
+loris_ref="${LORIS_REF:-main}"
+data_dir="${LORIS_TEST_DATA:-}"
+cache_dir="${LORIS_TEST_CACHE:-${HOME}/.cache/loris/test}"
+loris_dir=""
+compose=(docker compose --file "$SCRIPT_DIR/docker-compose.yml")
+
+# CI adds a cache backend through an override while local builds use Docker's persistent layer
+# cache. Keeping this selection outside the base Compose file makes the default command portable.
+if [[ -n "${LORIS_TEST_COMPOSE_OVERRIDE:-}" ]]; then
+    compose+=(--file "$LORIS_TEST_COMPOSE_OVERRIDE")
+fi
+
+usage() {
+    cat <<'EOF'
+Usage: test/run_integration_tests.sh [OPTIONS]
+
+Build and run the LORIS-MRI integration tests in Docker.
+
+Options:
+  --loris-ref REF   LORIS core branch, tag, or commit to test against (default: main)
+  --data-dir PATH   Existing imaging test dataset (otherwise downloaded and cached)
+  --cache-dir PATH  Cache directory (default: ~/.cache/loris/test)
+  -h, --help        Show this help
+
+Environment equivalents:
+  LORIS_REF, LORIS_TEST_DATA, LORIS_TEST_CACHE
+EOF
+}
+
+parse_arguments() {
+    while (($#)); do
+        case "$1" in
+            --loris-ref)
+                [[ $# -ge 2 ]] || { echo "ERROR: --loris-ref requires a value" >&2; exit 2; }
+                loris_ref="$2"
+                shift 2
+                ;;
+            --data-dir)
+                [[ $# -ge 2 ]] || { echo "ERROR: --data-dir requires a value" >&2; exit 2; }
+                data_dir="$2"
+                shift 2
+                ;;
+            --cache-dir)
+                [[ $# -ge 2 ]] || { echo "ERROR: --cache-dir requires a value" >&2; exit 2; }
+                cache_dir="$2"
+                shift 2
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                echo "ERROR: Unknown option: $1" >&2
+                usage >&2
+                exit 2
+                ;;
+        esac
+    done
+}
+
+check_requirements() {
+    command -v git >/dev/null || { echo "ERROR: Git is required." >&2; exit 1; }
+    command -v docker >/dev/null || { echo "ERROR: Docker is required." >&2; exit 1; }
+    docker compose version >/dev/null || { echo "ERROR: Docker Compose v2 is required." >&2; exit 1; }
+}
+
+# LORIS-MRI integration tests only need the core LORIS schema and Raisinbread seed data. Using a
+# sparse checkout avoids downloading unused files to save resources.
+prepare_loris_checkout() {
+    mkdir -p "$cache_dir"
+    cache_dir="$(cd "$cache_dir" && pwd)"
+    loris_dir="$cache_dir/loris-ref"
+
+    if [[ ! -d "$loris_dir/.git" ]]; then
+        echo "Cloning LORIS core..."
+        git clone --depth 1 --filter=blob:none --no-checkout --sparse \
+            https://github.com/aces/loris.git "$loris_dir"
+    fi
+
+    git -C "$loris_dir" sparse-checkout set \
+        SQL \
+        raisinbread/instruments/instrument_sql \
+        raisinbread/RB_files
+    echo "Fetching LORIS core ref '$loris_ref'..."
+    git -C "$loris_dir" fetch --depth 1 origin "$loris_ref"
+    git -C "$loris_dir" checkout --detach --force FETCH_HEAD
+    echo "Using LORIS core commit $(git -C "$loris_dir" rev-parse HEAD)"
+}
+
+# Use an AWS CLI container so synchronizing fixtures does not add an AWS CLI installation
+# requirement to developer machines. The cache belongs exclusively to this script, so `--delete`
+# can keep it identical to the bucket. Even though the DICOM study contains many files, unchanged
+# objects require only metadata comparisons and are not downloaded again.
+sync_test_dataset() {
+    data_dir="$cache_dir/loris-data"
+    mkdir -p "$data_dir"
+    echo "Synchronizing the imaging test dataset at $data_dir..."
+    docker run --rm \
+        --user "$(id -u):$(id -g)" \
+        --env HOME=/tmp \
+        --env AWS_ACCESS_KEY_ID="$BUCKET_ACCESS_KEY" \
+        --env AWS_SECRET_ACCESS_KEY="$BUCKET_SECRET_KEY" \
+        --env AWS_EC2_METADATA_DISABLED=true \
+        --volume "$data_dir:/data" \
+        "$AWS_CLI_IMAGE" \
+        s3 sync "s3://${BUCKET_NAME:-loris-rb-data}" /data \
+        --endpoint-url "${BUCKET_URL:-https://ace-minio-1.loris.ca:9000}" \
+        --delete \
+        --no-progress
+}
+
+prepare_test_dataset() {
+    if [[ -z "$data_dir" ]]; then
+        sync_test_dataset
+    fi
+
+    [[ -d "$data_dir" ]] || {
+        echo "ERROR: Imaging test dataset does not exist: $data_dir" >&2
+        exit 1
+    }
+    data_dir="$(cd "$data_dir" && pwd)"
+}
+
+configure_compose() {
+    export LORIS_CORE_DIR="$loris_dir"
+    export LORIS_TEST_DATA="$data_dir"
+    export COMPOSE_PROJECT_NAME="loris-mri-integration-${UID}"
+}
+
+# Integration tests modify both the database and the generated imaging tree. Always removing the
+# Compose project gives every invocation pristine state without discarding reusable image layers or
+# the read-only source dataset.
+cleanup() {
+    "${compose[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+build_images() {
+    echo "Building integration test images..."
+    "${compose[@]}" build
+}
+
+run_tests() {
+    echo "Running integration tests..."
+    "${compose[@]}" run --rm mri pytest python/tests/integration
+}
+
+main() {
+    parse_arguments "$@"
+    check_requirements
+    prepare_loris_checkout
+    prepare_test_dataset
+    configure_compose
+
+    # Also clear state left by a previously interrupted invocation before starting this one.
+    cleanup
+    build_images
+    run_tests
+}
+
+main "$@"


### PR DESCRIPTION
Move the logic for running the LORIS-MRI integration tests from Github Actions to a new `test/run_integration_tests.sh` script.

The details are as follows:
- Running the LORIS-MRI integration tests locally requires Git and Docker installed.
- The script downloads the relevant data (main LORIS repo SQL files, test dataset from S3) and builds the database and code Docker images locally.
- In order to not re-download data for every test run, test data is cached, by default under `~/.cache/loris/test` but can be changed with a CLI option.
- While the integration tests previously used `s3fs` to mount the S3 data, the tests now use a plain download. This is preferable because it does not require elevated privileges to install a new file system, and all the test files should be used in the integration tests anyway.
- The Github integration test action re-uses `test/run_integration_tests.sh`, avoiding duplication while still using the Github Actions Docker cache.
- The main time sink for cached runs is now the `pip install` phase of the Docker image build, which is not cached itself. This should be optimizable in a later PR.